### PR TITLE
FIX: Checks wether or not the module file has an intelclass.

### DIFF
--- a/pydm/application.py
+++ b/pydm/application.py
@@ -162,10 +162,16 @@ class PyDMApplication(QApplication):
       if len(classes) == 0:
         raise ValueError("Invalid File Format. {} has no class inheriting from Display. Nothing to open at this time.".format(pyfile))
       if len(classes) > 1:
-        warnings.warn("More than one Display class in file {}. Loading the first occurence: {}".format(pyfile, classes[0].__name__), RuntimeWarning, stacklevel=2)
+        warnings.warn("More than one Display class in file {}. The first one (in alphabetical order) will be opened: {}".format(pyfile, classes[0].__name__), RuntimeWarning, stacklevel=2)
+      #First occurence in code corresponds to last item in the list.
       cls = classes[0]
 
-    module_params = inspect.signature(cls).parameters
+    try:
+      #This only works in python 3 and up.
+      module_params = inspect.signature(cls).parameters
+    except AttributeError:
+      #Works in python 2, deprecated in 3.0 and up.
+      module_params = inspect.getargspec(cls.__init__).args
 
     if 'args' in module_params:
       return cls(args=args)

--- a/pydm/main_window.py
+++ b/pydm/main_window.py
@@ -91,8 +91,8 @@ class PyDMMainWindow(QMainWindow):
         self.app.new_window(filename)
       else:
         self.go(filename)
-    except (FileNotFoundError, ValueError, ImportError) as e:
-      self.statusBar().showMessage("Cannot go to file: '{0}', reason: '{1}'...".format(filename, e), 5000)
+    except (IOError, OSError, ValueError, ImportError) as e:
+      self.statusBar().showMessage("Cannot go to file: '{0}'. Reason: '{1}'.".format(filename, e), 5000)
   
   #Note: in go(), back(), and forward(), always do history stack manipulation *before* opening the file.
   #That way, the navigation button enable/disable state will work correctly.  This is stupid, and will be fixed eventually.

--- a/pydm/main_window.py
+++ b/pydm/main_window.py
@@ -84,10 +84,15 @@ class PyDMMainWindow(QMainWindow):
   
   def go_button_pressed(self):
     filename = str(self.ui.panelSearchLineEdit.text())
-    if QApplication.keyboardModifiers() == Qt.ShiftModifier:
-      self.app.new_window(filename)
-    else:
-      self.go(filename)
+    if not filename:
+        return
+    try:
+      if QApplication.keyboardModifiers() == Qt.ShiftModifier:
+        self.app.new_window(filename)
+      else:
+        self.go(filename)
+    except (FileNotFoundError, ValueError, ImportError) as e:
+      self.statusBar().showMessage("Cannot go to file: '{0}', reason: '{1}'...".format(filename, e), 5000)
   
   #Note: in go(), back(), and forward(), always do history stack manipulation *before* opening the file.
   #That way, the navigation button enable/disable state will work correctly.  This is stupid, and will be fixed eventually.


### PR DESCRIPTION
- [X] Returns the first class that inherits from Display in this case. This should fix #45.
- [X] Don't send args at load_py_file if class being instantiated does not support it.
- [x] Raise error if no class inheriting from Display is found at given module.