### PR TITLE
Precision improvements on widgets

### DIFF
--- a/examples/slider/slider.ui
+++ b/examples/slider/slider.ui
@@ -37,6 +37,12 @@
      <property name="maximum" stdset="0">
       <double>1.500000000000000</double>
      </property>
+     <property name="userDefinedPrecision" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="precision" stdset="0">
+      <number>2</number>
+     </property>
      <property name="channel">
       <string>ca://MTEST:Float</string>
      </property>

--- a/pydm/data_plugins/epics_plugins/pyepics_plugin.py
+++ b/pydm/data_plugins/epics_plugins/pyepics_plugin.py
@@ -11,11 +11,13 @@ class Connection(PyDMConnection):
     self.pv = epics.PV(pv, callback=self.send_new_value, connection_callback=self.send_connection_state, form='ctrl', auto_monitor=True)
     self.add_listener(channel)
   
-  def send_new_value(self, pvname=None, value=None, char_value=None, units=None, enum_strs=None, severity=None, count=None, write_access=None, ftype=None, upper_ctrl_limit=None, lower_ctrl_limit=None, *args, **kws):
+  def send_new_value(self, pvname=None, value=None, char_value=None, units=None, enum_strs=None, severity=None, count=None, write_access=None, ftype=None, upper_ctrl_limit=None, lower_ctrl_limit=None, precision=None, *args, **kws):
     if severity != None:
       self.new_severity_signal.emit(int(severity))
     if write_access != None:
       self.write_access_signal.emit(write_access)
+    if precision != None:
+      self.prec_signal.emit(precision)
     if enum_strs != None:
       enum_strs = tuple(b.decode(encoding='ascii') for b in enum_strs)
       self.enum_strings_signal.emit(enum_strs)

--- a/pydm/widgets/label.py
+++ b/pydm/widgets/label.py
@@ -82,6 +82,7 @@ class PyDMLabel(QLabel):
     self.value = None
     self._channels = None
     self._channel = init_channel
+    self._user_defined_prec = False
     self._prec = 0
     self._alarm_sensitive_text = False
     self._alarm_sensitive_border = True
@@ -138,6 +139,11 @@ class PyDMLabel(QLabel):
       self.enum_strings = enum_strings
       self.receiveValue(self.value)
   
+  @pyqtSlot(int)
+  def precisionChanged(self, new_prec):
+    if not self._user_defined_prec:
+      self.precision = new_prec
+  
   @pyqtProperty(bool, doc=
   """
   Whether or not the label's text color changes when alarm severity changes.
@@ -177,6 +183,14 @@ class PyDMLabel(QLabel):
     
   channel = pyqtProperty(str, getChannel, setChannel, resetChannel)
   
+  @pyqtProperty(bool)
+  def userDefinedPrecision(self):
+    return self._user_defined_prec
+  
+  @userDefinedPrecision.setter
+  def userDefinedPrecision(self, user_defined_prec):
+    self._user_defined_prec = user_defined_prec
+  
   def getPrecision(self):
     return self._prec
   
@@ -195,5 +209,5 @@ class PyDMLabel(QLabel):
   def channels(self):
     if self._channels != None:
       return self._channels
-    self._channels = [PyDMChannel(address=self.channel, connection_slot=self.connectionStateChanged, value_slot=self.receiveValue, severity_slot=self.alarmSeverityChanged, enum_strings_slot=self.enumStringsChanged)]
+    self._channels = [PyDMChannel(address=self.channel, connection_slot=self.connectionStateChanged, value_slot=self.receiveValue, severity_slot=self.alarmSeverityChanged, enum_strings_slot=self.enumStringsChanged, prec_slot=self.precisionChanged)]
     return self._channels

--- a/pydm/widgets/spinbox.py
+++ b/pydm/widgets/spinbox.py
@@ -112,7 +112,12 @@ class PyDMSpinbox(QDoubleSpinBox):
   @pyqtSlot(float)
   def receive_lower_limit(self,limit):
     self.setMinimum(limit)
-
+  
+  @pyqtSlot(int)
+  def receivePrecision(self, new_prec):
+    self._prec = new_prec
+    self.setDecimals(self._prec)
+  
   def getChannel(self):
     return str(self._channel)
 
@@ -147,5 +152,6 @@ class PyDMSpinbox(QDoubleSpinBox):
                         write_access_slot=self.writeAccessChanged,
                         upper_ctrl_limit_slot = self.receive_upper_limit,
                         lower_ctrl_limit_slot = self.receive_lower_limit,
+                        prec_slot = self.receivePrecision,
                         value_signal=self.send_value_signal,
                         )]


### PR DESCRIPTION
Widgets that can display floats now get their precision from the channel by default.  Properties exist on these widgets to override the channel's precision with a user-specified value.  The pyepics data plugin has been enhanced to emit the precision signal if a PV has precision specified.