### PR TITLE
Add properties for manual plot ranges.

### DIFF
--- a/pydm/widgets/baseplot.py
+++ b/pydm/widgets/baseplot.py
@@ -68,30 +68,6 @@ class BasePlot(PlotWidget, PyDMPrimitiveWidget):
         self.plotItem.clear()
         self._curves = []
     
-    def getAutoRangeX(self):
-        return self._auto_range_x
-    
-    def setAutoRangeX(self, value):
-        self._auto_range_x = value
-        self.plotItem.enableAutoRange(ViewBox.XAxis,enable=self._auto_range_x)
-            
-    def resetAutoRangeX(self):
-        self.setAutoRangeX(True)
-        
-    autoRangeX = pyqtProperty("bool", getAutoRangeX, setAutoRangeX, resetAutoRangeX)
-    
-    def getAutoRangeY(self):
-        return self._auto_range_y
-    
-    def setAutoRangeY(self, value):
-        self._auto_range_y = value
-        self.plotItem.enableAutoRange(ViewBox.YAxis,enable=self._auto_range_y)
-            
-    def resetAutoRangeY(self):
-        self.setAutoRangeY(True)
-        
-    autoRangeY = pyqtProperty("bool", getAutoRangeY, setAutoRangeY, resetAutoRangeY)
-    
     def getShowXGrid(self):
         return self._show_x_grid
     
@@ -172,3 +148,157 @@ class BasePlot(PlotWidget, PyDMPrimitiveWidget):
         self.setShowLegend(False)
         
     showLegend = pyqtProperty(bool, getShowLegend, setShowLegend, resetShowLegend)
+    
+    def getAutoRangeX(self):
+        return self._auto_range_x
+    
+    def setAutoRangeX(self, value):
+        self._auto_range_x = value
+        self.plotItem.enableAutoRange(ViewBox.XAxis,enable=self._auto_range_x)
+            
+    def resetAutoRangeX(self):
+        self.setAutoRangeX(True)
+    
+    def getAutoRangeY(self):
+        return self._auto_range_y
+    
+    def setAutoRangeY(self, value):
+        self._auto_range_y = value
+        self.plotItem.enableAutoRange(ViewBox.YAxis,enable=self._auto_range_y)
+            
+    def resetAutoRangeY(self):
+        self.setAutoRangeY(True)
+        
+    def getMinXRange(self):
+        """
+        Minimum X-axis value visible on the plot.
+
+        Returns
+        -------
+        float
+        """
+        return self.plotItem.viewRange()[0][0]
+    
+    def setMinXRange(self, new_min_x_range):
+        """
+        Set the minimum X-axis value visible on the plot.
+
+        Parameters
+        -------
+        new_min_x_range : float
+        """
+        viewRange = self.plotItem.viewRange()
+        viewRange[0][0] = new_min_x_range
+        self.plotItem.setXRange(viewRange[0][0], viewRange[0][1], padding=0)
+    
+    def getMaxXRange(self):
+        """
+        Maximum X-axis value visible on the plot.
+
+        Returns
+        -------
+        float
+        """
+        return self.plotItem.viewRange()[0][1]
+    
+    def setMaxXRange(self, new_max_x_range):
+        """
+        Set the Maximum X-axis value visible on the plot.
+
+        Parameters
+        -------
+        new_max_x_range : float
+        """
+        viewRange = self.plotItem.viewRange()
+        viewRange[0][1] = new_max_x_range
+        self.plotItem.setXRange(viewRange[0][0], viewRange[0][1], padding=0)
+    
+    def getMinYRange(self):
+        """
+        Minimum Y-axis value visible on the plot.
+
+        Returns
+        -------
+        float
+        """
+        return self.plotItem.viewRange()[1][0]
+    
+    def setMinYRange(self, new_min_y_range):
+        """
+        Set the minimum Y-axis value visible on the plot.
+
+        Parameters
+        -------
+        new_min_y_range : float
+        """
+        viewRange = self.plotItem.viewRange()
+        viewRange[1][0] = new_min_y_range
+        self.plotItem.setYRange(viewRange[1][0], viewRange[1][1], padding=0)
+    
+    def getMaxYRange(self):
+        """
+        Maximum Y-axis value visible on the plot.
+
+        Returns
+        -------
+        float
+        """
+        return self.plotItem.viewRange()[1][1]
+    
+    def setMaxYRange(self, new_max_y_range):
+        """
+        Set the maximum Y-axis value visible on the plot.
+
+        Parameters
+        -------
+        new_max_y_range : float
+        """
+        viewRange = self.plotItem.viewRange()
+        viewRange[1][1] = new_max_y_range
+        self.plotItem.setYRange(viewRange[1][0], viewRange[1][1], padding=0)
+    
+    
+    @pyqtProperty(bool)
+    def mouseEnabledX(self):
+        """
+        Whether or not mouse interactions are enabled for the X-axis.
+
+        Returns
+        -------
+        bool
+        """
+        return self.plotItem.getViewBox().state['mouseEnabled'][0]
+    
+    @mouseEnabledX.setter
+    def mouseEnabledX(self, x_enabled):
+        """
+        Whether or not mouse interactions are enabled for the X-axis.
+
+        Parameters
+        -------
+        x_enabled : bool
+        """
+        self.plotItem.setMouseEnabled(x=x_enabled)
+    
+    @pyqtProperty(bool)
+    def mouseEnabledY(self):
+        """
+        Whether or not mouse interactions are enabled for the Y-axis.
+
+        Returns
+        -------
+        bool
+        """
+        return self.plotItem.getViewBox().state['mouseEnabled'][1]
+    
+    @mouseEnabledY.setter
+    def mouseEnabledY(self, y_enabled):
+        """
+        Whether or not mouse interactions are enabled for the Y-axis.
+
+        Parameters
+        -------
+        y_enabled : bool
+        """
+        self.plotItem.setMouseEnabled(y=y_enabled)
+    

--- a/pydm/widgets/timeplot.py
+++ b/pydm/widgets/timeplot.py
@@ -121,6 +121,9 @@ class TimePlotCurveItem(PlotCurveItem):
 
     def max_x(self):
         return self.data_buffer[0, -1]
+    
+    def min_x(self):
+        return self.data_buffer[0, 0]
 
 class PyDMTimePlot(BasePlot):
     SynchronousMode = 1
@@ -307,6 +310,22 @@ class PyDMTimePlot(BasePlot):
 
     def channels(self):
         return [curve.channel for curve in self._curves]
+        
+    # The methods for autoRangeY, minYRange, and maxYRange are
+    # all defined in BasePlot, but we don't expose them as properties there, because not all plot
+    # subclasses necessarily want them to be user-configurable in Designer.    
+    autoRangeY = pyqtProperty(bool, BasePlot.getAutoRangeY, BasePlot.setAutoRangeY, BasePlot.resetAutoRangeY, doc="""
+    Whether or not the Y-axis automatically rescales to fit the data.  If true, the
+    values in minYRange and maxYRange are ignored.
+    """)
+    
+    minYRange = pyqtProperty(float, BasePlot.getMinYRange, BasePlot.setMinYRange, doc="""
+    Minimum Y-axis value visible on the plot.
+    """)
+    
+    maxYRange = pyqtProperty(float, BasePlot.getMaxYRange, BasePlot.setMaxYRange, doc="""
+    Maximum Y-axis value visible on the plot.
+    """)
 
 class TimeAxisItem(AxisItem):
     def tickStrings(self, values, scale, spacing):

--- a/pydm/widgets/timeplot.py
+++ b/pydm/widgets/timeplot.py
@@ -145,13 +145,6 @@ class PyDMTimePlot(BasePlot):
         self._update_interval = 100
         self.update_timer.setInterval(self._update_interval)
         self._update_mode = PyDMTimePlot.SynchronousMode
-        # Due to a bug in pyqtgraph, we have to remove a bunch of leftover garbage axes.
-        # It looks like this bug will be fixed in a future version of pyqtgraph.
-        # NOTE: I think this was fixed in PyQtGraph 0.10.0, see if removing this is OK.
-        for child in self.getPlotItem().childItems():
-            if isinstance(child, AxisItem):
-                if child not in [self.getPlotItem().axes[k]['item'] for k in self.getPlotItem().axes]:
-                    child.deleteLater()
 
     def initialize_for_designer(self):
         # If we are in Qt Designer, don't update the plot continuously.

--- a/pydm/widgets/waveformplot.py
+++ b/pydm/widgets/waveformplot.py
@@ -1,6 +1,6 @@
 from ..PyQt.QtGui import QColor
 from ..PyQt.QtCore import pyqtSignal, pyqtSlot, pyqtProperty
-from pyqtgraph import PlotCurveItem
+from pyqtgraph import PlotCurveItem, ViewBox
 import numpy as np
 from .baseplot import BasePlot
 from .channel import PyDMChannel
@@ -201,3 +201,32 @@ class PyDMWaveformPlot(BasePlot):
         chans.extend([curve.y_channel for curve in self._curves])
         chans.extend([curve.x_channel for curve in self._curves if curve.x_channel is not None])
         return chans
+    
+    # The methods for autoRangeX, minXRange, maxXRange, autoRangeY, minYRange, and maxYRange are
+    # all defined in BasePlot, but we don't expose them as properties there, because not all plot
+    # subclasses necessarily want them to be user-configurable in Designer.
+    autoRangeX = pyqtProperty(bool, BasePlot.getAutoRangeX, BasePlot.setAutoRangeX, BasePlot.resetAutoRangeX, doc="""
+    Whether or not the X-axis automatically rescales to fit the data.  If true, the
+    values in minXRange and maxXRange are ignored.
+    """)   
+    
+    minXRange = pyqtProperty(float, BasePlot.getMinXRange, BasePlot.setMinXRange, doc="""
+    Minimum X-axis value visible on the plot.
+    """)
+    
+    maxXRange = pyqtProperty(float, BasePlot.getMaxXRange, BasePlot.setMaxXRange, doc="""
+    Maximum X-axis value visible on the plot.
+    """)
+    
+    autoRangeY = pyqtProperty(bool, BasePlot.getAutoRangeY, BasePlot.setAutoRangeY, BasePlot.resetAutoRangeY, doc="""
+    Whether or not the Y-axis automatically rescales to fit the data.  If true, the
+    values in minYRange and maxYRange are ignored.
+    """)
+    
+    minYRange = pyqtProperty(float, BasePlot.getMinYRange, BasePlot.setMinYRange, doc="""
+    Minimum Y-axis value visible on the plot.
+    """)
+    
+    maxYRange = pyqtProperty(float, BasePlot.getMaxYRange, BasePlot.setMaxYRange, doc="""
+    Maximum Y-axis value visible on the plot.
+    """)


### PR DESCRIPTION
This PR adds properties for manually setting the Y axis range for TimePlot and WaveformPlot, and the X axis range for WaveformPlot.  It also adds two new properties to BasePlot for enabling/disabling mouse interaction for each axis.  Finally, it moves autoRange property definitions out of the base class and into the subclasses, so that autoRangeX isn't available for TimePlot.

This will close #100 if merged.