### PR TITLE
Enum combo box issue

### DIFF
--- a/pydm/data_plugins/pyepics_plugin.py
+++ b/pydm/data_plugins/pyepics_plugin.py
@@ -50,18 +50,25 @@ class Connection(PyDMConnection):
     if epics.ca.isConnected(self.pv.chid):
       self.send_connection_state(conn=True)
       self.pv.run_callbacks()
-      
-    try:
-      channel.value_signal[str].connect(self.put_value, Qt.QueuedConnection)
-      channel.value_signal[int].connect(self.put_value, Qt.QueuedConnection)
-      channel.value_signal[float].connect(self.put_value, Qt.QueuedConnection)
-    except:
-      pass
-      
-    try:
-      channel.waveform_signal.connect(self.put_waveform, Qt.QueuedConnection)
-    except:
-      pass
+    #If the channel is used for writing to PVs, hook it up to the 'put' methods.  
+    if channel.value_signal is not None:
+        try:
+            channel.value_signal[str].connect(self.put_value, Qt.QueuedConnection)
+        except KeyError:
+            pass
+        try:
+            channel.value_signal[int].connect(self.put_value, Qt.QueuedConnection)
+        except KeyError:
+            pass
+        try:
+            channel.value_signal[float].connect(self.put_value, Qt.QueuedConnection)
+        except KeyError:
+            pass
+    if channel.waveform_signal is not None:
+        try:
+            channel.waveform_signal.connect(self.put_value, Qt.QueuedConnection)
+        except KeyError:
+            pass
 
   def close(self):
     self.pv.disconnect()

--- a/pydm/widgets/enum_combo_box.py
+++ b/pydm/widgets/enum_combo_box.py
@@ -116,7 +116,6 @@ class PyDMEnumComboBox(QWidget):
   @pyqtSlot(int)
   def internal_combo_box_activated_int(self, index):
     if self._value != index:
-      self._value = index
       self.valueChanged.emit(index)
     self.activated[int].emit(index)
   


### PR DESCRIPTION
Fixes #27.

Two separate bugs combine to cause the issue:
1) When connecting put signal types in pyepics plugin, sometimes some would get skipped, if not all types were present on the target channel.
2) The enum combo box widget would not update the combo box's state after changing the value.