### PR TITLE
Pr alarm style sheet map

### DIFF
--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -100,14 +100,14 @@ class PyDMWidget(PyDMPrimitiveWidget):
             ALARM_DISCONNECTED: {"color": "white"}
         },
         ALARM_BORDER: {
-            ALARM_NONE: {"border": "0px"},
+            ALARM_NONE: {"border": "2px transparent"},
             ALARM_MINOR: {"border": "2px solid yellow"},
             ALARM_MAJOR: {"border": "2px solid red"},
             ALARM_INVALID: {"border": "2px solid purple"},
             ALARM_DISCONNECTED: {"border": "2px solid white"}
         },
         ALARM_CONTENT | ALARM_BORDER: {
-            ALARM_NONE: {"color": "black", "border": "0px"},
+            ALARM_NONE: {"color": "black", "border": "2px transparent"},
             ALARM_MINOR: {"color": "yellow", "border": "2px solid yellow"},
             ALARM_MAJOR: {"color": "red", "border": "2px solid red"},
             ALARM_INVALID: {"color": "purple", "border": "2px solid purple"},


### PR DESCRIPTION
Always use 2px-border decoration, irrespectively of widget alarm state.

The reason for this is to keep the widget area constant, thus avoiding PyDM widgets to get misaligned when its alarm state changes. This misalignment is happening when a parent widget area has many widgets within it and when 'grid' layout is being used.

I am not sure if the UI behavior (widget area constant) I am trying to achieve with this PR is actually feasible across all possible PyDM widgets.
