### PR TITLE
Default protocol

### DIFF
--- a/pydm/application.py
+++ b/pydm/application.py
@@ -21,12 +21,13 @@ from .PyQt.QtGui import QApplication, QColor, QWidget, QToolTip, QClipboard
 from .PyQt import uic
 from .main_window import PyDMMainWindow
 from .utilities import macro
-import .data_plugins
+import data_plugins
 
 DEFAULT_PROTOCOL = os.getenv("PYDM_DEFAULT_PROTOCOL")
   
 class PyDMApplication(QApplication):
-  plugins = { "ca": EPICSPlugin(), "fake": FakePlugin(), "archiver": ArchiverPlugin() }
+  #Instantiate our plugins.
+  plugins = {plugin.protocol: plugin() for plugin in data_plugins.plugin_modules}
   
   #HACK. To be replaced with some stylesheet stuff eventually.
   alarm_severity_color_map = {

--- a/pydm/application.py
+++ b/pydm/application.py
@@ -251,12 +251,12 @@ class PyDMApplication(QApplication):
   def show_address_tooltip(self, obj, event):
     addr = obj.channels()[0].address
     QToolTip.showText(event.globalPos(), addr)
-    #Strip the scheme out of the address before putting it in the clipboard.
+    #If the address has a protocol, and it is the default protocol, strip it out before putting it on the clipboard.
     m = re.match('(.+?):/{2,3}(.+?)$',addr)
-    if m is None:
-      QApplication.clipboard().setText(addr, mode=QClipboard.Selection)
-    else:
+    if m is not None and DEFAULT_PROTOCOL is not None and m.group(1) == DEFAULT_PROTOCOL:
       QApplication.clipboard().setText(m.group(2), mode=QClipboard.Selection)
+    else:
+      QApplication.clipboard().setText(addr, mode=QClipboard.Selection)
  
   def establish_widget_connections(self, widget):
     widgets = [widget]

--- a/pydm/application.py
+++ b/pydm/application.py
@@ -24,6 +24,9 @@ from .utilities import macro
 import data_plugins
 
 DEFAULT_PROTOCOL = os.getenv("PYDM_DEFAULT_PROTOCOL")
+if DEFAULT_PROTOCOL is not None:
+  #Get rid of the "://" part if it exists
+  DEFAULT_PROTOCOL = DEFAULT_PROTOCOL.split("://")[0]
   
 class PyDMApplication(QApplication):
   #Instantiate our plugins.
@@ -214,12 +217,16 @@ class PyDMApplication(QApplication):
       return None
     match = re.match('.*://', channel.address)
     if match:
-      try:
-        protocol = match.group(0)[:-3]
-        plugin_to_use = self.plugins[str(protocol)]
-        return plugin_to_use
-      except KeyError:
-        print("Couldn't find plugin: {0}".format(match.group(0)[:-3]))
+      protocol = match.group(0)[:-3]
+    elif DEFAULT_PROTOCOL is not None:
+      #If no protocol was specified, and the default protocol environment variable is specified, try to use that instead.
+      protocol = DEFAULT_PROTOCOL
+    try:
+      plugin_to_use = self.plugins[str(protocol)]
+      return plugin_to_use
+    except KeyError:
+      print("Couldn't find plugin for protocol: {0}".format(match.group(0)[:-3]))
+    warnings.warn("Channel {addr} did not specify a valid protocol and no default protocol is defined.  This channel will receive no data.  To specify a default protocol, set the PYDM_DEFAULT_PROTOCOL environment variable.", RuntimeWarning, stacklevel=2)
     return None
   
   def add_connection(self, channel):

--- a/pydm/application.py
+++ b/pydm/application.py
@@ -21,27 +21,9 @@ from .PyQt.QtGui import QApplication, QColor, QWidget, QToolTip, QClipboard
 from .PyQt import uic
 from .main_window import PyDMMainWindow
 from .utilities import macro
+import .data_plugins
 
-#If the user has PSP and pyca installed, use psp, which is faster.
-#Otherwise, use PyEPICS, which is slower, but more commonly used.
-#To force a particular library, set the PYDM_EPICS_LIB environment
-#variable to either pyepics or pyca.
-EPICS_LIB = os.getenv("PYDM_EPICS_LIB")
-if EPICS_LIB == "pyepics":
-  from .data_plugins.pyepics_plugin import PyEPICSPlugin
-  EPICSPlugin = PyEPICSPlugin
-elif EPICS_LIB == "pyca":
-  from .data_plugins.psp_plugin import PSPPlugin
-  EPICSPlugin = PSPPlugin
-else:
-  try:
-    from .data_plugins.psp_plugin import PSPPlugin
-    EPICSPlugin = PSPPlugin
-  except ImportError:
-    from .data_plugins.pyepics_plugin import PyEPICSPlugin
-    EPICSPlugin = PyEPICSPlugin
-from .data_plugins.fake_plugin import FakePlugin
-from .data_plugins.archiver_plugin import ArchiverPlugin
+DEFAULT_PROTOCOL = os.getenv("PYDM_DEFAULT_PROTOCOL")
   
 class PyDMApplication(QApplication):
   plugins = { "ca": EPICSPlugin(), "fake": FakePlugin(), "archiver": ArchiverPlugin() }
@@ -211,6 +193,20 @@ class PyDMApplication(QApplication):
     really only used by embedded displays."""
     full_path = self.get_path(ui_file)
     return self.open_file(full_path, macros=macros, command_line_args=command_line_args)
+
+  def initialize_plugins(self):
+    module = imp.load_source('intelclass', pyfile)
+    if hasattr(module, 'intelclass'):
+      cls = module.intelclass
+      if not issubclass(cls, Display):
+        raise ValueError("Invalid class definition at file {}. {} does not inherit from Display. Nothing to open at this time.".format(pyfile, cls.__name__))
+    else:
+      classes = [obj for name, obj in inspect.getmembers(module) if inspect.isclass(obj) and issubclass(obj, Display) and obj != Display]
+      if len(classes) == 0:
+        raise ValueError("Invalid File Format. {} has no class inheriting from Display. Nothing to open at this time.".format(pyfile))
+      if len(classes) > 1:
+        warnings.warn("More than one Display class in file {}. The first occurence (in alphabetical order) will be opened: {}".format(pyfile, classes[0].__name__), RuntimeWarning, stacklevel=2)
+      cls = classes[0]
 
   def plugin_for_channel(self, channel):
     if channel.address is None:

--- a/pydm/data_plugins/__init__.py
+++ b/pydm/data_plugins/__init__.py
@@ -1,5 +1,30 @@
-from .epics_plugin import EPICSPlugin
-from .archiver_plugin import ArchiverPlugin
-from .fake_plugin import FakePlugin
+import os
+import inspect
+import importlib
+import warnings
+from .plugin import PyDMPlugin
 
-__all__ = ["EPICSPlugin", "ArchiverPlugin", "FakePlugin"]
+#This code gets all .py files in the same directory that this file lives (data_plugins),
+#finds the ones that have PyDMPlugin subclasses, and adds them to a list of modules.
+#In principle, you should be able to add a new plugin just by putting a new file in this directory.
+
+#PyDMApplication uses the plugin_modules list to create an instance of each plugin.
+
+plugin_dir = os.path.dirname(os.path.realpath(__file__))
+filenames = [os.path.splitext(f)[0] for f in os.listdir(plugin_dir) if os.path.splitext(f)[1] == ".py" and os.path.splitext(f)[0] != "__init__"]
+
+plugin_modules = []
+for filename in filenames:
+  module = importlib.import_module("." + filename, "pydm.data_plugins")
+  classes = [obj for name, obj in inspect.getmembers(module) if inspect.isclass(obj) and issubclass(obj, PyDMPlugin) and obj is not PyDMPlugin]
+  #De-duplicate classes.
+  classes = list(set(classes))
+  if len(classes) == 0:
+    continue
+  if len(classes) > 1:
+    warnings.warn("More than one PyDMPlugin subclass in file {}. The first occurence (in alphabetical order) will be opened: {}".format(filename, classes[0].__name__), RuntimeWarning, stacklevel=0)
+  plugin = classes[0]
+  if plugin.protocol is not None:
+    if plugin.protocol in plugin_modules and plugin_modules[plugin.protocol] != plugin:
+      warnings.warn("More than one plugin is attempting to register the {protocol} protocol. The last protocol to register (currently {plugin}) will be used.".format(protocol=plugin.protocol, plugin=plugin.__name__), RuntimeWarning, stacklevel=0)
+    plugin_modules.append(plugin)  

--- a/pydm/data_plugins/__init__.py
+++ b/pydm/data_plugins/__init__.py
@@ -1,0 +1,5 @@
+from .epics_plugin import EPICSPlugin
+from .archiver_plugin import ArchiverPlugin
+from .fake_plugin import FakePlugin
+
+__all__ = ["EPICSPlugin", "ArchiverPlugin", "FakePlugin"]

--- a/pydm/data_plugins/__init__.py
+++ b/pydm/data_plugins/__init__.py
@@ -26,5 +26,5 @@ for filename in filenames:
   plugin = classes[0]
   if plugin.protocol is not None:
     if plugin.protocol in plugin_modules and plugin_modules[plugin.protocol] != plugin:
-      warnings.warn("More than one plugin is attempting to register the {protocol} protocol. The last protocol to register (currently {plugin}) will be used.".format(protocol=plugin.protocol, plugin=plugin.__name__), RuntimeWarning, stacklevel=0)
+      warnings.warn("More than one plugin is attempting to register the {protocol} protocol. Which plugin will get called to handle this protocol is undefined.".format(protocol=plugin.protocol, plugin=plugin.__name__), RuntimeWarning, stacklevel=0)
     plugin_modules.append(plugin)  

--- a/pydm/data_plugins/archiver_plugin.py
+++ b/pydm/data_plugins/archiver_plugin.py
@@ -17,5 +17,5 @@ class Connection(PyDMConnection):
       self.new_waveform_signal.emit(y_data)
       
 class ArchiverPlugin(PyDMPlugin):
-  protocol = "archiver://"
+  protocol = "archiver"
   connection_class = Connection

--- a/pydm/data_plugins/epics_plugin.py
+++ b/pydm/data_plugins/epics_plugin.py
@@ -17,3 +17,4 @@ else:
   except ImportError:
     from .pyepics_plugin import PyEPICSPlugin
     EPICSPlugin = PyEPICSPlugin
+EPICSPlugin.protocol = "ca"

--- a/pydm/data_plugins/epics_plugin.py
+++ b/pydm/data_plugins/epics_plugin.py
@@ -1,0 +1,19 @@
+#If the user has PSP and pyca installed, use psp, which is faster.
+#Otherwise, use PyEPICS, which is slower, but more commonly used.
+#To force a particular library, set the PYDM_EPICS_LIB environment
+#variable to either pyepics or pyca.
+import os
+EPICS_LIB = os.getenv("PYDM_EPICS_LIB")
+if EPICS_LIB == "pyepics":
+  from .pyepics_plugin import PyEPICSPlugin
+  EPICSPlugin = PyEPICSPlugin
+elif EPICS_LIB == "pyca":
+  from .psp_plugin import PSPPlugin
+  EPICSPlugin = PSPPlugin
+else:
+  try:
+    from .psp_plugin import PSPPlugin
+    EPICSPlugin = PSPPlugin
+  except ImportError:
+    from .pyepics_plugin import PyEPICSPlugin
+    EPICSPlugin = PyEPICSPlugin

--- a/pydm/data_plugins/fake_plugin.py
+++ b/pydm/data_plugins/fake_plugin.py
@@ -21,6 +21,6 @@ class Connection(PyDMConnection):
 		self.connection_state_signal.emit(conn)
 
 class FakePlugin(PyDMPlugin):
-	protocol = "fake://"
+	protocol = "fake"
 	connection_class = Connection
 			

--- a/pydm/data_plugins/plugin.py
+++ b/pydm/data_plugins/plugin.py
@@ -74,7 +74,7 @@ class PyDMPlugin(object):
         self.connections = {}
     
     def get_address(self, channel):
-        return str(channel.address.split(self.protocol + "://")[1])
+        return str(channel.address.split(self.protocol + "://")[-1])
     
     def add_connection(self, channel):  
         address = self.get_address(channel)

--- a/pydm/data_plugins/plugin.py
+++ b/pydm/data_plugins/plugin.py
@@ -72,9 +72,9 @@ class PyDMPlugin(object):
     connection_class = PyDMConnection
     def __init__(self):
         self.connections = {}
-  
+    
     def get_address(self, channel):
-        return str(channel.address.split(self.protocol)[1])
+        return str(channel.address.split(self.protocol + "://")[1])
     
     def add_connection(self, channel):  
         address = self.get_address(channel)

--- a/pydm/data_plugins/psp_plugin.py
+++ b/pydm/data_plugins/psp_plugin.py
@@ -128,7 +128,6 @@ class Connection(PyDMConnection):
         :type parent:  QWidget
         """
         super(Connection,self).__init__(channel, pv, parent)
-
         self.python_type = None
         self.pv = setup_pv(pv, self.connected_cb, self.monitor_cb)
         self.enums = None
@@ -393,5 +392,8 @@ class PSPPlugin(PyDMPlugin):
     """
     Class to define our protocol and point to our :class:`Connection` Class
     """
-    protocol = "ca://"
+    #NOTE: protocol is intentionally "None" to keep this plugin from getting directly imported.
+    #If this plugin is chosen as the One True EPICS Plugin in epics_plugin.py, the protocol will
+    #be properly set before it is used.
+    protocol = None
     connection_class = Connection

--- a/pydm/data_plugins/pyepics_plugin.py
+++ b/pydm/data_plugins/pyepics_plugin.py
@@ -85,5 +85,8 @@ class Connection(PyDMConnection):
     self.pv.disconnect()
 
 class PyEPICSPlugin(PyDMPlugin):
-  protocol = "ca://"
+  #NOTE: protocol is intentionally "None" to keep this plugin from getting directly imported.
+  #If this plugin is chosen as the One True EPICS Plugin in epics_plugin.py, the protocol will
+  #be properly set before it is used.
+  protocol = None
   connection_class = Connection


### PR DESCRIPTION
Implement a default protocol environment variable.  If the environment variable PYDM_DEFAULT_PROTOCOL is set, PyDM will use that whenever a channel was specified without a protocol, rather than just silently failing.  This PR also overhauls the data_plugins system so that you can add new plugins simply by adding files to the data_plugins directory, without needing to modify any other files.

Warning: this very slightly changes the PyDMPlugin base class so that protocols are specified *without* the "://" part.  If you have written your own custom data plugin, you will need to modify it to remove the "://".