### PR TITLE
Waveform plot redraw options

### DIFF
--- a/pydm/widgets/waveformplot.py
+++ b/pydm/widgets/waveformplot.py
@@ -257,7 +257,7 @@ class WaveformCurveItem(PlotDataItem):
         """
         self.y_waveform = new_waveform
         self.needs_new_y = False
-        if self.x_channel is None or not (self.needs_new_x or self.needs_new_y):
+        if self.x_channel is None or self.x_waveform is not None:
             self.data_changed.emit()
     
     def redrawCurve(self):

--- a/pydm/widgets/waveformplot_table_model.py
+++ b/pydm/widgets/waveformplot_table_model.py
@@ -13,7 +13,7 @@ class PyDMWaveformPlotCurvesModel(QAbstractTableModel):
     def __init__(self, plot, parent=None):
         super(PyDMWaveformPlotCurvesModel, self).__init__(parent=parent)
         self._plot = plot
-        self._column_names = ("Y Channel", "X Channel", "Label", "Color", "Connect Points", "Data Point Symbol")
+        self._column_names = ("Y Channel", "X Channel", "Label", "Color", "Connect Points", "Data Point Symbol", "Redraw Mode")
 
     @property
     def plot(self):
@@ -75,8 +75,8 @@ class PyDMWaveformPlotCurvesModel(QAbstractTableModel):
                 if curve.symbol is None:
                     return "None"
                 return self.name_for_symbol[curve.symbol]
-        #elif role == Qt.DecorationRole and column_name == "Color":
-        #    return curve.color
+            elif column_name == "Redraw Mode":
+                return curve.redraw_mode
         elif role == Qt.BackgroundRole and column_name == "Color":
             return QBrush(curve.color)
         elif role == Qt.CheckStateRole and column_name == "Connect Points":
@@ -109,6 +109,8 @@ class PyDMWaveformPlotCurvesModel(QAbstractTableModel):
                 curve.color = value
             elif column_name == "Data Point Symbol":
                 curve.symbol = str(value)
+            elif column_name == "Redraw Mode":
+                curve.redraw_mode = int(value)
             else:
                 return False
         elif role == Qt.CheckStateRole and column_name == "Connect Points":


### PR DESCRIPTION
A recent change made the waveform plot only redraw when both X and Y channels had received new values.  This is not always desired: sometimes, you might want to plot a Y channel against a static X waveform, for example.  This PR gives users the choice: They can choose to redraw whenever the X waveform updates (regardless of Y update status), redraw whenever Y updates (regardless of X), redraw when either updates (this is the original behavior, and the default), or whenever both X and Y update (useful if X and Y need to stay 'in sync', like when you are plotting two time-varying signals versus one another, and need to know that each X/Y pair happened at the same time.)  The property has been added to the curve editor too.