### PR TITLE
ENH: Check and print warnings in case users are trying to directly import from PyQt4/5

### DIFF
--- a/pydm/application.py
+++ b/pydm/application.py
@@ -141,9 +141,9 @@ class PyDMApplication(QApplication):
     if hasattr(cls, "PyQt5") or hasattr(cls, "PyQt4"):
       warnings.warn("Direct PyQt5/PyQt4 import detected. To ensure compatibility with PyQt4 and PyQt5 use: pydm.PyQt.", RuntimeWarning, stacklevel=0)
 
-    check(cls, "QtCore")
-    check(cls, "QtGui")
-    check(cls, "QtWidgets") 
+    check("QtCore")
+    check("QtGui")
+    check("QtWidgets") 
 
   def load_py_file(self, pyfile, args=None):
     #Add the intelligence module directory to the python path, so that submodules can be loaded.  Eventually, this should go away, and intelligence modules should behave as real python modules.
@@ -152,6 +152,7 @@ class PyDMApplication(QApplication):
 
     #Now load the intelligence module.
     module = imp.load_source('intelclass', pyfile)
+    self.__sanity_check_pyqt(module)
     if hasattr(module, 'intelclass'):
       cls = module.intelclass
       if not issubclass(cls, Display):
@@ -163,8 +164,6 @@ class PyDMApplication(QApplication):
       if len(classes) > 1:
         warnings.warn("More than one Display class in file {}. The first occurence (in alphabetical order) will be opened: {}".format(pyfile, classes[0].__name__), RuntimeWarning, stacklevel=2)
       cls = classes[0]
-
-    self.__sanity_check_pyqt(cls)
 
     try:
       #This only works in python 3 and up.

--- a/pydm/application.py
+++ b/pydm/application.py
@@ -133,17 +133,12 @@ class PyDMApplication(QApplication):
     return uic.loadUi(f)
     
   def __sanity_check_pyqt(self, cls):
-    def check(attr):
-      if hasattr(cls, attr):
-        if "pydm" not in getattr(cls, attr).__file__:
-          warnings.warn("To ensure compatibility with PyQt4 and PyQt5 please import {} from pydm.PyQt. E.g. from pydm.PyQt import {}".format(attr, attr), RuntimeWarning, stacklevel=0)
-
-    if hasattr(cls, "PyQt5") or hasattr(cls, "PyQt4"):
-      warnings.warn("Direct PyQt5/PyQt4 import detected. To ensure compatibility with PyQt4 and PyQt5 use: pydm.PyQt.", RuntimeWarning, stacklevel=0)
-
-    check("QtCore")
-    check("QtGui")
-    check("QtWidgets") 
+    for itm in dir(cls):
+      i = getattr(cls, itm)
+      if hasattr(i, "__file__"):
+        if any([True if v in i.__file__ else False for v in ["PyQt4", "PyQt5"]]):
+          warnings.warn("Direct PyQt5/PyQt4 import detected. To ensure compatibility with PyQt4 and PyQt5 consider using: pydm.PyQt for your imports.", RuntimeWarning, stacklevel=0)
+          return
 
   def load_py_file(self, pyfile, args=None):
     #Add the intelligence module directory to the python path, so that submodules can be loaded.  Eventually, this should go away, and intelligence modules should behave as real python modules.

--- a/pydm/application.py
+++ b/pydm/application.py
@@ -132,6 +132,19 @@ class PyDMApplication(QApplication):
       f = uifile
     return uic.loadUi(f)
     
+  def __sanity_check_pyqt(self, cls):
+    def check(attr):
+      if hasattr(cls, attr):
+        if "pydm" not in getattr(cls, attr).__file__:
+          warnings.warn("To ensure compatibility with PyQt4 and PyQt5 please import {} from pydm.PyQt. E.g. from pydm.PyQt import {}".format(attr, attr), RuntimeWarning, stacklevel=0)
+
+    if hasattr(cls, "PyQt5") or hasattr(cls, "PyQt4"):
+      warnings.warn("Direct PyQt5/PyQt4 import detected. To ensure compatibility with PyQt4 and PyQt5 use: pydm.PyQt.", RuntimeWarning, stacklevel=0)
+
+    check(cls, "QtCore")
+    check(cls, "QtGui")
+    check(cls, "QtWidgets") 
+
   def load_py_file(self, pyfile, args=None):
     #Add the intelligence module directory to the python path, so that submodules can be loaded.  Eventually, this should go away, and intelligence modules should behave as real python modules.
     module_dir = os.path.dirname(os.path.abspath(pyfile))
@@ -150,6 +163,8 @@ class PyDMApplication(QApplication):
       if len(classes) > 1:
         warnings.warn("More than one Display class in file {}. The first occurence (in alphabetical order) will be opened: {}".format(pyfile, classes[0].__name__), RuntimeWarning, stacklevel=2)
       cls = classes[0]
+
+    self.__sanity_check_pyqt(cls)
 
     try:
       #This only works in python 3 and up.


### PR DESCRIPTION
To ensure maximum compatibility one should be using ```pydm.PyQt``` for the imports.
This PR tries to babysit users into using the correct way and displays annoying warning messages in the following cases:

- User tries to import PyQt4 or import PyQt5
- User tries to use QtGui, QtCore or QtWidgets from PyQt4 or PyQt5 directly and not from PyDM.

