### PR TITLE
FIX: Edge cases in pyepics plugin

### DIFF
--- a/pydm/data_plugins/epics_plugins/pyepics_plugin.py
+++ b/pydm/data_plugins/epics_plugins/pyepics_plugin.py
@@ -56,7 +56,10 @@ class Connection(PyDMConnection):
             self.prec_signal.emit(precision)
         if enum_strs is not None and self._enum_strs != enum_strs:
             self._enum_strs = enum_strs
-            enum_strs = tuple(b.decode(encoding='ascii') for b in enum_strs)
+            try:
+                enum_strs = tuple(b.decode(encoding='ascii') for b in enum_strs)
+            except AttributeError:
+                pass
             self.enum_strings_signal.emit(enum_strs)
         if units is not None and len(units) > 0 and self._unit != units:
             if type(units) == bytes:
@@ -83,8 +86,9 @@ class Connection(PyDMConnection):
         self.connection_state_signal.emit(conn)
         if conn:
             self.clear_cache()
-            self.reload_access_state()
-            self.pv.run_callbacks()
+            if hasattr(self, 'pv'):
+                self.reload_access_state()
+                self.pv.run_callbacks()
 
     @pyqtSlot(int)
     @pyqtSlot(float)


### PR DESCRIPTION
With pyepics 3.2.7 and the newest PyDM, I hit two strange errors today. Not sure if these are the best solutions, but this is how I worked around them:

- Some (but not all) enum PVs enter the `enum_strs` block with python strings instead of bytestrings. These would then fail on the `b.decode step`. Fixed by catching `AttributeError`, since this means we don't need to decode the strings.
- Some PVs call the connection callback before the `__init__` statement for `self.pv` has completed, so when they enter the connection callback block, neither `reload_access_state` or `self.pv.run_callbacks` can work. Fixed by checking for the attribute before entering the block.