### PR TITLE
Create subtype attribute in PyDMWidget class

### DIFF
--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -181,7 +181,7 @@ class PyDMWidget(PyDMPrimitiveWidget):
         self.value = new_val
         self.channeltype = type(self.value)
         if self.channeltype == np.ndarray:
-            self.subtype = type(self.value[0])
+            self.subtype = self.value.dtype.type
         self.update_format_string()
 
     def alarm_severity_changed(self, new_alarm_severity):

--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -140,6 +140,7 @@ class PyDMWidget(PyDMPrimitiveWidget):
 
         self.value = None
         self.channeltype = None
+        self.subtype = None
         self.check_enable_state()
         # If this label is inside a PyDMApplication (not Designer) start it in the disconnected state.
         if is_pydm_app():
@@ -179,6 +180,8 @@ class PyDMWidget(PyDMPrimitiveWidget):
         """
         self.value = new_val
         self.channeltype = type(self.value)
+        if self.channeltype == np.ndarray:
+            self.subtype = type(self.value[0])
         self.update_format_string()
 
     def alarm_severity_changed(self, new_alarm_severity):

--- a/pydm/widgets/waveformtable.py
+++ b/pydm/widgets/waveformtable.py
@@ -12,7 +12,7 @@ class PyDMWaveformTable(QTableWidget, PyDMWritableWidget):
         self.columnHeader = "Value"
         self.waveform = None
         self.setHorizontalHeaderLabels([self.columnHeader])
-        
+
     def value_changed(self, new_waveform):
         PyDMWritableWidget.value_changed(self, new_waveform)
         self.waveform = new_waveform
@@ -29,10 +29,10 @@ class PyDMWaveformTable(QTableWidget, PyDMWritableWidget):
             self.setVerticalHeaderItem(i,index_cell)
             self.setItem(i,0,value_cell)
         self.cellChanged.connect(self.send_data_for_cell)
-    
+
     @pyqtSlot(int, int)
     def send_data_for_cell(self, row, column):
         item = self.item(row, column)
-        new_val = float(item.text())
+        new_val = self.subtype(item.text())
         self.waveform[row] = new_val
         self.send_value_signal[np.ndarray].emit(self.waveform)


### PR DESCRIPTION
This pull request creates an additional attribute to the PyDMWidget class named subtype which holds the type of the elements of the numpy.ndarray of a waveform channel. 
This attribute is used in the widget PyDMWaveformTable to convert the cell's text into the correct python type.