### PR TITLE
Fix to units work with bytes type

### DIFF
--- a/pydm/data_plugins/plugin.py
+++ b/pydm/data_plugins/plugin.py
@@ -8,7 +8,7 @@ class PyDMConnection(QObject):
     new_severity_signal =     pyqtSignal(int)
     write_access_signal =     pyqtSignal(bool)
     enum_strings_signal =     pyqtSignal(tuple)
-    unit_signal =             pyqtSignal([str],[bytes])
+    unit_signal =             pyqtSignal(str)
     prec_signal =             pyqtSignal(int)
 
     def __init__(self, channel, address, parent=None):

--- a/pydm/data_plugins/pyepics_plugin.py
+++ b/pydm/data_plugins/pyepics_plugin.py
@@ -18,6 +18,8 @@ class Connection(PyDMConnection):
       enum_strs = tuple(b.decode(encoding='ascii') for b in enum_strs)
       self.enum_strings_signal.emit(enum_strs)
     if units != None and len(units) > 0:
+      if type(units) == bytes:
+        units = units.decode()
       self.unit_signal.emit(units)
     if count > 1:
       self.new_waveform_signal.emit(value)


### PR DESCRIPTION
Some PVs return units as bytes, so with this change pydm doen's break in this cases.