### PR TITLE
Multiple plots

### DIFF
--- a/examples/timeplot_multiple_curves/README.txt
+++ b/examples/timeplot_multiple_curves/README.txt
@@ -1,0 +1,11 @@
+Example - TimePlot with Multiple Curves
+
+How to run:
+
+1) In a terminal, run the example ioc:
+
+	./example-ioc.py
+
+2) In another terminal. run the application:
+
+	python3.x multiple_plot_app.py

--- a/examples/timeplot_multiple_curves/example-ioc.py
+++ b/examples/timeplot_multiple_curves/example-ioc.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3.4
+
+'''
+Example ioc
+'''
+
+PREC = 2
+STRING_FORMAT = '% .'+str(PREC)+'f'
+
+from pcaspy import Driver, SimpleServer
+
+prefix = 'EX:'
+pvdb = {
+		'FUNC1' :
+			{
+			'value': 0.0,
+			'scan' : 1,
+			'hilim' : 9,
+			'hihi' : 8,
+			'high' : 7,
+			'low'  : 3,
+			'lolo' : 1,
+			'lolim' : 0,
+			},
+		'FUNC2' :
+			{
+			'value': 10.0,
+			'scan' : 0.5,
+			'hilim' : 9,
+			'hihi' : 8,
+			'high' : 7,
+			'low'  : 3,
+			'lolo' : 1,
+			'lolim' : 0,
+			}
+		}
+
+class myDriver(Driver):
+	def __init__(self):
+		super(myDriver, self).__init__()
+
+	def read(self, reason):
+		value = self.getParam(reason)
+
+		if reason == 'FUNC1':
+			if value == 9:
+				value = 0
+			else:
+				value = value + 1
+			self.setParam('FUNC1', value)
+
+		elif reason == 'FUNC2':
+			if value == 19:
+				value = 10
+			else:
+				value = value + 1
+			self.setParam('FUNC2', value)
+
+		return value
+            
+if __name__ == '__main__':
+	server = SimpleServer()
+	server.createPV(prefix, pvdb)
+	driver = myDriver()
+
+	# process CA transactions
+	print("Server is running... (ctrl+c to close)")
+	print("\nAvailable PVs:")
+	print("EX:FUNC1")
+	print("EX:FUNC2")
+	while True:
+		server.process(0.1)

--- a/examples/timeplot_multiple_curves/multiple_plot_app.py
+++ b/examples/timeplot_multiple_curves/multiple_plot_app.py
@@ -4,11 +4,13 @@ from os import path
 from pydm import PyDMApplication
 from pydm import Display
 
+purple = '9304FE'
+
 # Display Class -----------------------------------------------------------------
 class PlotControl(Display):
   def __init__(self, parent=None, args=None):
     super(PlotControl, self).__init__(parent=parent, args=None)
-    self.multiplePlot.addYChannel('ca://EX:FUNC2', '#9304FE')	# Add a new curve with defined color
+    self.multiplePlot.addYChannel('ca://EX:FUNC2', purple)	# Add a new curve with defined color
 
   def ui_filename(self):
     return 'plot.ui'

--- a/examples/timeplot_multiple_curves/multiple_plot_app.py
+++ b/examples/timeplot_multiple_curves/multiple_plot_app.py
@@ -2,8 +2,6 @@
 import sys
 from os import path
 from pydm import PyDMApplication
-#from pydm.PyQt import uic
-#from pydm.PyQt.QtGui import QWidget
 from pydm import Display
 
 # Display Class -----------------------------------------------------------------

--- a/examples/timeplot_multiple_curves/multiple_plot_app.py
+++ b/examples/timeplot_multiple_curves/multiple_plot_app.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3.4
+import sys
+from os import path
+from pydm import PyDMApplication
+#from pydm.PyQt import uic
+#from pydm.PyQt.QtGui import QWidget
+from pydm import Display
+
+# Display Class -----------------------------------------------------------------
+class PlotControl(Display):
+  def __init__(self, parent=None, args=None):
+    super(PlotControl, self).__init__(parent=parent, args=None)
+    self.multiplePlot.addYChannel('ca://EX:FUNC2', '#9304FE')	# Add a new curve with defined color
+
+  def ui_filename(self):
+    return 'plot.ui'
+    
+  def ui_filepath(self):
+    return path.join(path.dirname(path.realpath(__file__)), self.ui_filename())
+
+intelclass = PlotControl
+
+# Main --------------------------------------------------------------------------
+def main():
+  app = PyDMApplication(ui_file="multiple_plot_app.py")
+  sys.exit(app.exec_())
+
+if __name__ == '__main__':
+  main()

--- a/examples/timeplot_multiple_curves/plot.ui
+++ b/examples/timeplot_multiple_curves/plot.ui
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>865</width>
+    <height>492</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>TimePlot with Multiple Curves</string>
+  </property>
+  <widget class="PyDMTimePlot" name="multiplePlot">
+   <property name="geometry">
+    <rect>
+     <x>15</x>
+     <y>15</y>
+     <width>831</width>
+     <height>451</height>
+    </rect>
+   </property>
+   <property name="toolTip">
+    <string/>
+   </property>
+   <property name="whatsThis">
+    <string/>
+   </property>
+   <property name="autoRangeY">
+    <bool>true</bool>
+   </property>
+   <property name="curveColor">
+    <color>
+     <red>255</red>
+     <green>236</green>
+     <blue>4</blue>
+    </color>
+   </property>
+   <property name="title" stdset="0">
+    <string>Multiple PVs</string>
+   </property>
+   <property name="yChannel">
+    <string>ca://EX:FUNC1</string>
+   </property>
+   <property name="bufferSize">
+    <number>300</number>
+   </property>
+   <property name="updatesAsynchronously">
+    <bool>true</bool>
+   </property>
+   <property name="timeSpan">
+    <double>30.000000000000000</double>
+   </property>
+   <property name="updateInterval">
+    <double>0.100000000000000</double>
+   </property>
+  </widget>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>PyDMTimePlot</class>
+   <extends>QGraphicsView</extends>
+   <header>pydm.widgets.timeplot</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/examples/timeplot_multiple_curves/plot.ui
+++ b/examples/timeplot_multiple_curves/plot.ui
@@ -16,10 +16,10 @@
   <widget class="PyDMTimePlot" name="multiplePlot">
    <property name="geometry">
     <rect>
-     <x>15</x>
-     <y>15</y>
-     <width>831</width>
-     <height>451</height>
+     <x>35</x>
+     <y>30</y>
+     <width>796</width>
+     <height>426</height>
     </rect>
    </property>
    <property name="toolTip">
@@ -28,18 +28,15 @@
    <property name="whatsThis">
     <string/>
    </property>
-   <property name="autoRangeY">
-    <bool>true</bool>
-   </property>
    <property name="curveColor">
     <color>
      <red>255</red>
-     <green>236</green>
-     <blue>4</blue>
+     <green>215</green>
+     <blue>0</blue>
     </color>
    </property>
-   <property name="title" stdset="0">
-    <string>Multiple PVs</string>
+   <property name="showLegend">
+    <bool>true</bool>
    </property>
    <property name="yChannel">
     <string>ca://EX:FUNC1</string>
@@ -47,14 +44,8 @@
    <property name="bufferSize">
     <number>300</number>
    </property>
-   <property name="updatesAsynchronously">
-    <bool>true</bool>
-   </property>
    <property name="timeSpan">
     <double>30.000000000000000</double>
-   </property>
-   <property name="updateInterval">
-    <double>0.100000000000000</double>
    </property>
   </widget>
  </widget>

--- a/pydm/widgets/baseplot.py
+++ b/pydm/widgets/baseplot.py
@@ -20,6 +20,8 @@ class BasePlot(PlotWidget):
     self.curve = PlotCurveItem(pen=self._curveColor)
     self.addItem(self.curve)
     self._title = None
+    self._show_legend = False
+    self._legend = None
   
   def getAutoRangeX(self):
     return self._auto_range_x
@@ -112,3 +114,22 @@ class BasePlot(PlotWidget):
     self.setTitle(self._title)
     
   title = pyqtProperty(str, getPlotTitle, setPlotTitle, resetPlotTitle)
+
+  def getShowLegend(self):
+    return self._show_legend
+  
+  def setShowLegend(self, value):
+    self._show_legend = value
+    if self._show_legend:
+      if self._legend is None:
+        self._legend = self.addLegend()
+      else:
+        self._legend.show()
+    else:
+      if self._legend is not None:
+        self._legend.hide()
+
+  def resetShowLegend(self):
+    self._show_legend = False
+    
+  showLegend = pyqtProperty(bool, getShowLegend, setShowLegend, resetShowLegend)

--- a/pydm/widgets/timeplot.py
+++ b/pydm/widgets/timeplot.py
@@ -80,7 +80,7 @@ class PyDMTimePlot(BasePlot):
       self.update_timer.timeout.connect(self.asyncUpdate)
   
   # Adds a new curve to the current plot
-  def addYChannel(self, ychannel, curve_color=None):
+  def addYChannel(self, ychannel='', curve_color=None):
     # Allocate space for a new data buffer
     self.num_of_channels = self.num_of_channels + 1
     new_channel_id = self.num_of_channels
@@ -110,7 +110,7 @@ class PyDMTimePlot(BasePlot):
     self.data_buffer = np.zeros((1,self._bufferSize), order='f',dtype=float)
     self.data_buffer[0].fill(time.time())
     self.data_listener = []
-    self.addYChannel(self._ychannel)
+    if self._ychannel != '': self.addYChannel(self._ychannel)
 
   @pyqtSlot(float, int)
   @pyqtSlot(int, int)

--- a/pydm/widgets/timeplot.py
+++ b/pydm/widgets/timeplot.py
@@ -80,6 +80,8 @@ class PyDMTimePlot(BasePlot):
   
   # Adds a new curve to the current plot
   def addYChannel(self, ychannel='', curve_color=None):
+    if ychannel == '':
+      raise Exception('[Error] Parameter ychannel should be defined for a new curve.')
     # Add curve
     if ychannel == self._ychannel:
       new_curve = self.curve


### PR DESCRIPTION
Generalization of the structure of TimePlot in order to allow multiple curves to be plotted.
A sample of this feature was included in examples folder.

TimePlot continues to work the same way as before, but a method 'addYChannel' was created to add a curve to the plot. This method is used to add the curve for the PV defined in 'channel' property and also can be called in a Display class to add other curves.

Properties for curves besides the first one are not expose in QtDesigner, because it was not possible to create them dinamically. E.g. it is okay to turn yChannels into an array using type QStringList, but QtDesigner do not support an array of curveColor (there is not an array of QColor).