### PR TITLE
Fixed middle-click tooltip and clipboard functionality

### DIFF
--- a/pydm/application.py
+++ b/pydm/application.py
@@ -240,7 +240,12 @@ class PyDMApplication(QApplication):
   def show_address_tooltip(self, obj, event):
     addr = obj.channels()[0].address
     QToolTip.showText(event.globalPos(), addr)
-    QApplication.clipboard().setText(addr, mode=QClipboard.Selection)
+    #Strip the scheme out of the address before putting it in the clipboard.
+    m = re.match('(.+?):/{2,3}(.+?)$',addr)
+    if m is None:
+      QApplication.clipboard().setText(addr, mode=QClipboard.Selection)
+    else:
+      QApplication.clipboard().setText(m.group(2), mode=QClipboard.Selection)
  
   def establish_widget_connections(self, widget):
     widgets = [widget]

--- a/pydm/data_plugins/psp_plugin.py
+++ b/pydm/data_plugins/psp_plugin.py
@@ -230,7 +230,7 @@ class Connection(PyDMConnection):
           self.prec = self.pv.data['precision']
           self.prec_signal.emit(int(self.prec))
         
-        if self.units is None:
+        if self.units is None and 'units' in self.pv.data:
           self.units = self.pv.data['units']
           self.unit_signal.emit(self.units.decode(encoding='ascii'))
         

--- a/pydm/data_plugins/psp_plugin.py
+++ b/pydm/data_plugins/psp_plugin.py
@@ -226,21 +226,33 @@ class Connection(PyDMConnection):
           self.sevr = self.pv.severity
           self.new_severity_signal.emit(self.sevr)
 
-        if self.prec is None and 'precision' in self.pv.data:
-          self.prec = self.pv.data['precision']
-          self.prec_signal.emit(int(self.prec))
+        if self.prec is None:
+          try:
+            self.prec = self.pv.data['precision']
+            self.prec_signal.emit(int(self.prec))
+          except KeyError:
+            pass
         
-        if self.units is None and 'units' in self.pv.data:
-          self.units = self.pv.data['units']
-          self.unit_signal.emit(self.units.decode(encoding='ascii'))
+        if self.units is None:
+          try:
+            self.units = self.pv.data['units']
+            self.unit_signal.emit(self.units.decode(encoding='ascii'))
+          except KeyError:
+            pass
         
         if self.ctrl_llim is None:
-          self.ctrl_llim = self.pv.data['ctrl_llim']
-          self.lower_ctrl_limit_signal.emit(self.ctrl_llim)
+          try:
+            self.ctrl_llim = self.pv.data['ctrl_llim']
+            self.lower_ctrl_limit_signal.emit(self.ctrl_llim)
+          except KeyError:
+            pass
           
         if self.ctrl_hlim is None:
-          self.ctrl_hlim = self.pv.data['ctrl_hlim']
-          self.upper_ctrl_limit_signal.emit(self.ctrl_hlim)
+          try:
+            self.ctrl_hlim = self.pv.data['ctrl_hlim']
+            self.upper_ctrl_limit_signal.emit(self.ctrl_hlim)
+          except KeyError:
+            pass
 
         if self.count > 1:
             self.new_waveform_signal.emit(value)


### PR DESCRIPTION
1. Event filter was not being installed on any of the widgets because it was indented into the NameError exception block so it would only ever get installed if pyDM was unable to connect to a PV.  Also, the event filter was catching parent classes as well when called and therefore can't find the "channels" method for things like QWidget and QCombobox.  Moving the installEventFilter command into the hasattr check block fixes this.
 
2.  QTooltip and QClipboard were not being imported from QtGui
 
3.  PyDMChannel class must have changed under at some point because the event filter was performing a regex match to strip out some sort of "scheme" from the PV address string, but whatever that was it doesn't seem to exist anymore so the match always fails returning a NoneType.  Simply getting rid of this check and passing the address directly to the Clipboard works fine.
