### PR TITLE
PR: changes in PyDMSpinbox

### DIFF
--- a/pydm/data_plugins/archiver_plugin.py
+++ b/pydm/data_plugins/archiver_plugin.py
@@ -1,12 +1,14 @@
 from .plugin import PyDMPlugin, PyDMConnection
 import requests
 import numpy as np
+import os
 
 class Connection(PyDMConnection):
     def __init__(self, channel, address, parent=None):
         super(Connection, self).__init__(channel, address, parent)
         self.add_listener(channel)
-        url_string = "http://lcls-archapp.slac.stanford.edu/retrieval/data/getData.json?{params}".format(params=address)
+        base_url = os.getenv("PYDM_ARCHIVER_URL", "http://lcls-archapp.slac.stanford.edu")
+        url_string = "{base}/retrieval/data/getData.json?{params}".format(base=base_url, params=address)
         r = requests.get(url_string) #blocking.  BAD!
         if r.status_code == 200 and r.headers['content-type'] == 'application/json':
             data_dict = r.json()

--- a/pydm/utilities/units.py
+++ b/pydm/utilities/units.py
@@ -1,30 +1,58 @@
 from scipy import constants
 
-
-UNITS = {'length':   {'m'   : 1,
-                      'cm'  : constants.centi,
-                      'mm'  : constants.milli,
-                      'um'  : constants.micro,
-                      'nm'  : constants.nano,
-                      'pm'  : constants.pico,
-                      'in'  : constants.inch,
-                      'ft'  : constants.foot,
-                      'yds' : constants.yard,
+UNITS = {'length':   {'m': 1,
+                      'cm': constants.centi,
+                      'mm': constants.milli,
+                      'um': constants.micro,
+                      'nm': constants.nano,
+                      'pm': constants.pico,
+                      'in': constants.inch,
+                      'ft': constants.foot,
+                      'yds': constants.yard,
+                      },
+         'time':    {'s': 1,
+                     'ms': constants.milli,
+                     'us': constants.micro,
+                     'ns': constants.nano,
+                     'ps': constants.pico,
+                     'min': constants.minute,
+                     'hr': constants.hour,
+                     'weeks': constants.week,
+                     'days': constants.day,
                      },
-          'time':    {'s'     : 1,
-                      'ms'    : constants.milli,
-                      'us'    : constants.micro,
-                      'ns'    : constants.nano,
-                      'min'   : constants.minute,
-                      'hr'    : constants.hour,
-                      'weeks' : constants.week,
-                      'days'  : constants.day,
+         'frequency': {'Hz': 1,
+                       'kHz': constants.kilo,
+                       'MHz': constants.mega,
+                       'GHz': constants.giga,
+                       'THz': constants.tera,
+                       'mHz': constants.milli,
+                       },
+         'angle':   {'rad': 1,
+                     'mrad': constants.milli,
+                     'urad': constants.micro,
+                     'nrad': constants.nano,
+                     'degree': constants.degree,
+                     'turn': 2*constants.pi,
+                     },
+         'voltage': {'V': 1,
+                     'MV': constants.mega,
+                     'kV': constants.kilo,
+                     'mV': constants.milli,
+                     'uV': constants.micro,
+                     },
+         'current': {'A': 1,
+                     'MA': constants.mega,
+                     'kA': constants.kilo,
+                     'mA': constants.milli,
+                     'uA': constants.micro,
+                     'nA': constants.nano,
                      }
-        }
+         }
+
 
 def find_unittype(unit):
     """
-    Find the type of a unit string
+    Find the type of a unit string.
     """
     for tp in UNITS.keys():
         if unit in UNITS[tp].keys():
@@ -34,7 +62,7 @@ def find_unittype(unit):
 
 def find_unit(unit):
     """
-    Find the conversion of a unit string
+    Find the conversion of a unit string.
     """
     tp = find_unittype(unit)
     if tp:
@@ -43,30 +71,31 @@ def find_unit(unit):
         return None
 
 
-def convert(unit,desired):
+def convert(unit, desired):
     """
-    Find the conversion rate of two different unit strings
+    Find the conversion rate of two different unit strings.
     """
     current = find_unit(unit)
-    final   = find_unit(desired)
+    final = find_unit(desired)
 
     if find_unittype(unit) != find_unittype(desired):
         return None
 
     if current and final:
         return current/final
-    
+
     else:
         return None
 
+
 def find_unit_options(unit):
     """
-    Find the options for a given unit
+    Find the options for a given unit.
     """
     tp = find_unittype(unit)
     if tp:
-        units = [choice for choice,_ in 
-                 sorted(UNITS[tp].items(),key=lambda x: 1/x[1])]
+        units = [choice for choice, _ in
+                 sorted(UNITS[tp].items(), key=lambda x: 1/x[1])]
         return units
     else:
         return None

--- a/pydm/widgets/spinbox.py
+++ b/pydm/widgets/spinbox.py
@@ -26,6 +26,7 @@ class PyDMSpinbox(QDoubleSpinBox, PyDMWritableWidget):
 
         self.valueChanged.connect(self.send_value)  # signal from spinbox
         self.setKeyboardTracking(False)
+        self.setAccelerated(True)
 
     def event(self, event):
         """

--- a/pydm/widgets/spinbox.py
+++ b/pydm/widgets/spinbox.py
@@ -172,4 +172,4 @@ class PyDMSpinbox(QDoubleSpinBox, PyDMWritableWidget):
         val : bool
         """
         self._show_step_exponent = val
-        self.update()
+        self.update_format_string()

--- a/pydm/widgets/spinbox.py
+++ b/pydm/widgets/spinbox.py
@@ -24,6 +24,9 @@ class PyDMSpinbox(QDoubleSpinBox, PyDMWritableWidget):
         self.setDecimals(0)
         self.app = QApplication.instance()
 
+        self.valueChanged.connect(self.send_value)  # signal from spinbox
+        self.setKeyboardTracking(False)
+
     def event(self, event):
         """
         Method invoked when an event of any nature happens on the
@@ -53,20 +56,6 @@ class PyDMSpinbox(QDoubleSpinBox, PyDMWritableWidget):
                     self.step_exponent = -self.decimals()
 
                 self.update_step_size()
-                return True
-
-            if (event.key() == Qt.Key_Up):
-                self.setValue(self.value + self.singleStep())
-                self.send_value()
-                return True
-
-            if (event.key() == Qt.Key_Down):
-                self.setValue(self.value - self.singleStep())
-                self.send_value()
-                return True
-
-            if (event.key() == Qt.Key_Return):
-                self.send_value()
                 return True
 
         return super(PyDMSpinbox, self).event(event)
@@ -114,12 +103,11 @@ class PyDMSpinbox(QDoubleSpinBox, PyDMWritableWidget):
         self.setValue(new_val)
         self.valueBeingSet = False
 
-    def send_value(self):
+    def send_value(self, value):
         """
         Method invoked to send the current value on the QDoubleSpinBox to
         the channel using the `send_value_signal`.
         """
-        value = float(self.cleanText())
         if not self.valueBeingSet:
             self.send_value_signal[float].emit(value)
 

--- a/pydm/widgets/spinbox.py
+++ b/pydm/widgets/spinbox.py
@@ -28,8 +28,6 @@ class PyDMSpinbox(QDoubleSpinBox, PyDMWritableWidget):
         self.setKeyboardTracking(False)
         self.setAccelerated(True)
 
-        self.lineEdit().setToolTip('Step: 1E{0:+d}'.format(self.step_exponent))
-
     def event(self, event):
         """
         Method invoked when an event of any nature happens on the
@@ -93,12 +91,14 @@ class PyDMSpinbox(QDoubleSpinBox, PyDMWritableWidget):
         else:
             units = ""
 
-        self.lineEdit().setToolTip('Step: 1E{0:+d}'.format(self.step_exponent))
         if self._show_step_exponent:
             self.setSuffix("{units} Step: 1E{exp}".format(
                 units=units, exp=self.step_exponent))
+            self.lineEdit().setToolTip("")
         else:
             self.setSuffix(units)
+            self.lineEdit().setToolTip(
+                            'Step: 1E{0:+d}'.format(self.step_exponent))
 
     def value_changed(self, new_val):
         """

--- a/pydm/widgets/spinbox.py
+++ b/pydm/widgets/spinbox.py
@@ -42,20 +42,16 @@ class PyDMSpinbox(QDoubleSpinBox, PyDMWritableWidget):
         ----------
         event : QEvent
         """
-        if (event.type() == QEvent.KeyPress):
-            ctrl_hold = self.app.queryKeyboardModifiers() == Qt.ControlModifier
+        if event.type() == QEvent.KeyPress and \
+           self.app.queryKeyboardModifiers() == Qt.ControlModifier:
 
-            if ctrl_hold and (event.key() == Qt.Key_Left):
+            if event.key() == Qt.Key_Left:
                 self.step_exponent = self.step_exponent + 1
                 self.update_step_size()
                 return True
-
-            if ctrl_hold and (event.key() == Qt.Key_Right):
-                self.step_exponent = self.step_exponent - 1
-
-                if self.step_exponent < -self.decimals():
-                    self.step_exponent = -self.decimals()
-
+            elif event.key() == Qt.Key_Right:
+                self.step_exponent = max(self.step_exponent - 1,
+                                         -self.decimals())
                 self.update_step_size()
                 return True
 

--- a/pydm/widgets/spinbox.py
+++ b/pydm/widgets/spinbox.py
@@ -28,6 +28,8 @@ class PyDMSpinbox(QDoubleSpinBox, PyDMWritableWidget):
         self.setKeyboardTracking(False)
         self.setAccelerated(True)
 
+        self.lineEdit().setToolTip('Step: 1E{0:+d}'.format(self.step_exponent))
+
     def event(self, event):
         """
         Method invoked when an event of any nature happens on the
@@ -91,6 +93,7 @@ class PyDMSpinbox(QDoubleSpinBox, PyDMWritableWidget):
         else:
             units = ""
 
+        self.lineEdit().setToolTip('Step: 1E{0:+d}'.format(self.step_exponent))
         if self._show_step_exponent:
             self.setSuffix("{units} Step: 1E{exp}".format(
                 units=units, exp=self.step_exponent))

--- a/pydm/widgets/spinbox.py
+++ b/pydm/widgets/spinbox.py
@@ -57,6 +57,17 @@ class PyDMSpinbox(QDoubleSpinBox, PyDMWritableWidget):
 
         return super(PyDMSpinbox, self).event(event)
 
+    def contextMenuEvent(self, ev):
+        """Increment LineEdit menu to toggle the display of the step size."""
+        def toogle():
+            self.showStepExponent = not self.showStepExponent
+
+        menu = self.lineEdit().createStandardContextMenu()
+        menu.addSeparator()
+        ac = menu.addAction('Toggle Show Step Size')
+        ac.triggered.connect(toogle)
+        menu.exec_(ev.globalPos())
+
     def update_step_size(self):
         """
         Update the Single Step size on the QDoubleSpinBox.

--- a/pydm/widgets/waveformplot.py
+++ b/pydm/widgets/waveformplot.py
@@ -33,7 +33,7 @@ class WaveformCurveItem(PlotDataItem):
         The color used to draw the curve line and the symbols.
     lineStyle: int, optional
         Style of the line connecting the data points.
-        0 means no line (scatter plot).
+        Must be a value from the Qt::PenStyle enum (see http://doc.qt.io/qt-5/qt.html#PenStyle-enum).
     lineWidth: int, optional
         Width of the line connecting the data points.
     redraw_mode: int, optional
@@ -157,9 +157,7 @@ class WaveformCurveItem(PlotDataItem):
     def lineStyle(self):
         """
         Return the style of the line connecting the data points.
-
-        see Qt line styles.
-        0 means no line.
+        Must be a value from the Qt::PenStyle enum (see http://doc.qt.io/qt-5/qt.html#PenStyle-enum).
 
         Returns
         -------
@@ -171,9 +169,7 @@ class WaveformCurveItem(PlotDataItem):
     def lineStyle(self, new_style):
         """
         Set the style of the line connecting the data points.
-
-        see Qt line styles.
-        0 means no line.
+        Must be a value from the Qt::PenStyle enum (see http://doc.qt.io/qt-5/qt.html#PenStyle-enum).
 
         Parameters
         -------

--- a/pydm/widgets/waveformplot.py
+++ b/pydm/widgets/waveformplot.py
@@ -1,6 +1,6 @@
 from ..PyQt.QtGui import QColor
-from ..PyQt.QtCore import pyqtSignal, pyqtSlot, pyqtProperty
-from pyqtgraph import PlotDataItem
+from ..PyQt.QtCore import pyqtSignal, pyqtSlot, pyqtProperty, Qt
+from pyqtgraph import PlotDataItem, mkPen
 import numpy as np
 from .baseplot import BasePlot
 from .channel import PyDMChannel
@@ -24,24 +24,48 @@ class WaveformCurveItem(PlotDataItem):
     Parameters
     ----------
     y_addr : str, optional
-        The address to waveform data for the Y axis.  Curves must have Y data to plot.
+        The address to waveform data for the Y axis.
+        Curves must have Y data to plot.
     x_addr : str, optional
-        The address to waveform data for the X axis.  If None, the curve will plot Y data vs. the Y index.
+        The address to waveform data for the X axis.
+        If None, the curve will plot Y data vs. the Y index.
     color : QColor, optional
-        The color used to draw the curve line.  If connect_points is False, this is not used.
-    connect_points: bool, optional
-        Whether or not to draw a line to connect the data points.
+        The color used to draw the curve line and the symbols.
+    lineStyle: int, optional
+        Style of the line connecting the data points.
+        0 means no line (scatter plot).
+    lineWidth: int, optional
+        Width of the line connecting the data points.
     redraw_mode: int, optional
         Must be one four values:
         WaveformCurveItem.REDRAW_ON_EITHER: (Default) The curve will be redrawn after either X or Y receives new data.
         WaveformCurveItem.REDRAW_ON_X: The curve will only be redrawn after X receives new data.
         WaveformCurveItem.REDRAW_ON_Y: The curve will only be redrawn after Y receives new data.
         WaveformCurveItem.REDRAW_ON_BOTH: The curve will only be redrawn after both X and Y receive new data.
+    **kargs: optional
+        PlotDataItem keyword arguments, such as symbol and symbolSize.
     """
     REDRAW_ON_X, REDRAW_ON_Y, REDRAW_ON_EITHER, REDRAW_ON_BOTH = range(4)
-    symbols = OrderedDict([('None', None), ('Circle', 'o'), ('Square', 's'), ('Triangle', 't'), ('Diamond', 'd'), ('Plus', '+')])
+    symbols = OrderedDict([('None', None),
+                           ('Circle', 'o'),
+                           ('Square', 's'),
+                           ('Triangle', 't'),
+                           ('Star', 'star'),
+                           ('Pentagon', 'p'),
+                           ('Hexagon', 'h'),
+                           ('X', 'x'),
+                           ('Diamond', 'd'),
+                           ('Plus', '+')])
+    lines = OrderedDict([('NoLine', Qt.NoPen),
+                         ('Solid', Qt.SolidLine),
+                         ('Dash', Qt.DashLine),
+                         ('Dot', Qt.DotLine),
+                         ('DashDot', Qt.DashDotLine),
+                         ('DashDotDot', Qt.DashDotDotLine)])
     data_changed = pyqtSignal()
-    def __init__(self, y_addr=None, x_addr=None, color=None, connect_points=True, redraw_mode=REDRAW_ON_EITHER, **kws):
+
+    def __init__(self, y_addr=None, x_addr=None, color=None, lineStyle=None,
+                 lineWidth=None, redraw_mode=REDRAW_ON_EITHER, **kws):
         y_addr = "" if y_addr is None else y_addr
         if kws.get('name') is None:
             y_name = utilities.remove_protocol(y_addr)
@@ -61,12 +85,17 @@ class WaveformCurveItem(PlotDataItem):
         self.x_waveform = None
         self.y_waveform = None
         self._color = QColor('white')
+        self._pen = mkPen(self._color)
+        if lineWidth is not None:
+            self._pen.setWidth(lineWidth)
+        if lineStyle is not None:
+            self._pen.setStyle(lineStyle)
+        kws['pen'] = self._pen
         super(WaveformCurveItem, self).__init__(**kws)
         self.setSymbolBrush(None)
-        self.connect_points = connect_points
         if color is not None:
             self.color = color
-    
+
     @property
     def color_string(self):
         """
@@ -79,7 +108,7 @@ class WaveformCurveItem(PlotDataItem):
         str
         """
         return str(utilities.colors.svg_color_from_hex(self.color.name(), hex_on_fail=True))
-    
+
     @color_string.setter
     def color_string(self, new_color_string):
         """
@@ -93,7 +122,7 @@ class WaveformCurveItem(PlotDataItem):
             The new string to use for the curve color.
         """
         self.color = QColor(str(new_color_string))
-            
+
     @property
     def color(self):
         """
@@ -104,7 +133,7 @@ class WaveformCurveItem(PlotDataItem):
         QColor
         """
         return self._color
-    
+
     @color.setter
     def color(self, new_color):
         """
@@ -113,76 +142,125 @@ class WaveformCurveItem(PlotDataItem):
         Parameters
         -------
         new_color: QColor or str
-            The new color to use for the curve.  Strings are passed to WaveformCurveItem.color_string.
+            The new color to use for the curve.
+            Strings are passed to WaveformCurveItem.color_string.
         """
         if isinstance(new_color, str):
             self.color_string = new_color
             return
         self._color = new_color
-        if self.connect_points:
-            self.setPen(self._color)
-        if self.symbol is not None:
-            self.setSymbolPen(self._color)
-    
+        self._pen.setColor(self._color)
+        self.setPen(self._pen)
+        self.setSymbolPen(self._color)
+
     @property
-    def connect_points(self):
+    def lineStyle(self):
         """
-        Whether or not the data points are connected with a line.
+        Return the style of the line connecting the data points.
+
+        see Qt line styles.
+        0 means no line.
 
         Returns
         -------
-        bool
+        int
         """
-        return self._connect_points
-    
-    @connect_points.setter
-    def connect_points(self, connect):
+        return self._pen.style()
+
+    @lineStyle.setter
+    def lineStyle(self, new_style):
         """
-        Whether or not the data points are connected with a line.
+        Set the style of the line connecting the data points.
+
+        see Qt line styles.
+        0 means no line.
 
         Parameters
         -------
-        connect: bool
+        new_style: int
         """
-        self._connect_points = connect
-        if self._connect_points:
-            self.setPen(self._color)
-        else:
-            self.setPen(None)
-    
+        if new_style in self.lines.values():
+            self._pen.setStyle(new_style)
+            self.setPen(self._pen)
+
+    @property
+    def lineWidth(self):
+        """
+        Return the width of the line connecting the data points.
+
+        Returns
+        -------
+        int
+        """
+        return self._pen.width()
+
+    @lineWidth.setter
+    def lineWidth(self, new_width):
+        """
+        Set the width of the line connecting the data points.
+
+        Parameters
+        -------
+        new_width: int
+        """
+        self._pen.setWidth(int(new_width))
+        self.setPen(self._pen)
+
     @property
     def symbol(self):
         """
         The single-character code for the symbol drawn at each datapoint.
+
         See the documentation for pyqtgraph.PlotDataItem for possible values.
-        
+
         Returns
         -------
-        str
+        str or None
         """
         return self.opts['symbol']
-    
+
     @symbol.setter
     def symbol(self, new_symbol):
         """
         The single-character code for the symbol drawn at each datapoint.
+
         See the documentation for pyqtgraph.PlotDataItem for possible values.
-        
+
         Parameters
         -------
-        new_symbol: str
+        new_symbol: str or None
         """
         if new_symbol in self.symbols.values():
             self.setSymbol(new_symbol)
             self.setSymbolPen(self._color)
-        else:
-            self.setSymbol(None)
-    
+
+    @property
+    def symbolSize(self):
+        """
+        Return the size of the symbol to represent the data.
+
+        Returns
+        -------
+        int
+        """
+        return self.opts['symbolSize']
+
+    @symbolSize.setter
+    def symbolSize(self, new_size):
+        """
+        Set the size of the symbol to represent the data.
+
+        Parameters
+        -------
+        new_size: int
+        """
+        self.setSymbolSize(int(new_size))
+
     @property
     def x_address(self):
         """
         The address of the channel used to get the x axis waveform data.
-        
+
         Returns
         -------
         str
@@ -190,12 +268,12 @@ class WaveformCurveItem(PlotDataItem):
         if self.x_channel is None:
             return None
         return self.x_channel.address
-    
+
     @x_address.setter
     def x_address(self, new_address):
         """
         The address of the channel used to get the x axis waveform data.
-        
+
         Parameters
         -------
         new_address: str
@@ -204,12 +282,12 @@ class WaveformCurveItem(PlotDataItem):
             self.x_channel = None
             return
         self.x_channel = PyDMChannel(address=new_address, connection_slot=self.xConnectionStateChanged, value_slot=self.receiveXWaveform)
-    
+
     @property
     def y_address(self):
         """
         The address of the channel used to get the y axis waveform data.
-        
+
         Returns
         -------
         str
@@ -217,12 +295,12 @@ class WaveformCurveItem(PlotDataItem):
         if self.y_channel is None:
             return None
         return self.y_channel.address
-    
+
     @y_address.setter
     def y_address(self, new_address):
         """
         The address of the channel used to get the x axis wavefor data.
-        
+
         Parameters
         -------
         new_address: str
@@ -231,18 +309,26 @@ class WaveformCurveItem(PlotDataItem):
             self.y_channel = None
             return
         self.y_channel = PyDMChannel(address=new_address, connection_slot=self.yConnectionStateChanged, value_slot=self.receiveYWaveform)
-    
+
     def to_dict(self):
         """
-        Returns an OrderedDict representation with values for all properties 
+        Returns an OrderedDict representation with values for all properties
         needed to recreate this curve.
-        
+
         Returns
         -------
         OrderedDict
         """
-        return OrderedDict([("y_channel", self.y_address), ("x_channel", self.x_address), ("name", self.name()), ("color", self.color_string), ("connect_points", self.connect_points), ("symbol", self.symbol), ("redraw_mode", self.redraw_mode)])
-    
+        return OrderedDict([("y_channel", self.y_address),
+                            ("x_channel", self.x_address),
+                            ("name", self.name()),
+                            ("color", self.color_string),
+                            ("lineStyle", self.lineStyle),
+                            ("lineWidth", self.lineWidth),
+                            ("symbol", self.symbol),
+                            ("symbolSize", self.symbolSize),
+                            ("redraw_mode", self.redraw_mode)])
+
     def emit_data_changed_if_ready(self):
         """
         This is called whenever new waveform data is received for X or Y.
@@ -261,36 +347,40 @@ class WaveformCurveItem(PlotDataItem):
         elif self.redraw_mode == WaveformCurveItem.REDRAW_ON_BOTH:
             if not (self.needs_new_y or self.needs_new_x):
                 self.data_changed.emit()
-    
+
     @pyqtSlot(bool)
     def xConnectionStateChanged(self, connected):
         pass
-        
+
     @pyqtSlot(bool)
     def yConnectionStateChanged(self, connected):
         pass
-    
+
     @pyqtSlot(np.ndarray)
     def receiveXWaveform(self, new_waveform):
         """
         Handler for new x waveform data.
         """
+        if new_waveform is None:
+            return
         self.x_waveform = new_waveform
         self.needs_new_x = False
         #Don't redraw unless we already have Y data.
         if self.y_waveform is not None:
             self.emit_data_changed_if_ready()
-    
+
     @pyqtSlot(np.ndarray)
     def receiveYWaveform(self, new_waveform):
         """
         Handler for new y waveform data.
         """
+        if new_waveform is None:
+            return
         self.y_waveform = new_waveform
         self.needs_new_y = False
         if self.x_channel is None or self.x_waveform is not None:
             self.emit_data_changed_if_ready()
-    
+
     def redrawCurve(self):
         """
         redrawCurve is called by the curve's parent plot whenever the curve needs to be
@@ -298,6 +388,8 @@ class WaveformCurveItem(PlotDataItem):
         """
         #We try to be nice: if the X waveform doesn't have the same number of points as the Y waveform,
         #we'll truncate whichever was longer so that they are both the same size.
+        if self.y_waveform is None:
+            return
         if self.x_waveform is None:
             self.setData(y=self.y_waveform)
             return
@@ -308,12 +400,12 @@ class WaveformCurveItem(PlotDataItem):
         self.setData(x=self.x_waveform, y=self.y_waveform)
         self.needs_new_x = True
         self.needs_new_y = True
-    
+
     def limits(self):
         """
         Limits of the data for this curve.
         Returns a nested tuple of limits: ((xmin, xmax), (ymin, ymax))
-        
+
         Returns
         -------
         tuple
@@ -325,7 +417,7 @@ class WaveformCurveItem(PlotDataItem):
             return ((0, len(self.y_waveform)), (float(np.amin(self.y_waveform) - yspan), float(np.amax(self.y_waveform) + yspan)))
         else:
             return ((np.amin(self.x_waveform), np.amax(self.x_waveform)), (np.amin(self.y_waveform), np.amax(self.y_waveform)))
-    
+
 class PyDMWaveformPlot(BasePlot):
     """
     PyDMWaveformPlot is a widget to plot one or more waveforms.  Each curve can plot
@@ -370,13 +462,15 @@ class PyDMWaveformPlot(BasePlot):
         init_channel_pairs = zip(init_x_channels, init_y_channels)
         for (x_chan, y_chan) in init_channel_pairs:
             self.addChannel(y_chan, x_channel=x_chan)
-    
-    def addChannel(self, y_channel=None, x_channel=None, name=None, color=None, connect_points=True, redraw_mode=None, symbol=None):
+
+    def addChannel(self, y_channel=None, x_channel=None, name=None,
+                   color=None, lineStyle=None, lineWidth=None,
+                   symbol=None, symbolSize=None, redraw_mode=None):
         """
         Add a new curve to the plot.  In addition to the arguments below,
-        all other keyword arguments are passed to the underlying 
+        all other keyword arguments are passed to the underlying
         pyqtgraph.PlotDataItem used to draw the curve.
-        
+
         Parameters
         ----------
         y_channel: str
@@ -388,24 +482,45 @@ class PyDMWaveformPlot(BasePlot):
         color: str or QColor, optional
             A color for the line of the curve.  If not specified, the plot will
             automatically assign a unique color from a set of default colors.
-        connect_points: bool, optional
-            Whether or not to connect the datapoints with a line.  If you want
-            to make a scatter plot, set this to False.  Defaults to True.
+        lineStyle: int, optional
+            Style of the line connecting the data points.
+            0 means no line (scatter plot).
+        lineWidth: int, optional
+            Width of the line connecting the data points.
+        redraw_mode: int, optional
+            Must be one four values:
+            WaveformCurveItem.REDRAW_ON_EITHER: (Default) The curve will be redrawn after either X or Y receives new data.
+            WaveformCurveItem.REDRAW_ON_X: The curve will only be redrawn after X receives new data.
+            WaveformCurveItem.REDRAW_ON_Y: The curve will only be redrawn after Y receives new data.
+            WaveformCurveItem.REDRAW_ON_BOTH: The curve will only be redrawn after both X and Y receive new data.
+        symbol: str or None, optional
+            Which symbol to use to represent the data.
+        symbol: int, optional
+            Size of the symbol.
         """
         plot_opts = {}
-        if symbol is not None:
-            plot_opts['symbol'] = symbol
+        plot_opts['symbol'] = symbol
+        if symbolSize is not None:
+            plot_opts['symbolSize'] = symbolSize
+        if lineStyle is not None:
+            plot_opts['lineStyle'] = lineStyle
+        if lineWidth is not None:
+            plot_opts['lineWidth'] = lineWidth
         if redraw_mode is not None:
             plot_opts['redraw_mode'] = redraw_mode
-        curve = WaveformCurveItem(y_addr=y_channel, x_addr=x_channel, name=name, color=color, connect_points=connect_points, **plot_opts)
+        curve = WaveformCurveItem(y_addr=y_channel,
+                                  x_addr=x_channel,
+                                  name=name,
+                                  color=color,
+                                  **plot_opts)
         curve.data_changed.connect(self.redrawPlot)
         self.channel_pairs[(y_channel, x_channel)] = curve
         self.addCurve(curve, curve_color=color)
-    
+
     def removeChannel(self, curve):
         """
         Remove a curve from the plot.
-        
+
         Parameters
         ----------
         curve: WaveformCurveItem
@@ -413,12 +528,12 @@ class PyDMWaveformPlot(BasePlot):
         """
         curve.data_changed.disconnect(self.redrawPlot)
         self.removeCurve(curve)
-    
+
     def removeChannelAtIndex(self, index):
         """
         Remove a curve from the plot, given an index
         for a curve.
-        
+
         Parameters
         ----------
         index: int
@@ -426,7 +541,7 @@ class PyDMWaveformPlot(BasePlot):
         """
         curve = self._curves[index]
         self.removeChannel(curve)
-        
+
     def updateAxes(self):
         """
         Update the X and Y axes for the plot to fit all data in
@@ -448,9 +563,9 @@ class PyDMWaveformPlot(BasePlot):
             if plot_ymin is None or curve_ymin < plot_ymin:
                 plot_ymin = curve_ymin
             if plot_ymax is None or curve_ymax > plot_ymax:
-                plot_ymax = curve_ymax  
+                plot_ymax = curve_ymax
         self.plotItem.setLimits(xMin=plot_xmin, xMax=plot_xmax, yMin=plot_ymin, yMax=plot_ymax)
-    
+
     @pyqtSlot()
     def redrawPlot(self):
         """
@@ -460,26 +575,26 @@ class PyDMWaveformPlot(BasePlot):
         self.updateAxes()
         for curve in self._curves:
             curve.redrawCurve()
-    
+
     def clearCurves(self):
         """
         Remove all curves from the plot.
         """
         super(PyDMWaveformPlot, self).clear()
-    
+
     def getCurves(self):
         """
         Get a list of json representations for each curve.
         """
         return [json.dumps(curve.to_dict()) for curve in self._curves]
-     
+
     def setCurves(self, new_list):
         """
         Replace all existing curves with new ones.  This function
         is mostly used as a way to load curves from a .ui file, and
         almost all users will want to add curves through addChannel,
         not this method.
-        
+
         Parameters
         ----------
         new_list: list
@@ -495,14 +610,20 @@ class PyDMWaveformPlot(BasePlot):
             color = d.get('color')
             if color:
                 color = QColor(color)
-            self.addChannel(d['y_channel'], d['x_channel'], name=d.get('name'), color=color, connect_points=d.get('connect_points', True), symbol=d.get('symbol'), redraw_mode=d.get('redraw_mode'))
-        
+            self.addChannel(d['y_channel'], d['x_channel'],
+                            name=d.get('name'), color=color,
+                            lineStyle=d.get('lineStyle'),
+                            lineWidth=d.get('lineWidth'),
+                            symbol=d.get('symbol'),
+                            symbolSize=d.get('symbolSize'),
+                            redraw_mode=d.get('redraw_mode'))
+
     curves = pyqtProperty("QStringList", getCurves, setCurves)
-                    
+
     def channels(self):
         """
         Returns the list of channels used by all curves in the plot.
-        
+
         Returns
         -------
         list
@@ -511,32 +632,32 @@ class PyDMWaveformPlot(BasePlot):
         chans.extend([curve.y_channel for curve in self._curves])
         chans.extend([curve.x_channel for curve in self._curves if curve.x_channel is not None])
         return chans
-    
+
     # The methods for autoRangeX, minXRange, maxXRange, autoRangeY, minYRange, and maxYRange are
     # all defined in BasePlot, but we don't expose them as properties there, because not all plot
     # subclasses necessarily want them to be user-configurable in Designer.
     autoRangeX = pyqtProperty(bool, BasePlot.getAutoRangeX, BasePlot.setAutoRangeX, BasePlot.resetAutoRangeX, doc="""
     Whether or not the X-axis automatically rescales to fit the data.  If true, the
     values in minXRange and maxXRange are ignored.
-    """)   
-    
+    """)
+
     minXRange = pyqtProperty(float, BasePlot.getMinXRange, BasePlot.setMinXRange, doc="""
     Minimum X-axis value visible on the plot.
     """)
-    
+
     maxXRange = pyqtProperty(float, BasePlot.getMaxXRange, BasePlot.setMaxXRange, doc="""
     Maximum X-axis value visible on the plot.
     """)
-    
+
     autoRangeY = pyqtProperty(bool, BasePlot.getAutoRangeY, BasePlot.setAutoRangeY, BasePlot.resetAutoRangeY, doc="""
     Whether or not the Y-axis automatically rescales to fit the data.  If true, the
     values in minYRange and maxYRange are ignored.
     """)
-    
+
     minYRange = pyqtProperty(float, BasePlot.getMinYRange, BasePlot.setMinYRange, doc="""
     Minimum Y-axis value visible on the plot.
     """)
-    
+
     maxYRange = pyqtProperty(float, BasePlot.getMaxYRange, BasePlot.setMaxYRange, doc="""
     Maximum Y-axis value visible on the plot.
     """)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-pyqtgraph>=0.10.0
 numpy>=1.11.0
 scipy>=0.12.0
 pyepics>=3.2.7

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open(path.join(cur_dir, 'requirements.txt')) as f:
     requirements = f.read().split()
 
 # Remove the 'optional' requirements
-optional = ('PyQt5', 'PySide', 'psutil', 'pcaspy', 'pyepics')
+optional = ('PyQt5', 'PySide', 'psutil', 'pcaspy', 'pyepics', 'pyqtgraph')
 for package in optional:
     if package in requirements:
         requirements.remove(package)
@@ -27,13 +27,14 @@ extras_require = {
 
 if "CONDA_PREFIX" not in environ:
     extras_require['PyQt5'] = ['PyQt5']
+    extras_require['pyqtgraph'] = ['pyqtgraph']
 else:
     print("******************************************************************")
     print("*                              WARNING                           *") 
     print("******************************************************************")
     print("Installing at an Anaconda Environment, to avoid naming conflicts ")
     print("make sure you do:")
-    print("conda install pyqt=5")
+    print("conda install pyqt=5 pyqtgraph")
     print("******************************************************************")
     print("For more info please check: ")
     print("https://github.com/ContinuumIO/anaconda-issues/issues/1554")


### PR DESCRIPTION
There was a bug in PyDMSpinbox that was triggered due to the locale configuration:

 - Use of keyboard arrows was triggering float conversion errors for Locale's configuration where comma is used instead of dot. The solution delegates to the base widget the total handling of float conversions and employ the property setKeyboardTracking to get the appropriate behaviour when using the lineEdit of the Spinbox.

Besides, some changes in behavior were also done:

 - Added an option to the lineEdit of the PyDMSpinbox to toggle the display of the step size info;
 - Set the accelerated property to True by default;
 - When the info of the step size is not shown in the lineEdit, a toolTip shows it;
