### PR TITLE
[Label and Slider] Update colormap when channel is disconnected

### DIFF
--- a/pydm/widgets/label.py
+++ b/pydm/widgets/label.py
@@ -120,8 +120,6 @@ class PyDMLabel(QLabel):
   #0 = NO_ALARM, 1 = MINOR, 2 = MAJOR, 3 = INVALID  
   @pyqtSlot(int)
   def alarmSeverityChanged(self, new_alarm_severity):
-    if not self._connected:
-      new_alarm_severity = self.ALARM_DISCONNECTED
     self.setStyleSheet(self.alarm_style_sheet_map[self._alarm_flags][new_alarm_severity])
     
   #false = disconnected, true = connected
@@ -131,6 +129,7 @@ class PyDMLabel(QLabel):
     if connected:
       self.connected_signal.emit()
     else:
+      self.alarmSeverityChanged(self.ALARM_DISCONNECTED)
       self.disconnected_signal.emit()
   
   @pyqtSlot(tuple)

--- a/pydm/widgets/slider.py
+++ b/pydm/widgets/slider.py
@@ -143,6 +143,8 @@ class PyDMSlider(QFrame):
   def connectionStateChanged(self, connected):
     self._connected = connected
     self.set_enable_state()
+    if not self._connected:
+      self.alarmSeverityChanged(self.ALARM_DISCONNECTED)
   
   @pyqtSlot(bool)
   def writeAccessChanged(self, write_access):
@@ -151,8 +153,6 @@ class PyDMSlider(QFrame):
   
   @pyqtSlot(int)
   def alarmSeverityChanged(self, new_alarm_severity):
-    if not self._connected:
-      new_alarm_severity = self.ALARM_DISCONNECTED
     self.value_label.setStyleSheet(self.alarm_style_sheet_map[new_alarm_severity])
   
   def set_enable_state(self):


### PR DESCRIPTION
Hi,

This pull request fix a problem happening with PyDMLabel and PyDMSlider: when channel is disconnected, their colormaps are **not** set to  ALARM_DISCONNECTED.

This happens because method 'alarmSeverityChanged' (which changes stylesheet) is called only when a new value is received. Once the channel the disconnected, no new value is received, thus stylesheet is never updated.