### PR TITLE
[Byte] pyqtProperty of type QStringList working for both PyQt4 and PyQt5

### DIFF
--- a/pydm/widgets/byte.py
+++ b/pydm/widgets/byte.py
@@ -1,5 +1,5 @@
 from ..PyQt.QtGui import QWidget, QTabWidget, QColor, QPen, QGridLayout, QLabel, QPalette, QFontMetrics, QPainter, QBrush, QStyleOption, QStyle
-from ..PyQt.QtCore import pyqtSignal, pyqtSlot, pyqtProperty, Qt, QStringList, QSize, QPoint
+from ..PyQt.QtCore import pyqtSignal, pyqtSlot, pyqtProperty, Qt, QSize, QPoint
 from .channel import PyDMChannel
 import numpy as np
 
@@ -284,7 +284,7 @@ class PyDMByteIndicator(QWidget):
     self._shift = new_shift
     self.update_indicators()
   
-  @pyqtProperty(QStringList, doc=
+  @pyqtProperty('QStringList', doc=
   """
   Labels for each bit.
   """)


### PR DESCRIPTION
Hi,

PyDMByteIndicator imports QStringList from QtCore. However, this class does not exist in PyQt5 (http://pyqt.sourceforge.net/Docs/PyQt5/sip-classes.html), which leads to an error.

QStringList is used as the type of a pyqtProperty in this class. Using a string to define the type works for both PyQt4 and 5.

Thanks,
Laís