### PR TITLE
FIX: Start PyDMWidget with AlarmDisconnected...

### DIFF
--- a/designer_plugin.py
+++ b/designer_plugin.py
@@ -1,4 +1,2 @@
-print("Test")
 print("Loading PyDM Widgets")
 from pydm.widgets.qtplugins import *
-print("Test...")

--- a/examples/drawing/draw_alarm.ui
+++ b/examples/drawing/draw_alarm.ui
@@ -10,6 +10,12 @@
     <height>300</height>
    </rect>
   </property>
+  <property name="minimumSize">
+   <size>
+    <width>400</width>
+    <height>300</height>
+   </size>
+  </property>
   <property name="windowTitle">
    <string>Dialog</string>
   </property>
@@ -27,11 +33,11 @@
        <property name="whatsThis">
         <string/>
        </property>
+       <property name="channel" stdset="0">
+        <string>ca://MTEST:Float</string>
+       </property>
        <property name="alarmSensitiveText" stdset="0">
         <bool>true</bool>
-       </property>
-       <property name="channel">
-        <string>ca://MTEST:Float</string>
        </property>
       </widget>
      </item>
@@ -44,16 +50,25 @@
         <string/>
        </property>
        <property name="styleSheet">
-        <string notr="true">QWidget {color: yellow; border: 2px solid red;}</string>
+        <string notr="true"/>
        </property>
-       <property name="alarmSensitiveText" stdset="0">
+       <property name="alarmSensitiveContent" stdset="0">
         <bool>true</bool>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://MTEST:Float</string>
        </property>
        <property name="brush" stdset="0">
         <brush brushstyle="SolidPattern">
          <color alpha="255">
-          <red>255</red>
-          <green>0</green>
+          <red>128</red>
+          <green>255</green>
           <blue>0</blue>
          </color>
         </brush>
@@ -64,8 +79,8 @@
        <property name="penWidth" stdset="0">
         <double>10.000000000000000</double>
        </property>
-       <property name="channel" stdset="0">
-        <string>ca://MTEST:Float</string>
+       <property name="alarmSensitiveText" stdset="0">
+        <bool>false</bool>
        </property>
       </widget>
      </item>
@@ -75,14 +90,14 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>PyDMLabel</class>
-   <extends>QLabel</extends>
-   <header>pydm.widgets.label</header>
-  </customwidget>
-  <customwidget>
    <class>PyDMDrawingRectangle</class>
    <extends>QWidget</extends>
    <header>pydm.widgets.drawing</header>
+  </customwidget>
+  <customwidget>
+   <class>PyDMLabel</class>
+   <extends>QLabel</extends>
+   <header>pydm.widgets.label</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/examples/drawing/drawing_demo.ui
+++ b/examples/drawing/drawing_demo.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>559</width>
-    <height>497</height>
+    <width>646</width>
+    <height>510</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -18,94 +18,86 @@
     <rect>
      <x>20</x>
      <y>30</y>
-     <width>141</width>
-     <height>141</height>
+     <width>140</width>
+     <height>140</height>
     </rect>
    </property>
    <property name="toolTip">
     <string/>
    </property>
    <property name="whatsThis">
-    <string/>
-   </property>
-   <property name="penStyle" stdset="0">
-    <enum>Qt::NoPen</enum>
-   </property>
-   <property name="penWidth" stdset="0">
-    <double>0.000000000000000</double>
-   </property>
-   <property name="rotation" stdset="0">
-    <double>0.000000000000000</double>
+    <string>
+    Renders an image given by the ```filename``` property.
+    This class inherits from PyDMDrawing.
+
+    Parameters
+    ----------
+    parent : QWidget
+        The parent widget for the Label
+    init_channel : str, optional
+        The channel to be used by the widget.
+    </string>
    </property>
    <property name="filename" stdset="0">
     <string>SLAC_logo.jpeg</string>
    </property>
   </widget>
-  <widget class="QLabel" name="label">
-   <property name="geometry">
-    <rect>
-     <x>20</x>
-     <y>10</y>
-     <width>141</width>
-     <height>20</height>
-    </rect>
-   </property>
-   <property name="text">
-    <string>PyDMDrawingImage</string>
-   </property>
-   <property name="alignment">
-    <set>Qt::AlignCenter</set>
-   </property>
-  </widget>
   <widget class="PyDMDrawingLine" name="PyDMDrawingLine">
    <property name="geometry">
     <rect>
-     <x>180</x>
+     <x>250</x>
      <y>30</y>
-     <width>141</width>
-     <height>141</height>
+     <width>140</width>
+     <height>140</height>
     </rect>
    </property>
    <property name="toolTip">
     <string/>
    </property>
    <property name="whatsThis">
-    <string/>
+    <string>
+    A widget with a line drawn in it.
+    This class inherits from PyDMDrawing.
+
+    Parameters
+    ----------
+    parent : QWidget
+        The parent widget for the Label
+    init_channel : str, optional
+        The channel to be used by the widget.
+    </string>
    </property>
-  </widget>
-  <widget class="QLabel" name="label_2">
-   <property name="geometry">
-    <rect>
-     <x>180</x>
-     <y>10</y>
-     <width>141</width>
-     <height>20</height>
-    </rect>
-   </property>
-   <property name="text">
-    <string>PyDMDrawingLine</string>
-   </property>
-   <property name="alignment">
-    <set>Qt::AlignCenter</set>
+   <property name="alarmSensitiveBorder" stdset="0">
+    <bool>false</bool>
    </property>
   </widget>
   <widget class="PyDMDrawingRectangle" name="PyDMDrawingRectangle">
    <property name="geometry">
     <rect>
-     <x>390</x>
+     <x>480</x>
      <y>30</y>
-     <width>141</width>
-     <height>141</height>
+     <width>140</width>
+     <height>140</height>
     </rect>
    </property>
    <property name="toolTip">
     <string/>
    </property>
    <property name="whatsThis">
-    <string/>
+    <string>
+    A widget with a rectangle drawn in it.
+    This class inherits from PyDMDrawing.
+
+    Parameters
+    ----------
+    parent : QWidget
+        The parent widget for the Label
+    init_channel : str, optional
+        The channel to be used by the widget.
+    </string>
    </property>
    <property name="brush" stdset="0">
-    <brush brushstyle="Dense3Pattern">
+    <brush brushstyle="Dense1Pattern">
      <color alpha="255">
       <red>255</red>
       <green>0</green>
@@ -124,16 +116,26 @@
    <property name="geometry">
     <rect>
      <x>20</x>
-     <y>210</y>
-     <width>141</width>
-     <height>141</height>
+     <y>200</y>
+     <width>140</width>
+     <height>140</height>
     </rect>
    </property>
    <property name="toolTip">
     <string/>
    </property>
    <property name="whatsThis">
-    <string/>
+    <string>
+    A widget with a triangle drawn in it.
+    This class inherits from PyDMDrawing.
+
+    Parameters
+    ----------
+    parent : QWidget
+        The parent widget for the Label
+    init_channel : str, optional
+        The channel to be used by the widget.
+    </string>
    </property>
    <property name="brush" stdset="0">
     <brush brushstyle="NoBrush">
@@ -148,15 +150,15 @@
     <enum>Qt::SolidLine</enum>
    </property>
    <property name="penWidth" stdset="0">
-    <double>4.000000000000000</double>
+    <double>5.000000000000000</double>
    </property>
   </widget>
   <widget class="PyDMDrawingEllipse" name="PyDMDrawingEllipse">
    <property name="geometry">
     <rect>
-     <x>170</x>
-     <y>230</y>
-     <width>191</width>
+     <x>200</x>
+     <y>220</y>
+     <width>241</width>
      <height>111</height>
     </rect>
    </property>
@@ -164,7 +166,17 @@
     <string/>
    </property>
    <property name="whatsThis">
-    <string/>
+    <string>
+    A widget with an ellipse drawn in it.
+    This class inherits from PyDMDrawing.
+
+    Parameters
+    ----------
+    parent : QWidget
+        The parent widget for the Label
+    init_channel : str, optional
+        The channel to be used by the widget.
+    </string>
    </property>
    <property name="brush" stdset="0">
     <brush brushstyle="SolidPattern">
@@ -179,23 +191,33 @@
     <enum>Qt::SolidLine</enum>
    </property>
    <property name="penWidth" stdset="0">
-    <double>8.000000000000000</double>
+    <double>5.000000000000000</double>
    </property>
   </widget>
   <widget class="PyDMDrawingCircle" name="PyDMDrawingCircle">
    <property name="geometry">
     <rect>
-     <x>390</x>
-     <y>210</y>
-     <width>141</width>
-     <height>141</height>
+     <x>480</x>
+     <y>200</y>
+     <width>140</width>
+     <height>140</height>
     </rect>
    </property>
    <property name="toolTip">
     <string/>
    </property>
    <property name="whatsThis">
-    <string/>
+    <string>
+    A widget with a circle drawn in it.
+    This class inherits from PyDMDrawing.
+
+    Parameters
+    ----------
+    parent : QWidget
+        The parent widget for the Label
+    init_channel : str, optional
+        The channel to be used by the widget.
+    </string>
    </property>
    <property name="brush" stdset="0">
     <brush brushstyle="DiagCrossPattern">
@@ -207,49 +229,69 @@
     </brush>
    </property>
    <property name="penStyle" stdset="0">
-    <enum>Qt::DashDotDotLine</enum>
+    <enum>Qt::DashDotLine</enum>
    </property>
    <property name="penWidth" stdset="0">
-    <double>6.000000000000000</double>
+    <double>5.000000000000000</double>
    </property>
   </widget>
   <widget class="PyDMDrawingArc" name="PyDMDrawingArc">
    <property name="geometry">
     <rect>
-     <x>20</x>
-     <y>390</y>
-     <width>141</width>
-     <height>141</height>
-    </rect>
-   </property>
-   <property name="toolTip">
-    <string/>
-   </property>
-   <property name="penStyle" stdset="0">
-    <enum>Qt::DashDotDotLine</enum>
-   </property>
-  </widget>
-  <widget class="PyDMDrawingPie" name="PyDMDrawingPie">
-   <property name="geometry">
-    <rect>
-     <x>200</x>
-     <y>390</y>
-     <width>141</width>
-     <height>141</height>
+     <x>30</x>
+     <y>400</y>
+     <width>140</width>
+     <height>140</height>
     </rect>
    </property>
    <property name="toolTip">
     <string/>
    </property>
    <property name="whatsThis">
+    <string>
+    A widget with an arc drawn in it.
+    This class inherits from PyDMDrawing.
+
+    Parameters
+    ----------
+    parent : QWidget
+        The parent widget for the Label
+    init_channel : str, optional
+        The channel to be used by the widget.
+    </string>
+   </property>
+  </widget>
+  <widget class="PyDMDrawingPie" name="PyDMDrawingPie">
+   <property name="geometry">
+    <rect>
+     <x>270</x>
+     <y>400</y>
+     <width>140</width>
+     <height>140</height>
+    </rect>
+   </property>
+   <property name="toolTip">
     <string/>
+   </property>
+   <property name="whatsThis">
+    <string>
+    A widget with a pie drawn in it.
+    This class inherits from PyDMDrawing.
+
+    Parameters
+    ----------
+    parent : QWidget
+        The parent widget for the Label
+    init_channel : str, optional
+        The channel to be used by the widget.
+    </string>
    </property>
    <property name="brush" stdset="0">
     <brush brushstyle="SolidPattern">
      <color alpha="255">
       <red>255</red>
       <green>255</green>
-      <blue>102</blue>
+      <blue>0</blue>
      </color>
     </brush>
    </property>
@@ -261,181 +303,156 @@
     </color>
    </property>
    <property name="penWidth" stdset="0">
-    <double>4.000000000000000</double>
+    <double>5.000000000000000</double>
    </property>
   </widget>
   <widget class="PyDMDrawingChord" name="PyDMDrawingChord">
    <property name="geometry">
     <rect>
-     <x>390</x>
-     <y>390</y>
-     <width>141</width>
-     <height>141</height>
+     <x>450</x>
+     <y>400</y>
+     <width>140</width>
+     <height>140</height>
     </rect>
    </property>
    <property name="toolTip">
     <string/>
    </property>
    <property name="whatsThis">
-    <string/>
+    <string>
+    A widget with a chord drawn in it.
+    This class inherits from PyDMDrawing.
+
+    Parameters
+    ----------
+    parent : QWidget
+        The parent widget for the Label
+    init_channel : str, optional
+        The channel to be used by the widget.
+    </string>
+   </property>
+  </widget>
+  <widget class="QLabel" name="label">
+   <property name="geometry">
+    <rect>
+     <x>20</x>
+     <y>10</y>
+     <width>141</width>
+     <height>16</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>PyDMDrawingImage</string>
+   </property>
+  </widget>
+  <widget class="QLabel" name="label_2">
+   <property name="geometry">
+    <rect>
+     <x>250</x>
+     <y>10</y>
+     <width>141</width>
+     <height>16</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>PyDMDrawingLine</string>
    </property>
   </widget>
   <widget class="QLabel" name="label_3">
    <property name="geometry">
     <rect>
-     <x>370</x>
+     <x>480</x>
      <y>10</y>
-     <width>181</width>
-     <height>20</height>
+     <width>151</width>
+     <height>16</height>
     </rect>
    </property>
    <property name="text">
     <string>PyDMDrawingRectangle</string>
    </property>
-   <property name="alignment">
-    <set>Qt::AlignCenter</set>
-   </property>
   </widget>
   <widget class="QLabel" name="label_4">
    <property name="geometry">
     <rect>
      <x>20</x>
-     <y>190</y>
-     <width>141</width>
-     <height>20</height>
+     <y>180</y>
+     <width>151</width>
+     <height>16</height>
     </rect>
    </property>
    <property name="text">
     <string>PyDMDrawingTriangle</string>
    </property>
-   <property name="alignment">
-    <set>Qt::AlignCenter</set>
-   </property>
   </widget>
   <widget class="QLabel" name="label_5">
    <property name="geometry">
     <rect>
-     <x>190</x>
-     <y>190</y>
-     <width>141</width>
-     <height>20</height>
+     <x>250</x>
+     <y>180</y>
+     <width>151</width>
+     <height>16</height>
     </rect>
    </property>
    <property name="text">
     <string>PyDMDrawingEllipse</string>
    </property>
-   <property name="alignment">
-    <set>Qt::AlignCenter</set>
-   </property>
   </widget>
   <widget class="QLabel" name="label_6">
    <property name="geometry">
     <rect>
-     <x>390</x>
-  <widget class="QLabel" name="label_4">
-   <property name="geometry">
-    <rect>
-     <x>20</x>
-    <string>PyDMDrawingCircle</string>
+     <x>490</x>
+     <y>180</y>
+     <width>151</width>
+     <height>16</height>
+    </rect>
    </property>
-   <property name="alignment">
-    <set>Qt::AlignCenter</set>
+   <property name="text">
+    <string>PyDMDrawingCircle</string>
    </property>
   </widget>
   <widget class="QLabel" name="label_7">
    <property name="geometry">
     <rect>
-     <x>20</x>
-     <y>360</y>
-     <width>141</width>
-     <height>20</height>
+     <x>30</x>
+     <y>370</y>
+     <width>151</width>
+     <height>16</height>
     </rect>
    </property>
    <property name="text">
     <string>PyDMDrawingArc</string>
    </property>
-   <property name="alignment">
-    <set>Qt::AlignCenter</set>
-   </property>
   </widget>
   <widget class="QLabel" name="label_8">
    <property name="geometry">
     <rect>
-     <x>210</x>
-     <y>360</y>
-     <width>141</width>
-     <height>20</height>
+     <x>300</x>
+     <y>370</y>
+     <width>151</width>
+     <height>16</height>
     </rect>
    </property>
    <property name="text">
     <string>PyDMDrawingPie</string>
    </property>
-   <property name="alignment">
-    <set>Qt::AlignCenter</set>
-   </property>
   </widget>
   <widget class="QLabel" name="label_9">
    <property name="geometry">
     <rect>
-     <x>400</x>
-     <y>360</y>
-     <width>141</width>
-     <height>20</height>
+     <x>500</x>
+     <y>370</y>
+     <width>151</width>
+     <height>16</height>
     </rect>
    </property>
    <property name="text">
     <string>PyDMDrawingChord</string>
-   </property>
-   <property name="alignment">
-    <set>Qt::AlignCenter</set>
-   </property>
-  </widget>
-  <widget class="QLabel" name="label_8">
-   <property name="geometry">
-    <rect>
-     <x>210</x>
-     <y>360</y>
-     <width>141</width>
-     <height>20</height>
-    </rect>
-   </property>
-   <property name="text">
-    <string>PyDMDrawingPie</string>
-   </property>
-   <property name="alignment">
-    <set>Qt::AlignCenter</set>
-   </property>
-  </widget>
-  <widget class="QLabel" name="label_9">
-   <property name="geometry">
-    <rect>
-     <x>400</x>
-     <y>360</y>
-     <width>141</width>
-     <height>20</height>
-    </rect>
-   </property>
-   <property name="text">
-    <string>PyDMDrawingChord</string>
-   </property>
-   <property name="alignment">
-    <set>Qt::AlignCenter</set>
    </property>
   </widget>
  </widget>
  <customwidgets>
   <customwidget>
-   <class>PyDMDrawingRectangle</class>
-   <extends>QWidget</extends>
-   <header>pydm.widgets.drawing</header>
-  </customwidget>
-  <customwidget>
-   <class>PyDMDrawingChord</class>
-   <extends>PyDMDrawingArc</extends>
-   <header>pydm.widgets.drawing</header>
-  </customwidget>
-  <customwidget>
-   <class>PyDMDrawingCircle</class>
+   <class>PyDMDrawingImage</class>
    <extends>QWidget</extends>
    <header>pydm.widgets.drawing</header>
   </customwidget>
@@ -445,12 +462,22 @@
    <header>pydm.widgets.drawing</header>
   </customwidget>
   <customwidget>
-   <class>PyDMDrawingPie</class>
-   <extends>PyDMDrawingArc</extends>
+   <class>PyDMDrawingRectangle</class>
+   <extends>QWidget</extends>
+   <header>pydm.widgets.drawing</header>
+  </customwidget>
+  <customwidget>
+   <class>PyDMDrawingTriangle</class>
+   <extends>QWidget</extends>
    <header>pydm.widgets.drawing</header>
   </customwidget>
   <customwidget>
    <class>PyDMDrawingEllipse</class>
+   <extends>QWidget</extends>
+   <header>pydm.widgets.drawing</header>
+  </customwidget>
+  <customwidget>
+   <class>PyDMDrawingCircle</class>
    <extends>QWidget</extends>
    <header>pydm.widgets.drawing</header>
   </customwidget>
@@ -460,17 +487,16 @@
    <header>pydm.widgets.drawing</header>
   </customwidget>
   <customwidget>
-   <class>PyDMDrawingImage</class>
-   <extends>QWidget</extends>
+   <class>PyDMDrawingPie</class>
+   <extends>PyDMDrawingArc</extends>
    <header>pydm.widgets.drawing</header>
   </customwidget>
   <customwidget>
-   <class>PyDMDrawingTriangle</class>
-   <extends>QWidget</extends>
+   <class>PyDMDrawingChord</class>
+   <extends>PyDMDrawingArc</extends>
    <header>pydm.widgets.drawing</header>
   </customwidget>
  </customwidgets>
  <resources/>
  <connections/>
 </ui>
-

--- a/pydm/utilities/__init__.py
+++ b/pydm/utilities/__init__.py
@@ -7,6 +7,15 @@ from .iconfont import IconFont
 import os
 import sys
 
+def is_pydm_app():
+    from ..application import PyDMApplication
+    from ..PyQt.QtGui import QApplication
+    app = QApplication.instance()
+    if isinstance(app, PyDMApplication):
+        return True
+    else:
+        return False
+
 try:  # Forced testing
     from shutil import which
 except ImportError:  # Forced testing

--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -3,6 +3,7 @@ from ..PyQt.QtGui import QApplication, QColor, QCursor
 from ..PyQt.QtCore import Qt, QEvent, pyqtSignal, pyqtSlot, pyqtProperty
 from .channel import PyDMChannel
 from ..application import PyDMApplication
+from ..utilities import is_pydm_app
 
 def compose_stylesheet(style, base_class=None, obj=None):
     """
@@ -141,8 +142,7 @@ class PyDMWidget(PyDMPrimitiveWidget):
         self.channeltype = None
         self.check_enable_state()
         # If this label is inside a PyDMApplication (not Designer) start it in the disconnected state.
-        app = QApplication.instance()
-        if isinstance(app, PyDMApplication):
+        if is_pydm_app():
             self.alarmSeverityChanged(self.ALARM_DISCONNECTED)
 
     def init_for_designer(self):
@@ -411,7 +411,8 @@ class PyDMWidget(PyDMPrimitiveWidget):
         """
         self._alarm_sensitive_content = checked
         self._alarm_flags = (self.ALARM_CONTENT * self._alarm_sensitive_content) | (self.ALARM_BORDER * self._alarm_sensitive_border)
-        self.alarm_severity_changed(self._alarm_state)
+        if is_pydm_app():
+            self.alarm_severity_changed(self._alarm_state)
 
     @pyqtProperty(bool)
     def alarmSensitiveBorder(self):
@@ -440,7 +441,8 @@ class PyDMWidget(PyDMPrimitiveWidget):
         """
         self._alarm_sensitive_border = checked
         self._alarm_flags = (self.ALARM_CONTENT * self._alarm_sensitive_content) | (self.ALARM_BORDER * self._alarm_sensitive_border)
-        self.alarm_severity_changed(self._alarm_state)
+        if is_pydm_app():
+            self.alarm_severity_changed(self._alarm_state)
 
     @pyqtProperty(bool)
     def precisionFromPV(self):

--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -123,8 +123,8 @@ class PyDMWidget(PyDMPrimitiveWidget):
         self._alarm_sensitive_content = False
         self._alarm_sensitive_border = True
         self._alarm_flags = (self.ALARM_CONTENT * self._alarm_sensitive_content) | (self.ALARM_BORDER * self._alarm_sensitive_border)
-        self._alarm_state = 0
-        self._style = dict()
+        self._alarm_state = self.ALARM_DISCONNECTED
+        self._style = self.alarm_style_sheet_map[self._alarm_flags][self._alarm_state]
         self._connected = False
 
         self._precision_from_pv = True
@@ -198,12 +198,11 @@ class PyDMWidget(PyDMPrimitiveWidget):
             and 3 = INVALID
         """
         # 0 = NO_ALARM, 1 = MINOR, 2 = MAJOR, 3 = INVALID
-        if self._channels is not None:
-            self._alarm_state = new_alarm_severity
-            self._style = dict(self.alarm_style_sheet_map[self._alarm_flags][new_alarm_severity])
-            style = compose_stylesheet(style=self._style, obj=self)
-            self.setStyleSheet(style)
-            self.update()
+        self._alarm_state = new_alarm_severity
+        self._style = dict(self.alarm_style_sheet_map[self._alarm_flags][new_alarm_severity])
+        style = compose_stylesheet(style=self._style, obj=self)
+        self.setStyleSheet(style)
+        self.update()
 
     def enum_strings_changed(self, new_enum_strings):
         """
@@ -412,6 +411,7 @@ class PyDMWidget(PyDMPrimitiveWidget):
         """
         self._alarm_sensitive_content = checked
         self._alarm_flags = (self.ALARM_CONTENT * self._alarm_sensitive_content) | (self.ALARM_BORDER * self._alarm_sensitive_border)
+        self.alarm_severity_changed(self._alarm_state)
 
     @pyqtProperty(bool)
     def alarmSensitiveBorder(self):
@@ -440,6 +440,7 @@ class PyDMWidget(PyDMPrimitiveWidget):
         """
         self._alarm_sensitive_border = checked
         self._alarm_flags = (self.ALARM_CONTENT * self._alarm_sensitive_content) | (self.ALARM_BORDER * self._alarm_sensitive_border)
+        self.alarm_severity_changed(self._alarm_state)
 
     @pyqtProperty(bool)
     def precisionFromPV(self):

--- a/pydm/widgets/drawing.py
+++ b/pydm/widgets/drawing.py
@@ -83,12 +83,11 @@ class PyDMDrawing(QWidget, PyDMWidget):
         self.style().drawPrimitive(QStyle.PE_Widget, opt, self._painter, self)
         self._painter.setRenderHint(QPainter.Antialiasing)
 
-        if self._alarm_sensitive_content and self._alarm_state != 0:
+        color = self._default_color
+        if self._alarm_sensitive_content and self._alarm_state != 0 and self.channels() is not None:
             alarm_color = self._style.get("color", None)
             if alarm_color is not None:
                 color = QColor(alarm_color)
-        else:
-            color = self._default_color
 
         self._brush.setColor(color)
 
@@ -97,6 +96,25 @@ class PyDMDrawing(QWidget, PyDMWidget):
 
         self.draw_item()
         self._painter.end()
+
+    def alarm_severity_changed(self, new_alarm_severity):
+        """
+        Callback invoked when the Channel alarm severity is changed.
+        This callback is not processed if the widget has no channel
+        associated with it.
+        This callback handles the composition of the stylesheet to be
+        applied and the call
+        to update to redraw the widget with the needed changes for the
+        new state.
+
+        Parameters
+        ----------
+        new_alarm_severity : int
+            The new severity where 0 = NO_ALARM, 1 = MINOR, 2 = MAJOR
+            and 3 = INVALID
+        """
+        PyDMWidget.alarm_severity_changed(self, new_alarm_severity)
+        self.update()
 
     def draw_item(self):
         """

--- a/pydm/widgets/drawing.py
+++ b/pydm/widgets/drawing.py
@@ -54,6 +54,7 @@ class PyDMDrawing(QWidget, PyDMWidget):
     def __init__(self, parent=None, init_channel=None):
         QWidget.__init__(self, parent)
         PyDMWidget.__init__(self, init_channel=init_channel)
+        self.alarmSensitiveBorder = False
         self._rotation = 0.0
         self._brush = QBrush(Qt.SolidPattern)
         self._default_color = QColor()


### PR DESCRIPTION
Drawing now calls update on Alarm State Update.

While testing some alarm conditions with Joao we were able to notice that PyDMDrawings were not respecting the alarm condition. Now it works properly and respect also the disconnected state.
Alarms are only valid for drawings if they have a channel set.

Attn. @joaopmrod