### PR TITLE
Pr enhancement of PyDMWaveformTable

### DIFF
--- a/examples/oscilloscope/scope.ui
+++ b/examples/oscilloscope/scope.ui
@@ -22,9 +22,6 @@
      <property name="whatsThis">
       <string/>
      </property>
-     <property name="autoRangeX">
-      <bool>true</bool>
-     </property>
      <property name="showXGrid">
       <bool>true</bool>
      </property>
@@ -36,8 +33,11 @@
      </property>
      <property name="curves">
       <stringlist>
-       <string>{&quot;y_channel&quot;: &quot;ca://MTEST:Waveform&quot;, &quot;x_channel&quot;: &quot;ca://MTEST:TimeBase&quot;, &quot;name&quot;: &quot;Scope Trace&quot;, &quot;color&quot;: &quot;white&quot;}</string>
+       <string>{&quot;y_channel&quot;: &quot;ca://MTEST:Waveform&quot;, &quot;x_channel&quot;: &quot;ca://MTEST:TimeBase&quot;, &quot;name&quot;: &quot;Scope Trace&quot;, &quot;color&quot;: &quot;white&quot;, &quot;lineStyle&quot;: 1, &quot;lineWidth&quot;: 1, &quot;symbol&quot;: null, &quot;symbolSize&quot;: 10, &quot;redraw_mode&quot;: 2}</string>
       </stringlist>
+     </property>
+     <property name="autoRangeX">
+      <bool>true</bool>
      </property>
      <property name="yChannel" stdset="0">
       <string>ca://MTEST:Waveform</string>
@@ -72,7 +72,7 @@
           <property name="whatsThis">
            <string/>
           </property>
-          <property name="channel">
+          <property name="channel" stdset="0">
            <string>ca://MTEST:Run</string>
           </property>
          </widget>
@@ -239,19 +239,19 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>PyDMLineEdit</class>
-   <extends>QLineEdit</extends>
-   <header>pydm.widgets.line_edit</header>
-  </customwidget>
-  <customwidget>
    <class>PyDMWaveformPlot</class>
    <extends>QGraphicsView</extends>
    <header>pydm.widgets.waveformplot</header>
   </customwidget>
   <customwidget>
    <class>PyDMEnumComboBox</class>
-   <extends>QWidget</extends>
+   <extends>QFrame</extends>
    <header>pydm.widgets.enum_combo_box</header>
+  </customwidget>
+  <customwidget>
+   <class>PyDMLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header>pydm.widgets.line_edit</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/examples/scale_indicator/scale.ui
+++ b/examples/scale_indicator/scale.ui
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>338</width>
+    <height>137</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0" colspan="3">
+    <widget class="PyDMScaleIndicator" name="PyDMScaleIndicator">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="whatsThis">
+      <string/>
+     </property>
+     <property name="styleSheet">
+      <string notr="true"/>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::NoFrame</enum>
+     </property>
+     <property name="midLineWidth">
+      <number>0</number>
+     </property>
+     <property name="alarmSensitiveContent" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="alarmSensitiveBorder" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="precision" stdset="0">
+      <number>0</number>
+     </property>
+     <property name="showUnits" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="channel" stdset="0">
+         <string>ca://MTEST:Float</string>
+     </property>
+     <property name="showValue" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="showLimits" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="numDivisions" stdset="0">
+      <number>10</number>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1" colspan="2">
+    <widget class="PyDMLineEdit" name="PyDMLineEdit">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="whatsThis">
+      <string>
+    A QLineEdit (writable text field) with support for Channels and more
+    from PyDM.
+    This widget offers an unit conversion menu when users Right Click
+    into it.
+
+    Parameters
+    ----------
+    parent : QWidget
+        The parent widget for the Label
+    init_channel : str, optional
+        The channel to be used by the widget.
+    </string>
+     </property>
+     <property name="alarmSensitiveContent" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="alarmSensitiveBorder" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="channel" stdset="0">
+         <string>ca://MTEST:Float</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="PyDMLabel" name="PyDMLabel">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="whatsThis">
+      <string>
+    A QLabel with support for Channels and more from PyDM
+
+    Parameters
+    ----------
+    parent : QWidget
+        The parent widget for the Label
+    init_channel : str, optional
+        The channel to be used by the widget.
+    </string>
+     </property>
+     <property name="text">
+         <string>ca://MTEST:Float</string>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>PyDMLabel</class>
+   <extends>QLabel</extends>
+   <header>pydm.widgets.label</header>
+  </customwidget>
+  <customwidget>
+   <class>PyDMLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header>pydm.widgets.line_edit</header>
+  </customwidget>
+  <customwidget>
+   <class>PyDMScaleIndicator</class>
+   <extends>QFrame</extends>
+   <header>pydm.widgets.scale</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/pydm/data_plugins/archiver_plugin.py
+++ b/pydm/data_plugins/archiver_plugin.py
@@ -1,12 +1,14 @@
 from .plugin import PyDMPlugin, PyDMConnection
 import requests
 import numpy as np
+import os
 
 class Connection(PyDMConnection):
     def __init__(self, channel, address, parent=None):
         super(Connection, self).__init__(channel, address, parent)
         self.add_listener(channel)
-        url_string = "http://lcls-archapp.slac.stanford.edu/retrieval/data/getData.json?{params}".format(params=address)
+        base_url = os.getenv("PYDM_ARCHIVER_URL", "http://lcls-archapp.slac.stanford.edu")
+        url_string = "{base}/retrieval/data/getData.json?{params}".format(base=base_url, params=address)
         r = requests.get(url_string) #blocking.  BAD!
         if r.status_code == 200 and r.headers['content-type'] == 'application/json':
             data_dict = r.json()

--- a/pydm/utilities/units.py
+++ b/pydm/utilities/units.py
@@ -1,30 +1,58 @@
 from scipy import constants
 
-
-UNITS = {'length':   {'m'   : 1,
-                      'cm'  : constants.centi,
-                      'mm'  : constants.milli,
-                      'um'  : constants.micro,
-                      'nm'  : constants.nano,
-                      'pm'  : constants.pico,
-                      'in'  : constants.inch,
-                      'ft'  : constants.foot,
-                      'yds' : constants.yard,
+UNITS = {'length':   {'m': 1,
+                      'cm': constants.centi,
+                      'mm': constants.milli,
+                      'um': constants.micro,
+                      'nm': constants.nano,
+                      'pm': constants.pico,
+                      'in': constants.inch,
+                      'ft': constants.foot,
+                      'yds': constants.yard,
+                      },
+         'time':    {'s': 1,
+                     'ms': constants.milli,
+                     'us': constants.micro,
+                     'ns': constants.nano,
+                     'ps': constants.pico,
+                     'min': constants.minute,
+                     'hr': constants.hour,
+                     'weeks': constants.week,
+                     'days': constants.day,
                      },
-          'time':    {'s'     : 1,
-                      'ms'    : constants.milli,
-                      'us'    : constants.micro,
-                      'ns'    : constants.nano,
-                      'min'   : constants.minute,
-                      'hr'    : constants.hour,
-                      'weeks' : constants.week,
-                      'days'  : constants.day,
+         'frequency': {'Hz': 1,
+                       'kHz': constants.kilo,
+                       'MHz': constants.mega,
+                       'GHz': constants.giga,
+                       'THz': constants.tera,
+                       'mHz': constants.milli,
+                       },
+         'angle':   {'rad': 1,
+                     'mrad': constants.milli,
+                     'urad': constants.micro,
+                     'nrad': constants.nano,
+                     'degree': constants.degree,
+                     'turn': 2*constants.pi,
+                     },
+         'voltage': {'V': 1,
+                     'MV': constants.mega,
+                     'kV': constants.kilo,
+                     'mV': constants.milli,
+                     'uV': constants.micro,
+                     },
+         'current': {'A': 1,
+                     'MA': constants.mega,
+                     'kA': constants.kilo,
+                     'mA': constants.milli,
+                     'uA': constants.micro,
+                     'nA': constants.nano,
                      }
-        }
+         }
+
 
 def find_unittype(unit):
     """
-    Find the type of a unit string
+    Find the type of a unit string.
     """
     for tp in UNITS.keys():
         if unit in UNITS[tp].keys():
@@ -34,7 +62,7 @@ def find_unittype(unit):
 
 def find_unit(unit):
     """
-    Find the conversion of a unit string
+    Find the conversion of a unit string.
     """
     tp = find_unittype(unit)
     if tp:
@@ -43,30 +71,31 @@ def find_unit(unit):
         return None
 
 
-def convert(unit,desired):
+def convert(unit, desired):
     """
-    Find the conversion rate of two different unit strings
+    Find the conversion rate of two different unit strings.
     """
     current = find_unit(unit)
-    final   = find_unit(desired)
+    final = find_unit(desired)
 
     if find_unittype(unit) != find_unittype(desired):
         return None
 
     if current and final:
         return current/final
-    
+
     else:
         return None
 
+
 def find_unit_options(unit):
     """
-    Find the options for a given unit
+    Find the options for a given unit.
     """
     tp = find_unittype(unit)
     if tp:
-        units = [choice for choice,_ in 
-                 sorted(UNITS[tp].items(),key=lambda x: 1/x[1])]
+        units = [choice for choice, _ in
+                 sorted(UNITS[tp].items(), key=lambda x: 1/x[1])]
         return units
     else:
         return None

--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -100,14 +100,14 @@ class PyDMWidget(PyDMPrimitiveWidget):
             ALARM_DISCONNECTED: {"color": "white"}
         },
         ALARM_BORDER: {
-            ALARM_NONE: {"border": "0px"},
+            ALARM_NONE: {"border": "2px transparent"},
             ALARM_MINOR: {"border": "2px solid yellow"},
             ALARM_MAJOR: {"border": "2px solid red"},
             ALARM_INVALID: {"border": "2px solid purple"},
             ALARM_DISCONNECTED: {"border": "2px solid white"}
         },
         ALARM_CONTENT | ALARM_BORDER: {
-            ALARM_NONE: {"color": "black", "border": "0px"},
+            ALARM_NONE: {"color": "black", "border": "2px transparent"},
             ALARM_MINOR: {"color": "yellow", "border": "2px solid yellow"},
             ALARM_MAJOR: {"color": "red", "border": "2px solid red"},
             ALARM_INVALID: {"color": "purple", "border": "2px solid purple"},

--- a/pydm/widgets/qtplugin_base.py
+++ b/pydm/widgets/qtplugin_base.py
@@ -17,6 +17,15 @@ affect any of your widgets, but it will be annoying.
 """
 from ..PyQt import QtGui, QtDesigner
 
+# TODO: Change to Enum once we drop support
+#       for the almost dead and agonizing Python 2.7
+#       <pitchforks> Death to Python 2.7! </ pitchforks>
+class WidgetCategory(object):
+    DISPLAY = "PyDM Display Widgets"
+    INPUT = "PyDM Input Widgets"
+    PLOT = "PyDM Plot Widgets"
+    DRAWING = "PyDM Drawing Widgets"
+
 def qtplugin_factory(cls, is_container=False, group='PyDM Widgets'):
     """
     Helper function to create a generic PyDMDesignerPlugin class.

--- a/pydm/widgets/qtplugins.py
+++ b/pydm/widgets/qtplugins.py
@@ -20,6 +20,7 @@ from .slider import PyDMSlider
 from .spinbox import PyDMSpinbox
 from .symbol import PyDMSymbol
 from .waveformtable import PyDMWaveformTable
+from .scale import PyDMScaleIndicator
 
 # Time Plot plugin
 from .timeplot_qtplugin import PyDMTimePlotPlugin
@@ -84,3 +85,6 @@ PyDMSymbolPlugin = qtplugin_factory(PyDMSymbol)
 
 # Waveform Table plugin
 PyDMWaveformTablePlugin = qtplugin_factory(PyDMWaveformTable)
+
+# Scale Indicator plugin
+PyDMScaleIndicatorPlugin = qtplugin_factory(PyDMScaleIndicator)

--- a/pydm/widgets/qtplugins.py
+++ b/pydm/widgets/qtplugins.py
@@ -1,4 +1,4 @@
-from .qtplugin_base import qtplugin_factory
+from .qtplugin_base import qtplugin_factory, WidgetCategory
 
 from .byte import PyDMByteIndicator
 
@@ -24,67 +24,68 @@ from .scale import PyDMScaleIndicator
 
 # Time Plot plugin
 from .timeplot_qtplugin import PyDMTimePlotPlugin
+
 # Waveform Plot plugin
 from .waveformplot_qtplugin import PyDMWaveformPlotPlugin
 
 # Byte plugin
-PyDMByteIndicatorPlugin = qtplugin_factory(PyDMByteIndicator)
+PyDMByteIndicatorPlugin = qtplugin_factory(PyDMByteIndicator, group=WidgetCategory.DISPLAY)
 
 # Checkbox plugin
-PyDMCheckboxPlugin = qtplugin_factory(PyDMCheckbox)
+PyDMCheckboxPlugin = qtplugin_factory(PyDMCheckbox, group=WidgetCategory.INPUT)
 
 # Drawing plugins
-PyDMDrawingImagePlugin = qtplugin_factory(PyDMDrawingImage)
-PyDMDrawingLinePlugin = qtplugin_factory(PyDMDrawingLine)
-PyDMDrawingRectanglePlugin = qtplugin_factory(PyDMDrawingRectangle)
-PyDMDrawingTrianglePlugin = qtplugin_factory(PyDMDrawingTriangle)
-PyDMDrawingEllipsePlugin = qtplugin_factory(PyDMDrawingEllipse)
-PyDMDrawingCirclePlugin = qtplugin_factory(PyDMDrawingCircle)
-PyDMDrawingArcPlugin = qtplugin_factory(PyDMDrawingArc)
-PyDMDrawingPiePlugin = qtplugin_factory(PyDMDrawingPie)
-PyDMDrawingChordPlugin = qtplugin_factory(PyDMDrawingChord)
+PyDMDrawingArcPlugin = qtplugin_factory(PyDMDrawingArc, group=WidgetCategory.DRAWING)
+PyDMDrawingChordPlugin = qtplugin_factory(PyDMDrawingChord, group=WidgetCategory.DRAWING)
+PyDMDrawingCirclePlugin = qtplugin_factory(PyDMDrawingCircle, group=WidgetCategory.DRAWING)
+PyDMDrawingEllipsePlugin = qtplugin_factory(PyDMDrawingEllipse, group=WidgetCategory.DRAWING)
+PyDMDrawingImagePlugin = qtplugin_factory(PyDMDrawingImage, group=WidgetCategory.DRAWING)
+PyDMDrawingLinePlugin = qtplugin_factory(PyDMDrawingLine, group=WidgetCategory.DRAWING)
+PyDMDrawingPiePlugin = qtplugin_factory(PyDMDrawingPie, group=WidgetCategory.DRAWING)
+PyDMDrawingRectanglePlugin = qtplugin_factory(PyDMDrawingRectangle, group=WidgetCategory.DRAWING)
+PyDMDrawingTrianglePlugin = qtplugin_factory(PyDMDrawingTriangle, group=WidgetCategory.DRAWING)
 
 # Embedded Display plugin
-PyDMEmbeddedDisplayPlugin = qtplugin_factory(PyDMEmbeddedDisplay)
+PyDMEmbeddedDisplayPlugin = qtplugin_factory(PyDMEmbeddedDisplay, group=WidgetCategory.DISPLAY)
 
 # Enum Combobox plugin
-PyDMEnumComboBoxPlugin = qtplugin_factory(PyDMEnumComboBox)
+PyDMEnumComboBoxPlugin = qtplugin_factory(PyDMEnumComboBox, group=WidgetCategory.INPUT)
 
 
 # Image plugin
-PyDMImageViewPlugin = qtplugin_factory(PyDMImageView)
+PyDMImageViewPlugin = qtplugin_factory(PyDMImageView, group=WidgetCategory.DISPLAY)
 
 # Indicator plugin
-PyDMIndicatorPlugin = qtplugin_factory(PyDMIndicator)
+PyDMIndicatorPlugin = qtplugin_factory(PyDMIndicator, group=WidgetCategory.DISPLAY)
 
 # Label plugin
-PyDMLabelPlugin = qtplugin_factory(PyDMLabel)
+PyDMLabelPlugin = qtplugin_factory(PyDMLabel, group=WidgetCategory.DISPLAY)
 
 # Line Edit plugin
-PyDMLineEditPlugin = qtplugin_factory(PyDMLineEdit)
+PyDMLineEditPlugin = qtplugin_factory(PyDMLineEdit, group=WidgetCategory.INPUT)
 
 # Push Button plugin
-PyDMPushButtonPlugin = qtplugin_factory(PyDMPushButton)
+PyDMPushButtonPlugin = qtplugin_factory(PyDMPushButton, group=WidgetCategory.INPUT)
 
 
 # Related Display Button plugin
-PyDMRelatedDisplayButtonPlugin = qtplugin_factory(PyDMRelatedDisplayButton)
+PyDMRelatedDisplayButtonPlugin = qtplugin_factory(PyDMRelatedDisplayButton, group=WidgetCategory.DISPLAY)
 
 # Shell Command plugin
-PyDMShellCommandPlugin = qtplugin_factory(PyDMShellCommand)
+PyDMShellCommandPlugin = qtplugin_factory(PyDMShellCommand, group=WidgetCategory.INPUT)
 
 # Slider plugin
-PyDMSliderPlugin = qtplugin_factory(PyDMSlider)
+PyDMSliderPlugin = qtplugin_factory(PyDMSlider, group=WidgetCategory.INPUT)
 
 
 # Spinbox plugin
-PyDMSpinboxplugin = qtplugin_factory(PyDMSpinbox)
-
-# Symbol plugin
-PyDMSymbolPlugin = qtplugin_factory(PyDMSymbol)
-
-# Waveform Table plugin
-PyDMWaveformTablePlugin = qtplugin_factory(PyDMWaveformTable)
+PyDMSpinboxplugin = qtplugin_factory(PyDMSpinbox, group=WidgetCategory.INPUT)
 
 # Scale Indicator plugin
-PyDMScaleIndicatorPlugin = qtplugin_factory(PyDMScaleIndicator)
+PyDMScaleIndicatorPlugin = qtplugin_factory(PyDMScaleIndicator, group=WidgetCategory.DISPLAY)
+
+# Symbol plugin
+PyDMSymbolPlugin = qtplugin_factory(PyDMSymbol, group=WidgetCategory.DISPLAY)
+
+# Waveform Table plugin
+PyDMWaveformTablePlugin = qtplugin_factory(PyDMWaveformTable, group=WidgetCategory.DISPLAY)

--- a/pydm/widgets/scale.py
+++ b/pydm/widgets/scale.py
@@ -1,0 +1,285 @@
+from .base import PyDMWidget, compose_stylesheet
+from ..PyQt.QtGui import QFrame, QVBoxLayout, QHBoxLayout, QPainter, QColor, QPolygon, QPen, QLabel, QSizePolicy
+from ..PyQt.QtCore import Qt, QPoint, pyqtProperty
+from .channel import PyDMChannel
+import sys
+
+
+class QScale(QFrame):
+    def __init__(self, parent=None):
+        super(QScale, self).__init__(parent)
+        self._value = 0
+        self._lower_limit = 0
+        self._upper_limit = 10
+        #self._orientation = 'horizontal'
+        self.position = 0 # unit: pixel
+
+        self._bg_color = QColor('darkgray')
+        self._bg_size_rate = 0.8    # from 0 to 1
+
+        self._pointer_color = QColor('white')
+        self._pointer_width_rate = 0.05
+
+        self._num_divisions = 10
+        self._show_ticks = True
+        self._tick_pen = QPen()
+        self._tick_color = QColor('black')
+        self._tick_width = 0
+        self._tick_size_rate = 0.1 # from 0 to 1
+        self._painter = QPainter()
+
+        self.setMinimumSize(0, 2)
+
+    def setTickPen(self):
+        self._tick_pen.setColor(self._tick_color)
+        self._tick_pen.setWidth(self._tick_width)
+
+    def drawTicks(self):
+        if not self._show_ticks:
+            return
+        self._painter.setPen(self._tick_pen)
+        division_size = self.width() / self._num_divisions
+        tick_y0 = self.height()
+        tick_yf = tick_y0 - self._tick_size_rate*self.height()
+        tick_yf = (1 - self._tick_size_rate)*self.height()
+        for i in range(self._num_divisions+1):
+            x = i*division_size
+            self._painter.drawLine(x, tick_y0, x, tick_yf) # x1, y1, x2, y2
+
+    def drawIndicator(self):
+        # Draw a pointer as indicator of current value
+        if self.position < 0 or self.position > self.width():
+            return
+        self.setPosition()
+        self._painter.setPen(Qt.transparent)
+        self._painter.setBrush(self._pointer_color)
+        pointer_width = self._pointer_width_rate * self.width()
+        pointer_height = self._bg_size_rate * self.height()
+        points = [
+                QPoint(self.position, 0),
+                QPoint(self.position + 0.5*pointer_width, 0.5*pointer_height),
+                QPoint(self.position, pointer_height),
+                QPoint(self.position - 0.5*pointer_width, 0.5*pointer_height)
+        ]
+        self._painter.drawPolygon(QPolygon(points))
+
+    def drawBackground(self):
+        self._painter.setPen(Qt.transparent)
+        self._painter.setBrush(self._bg_color)
+        bg_width = self.width()
+        bg_height = self._bg_size_rate * self.height()
+        self._painter.drawRect(0, 0, bg_width, bg_height)
+
+    def paintEvent(self, event):
+        self._painter.begin(self)
+        #self._painter.rotate(-90)
+        self._painter.setRenderHint(QPainter.Antialiasing)
+        self.drawBackground()
+        self.drawTicks()
+        self.drawIndicator()
+        self._painter.end()
+
+    def setPosition(self):
+        try:
+            proportion = (self._value - self._lower_limit) / (self._upper_limit - self._lower_limit)
+        except:
+            proportion = -1 # Invalid
+        self.position = int(proportion * self.width())
+
+    def updateIndicator(self):
+        self.setPosition()
+        self.repaint()
+
+    def setValue(self, value):
+        self._value = value
+        self.updateIndicator()
+
+    def setUpperLimit(self, new_limit):
+        self._upper_limit = new_limit
+
+    def setLowerLimit(self, new_limit):
+        self._lower_limit = new_limit
+
+    def getShowTicks(self):
+        return self._show_ticks
+
+    def setShowTicks(self, checked):
+        if self._show_ticks != bool(checked):
+            self._show_ticks = checked
+            self.repaint()
+
+    def getBackgroundColor(self):
+        return self._bg_color
+
+    def setBackgroundColor(self, color):
+        self._bg_color = color
+        self.repaint()
+
+    def getIndicatorColor(self):
+        return self._pointer_color
+
+    def setIndicatorColor(self, color):
+        self._pointer_color = color
+        self.repaint()
+
+    def getBackgroundSizeRate(self):
+        return self._bg_size_rate
+
+    def setBackgroundSizeRate(self, rate):
+        if rate >= 0 and rate <=1 and self._bg_size_rate != rate:
+            self._bg_size_rate = rate
+            self.repaint()
+
+    def getTickSizeRate(self):
+        return self._tick_size_rate
+
+    def setTickSizeRate(self, rate):
+        if rate >= 0 and rate <=1 and self._tick_size_rate != rate:
+            self._tick_size_rate = rate
+            self.repaint()
+
+    def getNumDivisions(self):
+        return self._num_divisions
+
+    def setNumDivisions(self, divisions):
+        if isinstance(divisions, int) and divisions > 0 and self._num_divisions != divisions:
+            self._num_divisions = divisions
+            self.repaint()
+    
+class PyDMScaleIndicator(QFrame, PyDMWidget):
+
+    def __init__(self, parent=None, init_channel=None):
+        QFrame.__init__(self, parent)
+        PyDMWidget.__init__(self, init_channel=init_channel)
+        self._show_value = True
+        self._show_limits = True
+
+        self.scale_indicator = QScale()
+        self.value_label = QLabel()
+        self.lower_label = QLabel()
+        self.upper_label = QLabel()
+
+        self.value_label.setText('<val>')
+        self.lower_label.setText('<min>')
+        self.upper_label.setText('<max>')
+        
+        self.value_label.setAlignment(Qt.AlignCenter)
+        self.lower_label.setAlignment(Qt.AlignLeft)
+        self.upper_label.setAlignment(Qt.AlignRight)
+
+        self.buildLayout()
+
+    def updateAll(self):
+        self.lower_label.setText(str(self.scale_indicator._lower_limit))
+        self.upper_label.setText(str(self.scale_indicator._upper_limit))
+        self.value_label.setText(self.format_string.format(self.scale_indicator._value))
+
+    def value_changed(self, new_value):
+        super(PyDMScaleIndicator, self).value_changed(new_value)
+        self.scale_indicator.setValue(new_value)
+        self.updateAll()
+
+    def upperCtrlLimitChanged(self, new_limit):
+        super(PyDMScaleIndicator, self).upperCtrlLimitChanged(new_limit)
+        self.scale_indicator.setUpperLimit(new_limit)
+        self.updateAll()
+
+    def lowerCtrlLimitChanged(self, new_limit):
+        super(PyDMScaleIndicator, self).lowerCtrlLimitChanged(new_limit)
+        self.scale_indicator.setLowerLimit(new_limit)
+        self.updateAll()
+
+    def buildLayout(self):
+        self.limits_layout = QHBoxLayout()
+        self.limits_layout.addWidget(self.lower_label)
+        self.limits_layout.addWidget(self.upper_label)
+        self.layout = QVBoxLayout()
+        self.layout.addWidget(self.value_label)
+        self.layout.addWidget(self.scale_indicator)
+        self.layout.setContentsMargins(1, 1, 1, 1)
+        self.layout.addItem(self.limits_layout)
+        self.setLayout(self.layout)
+
+    @pyqtProperty(bool)
+    def showValue(self):
+        return self._show_value
+
+    @showValue.setter
+    def showValue(self, checked):
+        if self._show_value != bool(checked):
+            self._show_value = checked
+        if checked:
+            self.value_label.show()
+        else:
+            self.value_label.hide()
+
+    @pyqtProperty(bool)
+    def showLimits(self):
+        return self._show_limits
+
+    @showLimits.setter
+    def showLimits(self, checked):
+        if self._show_limits != bool(checked):
+            self._show_limits = checked
+        if checked:
+            self.lower_label.show()
+            self.upper_label.show()
+        else:
+            self.lower_label.hide()
+            self.upper_label.hide()
+
+    def alarm_severity_changed(self, new_alarm_severity):
+        PyDMWidget.alarm_severity_changed(self, new_alarm_severity)
+        if self._channels is not None:
+            style = compose_stylesheet(style=self._style, obj=self.value_label)
+            self.value_label.setStyleSheet(style)
+            self.repaint()
+
+    @pyqtProperty(bool)
+    def showTicks(self):
+        return self.scale_indicator.getShowTicks()
+
+    @showTicks.setter
+    def showTicks(self, checked):
+        self.scale_indicator.setShowTicks(checked)
+
+    @pyqtProperty(QColor)
+    def backgroundColor(self):
+        return self.scale_indicator.getBackgroundColor()
+
+    @backgroundColor.setter
+    def backgroundColor(self, color):
+        self.scale_indicator.setBackgroundColor(color)
+
+    @pyqtProperty(QColor)
+    def indicatorColor(self):
+        return self.scale_indicator.getIndicatorColor()
+
+    @indicatorColor.setter
+    def indicatorColor(self, color):
+        self.scale_indicator.setIndicatorColor(color)
+
+    @pyqtProperty(float)
+    def backgroundSizeRate(self):
+        return self.scale_indicator.getBackgroundSizeRate()
+
+    @backgroundSizeRate.setter
+    def backgroundSizeRate(self, rate):
+        self.scale_indicator.setBackgroundSizeRate(rate)
+
+    @pyqtProperty(float)
+    def tickSizeRate(self):
+        return self.scale_indicator.getTickSizeRate()
+
+    @tickSizeRate.setter
+    def tickSizeRate(self, rate):
+        self.scale_indicator.setTickSizeRate(rate)
+
+    @pyqtProperty(int)
+    def numDivisions(self):
+        return self.scale_indicator.getNumDivisions()
+
+    @numDivisions.setter
+    def numDivisions(self, divisions):
+        self.scale_indicator.setNumDivisions(divisions)
+

--- a/pydm/widgets/timeplot.py
+++ b/pydm/widgets/timeplot.py
@@ -56,7 +56,7 @@ class TimePlotCurveItem(PlotCurveItem):
     @property
     def color(self):
         return self.opts['pen'].color()
-    
+
     @color.setter
     def color(self, new_color):
         if isinstance(new_color, str):
@@ -135,9 +135,12 @@ class PyDMTimePlot(BasePlot):
     def __init__(self, parent=None, init_y_channels=[], background='default'):
         self._bottom_axis = TimeAxisItem('bottom')
         self._left_axis = AxisItem('left')
-        super(PyDMTimePlot, self).__init__(parent=parent, background=background, axisItems={'bottom': self._bottom_axis, 'left': self._left_axis})
-        for channel in init_y_channels:
-            self.addYChannel(channel)
+        super(PyDMTimePlot, self).__init__(
+                                    parent=parent,
+                                    background=background,
+                                    axisItems={'bottom': self._bottom_axis,
+                                               'left': self._left_axis}
+                                    )
         self.plotItem.disableAutoRange(ViewBox.XAxis)
         self.getViewBox().setMouseEnabled(x=False)
         self._bufferSize = 1200
@@ -149,6 +152,8 @@ class PyDMTimePlot(BasePlot):
         self._update_interval = 100
         self.update_timer.setInterval(self._update_interval)
         self._update_mode = PyDMTimePlot.SynchronousMode
+        for channel in init_y_channels:
+            self.addYChannel(channel)
 
     def initialize_for_designer(self):
         # If we are in Qt Designer, don't update the plot continuously.
@@ -309,19 +314,19 @@ class PyDMTimePlot(BasePlot):
 
     def channels(self):
         return [curve.channel for curve in self._curves]
-        
+
     # The methods for autoRangeY, minYRange, and maxYRange are
     # all defined in BasePlot, but we don't expose them as properties there, because not all plot
-    # subclasses necessarily want them to be user-configurable in Designer.    
+    # subclasses necessarily want them to be user-configurable in Designer.
     autoRangeY = pyqtProperty(bool, BasePlot.getAutoRangeY, BasePlot.setAutoRangeY, BasePlot.resetAutoRangeY, doc="""
     Whether or not the Y-axis automatically rescales to fit the data.  If true, the
     values in minYRange and maxYRange are ignored.
     """)
-    
+
     minYRange = pyqtProperty(float, BasePlot.getMinYRange, BasePlot.setMinYRange, doc="""
     Minimum Y-axis value visible on the plot.
     """)
-    
+
     maxYRange = pyqtProperty(float, BasePlot.getMaxYRange, BasePlot.setMaxYRange, doc="""
     Maximum Y-axis value visible on the plot.
     """)

--- a/pydm/widgets/timeplot_qtplugin.py
+++ b/pydm/widgets/timeplot_qtplugin.py
@@ -1,7 +1,7 @@
 from ..PyQt.QtDesigner import QExtensionFactory, QPyDesignerTaskMenuExtension
 from ..PyQt.QtGui import QAction
 from ..PyQt.QtCore import pyqtSlot
-from .qtplugin_base import PyDMDesignerPlugin
+from .qtplugin_base import PyDMDesignerPlugin, WidgetCategory
 from .timeplot import PyDMTimePlot
 from .timeplot_curve_editor import TimePlotCurveEditorDialog
 Q_TYPEID = {'QPyDesignerContainerExtension':         'com.trolltech.Qt.Designer.Container',
@@ -11,7 +11,7 @@ Q_TYPEID = {'QPyDesignerContainerExtension':         'com.trolltech.Qt.Designer.
                         
 class PyDMTimePlotPlugin(PyDMDesignerPlugin):
     def __init__(self):
-        super(PyDMTimePlotPlugin, self).__init__(PyDMTimePlot)
+        super(PyDMTimePlotPlugin, self).__init__(PyDMTimePlot, group=WidgetCategory.PLOT)
         self.factory = None
         
     def initialize(self, core):

--- a/pydm/widgets/waveformplot.py
+++ b/pydm/widgets/waveformplot.py
@@ -33,7 +33,7 @@ class WaveformCurveItem(PlotDataItem):
         The color used to draw the curve line and the symbols.
     lineStyle: int, optional
         Style of the line connecting the data points.
-        0 means no line (scatter plot).
+        Must be a value from the Qt::PenStyle enum (see http://doc.qt.io/qt-5/qt.html#PenStyle-enum).
     lineWidth: int, optional
         Width of the line connecting the data points.
     redraw_mode: int, optional
@@ -157,9 +157,7 @@ class WaveformCurveItem(PlotDataItem):
     def lineStyle(self):
         """
         Return the style of the line connecting the data points.
-
-        see Qt line styles.
-        0 means no line.
+        Must be a value from the Qt::PenStyle enum (see http://doc.qt.io/qt-5/qt.html#PenStyle-enum).
 
         Returns
         -------
@@ -171,9 +169,7 @@ class WaveformCurveItem(PlotDataItem):
     def lineStyle(self, new_style):
         """
         Set the style of the line connecting the data points.
-
-        see Qt line styles.
-        0 means no line.
+        Must be a value from the Qt::PenStyle enum (see http://doc.qt.io/qt-5/qt.html#PenStyle-enum).
 
         Parameters
         -------

--- a/pydm/widgets/waveformplot.py
+++ b/pydm/widgets/waveformplot.py
@@ -1,6 +1,6 @@
 from ..PyQt.QtGui import QColor
-from ..PyQt.QtCore import pyqtSignal, pyqtSlot, pyqtProperty
-from pyqtgraph import PlotDataItem
+from ..PyQt.QtCore import pyqtSignal, pyqtSlot, pyqtProperty, Qt
+from pyqtgraph import PlotDataItem, mkPen
 import numpy as np
 from .baseplot import BasePlot
 from .channel import PyDMChannel
@@ -24,24 +24,48 @@ class WaveformCurveItem(PlotDataItem):
     Parameters
     ----------
     y_addr : str, optional
-        The address to waveform data for the Y axis.  Curves must have Y data to plot.
+        The address to waveform data for the Y axis.
+        Curves must have Y data to plot.
     x_addr : str, optional
-        The address to waveform data for the X axis.  If None, the curve will plot Y data vs. the Y index.
+        The address to waveform data for the X axis.
+        If None, the curve will plot Y data vs. the Y index.
     color : QColor, optional
-        The color used to draw the curve line.  If connect_points is False, this is not used.
-    connect_points: bool, optional
-        Whether or not to draw a line to connect the data points.
+        The color used to draw the curve line and the symbols.
+    lineStyle: int, optional
+        Style of the line connecting the data points.
+        0 means no line (scatter plot).
+    lineWidth: int, optional
+        Width of the line connecting the data points.
     redraw_mode: int, optional
         Must be one four values:
         WaveformCurveItem.REDRAW_ON_EITHER: (Default) The curve will be redrawn after either X or Y receives new data.
         WaveformCurveItem.REDRAW_ON_X: The curve will only be redrawn after X receives new data.
         WaveformCurveItem.REDRAW_ON_Y: The curve will only be redrawn after Y receives new data.
         WaveformCurveItem.REDRAW_ON_BOTH: The curve will only be redrawn after both X and Y receive new data.
+    **kargs: optional
+        PlotDataItem keyword arguments, such as symbol and symbolSize.
     """
     REDRAW_ON_X, REDRAW_ON_Y, REDRAW_ON_EITHER, REDRAW_ON_BOTH = range(4)
-    symbols = OrderedDict([('None', None), ('Circle', 'o'), ('Square', 's'), ('Triangle', 't'), ('Diamond', 'd'), ('Plus', '+')])
+    symbols = OrderedDict([('None', None),
+                           ('Circle', 'o'),
+                           ('Square', 's'),
+                           ('Triangle', 't'),
+                           ('Star', 'star'),
+                           ('Pentagon', 'p'),
+                           ('Hexagon', 'h'),
+                           ('X', 'x'),
+                           ('Diamond', 'd'),
+                           ('Plus', '+')])
+    lines = OrderedDict([('NoLine', Qt.NoPen),
+                         ('Solid', Qt.SolidLine),
+                         ('Dash', Qt.DashLine),
+                         ('Dot', Qt.DotLine),
+                         ('DashDot', Qt.DashDotLine),
+                         ('DashDotDot', Qt.DashDotDotLine)])
     data_changed = pyqtSignal()
-    def __init__(self, y_addr=None, x_addr=None, color=None, connect_points=True, redraw_mode=REDRAW_ON_EITHER, **kws):
+
+    def __init__(self, y_addr=None, x_addr=None, color=None, lineStyle=None,
+                 lineWidth=None, redraw_mode=REDRAW_ON_EITHER, **kws):
         y_addr = "" if y_addr is None else y_addr
         if kws.get('name') is None:
             y_name = utilities.remove_protocol(y_addr)
@@ -61,12 +85,17 @@ class WaveformCurveItem(PlotDataItem):
         self.x_waveform = None
         self.y_waveform = None
         self._color = QColor('white')
+        self._pen = mkPen(self._color)
+        if lineWidth is not None:
+            self._pen.setWidth(lineWidth)
+        if lineStyle is not None:
+            self._pen.setStyle(lineStyle)
+        kws['pen'] = self._pen
         super(WaveformCurveItem, self).__init__(**kws)
         self.setSymbolBrush(None)
-        self.connect_points = connect_points
         if color is not None:
             self.color = color
-    
+
     @property
     def color_string(self):
         """
@@ -79,7 +108,7 @@ class WaveformCurveItem(PlotDataItem):
         str
         """
         return str(utilities.colors.svg_color_from_hex(self.color.name(), hex_on_fail=True))
-    
+
     @color_string.setter
     def color_string(self, new_color_string):
         """
@@ -93,7 +122,7 @@ class WaveformCurveItem(PlotDataItem):
             The new string to use for the curve color.
         """
         self.color = QColor(str(new_color_string))
-            
+
     @property
     def color(self):
         """
@@ -104,7 +133,7 @@ class WaveformCurveItem(PlotDataItem):
         QColor
         """
         return self._color
-    
+
     @color.setter
     def color(self, new_color):
         """
@@ -113,76 +142,125 @@ class WaveformCurveItem(PlotDataItem):
         Parameters
         -------
         new_color: QColor or str
-            The new color to use for the curve.  Strings are passed to WaveformCurveItem.color_string.
+            The new color to use for the curve.
+            Strings are passed to WaveformCurveItem.color_string.
         """
         if isinstance(new_color, str):
             self.color_string = new_color
             return
         self._color = new_color
-        if self.connect_points:
-            self.setPen(self._color)
-        if self.symbol is not None:
-            self.setSymbolPen(self._color)
-    
+        self._pen.setColor(self._color)
+        self.setPen(self._pen)
+        self.setSymbolPen(self._color)
+
     @property
-    def connect_points(self):
+    def lineStyle(self):
         """
-        Whether or not the data points are connected with a line.
+        Return the style of the line connecting the data points.
+
+        see Qt line styles.
+        0 means no line.
 
         Returns
         -------
-        bool
+        int
         """
-        return self._connect_points
-    
-    @connect_points.setter
-    def connect_points(self, connect):
+        return self._pen.style()
+
+    @lineStyle.setter
+    def lineStyle(self, new_style):
         """
-        Whether or not the data points are connected with a line.
+        Set the style of the line connecting the data points.
+
+        see Qt line styles.
+        0 means no line.
 
         Parameters
         -------
-        connect: bool
+        new_style: int
         """
-        self._connect_points = connect
-        if self._connect_points:
-            self.setPen(self._color)
-        else:
-            self.setPen(None)
-    
+        if new_style in self.lines.values():
+            self._pen.setStyle(new_style)
+            self.setPen(self._pen)
+
+    @property
+    def lineWidth(self):
+        """
+        Return the width of the line connecting the data points.
+
+        Returns
+        -------
+        int
+        """
+        return self._pen.width()
+
+    @lineWidth.setter
+    def lineWidth(self, new_width):
+        """
+        Set the width of the line connecting the data points.
+
+        Parameters
+        -------
+        new_width: int
+        """
+        self._pen.setWidth(int(new_width))
+        self.setPen(self._pen)
+
     @property
     def symbol(self):
         """
         The single-character code for the symbol drawn at each datapoint.
+
         See the documentation for pyqtgraph.PlotDataItem for possible values.
-        
+
         Returns
         -------
-        str
+        str or None
         """
         return self.opts['symbol']
-    
+
     @symbol.setter
     def symbol(self, new_symbol):
         """
         The single-character code for the symbol drawn at each datapoint.
+
         See the documentation for pyqtgraph.PlotDataItem for possible values.
-        
+
         Parameters
         -------
-        new_symbol: str
+        new_symbol: str or None
         """
         if new_symbol in self.symbols.values():
             self.setSymbol(new_symbol)
             self.setSymbolPen(self._color)
-        else:
-            self.setSymbol(None)
-    
+
+    @property
+    def symbolSize(self):
+        """
+        Return the size of the symbol to represent the data.
+
+        Returns
+        -------
+        int
+        """
+        return self.opts['symbolSize']
+
+    @symbolSize.setter
+    def symbolSize(self, new_size):
+        """
+        Set the size of the symbol to represent the data.
+
+        Parameters
+        -------
+        new_size: int
+        """
+        self.setSymbolSize(int(new_size))
+
     @property
     def x_address(self):
         """
         The address of the channel used to get the x axis waveform data.
-        
+
         Returns
         -------
         str
@@ -190,12 +268,12 @@ class WaveformCurveItem(PlotDataItem):
         if self.x_channel is None:
             return None
         return self.x_channel.address
-    
+
     @x_address.setter
     def x_address(self, new_address):
         """
         The address of the channel used to get the x axis waveform data.
-        
+
         Parameters
         -------
         new_address: str
@@ -204,12 +282,12 @@ class WaveformCurveItem(PlotDataItem):
             self.x_channel = None
             return
         self.x_channel = PyDMChannel(address=new_address, connection_slot=self.xConnectionStateChanged, value_slot=self.receiveXWaveform)
-    
+
     @property
     def y_address(self):
         """
         The address of the channel used to get the y axis waveform data.
-        
+
         Returns
         -------
         str
@@ -217,12 +295,12 @@ class WaveformCurveItem(PlotDataItem):
         if self.y_channel is None:
             return None
         return self.y_channel.address
-    
+
     @y_address.setter
     def y_address(self, new_address):
         """
         The address of the channel used to get the x axis wavefor data.
-        
+
         Parameters
         -------
         new_address: str
@@ -231,18 +309,26 @@ class WaveformCurveItem(PlotDataItem):
             self.y_channel = None
             return
         self.y_channel = PyDMChannel(address=new_address, connection_slot=self.yConnectionStateChanged, value_slot=self.receiveYWaveform)
-    
+
     def to_dict(self):
         """
-        Returns an OrderedDict representation with values for all properties 
+        Returns an OrderedDict representation with values for all properties
         needed to recreate this curve.
-        
+
         Returns
         -------
         OrderedDict
         """
-        return OrderedDict([("y_channel", self.y_address), ("x_channel", self.x_address), ("name", self.name()), ("color", self.color_string), ("connect_points", self.connect_points), ("symbol", self.symbol), ("redraw_mode", self.redraw_mode)])
-    
+        return OrderedDict([("y_channel", self.y_address),
+                            ("x_channel", self.x_address),
+                            ("name", self.name()),
+                            ("color", self.color_string),
+                            ("lineStyle", self.lineStyle),
+                            ("lineWidth", self.lineWidth),
+                            ("symbol", self.symbol),
+                            ("symbolSize", self.symbolSize),
+                            ("redraw_mode", self.redraw_mode)])
+
     def emit_data_changed_if_ready(self):
         """
         This is called whenever new waveform data is received for X or Y.
@@ -261,36 +347,40 @@ class WaveformCurveItem(PlotDataItem):
         elif self.redraw_mode == WaveformCurveItem.REDRAW_ON_BOTH:
             if not (self.needs_new_y or self.needs_new_x):
                 self.data_changed.emit()
-    
+
     @pyqtSlot(bool)
     def xConnectionStateChanged(self, connected):
         pass
-        
+
     @pyqtSlot(bool)
     def yConnectionStateChanged(self, connected):
         pass
-    
+
     @pyqtSlot(np.ndarray)
     def receiveXWaveform(self, new_waveform):
         """
         Handler for new x waveform data.
         """
+        if new_waveform is None:
+            return
         self.x_waveform = new_waveform
         self.needs_new_x = False
         #Don't redraw unless we already have Y data.
         if self.y_waveform is not None:
             self.emit_data_changed_if_ready()
-    
+
     @pyqtSlot(np.ndarray)
     def receiveYWaveform(self, new_waveform):
         """
         Handler for new y waveform data.
         """
+        if new_waveform is None:
+            return
         self.y_waveform = new_waveform
         self.needs_new_y = False
         if self.x_channel is None or self.x_waveform is not None:
             self.emit_data_changed_if_ready()
-    
+
     def redrawCurve(self):
         """
         redrawCurve is called by the curve's parent plot whenever the curve needs to be
@@ -298,6 +388,8 @@ class WaveformCurveItem(PlotDataItem):
         """
         #We try to be nice: if the X waveform doesn't have the same number of points as the Y waveform,
         #we'll truncate whichever was longer so that they are both the same size.
+        if self.y_waveform is None:
+            return
         if self.x_waveform is None:
             self.setData(y=self.y_waveform)
             return
@@ -308,12 +400,12 @@ class WaveformCurveItem(PlotDataItem):
         self.setData(x=self.x_waveform, y=self.y_waveform)
         self.needs_new_x = True
         self.needs_new_y = True
-    
+
     def limits(self):
         """
         Limits of the data for this curve.
         Returns a nested tuple of limits: ((xmin, xmax), (ymin, ymax))
-        
+
         Returns
         -------
         tuple
@@ -325,7 +417,7 @@ class WaveformCurveItem(PlotDataItem):
             return ((0, len(self.y_waveform)), (float(np.amin(self.y_waveform) - yspan), float(np.amax(self.y_waveform) + yspan)))
         else:
             return ((np.amin(self.x_waveform), np.amax(self.x_waveform)), (np.amin(self.y_waveform), np.amax(self.y_waveform)))
-    
+
 class PyDMWaveformPlot(BasePlot):
     """
     PyDMWaveformPlot is a widget to plot one or more waveforms.  Each curve can plot
@@ -370,13 +462,15 @@ class PyDMWaveformPlot(BasePlot):
         init_channel_pairs = zip(init_x_channels, init_y_channels)
         for (x_chan, y_chan) in init_channel_pairs:
             self.addChannel(y_chan, x_channel=x_chan)
-    
-    def addChannel(self, y_channel=None, x_channel=None, name=None, color=None, connect_points=True, redraw_mode=None, symbol=None):
+
+    def addChannel(self, y_channel=None, x_channel=None, name=None,
+                   color=None, lineStyle=None, lineWidth=None,
+                   symbol=None, symbolSize=None, redraw_mode=None):
         """
         Add a new curve to the plot.  In addition to the arguments below,
-        all other keyword arguments are passed to the underlying 
+        all other keyword arguments are passed to the underlying
         pyqtgraph.PlotDataItem used to draw the curve.
-        
+
         Parameters
         ----------
         y_channel: str
@@ -388,24 +482,45 @@ class PyDMWaveformPlot(BasePlot):
         color: str or QColor, optional
             A color for the line of the curve.  If not specified, the plot will
             automatically assign a unique color from a set of default colors.
-        connect_points: bool, optional
-            Whether or not to connect the datapoints with a line.  If you want
-            to make a scatter plot, set this to False.  Defaults to True.
+        lineStyle: int, optional
+            Style of the line connecting the data points.
+            0 means no line (scatter plot).
+        lineWidth: int, optional
+            Width of the line connecting the data points.
+        redraw_mode: int, optional
+            Must be one four values:
+            WaveformCurveItem.REDRAW_ON_EITHER: (Default) The curve will be redrawn after either X or Y receives new data.
+            WaveformCurveItem.REDRAW_ON_X: The curve will only be redrawn after X receives new data.
+            WaveformCurveItem.REDRAW_ON_Y: The curve will only be redrawn after Y receives new data.
+            WaveformCurveItem.REDRAW_ON_BOTH: The curve will only be redrawn after both X and Y receive new data.
+        symbol: str or None, optional
+            Which symbol to use to represent the data.
+        symbol: int, optional
+            Size of the symbol.
         """
         plot_opts = {}
-        if symbol is not None:
-            plot_opts['symbol'] = symbol
+        plot_opts['symbol'] = symbol
+        if symbolSize is not None:
+            plot_opts['symbolSize'] = symbolSize
+        if lineStyle is not None:
+            plot_opts['lineStyle'] = lineStyle
+        if lineWidth is not None:
+            plot_opts['lineWidth'] = lineWidth
         if redraw_mode is not None:
             plot_opts['redraw_mode'] = redraw_mode
-        curve = WaveformCurveItem(y_addr=y_channel, x_addr=x_channel, name=name, color=color, connect_points=connect_points, **plot_opts)
+        curve = WaveformCurveItem(y_addr=y_channel,
+                                  x_addr=x_channel,
+                                  name=name,
+                                  color=color,
+                                  **plot_opts)
         curve.data_changed.connect(self.redrawPlot)
         self.channel_pairs[(y_channel, x_channel)] = curve
         self.addCurve(curve, curve_color=color)
-    
+
     def removeChannel(self, curve):
         """
         Remove a curve from the plot.
-        
+
         Parameters
         ----------
         curve: WaveformCurveItem
@@ -413,12 +528,12 @@ class PyDMWaveformPlot(BasePlot):
         """
         curve.data_changed.disconnect(self.redrawPlot)
         self.removeCurve(curve)
-    
+
     def removeChannelAtIndex(self, index):
         """
         Remove a curve from the plot, given an index
         for a curve.
-        
+
         Parameters
         ----------
         index: int
@@ -426,7 +541,7 @@ class PyDMWaveformPlot(BasePlot):
         """
         curve = self._curves[index]
         self.removeChannel(curve)
-        
+
     def updateAxes(self):
         """
         Update the X and Y axes for the plot to fit all data in
@@ -448,9 +563,9 @@ class PyDMWaveformPlot(BasePlot):
             if plot_ymin is None or curve_ymin < plot_ymin:
                 plot_ymin = curve_ymin
             if plot_ymax is None or curve_ymax > plot_ymax:
-                plot_ymax = curve_ymax  
+                plot_ymax = curve_ymax
         self.plotItem.setLimits(xMin=plot_xmin, xMax=plot_xmax, yMin=plot_ymin, yMax=plot_ymax)
-    
+
     @pyqtSlot()
     def redrawPlot(self):
         """
@@ -460,26 +575,26 @@ class PyDMWaveformPlot(BasePlot):
         self.updateAxes()
         for curve in self._curves:
             curve.redrawCurve()
-    
+
     def clearCurves(self):
         """
         Remove all curves from the plot.
         """
         super(PyDMWaveformPlot, self).clear()
-    
+
     def getCurves(self):
         """
         Get a list of json representations for each curve.
         """
         return [json.dumps(curve.to_dict()) for curve in self._curves]
-     
+
     def setCurves(self, new_list):
         """
         Replace all existing curves with new ones.  This function
         is mostly used as a way to load curves from a .ui file, and
         almost all users will want to add curves through addChannel,
         not this method.
-        
+
         Parameters
         ----------
         new_list: list
@@ -495,14 +610,20 @@ class PyDMWaveformPlot(BasePlot):
             color = d.get('color')
             if color:
                 color = QColor(color)
-            self.addChannel(d['y_channel'], d['x_channel'], name=d.get('name'), color=color, connect_points=d.get('connect_points', True), symbol=d.get('symbol'), redraw_mode=d.get('redraw_mode'))
-        
+            self.addChannel(d['y_channel'], d['x_channel'],
+                            name=d.get('name'), color=color,
+                            lineStyle=d.get('lineStyle'),
+                            lineWidth=d.get('lineWidth'),
+                            symbol=d.get('symbol'),
+                            symbolSize=d.get('symbolSize'),
+                            redraw_mode=d.get('redraw_mode'))
+
     curves = pyqtProperty("QStringList", getCurves, setCurves)
-                    
+
     def channels(self):
         """
         Returns the list of channels used by all curves in the plot.
-        
+
         Returns
         -------
         list
@@ -511,32 +632,32 @@ class PyDMWaveformPlot(BasePlot):
         chans.extend([curve.y_channel for curve in self._curves])
         chans.extend([curve.x_channel for curve in self._curves if curve.x_channel is not None])
         return chans
-    
+
     # The methods for autoRangeX, minXRange, maxXRange, autoRangeY, minYRange, and maxYRange are
     # all defined in BasePlot, but we don't expose them as properties there, because not all plot
     # subclasses necessarily want them to be user-configurable in Designer.
     autoRangeX = pyqtProperty(bool, BasePlot.getAutoRangeX, BasePlot.setAutoRangeX, BasePlot.resetAutoRangeX, doc="""
     Whether or not the X-axis automatically rescales to fit the data.  If true, the
     values in minXRange and maxXRange are ignored.
-    """)   
-    
+    """)
+
     minXRange = pyqtProperty(float, BasePlot.getMinXRange, BasePlot.setMinXRange, doc="""
     Minimum X-axis value visible on the plot.
     """)
-    
+
     maxXRange = pyqtProperty(float, BasePlot.getMaxXRange, BasePlot.setMaxXRange, doc="""
     Maximum X-axis value visible on the plot.
     """)
-    
+
     autoRangeY = pyqtProperty(bool, BasePlot.getAutoRangeY, BasePlot.setAutoRangeY, BasePlot.resetAutoRangeY, doc="""
     Whether or not the Y-axis automatically rescales to fit the data.  If true, the
     values in minYRange and maxYRange are ignored.
     """)
-    
+
     minYRange = pyqtProperty(float, BasePlot.getMinYRange, BasePlot.setMinYRange, doc="""
     Minimum Y-axis value visible on the plot.
     """)
-    
+
     maxYRange = pyqtProperty(float, BasePlot.getMaxYRange, BasePlot.setMaxYRange, doc="""
     Maximum Y-axis value visible on the plot.
     """)

--- a/pydm/widgets/waveformplot_qtplugin.py
+++ b/pydm/widgets/waveformplot_qtplugin.py
@@ -1,13 +1,13 @@
 from ..PyQt.QtDesigner import QExtensionFactory, QPyDesignerTaskMenuExtension
 from ..PyQt.QtGui import QAction
 from ..PyQt.QtCore import pyqtSlot
-from .qtplugin_base import PyDMDesignerPlugin
+from .qtplugin_base import PyDMDesignerPlugin, WidgetCategory
 from .waveformplot import PyDMWaveformPlot
 from .waveformplot_curve_editor import WaveformPlotCurveEditorDialog
 
 class PyDMWaveformPlotPlugin(PyDMDesignerPlugin):
     def __init__(self):
-        super(PyDMWaveformPlotPlugin, self).__init__(PyDMWaveformPlot)
+        super(PyDMWaveformPlotPlugin, self).__init__(PyDMWaveformPlot, group=WidgetCategory.PLOT)
         self.factory = None
         
     def initialize(self, core):

--- a/pydm/widgets/waveformtable.py
+++ b/pydm/widgets/waveformtable.py
@@ -1,38 +1,155 @@
 from ..PyQt.QtGui import QTableWidget, QTableWidgetItem
-from ..PyQt.QtCore import pyqtSignal, pyqtSlot, pyqtProperty, Qt
-from .channel import PyDMChannel
+from ..PyQt.QtCore import pyqtSlot, pyqtProperty, Qt
 import numpy as np
 from .base import PyDMWritableWidget
 
+
 class PyDMWaveformTable(QTableWidget, PyDMWritableWidget):
+    """
+    A QTableWidget with support for Channels and more from PyDM.
+
+    Values of the array are displayed in the selected number of columns.
+    The number of rows is determined by the size of the waveform.
+    It is possible to define the labels of each row and column.
+
+    Parameters
+    ----------
+    parent : QWidget
+        The parent widget for the Label
+    init_channel : str, optional
+        The channel to be used by the widget.
+    """
+
     def __init__(self, parent=None, init_channel=None):
         QTableWidget.__init__(self, parent)
         PyDMWritableWidget.__init__(self, init_channel=init_channel)
-        self.setColumnCount(1)
-        self.columnHeader = "Value"
+        self._columnHeaders = ["Value"]
+        self._rowHeaders = []
+        self._itemsFlags = (Qt.ItemIsSelectable |
+                            Qt.ItemIsEditable |
+                            Qt.ItemIsEnabled)
         self.waveform = None
-        self.setHorizontalHeaderLabels([self.columnHeader])
+        self._valueBeingSet = False
+        self.setColumnCount(1)
+        self.cellChanged.connect(self.send_waveform)
 
     def value_changed(self, new_waveform):
+        """
+        Callback invoked when the Channel value is changed.
+
+        Parameters
+        ----------
+        new_waveform : np.ndarray
+            The new waveform value from the channel.
+        """
         PyDMWritableWidget.value_changed(self, new_waveform)
+        self._valueBeingSet = True
         self.waveform = new_waveform
-        self.setRowCount(len(new_waveform))
-        #TODO: Fix this hacky crap where I disconnect/reconnect the changed signal whenever the pv updates.
-        try:
-            self.cellChanged.disconnect()
-        except:
-            pass
-        for i, element in enumerate(new_waveform):
-            index_cell = QTableWidgetItem(str(i))
+        col_count = self.columnCount()
+        len_wave = len(new_waveform)
+        row_count = len_wave//col_count + (1 if len_wave % col_count else 0)
+        self.setRowCount(row_count)
+        for ind, element in enumerate(new_waveform):
+            i, j = ind//col_count, ind % col_count
             value_cell = QTableWidgetItem(str(element))
-            value_cell.setFlags(Qt.ItemIsSelectable | Qt.ItemIsEditable | Qt.ItemIsEnabled)
-            self.setVerticalHeaderItem(i,index_cell)
-            self.setItem(i,0,value_cell)
-        self.cellChanged.connect(self.send_data_for_cell)
+            value_cell.setFlags(self._itemsFlags)
+            self.setItem(i, j, value_cell)
+
+        self.setVerticalHeaderLabels(self._rowHeaders)
+        self.setHorizontalHeaderLabels(self._columnHeaders)
+        self._valueBeingSet = False
 
     @pyqtSlot(int, int)
-    def send_data_for_cell(self, row, column):
+    def send_waveform(self, row, column):
+        """Update Channel value when cell value is changed.
+
+        Parameters
+        ----------
+        row : int
+            Row of the changed cell.
+        column : int
+            Column of the changed cell.
+        """
+        if self._valueBeingSet:
+            return
         item = self.item(row, column)
         new_val = self.subtype(item.text())
-        self.waveform[row] = new_val
+        ind = row*self.columnCount() + column
+        self.waveform[ind] = new_val
         self.send_value_signal[np.ndarray].emit(self.waveform)
+
+    @pyqtProperty("QStringList")
+    def columnHeaderLabels(self):
+        """
+        Return the list of labels for the columns of the Table.
+
+        Returns
+        -------
+        list of strings
+        """
+        return self._columnHeaders
+
+    @columnHeaderLabels.setter
+    def columnHeaderLabels(self, new_labels):
+        """
+        Set the list of labels for the columns of the Table.
+
+        If new_labels is empty the column numbers will be used.
+
+        Parameters
+        ----------
+        new_labels : list of strings
+        """
+        if new_labels:
+            new_labels += (self.columnCount() - len(new_labels)) * [""]
+        self._columnHeaders = new_labels
+        self.setHorizontalHeaderLabels(self._columnHeaders)
+
+    @pyqtProperty("QStringList")
+    def rowHeaderLabels(self):
+        """
+        Return the list of labels for the rows of the Table.
+
+        Returns
+        -------
+        list of strings
+        """
+        return self._rowHeaders
+
+    @rowHeaderLabels.setter
+    def rowHeaderLabels(self, new_labels):
+        """
+        Set the list of labels for the rows of the Table.
+
+        If new_labels is empty the row numbers will be used.
+
+        Parameters
+        ----------
+        new_labels : list of strings
+        """
+        if new_labels:
+            new_labels += (self.rowCount() - len(new_labels)) * [""]
+        self._rowHeaders = new_labels
+        self.setVerticalHeaderLabels(self._rowHeaders)
+
+    @pyqtProperty(Qt.ItemFlags)
+    def itemsFlags(self):
+        """
+        Return the flags used in the TableWidgetItems.
+
+        Returns
+        -------
+        Qt.ItemFlags
+        """
+        return Qt.ItemFlags(self._itemsFlags)
+
+    @itemsFlags.setter
+    def itemsFlags(self, new_flags):
+        """
+        Set the flags to be used in the TableWidgetItems.
+
+        Parameters
+        ----------
+        new_flags : Qt.ItemFlags
+        """
+        self._itemsFlags = Qt.ItemFlags(new_flags)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-pyqtgraph>=0.10.0
 numpy>=1.11.0
 scipy>=0.12.0
 pyepics>=3.2.7

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open(path.join(cur_dir, 'requirements.txt')) as f:
     requirements = f.read().split()
 
 # Remove the 'optional' requirements
-optional = ('PyQt5', 'PySide', 'psutil', 'pcaspy', 'pyepics')
+optional = ('PyQt5', 'PySide', 'psutil', 'pcaspy', 'pyepics', 'pyqtgraph')
 for package in optional:
     if package in requirements:
         requirements.remove(package)
@@ -27,13 +27,14 @@ extras_require = {
 
 if "CONDA_PREFIX" not in environ:
     extras_require['PyQt5'] = ['PyQt5']
+    extras_require['pyqtgraph'] = ['pyqtgraph']
 else:
     print("******************************************************************")
     print("*                              WARNING                           *") 
     print("******************************************************************")
     print("Installing at an Anaconda Environment, to avoid naming conflicts ")
     print("make sure you do:")
-    print("conda install pyqt=5")
+    print("conda install pyqt=5 pyqtgraph")
     print("******************************************************************")
     print("For more info please check: ")
     print("https://github.com/ContinuumIO/anaconda-issues/issues/1554")


### PR DESCRIPTION
I've done some enhancements on the widget PyDMWaveformTable:

 - The number of columns can be larger than one. Useful to display an array that represents matrices or to display the array horizontally.

- Now it is possible to select the labels of the Headers of each row and column in QtDesigner.

 - It is also possible to select the flags to be applied to the Table items in QtDesigner.