### PR TITLE
Implement channel limits and units in widgets.

### DIFF
--- a/pydm/widgets/channel.py
+++ b/pydm/widgets/channel.py
@@ -82,7 +82,6 @@ class PyDMChannel:
         self.unit_slot         = unit_slot
         self.prec_slot         = prec_slot
 
-        #TODO: added following slots
         self.upper_ctrl_limit_slot = upper_ctrl_limit_slot
         self.lower_ctrl_limit_slot = lower_ctrl_limit_slot
         

--- a/pydm/widgets/label.py
+++ b/pydm/widgets/label.py
@@ -169,7 +169,6 @@ class PyDMLabel(QLabel):
   
   @pyqtSlot(str)
   def unitsChanged(self, new_units):
-    print("Got new units: {}".format(new_units))
     self._unit_string = str(new_units)
     self.refresh_format_string()
   

--- a/testing-ioc.py
+++ b/testing-ioc.py
@@ -40,7 +40,7 @@ pvdb = {
         'TwoSpotImage'     : { 'type' : 'char', 'count': IMAGE_SIZE**2, 'value': numpy.zeros(IMAGE_SIZE**2,dtype=numpy.uint8), 'asg' : 'default' },
         'ImageWidth'       : { 'type' : 'int', 'value' : IMAGE_SIZE, 'asg' : 'default' },
         'String'           : { 'type' : 'string', 'value': "Test String", 'asg' : 'default'},
-        'Float'            : { 'type' : 'float', 'value': 0.0, 'lolim': -1.2, 'lolo': -1.0, 'low': -0.8, 'high': 0.8, 'hihi': 1.0, 'hilim': 1.2, 'units': 'mJ', 'prec': 3, 'asg' : 'default' },
+        'Float'            : { 'type' : 'float', 'value': 0.0, 'lolim': -1.2, 'lolo': -1.0, 'low': -0.8, 'high': 0.8, 'hihi': 1.0, 'hilim': 1.2, 'unit': 'mJ', 'prec': 3, 'asg' : 'default' },
         'StatusBits'       : { 'type' : 'int', 'value': 0b101010, 'lolim': 0, 'hilim': 32, 'asg' : 'default' }
 }
 


### PR DESCRIPTION
This PR adds support for displaying units and setting limits based on information from data plugins (for example, setting slider minimum and maximum from EPICS HOPR and LOPR fields).  Additionally, there are many bug fixes for the slider widget.  Previously there were many cases where it could enter an infinite loop of slider changes causing the channel to change, causing the slider to change again, etc.  I am surprised it ever worked at all, to be honest.

This will (finally) close #41 when merged.