### PR TITLE
Fix list of chars to string error, issue #107

### DIFF
--- a/pydm/data_plugins/epics_plugins/pyepics_plugin.py
+++ b/pydm/data_plugins/epics_plugins/pyepics_plugin.py
@@ -32,7 +32,13 @@ class Connection(PyDMConnection):
             self.unit_signal.emit(units)
         if value is not None:
             if count > 1:
-                self.new_waveform_signal.emit(value)
+                if self.pv.type == 'ctrl_char':
+                    try:
+                        self.new_value_signal[str].emit(''.join(chr(i) for i in value))
+                    except:
+                        self.new_waveform_signal.emit(value)
+                else:
+                    self.new_waveform_signal.emit(value)
             else:
                 if ftype in int_types:
                     self.new_value_signal[int].emit(int(value))


### PR DESCRIPTION
Fixes #107 and works also in LineEdit and what else, which is nice for writing maybe a whole thesis in an epics PV... **EDIT:** I just found out that the LineEdit widget seems to have a limit of about 32767 (=2**15) characters, so probably no thesis.

This prohibits the use of character type PVs for images and other real waveforms. Which is actually the case in the testing-ioc.py and and I don't see the reason for that.

Greetings
menno

