### PR TITLE
Fix a bug where non-connected widgets were not fully disabled.

### DIFF
--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -139,7 +139,7 @@ class PyDMWidget(PyDMPrimitiveWidget):
 
         self.value = None
         self.channeltype = None
-
+        self.check_enable_state()
         # If this label is inside a PyDMApplication (not Designer) start it in the disconnected state.
         app = QApplication.instance()
         if isinstance(app, PyDMApplication):
@@ -675,8 +675,8 @@ class PyDMWritableWidget(PyDMWidget):
     send_value_signal = pyqtSignal([int], [float], [str], [bool], [np.ndarray])
 
     def __init__(self, init_channel=None):
-        super(PyDMWritableWidget, self).__init__(init_channel=init_channel)
         self._write_access = False
+        super(PyDMWritableWidget, self).__init__(init_channel=init_channel)
         self.installEventFilter(self)
 
     def init_for_designer(self):

--- a/pydm/widgets/related_display_button.py
+++ b/pydm/widgets/related_display_button.py
@@ -69,6 +69,13 @@ class PyDMRelatedDisplayButton(QFrame, PyDMWidget):
             self.push_button.setStyleSheet(style)
             self.push_button.update()
 
+    def check_enable_state(self):
+        """
+        Because the related display button's channel is only used for alarm
+        status, the widget is never disabled by connection state.
+        """
+        self.setEnabled(True)
+
     @pyqtProperty(str)
     def text(self):
         """


### PR DESCRIPTION
Fixes #118.  Calls the check_enable_state() on widget initialization (which should disable it).  Related Display Button overrides check_enable_state() now so that it is never disabled.