### PR TITLE
Widgets categories

### DIFF
--- a/pydm/widgets/qtplugin_base.py
+++ b/pydm/widgets/qtplugin_base.py
@@ -17,7 +17,7 @@ affect any of your widgets, but it will be annoying.
 """
 from ..PyQt import QtGui, QtDesigner
 
-def qtplugin_factory(cls, is_container=False):
+def qtplugin_factory(cls, is_container=False, group='PyDM Widgets'):
     """
     Helper function to create a generic PyDMDesignerPlugin class.
 
@@ -27,7 +27,7 @@ def qtplugin_factory(cls, is_container=False):
     class Plugin(PyDMDesignerPlugin):
         __doc__ = "PyDMDesigner Plugin for {}".format(cls.__name__)
         def __init__(self):
-            super(Plugin, self).__init__(cls, is_container)
+            super(Plugin, self).__init__(cls, is_container, group)
     return Plugin
 
 class PyDMDesignerPlugin(QtDesigner.QPyDesignerCustomWidgetPlugin):
@@ -35,7 +35,7 @@ class PyDMDesignerPlugin(QtDesigner.QPyDesignerCustomWidgetPlugin):
     Parent class to standardize how pydm plugins are accessed in qt designer.
     All functions have default returns that can be overriden as necessary.
     """
-    def __init__(self, cls, is_container=False):
+    def __init__(self, cls, is_container=False, group='PyDM Widgets'):
         """
         Set up the plugin using the class info in cls
 
@@ -46,6 +46,7 @@ class PyDMDesignerPlugin(QtDesigner.QPyDesignerCustomWidgetPlugin):
         self.initialized = False
         self.is_container = is_container
         self.cls = cls
+        self.group = group
 
     def initialize(self, core):
         """
@@ -91,7 +92,7 @@ class PyDMDesignerPlugin(QtDesigner.QPyDesignerCustomWidgetPlugin):
         Return a common group name so all PyDM Widgets are together in
         Qt Designer.
         """
-        return "PyDM Widgets"
+        return self.group
 
     def toolTip(self):
         """


### PR DESCRIPTION
Hi,

This pull request adds the `group` parameter in method `plugin_factory`, as discussed in issue #95 .
This way, it is possible to organize PyDM widgets in groups (or categories) inside Designer widget box.

Thanks,
Laís