### PR TITLE
Scatter plots

### DIFF
--- a/pydm/widgets/baseplot.py
+++ b/pydm/widgets/baseplot.py
@@ -30,7 +30,7 @@ class BasePlot(PlotWidget, PyDMPrimitiveWidget):
     def addCurve(self, plot_item, curve_color=None):
         if curve_color is None:
             curve_color = utilities.colors.default_colors[len(self._curves) % len(utilities.colors.default_colors)]
-        plot_item.setPen(QColor(curve_color))
+            plot_item.color_string = curve_color        
         self._curves.append(plot_item)
         self.addItem(plot_item)
         #self._legend.addItem(plot_item, plot_item.curve_name)

--- a/pydm/widgets/timeplot.py
+++ b/pydm/widgets/timeplot.py
@@ -51,11 +51,18 @@ class TimePlotCurveItem(PlotCurveItem):
 
     @color_string.setter
     def color_string(self, new_color_string):
-        self.setPen(QColor(str(new_color_string)))
+        self.color = QColor(str(new_color_string))
 
     @property
     def color(self):
         return self.opts['pen'].color()
+    
+    @color.setter
+    def color(self, new_color):
+        if isinstance(new_color, str):
+            self.color_string = new_color
+            return
+        self.setPen(new_color)
 
     @pyqtSlot(bool)
     def connectionStateChanged(self, connected):

--- a/pydm/widgets/timeplot.py
+++ b/pydm/widgets/timeplot.py
@@ -165,6 +165,8 @@ class PyDMTimePlot(BasePlot):
         # Add curve
         new_curve = TimePlotCurveItem(ychannel, name=name)
         new_curve.setUpdatesAsynchronously(self.updatesAsynchronously)
+        if color:
+            new_curve.setPen(color)
         self.update_timer.timeout.connect(new_curve.asyncUpdate)
         self.addCurve(new_curve, curve_color=color)
         self.redraw_timer.start()

--- a/pydm/widgets/timeplot_curve_editor.py
+++ b/pydm/widgets/timeplot_curve_editor.py
@@ -28,7 +28,7 @@ class TimePlotCurveEditorDialog(QDialog):
         self.table_view.setSelectionMode(QAbstractItemView.SingleSelection)
         self.table_view.setSelectionBehavior(QAbstractItemView.SelectRows)
         color_delegate = ColorColumnDelegate(self)
-        self.table_view.setItemDelegateForColumn(4, color_delegate)
+        self.table_view.setItemDelegateForColumn(2, color_delegate)
         self.table_view.doubleClicked.connect(self.handleDoubleClick)
         self.table_view.setSortingEnabled(False)
         self.table_view.horizontalHeader().setStretchLastSection(True)

--- a/pydm/widgets/timeplot_curve_editor.py
+++ b/pydm/widgets/timeplot_curve_editor.py
@@ -1,5 +1,5 @@
-from ..PyQt.QtGui import QDialog, QVBoxLayout, QHBoxLayout, QTableView, QAbstractItemView, QSpacerItem, QSizePolicy, QDialogButtonBox, QPushButton, QItemSelection
-from ..PyQt.QtCore import Qt, pyqtSlot
+from ..PyQt.QtGui import QDialog, QVBoxLayout, QHBoxLayout, QTableView, QAbstractItemView, QSpacerItem, QSizePolicy, QDialogButtonBox, QPushButton, QItemSelection, QStyledItemDelegate, QColorDialog
+from ..PyQt.QtCore import Qt, pyqtSlot, QModelIndex
 from ..PyQt.QtDesigner import QDesignerFormWindowInterface
 from .timeplot_table_model import PyDMTimePlotCurvesModel
 
@@ -27,6 +27,9 @@ class TimePlotCurveEditorDialog(QDialog):
         self.table_view.setDragDropOverwriteMode(False)
         self.table_view.setSelectionMode(QAbstractItemView.SingleSelection)
         self.table_view.setSelectionBehavior(QAbstractItemView.SelectRows)
+        color_delegate = ColorColumnDelegate(self)
+        self.table_view.setItemDelegateForColumn(4, color_delegate)
+        self.table_view.doubleClicked.connect(self.handleDoubleClick)
         self.table_view.setSortingEnabled(False)
         self.table_view.horizontalHeader().setStretchLastSection(True)
         self.table_view.verticalHeader().setVisible(False)
@@ -62,10 +65,23 @@ class TimePlotCurveEditorDialog(QDialog):
     def handleSelectionChange(self, selected, deselected):
         self.remove_button.setEnabled(self.table_view.selectionModel().hasSelection())
     
+    @pyqtSlot(QModelIndex)
+    def handleDoubleClick(self, index):
+        if self.table_model.needsColorDialog(index):
+            #The table model returns a QBrush for BackgroundRole, not a QColor.
+            init_color = self.table_model.data(index, Qt.BackgroundRole).color()
+            color = QColorDialog.getColor(init_color, self)
+            if color.isValid():
+                self.table_model.setData(index, color, role=Qt.EditRole)
+    
     @pyqtSlot()
     def saveChanges(self):
         formWindow = QDesignerFormWindowInterface.findFormWindow(self.plot)
         if formWindow:
             formWindow.cursor().setProperty("curves", self.plot.curves)
         self.accept()
+    
+class ColorColumnDelegate(QStyledItemDelegate):
+    def createEditor(self, parent, option, index):
+        return None
         

--- a/pydm/widgets/timeplot_table_model.py
+++ b/pydm/widgets/timeplot_table_model.py
@@ -24,8 +24,9 @@ class PyDMTimePlotCurvesModel(QAbstractTableModel):
         self.plot.clearCurves()
 
     def flags(self, index):
-        f = Qt.ItemIsSelectable | Qt.ItemIsEnabled | Qt.ItemIsEditable
-        return f
+        if self._column_names[index.column()] == "Color":
+            return Qt.ItemIsSelectable | Qt.ItemIsEnabled
+        return Qt.ItemIsSelectable | Qt.ItemIsEnabled | Qt.ItemIsEditable
 
     def rowCount(self, parent=None):
         if parent is not None and parent.isValid():
@@ -80,7 +81,7 @@ class PyDMTimePlotCurvesModel(QAbstractTableModel):
         elif column_name == "Label":
             curve.setData(name=str(value))
         elif column_name == "Color":
-            curve.color_string = str(value)
+            curve.color = value
         self.dataChanged.emit(index, index)
         return True
 
@@ -102,3 +103,9 @@ class PyDMTimePlotCurvesModel(QAbstractTableModel):
         self.beginRemoveRows(QModelIndex(), index.row(), index.row())
         self._plot.removeYChannelAtIndex(index.row())
         self.endRemoveRows()
+    
+    def needsColorDialog(self, index):
+        column_name = self._column_names[index.column()]
+        if column_name == "Color":
+            return True
+        return False

--- a/pydm/widgets/waveformplot.py
+++ b/pydm/widgets/waveformplot.py
@@ -56,7 +56,6 @@ class WaveformCurveItem(PlotDataItem):
         if isinstance(new_color, str):
             self.color_string = new_color
             return
-        print("Curve is settings its color to: {}".format(new_color.name()))
         self._color = new_color
         if self.connect_points:
             self.setPen(self._color)

--- a/pydm/widgets/waveformplot.py
+++ b/pydm/widgets/waveformplot.py
@@ -45,7 +45,6 @@ class WaveformCurveItem(PlotDataItem):
     def color_string(self, new_color_string):
         self._color = QColor(str(new_color_string))
         if self.connect_points:
-            print("Color string changed, resetting pen.")
             self.setPen(self._color)
             
     @property
@@ -58,16 +57,13 @@ class WaveformCurveItem(PlotDataItem):
     
     @connect_points.setter
     def connect_points(self, connect):
-        print("Setting connect_points to: {}".format(connect))
         self._connect_points = connect
         if self._connect_points:
             self.setPen(self._color)
         else:
-            print("Disabling pen, supposedly.")
             self.setPen(None)
     
     def setPen(self, pen):
-        print("Pen is now set to: {}".format(pen))
         super(WaveformCurveItem, self).setPen(pen)
     
     @property
@@ -76,7 +72,6 @@ class WaveformCurveItem(PlotDataItem):
     
     @symbol.setter
     def symbol(self, new_symbol):
-        print("setting symbol to: {}".format(new_symbol))
         if new_symbol in self.symbols.values():
             self.setSymbol(new_symbol)
         else:
@@ -180,7 +175,6 @@ class PyDMWaveformPlot(BasePlot):
         curve = WaveformCurveItem(y_addr=y_channel, x_addr=x_channel, name=name, color=color, connect_points=connect_points, **plot_opts)
         curve.data_changed.connect(self.redrawPlot)
         self.channel_pairs[(y_channel, x_channel)] = curve
-        print("Waveform Plot is adding a new curve with color: {}".format(color))
         self.addCurve(curve, curve_color=color)
     
     def removeChannel(self, curve):
@@ -232,7 +226,6 @@ class PyDMWaveformPlot(BasePlot):
         self.clearCurves()
         for d in new_list:
             color = d.get('color')
-            print("Color retrieved from json: {}".format(color))
             if color:
                 color = QColor(color)
             self.addChannel(d['y_channel'], d['x_channel'], name=d.get('name'), color=color, connect_points=d.get('connect_points', True), symbol=d.get('symbol'))

--- a/pydm/widgets/waveformplot.py
+++ b/pydm/widgets/waveformplot.py
@@ -45,13 +45,21 @@ class WaveformCurveItem(PlotDataItem):
     
     @color_string.setter
     def color_string(self, new_color_string):
-        self._color = QColor(str(new_color_string))
-        if self.connect_points:
-            self.setPen(self._color)
+        self.color = QColor(str(new_color_string))
             
     @property
     def color(self):
         return self._color
+    
+    @color.setter
+    def color(self, new_color):
+        if isinstance(new_color, str):
+            self.color_string = new_color
+            return
+        print("Curve is settings its color to: {}".format(new_color.name()))
+        self._color = new_color
+        if self.connect_points:
+            self.setPen(self._color)
     
     @property
     def connect_points(self):

--- a/pydm/widgets/waveformplot.py
+++ b/pydm/widgets/waveformplot.py
@@ -25,6 +25,8 @@ class WaveformCurveItem(PlotDataItem):
                 x_name = utilities.remove_protocol(x_addr)
                 plot_name = "{y} vs. {x}".format(y=y_name, x=x_name)
             kws['name'] = plot_name
+        self.needs_new_x = True
+        self.needs_new_y = True
         self.x_channel = None
         self.y_channel = None
         self.x_address = x_addr
@@ -117,14 +119,16 @@ class WaveformCurveItem(PlotDataItem):
     @pyqtSlot(np.ndarray)
     def receiveXWaveform(self, new_waveform):
         self.x_waveform = new_waveform
+        self.needs_new_x = False
         #Don't redraw unless we already have Y data.
-        if self.y_waveform is not None:
+        if not (self.needs_new_x or self.needs_new_y):
             self.data_changed.emit()
     
     @pyqtSlot(np.ndarray)
     def receiveYWaveform(self, new_waveform):
         self.y_waveform = new_waveform
-        if self.x_channel is None or self.x_waveform is not None:
+        self.needs_new_y = False
+        if self.x_channel is None or not (self.needs_new_x or self.needs_new_y):
             self.data_changed.emit()
     
     def redrawCurve(self):
@@ -138,6 +142,8 @@ class WaveformCurveItem(PlotDataItem):
         #elif self.x_waveform.shape[0] < self.y_waveform.shape[0]:
         #    self.y_waveform = self.y_waveform[:self.x_waveform.shape[0]]
         self.setData(x=self.x_waveform, y=self.y_waveform)
+        self.needs_new_x = True
+        self.needs_new_y = True
     
     def limits(self):
         """Returns a nested tuple of limits: ((xmin, xmax), (ymin, ymax))"""

--- a/pydm/widgets/waveformplot_curve_editor.py
+++ b/pydm/widgets/waveformplot_curve_editor.py
@@ -84,7 +84,6 @@ class WaveformPlotCurveEditorDialog(QDialog):
             init_color = self.table_model.data(index, Qt.BackgroundRole).color()
             color = QColorDialog.getColor(init_color, self)
             if color.isValid():
-                print("Dialog picked color for curve: {}".format(color.name()))
                 self.table_model.setData(index, color, role=Qt.EditRole)
     
     @pyqtSlot()

--- a/pydm/widgets/waveformplot_curve_editor.py
+++ b/pydm/widgets/waveformplot_curve_editor.py
@@ -26,9 +26,9 @@ class WaveformPlotCurveEditorDialog(QDialog):
         self.remove_button.clicked.connect(self.removeSelectedCurve)
         self.remove_button.setEnabled(False)
         symbol_delegate = SymbolColumnDelegate(self)
-        self.table_view.setItemDelegateForColumn(5, symbol_delegate)
+        self.table_view.setItemDelegateForColumn(4, symbol_delegate)
         color_delegate = ColorColumnDelegate(self)
-        self.table_view.setItemDelegateForColumn(4, color_delegate)
+        self.table_view.setItemDelegateForColumn(3, color_delegate)
         self.table_view.selectionModel().selectionChanged.connect(self.handleSelectionChange)
         self.table_view.doubleClicked.connect(self.handleDoubleClick)
         

--- a/pydm/widgets/waveformplot_table_model.py
+++ b/pydm/widgets/waveformplot_table_model.py
@@ -2,12 +2,18 @@ from ..PyQt.QtCore import QAbstractTableModel, Qt, QModelIndex, QVariant
 from ..PyQt.QtGui import QBrush, QColor
 from operator import itemgetter
 from .. import utilities
+from .waveformplot import WaveformCurveItem
 
 class PyDMWaveformPlotCurvesModel(QAbstractTableModel):
+    name_for_symbol = {v: k for k, v in WaveformCurveItem.symbols.items()}
+    """ This is the data model used by the waveform plot curve editor.
+    It basically acts as a go-between for the curves in a plot, and
+    QTableView items.
+    """
     def __init__(self, plot, parent=None):
         super(PyDMWaveformPlotCurvesModel, self).__init__(parent=parent)
         self._plot = plot
-        self._column_names = ("Y Channel", "X Channel", "Label", "Color")
+        self._column_names = ("Y Channel", "X Channel", "Label", "Color", "Connect Points", "Data Point Symbol")
 
     @property
     def plot(self):
@@ -24,8 +30,10 @@ class PyDMWaveformPlotCurvesModel(QAbstractTableModel):
         self.plot.clearCurves()
 
     def flags(self, index):
-        f = Qt.ItemIsSelectable | Qt.ItemIsEnabled | Qt.ItemIsEditable
-        return f
+        column_name = self._column_names[index.column()]
+        if column_name == "Connect Points":
+            return Qt.ItemIsSelectable | Qt.ItemIsEnabled | Qt.ItemIsUserCheckable
+        return Qt.ItemIsSelectable | Qt.ItemIsEnabled | Qt.ItemIsEditable
 
     def rowCount(self, parent=None):
         if parent is not None and parent.isValid():
@@ -59,16 +67,25 @@ class PyDMWaveformPlotCurvesModel(QAbstractTableModel):
                 return str(curve.name())
             elif column_name == "Color":
                 return curve.color_string
+            elif column_name == "Connect Points":
+                return QVariant()
+            elif column_name == "Data Point Symbol":
+                if curve.symbol is None:
+                    return "None"
+                return self.name_for_symbol[curve.symbol]
         #elif role == Qt.DecorationRole and column_name == "Color":
         #    return curve.color
         elif role == Qt.BackgroundRole and column_name == "Color":
             return QBrush(curve.color)
+        elif role == Qt.CheckStateRole and column_name == "Connect Points":
+            if curve.connect_points:
+                return Qt.Checked
+            else:
+                return Qt.Unchecked
         else:
             return QVariant()
 
     def setData(self, index, value, role=Qt.EditRole):
-        if role != Qt.EditRole:
-            return False
         if not index.isValid():
             return False
         if index.row() >= self.rowCount():
@@ -77,16 +94,25 @@ class PyDMWaveformPlotCurvesModel(QAbstractTableModel):
             return False
         column_name = self._column_names[index.column()]
         curve = self.plot._curves[index.row()]
-        if isinstance(value, QVariant):
-            value = value.toString()
-        if column_name == "Y Channel":
-            curve.y_address = str(value)
-        elif column_name == "X Channel":
-            curve.x_address = str(value)
-        elif column_name == "Label":
-            curve.setData(name=str(value))
-        elif column_name == "Color":
-            curve.color_string = str(value)
+        if role == Qt.EditRole:
+            if isinstance(value, QVariant):
+                value = value.toString()
+            if column_name == "Y Channel":
+                curve.y_address = str(value)
+            elif column_name == "X Channel":
+                curve.x_address = str(value)
+            elif column_name == "Label":
+                curve.setData(name=str(value))
+            elif column_name == "Color":
+                curve.color_string = str(value)
+            elif column_name == "Data Point Symbol":
+                curve.symbol = str(value)
+            else:
+                return False
+        elif role == Qt.CheckStateRole and column_name == "Connect Points":
+            curve.connect_points = bool(value)
+        else:
+            return False
         self.dataChanged.emit(index, index)
         return True
 

--- a/pydm/widgets/waveformplot_table_model.py
+++ b/pydm/widgets/waveformplot_table_model.py
@@ -33,6 +33,8 @@ class PyDMWaveformPlotCurvesModel(QAbstractTableModel):
         column_name = self._column_names[index.column()]
         if column_name == "Connect Points":
             return Qt.ItemIsSelectable | Qt.ItemIsEnabled | Qt.ItemIsUserCheckable
+        if column_name == "Color":
+            return Qt.ItemIsSelectable | Qt.ItemIsEnabled
         return Qt.ItemIsSelectable | Qt.ItemIsEnabled | Qt.ItemIsEditable
 
     def rowCount(self, parent=None):
@@ -104,7 +106,7 @@ class PyDMWaveformPlotCurvesModel(QAbstractTableModel):
             elif column_name == "Label":
                 curve.setData(name=str(value))
             elif column_name == "Color":
-                curve.color_string = str(value)
+                curve.color = value
             elif column_name == "Data Point Symbol":
                 curve.symbol = str(value)
             else:
@@ -134,3 +136,9 @@ class PyDMWaveformPlotCurvesModel(QAbstractTableModel):
         self.beginRemoveRows(QModelIndex(), index.row(), index.row())
         self._plot.removeChannelAtIndex(index.row())
         self.endRemoveRows()
+    
+    def needsColorDialog(self, index):
+        column_name = self._column_names[index.column()]
+        if column_name == "Color":
+            return True
+        return False


### PR DESCRIPTION
This PR adds modifications to let users make scatter plots with PyDMWaveformPlot.  It also adds another new feature: the curve editors for waveform and time plots now use QColorDialog to pick colors - no more need to remember hex codes or color names from the SVG spec.