### PR TITLE
FIX: Remove pyqtgraph from the list of dependencies …

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-pyqtgraph>=0.10.0
 numpy>=1.11.0
 scipy>=0.12.0
 pyepics>=3.2.7

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open(path.join(cur_dir, 'requirements.txt')) as f:
     requirements = f.read().split()
 
 # Remove the 'optional' requirements
-optional = ('PyQt5', 'PySide', 'psutil', 'pcaspy', 'pyepics')
+optional = ('PyQt5', 'PySide', 'psutil', 'pcaspy', 'pyepics', 'pyqtgraph')
 for package in optional:
     if package in requirements:
         requirements.remove(package)
@@ -27,13 +27,14 @@ extras_require = {
 
 if "CONDA_PREFIX" not in environ:
     extras_require['PyQt5'] = ['PyQt5']
+    extras_require['pyqtgraph'] = ['pyqtgraph']
 else:
     print("******************************************************************")
     print("*                              WARNING                           *") 
     print("******************************************************************")
     print("Installing at an Anaconda Environment, to avoid naming conflicts ")
     print("make sure you do:")
-    print("conda install pyqt=5")
+    print("conda install pyqt=5 pyqtgraph")
     print("******************************************************************")
     print("For more info please check: ")
     print("https://github.com/ContinuumIO/anaconda-issues/issues/1554")


### PR DESCRIPTION
 as it was making conda unhappy.

Again the issue of "anaconda" and "riverbank" and the package names.
pyqtgraph dependency was at the requirements.txt and with that forcing to install PyQt5 causing major issues on the package area.

Attn. @shengb