### PR TITLE
PR: Improve PyDMImageView

### DIFF
--- a/pydm/widgets/image.py
+++ b/pydm/widgets/image.py
@@ -1,15 +1,35 @@
 from ..PyQt.QtGui import QActionGroup
-from ..PyQt.QtCore import pyqtSlot, pyqtProperty
-from pyqtgraph import ImageView
-from pyqtgraph import ColorMap
+from ..PyQt.QtCore import pyqtSlot, pyqtProperty, Q_ENUMS
+from pyqtgraph import ImageView, ColorMap
 import numpy as np
 from .channel import PyDMChannel
 from .colormaps import cmaps
 from .base import PyDMWidget
+from collections import OrderedDict
+
+READINGORDER = OrderedDict([
+                            ('Fortranlike', 0),
+                            ('Clike', 1),
+                            ])
+COLORMAP = OrderedDict()
+for i, cm in enumerate(sorted(cmaps.keys())):
+    COLORMAP[cm] = i
+
 
 class PyDMImageView(ImageView, PyDMWidget):
     """
-    A PyQtGraph ImageView with support for Channels and more from PyDM
+    A PyQtGraph ImageView with support for Channels and more from PyDM.
+
+    If there is no :attr:`channelWidth` it is possible to define the width of
+    the image with the :attr:`width` property.
+
+    If the :attr:`imageChannel` contains the width of the image in the first
+    element of the array, set :attr:`widthFromImageChannel` to true and it will
+    overright the :attr:`widthChannel` property and the :attr:`width` property.
+
+    The :attr:`normalizeData` property defines if the colors of the images are
+    relative to the :attr:`colorMapMin` and :attr:`colorMapMax` property or to
+    the minimum and maximum values of the image.
 
     Parameters
     ----------
@@ -22,38 +42,77 @@ class PyDMImageView(ImageView, PyDMWidget):
         information
     """
 
-    color_maps = cmaps
+    # enumMap for readingOrderMap
+    locals().update(**READINGORDER)
+
+    class readingOrderMap:
+        for k in sorted(READINGORDER.keys()):
+            locals()[k] = READINGORDER[k]
+
+    Q_ENUMS(readingOrderMap)
+
+    # enumMap for colormapMap
+    locals().update(**COLORMAP)
+
+    class colormapMap:
+        for k in sorted(COLORMAP.keys()):
+            locals()[k] = COLORMAP[k]
+
+    Q_ENUMS(colormapMap)
+
+    readingorderdict = {}
+    for rd, i in READINGORDER.items():
+        readingorderdict[i] = rd
+
+    colormapdict = {}
+    for cm, i in COLORMAP.items():
+        colormapdict[i] = cmaps[cm]
+
     def __init__(self, parent=None, image_channel=None, width_channel=None):
+        """Initialize the object."""
         ImageView.__init__(self, parent)
         PyDMWidget.__init__(self)
-        self.axes = dict({'t': None, "x": 0, "y": 1, "c": None})
         self._imagechannel = image_channel
         self._widthchannel = width_channel
         self.image_waveform = np.zeros(0)
-        self.image_width = 0
+        self._image_width = 0
+        self._width_from_image_channel = False
+        self._normalize_data = False
+
+        # Hide some itens of the widget
         self.ui.histogram.hide()
         del self.ui.histogram
         self.ui.roiBtn.hide()
         self.ui.menuBtn.hide()
+
+        # Set color map limits
         self.cm_min = 0.0
         self.cm_max = 255.0
-        self.data_max_int = 255  # This is the max value for the image waveform's data type.  It gets set when the waveform updates.
-        self._colormapname = "inferno"
-        self._cm_colors = None
+
+        # Reading order of numpy array data
+        self._readingOrder = 0
+
+        self._colormapindex = COLORMAP["inferno"]
+        self._cm_colors = self.colormapdict[self._colormapindex]
         self._needs_reshape = False
-        self.setColorMapToPreset(self._colormapname)
+        self.setColorMap()
+
+        # Menu to change Color Map
         cm_menu = self.getView().getMenu(None).addMenu("Color Map")
         cm_group = QActionGroup(self)
-        for map_name in self.color_maps:
+        for map_name in COLORMAP.keys():
             action = cm_group.addAction(map_name)
             action.setCheckable(True)
+            action.index = COLORMAP[map_name]
             cm_menu.addAction(action)
-            if map_name == self._colormapname:
+            if action.index == self._colormapindex:
                 action.setChecked(True)
-        cm_menu.triggered.connect(self.changeColorMap)
+        cm_menu.triggered.connect(self._changeColorMap)
 
-    def changeColorMap(self, action):
+    def _changeColorMap(self, action):
         """
+        Change the colormap via action from ContextMenu.
+
         Method invoked by the colormap Action Menu that changes the
         current colormap used to render the image.
 
@@ -61,70 +120,11 @@ class PyDMImageView(ImageView, PyDMWidget):
         ----------
         action : QAction
         """
-        self.setColorMapToPreset(str(action.text()))
-
-    @pyqtSlot(int)
-    def setColorMapMin(self, new_min):
-        """
-        Set the minimal value for the colormap
-
-        Parameters
-        ----------
-        new_min : int
-        """
-        if self.cm_min != new_min:
-            self.cm_min = new_min
-            if self.cm_min > self.cm_max:
-                self.cm_max = self.cm_min
-            self.setColorMap()
-
-    @pyqtSlot(int)
-    def setColorMapMax(self, new_max):
-        """
-        Set the maximum value for the colormap
-
-        Parameters
-        ----------
-        new_max : int
-        """
-        if self.cm_max != new_max:
-            if new_max >= self.data_max_int:
-                new_max = self.data_max_int
-            self.cm_max = new_max
-            if self.cm_max < self.cm_min:
-                self.cm_min = self.cm_max
-            self.setColorMap()
-
-    def setColorMapLimits(self, mn, mx):
-        """
-        Set the limit values for the colormap
-
-        Parameters
-        ----------
-        mn : int
-            The lower limit
-        mx : int
-            The upper limit
-        """
-        self.cm_max = mx
-        self.cm_min = mn
-        self.setColorMap()
-
-    def setColorMapToPreset(self, name):
-        """
-        Load a predefined colormap
-
-        Parameters
-        ----------
-        name : str
-        """
-        self._colormapname = str(name)
-        self._cm_colors = self.color_maps[str(name)]
-        self.setColorMap()
+        self.colormap = action.index
 
     def setColorMap(self, cmap=None):
         """
-        Update the image colormap
+        Update the image colormap.
 
         Parameters
         ----------
@@ -133,17 +133,18 @@ class PyDMImageView(ImageView, PyDMWidget):
         if not cmap:
             if not self._cm_colors.any():
                 return
-            pos = np.linspace(0.0, 1.0, num=len(self._cm_colors))  # take default values
+            pos = np.linspace(0.0, 1.0, num=len(self._cm_colors))
             cmap = ColorMap(pos, self._cm_colors)
         self.getView().setBackgroundColor(cmap.map(0))
-        lut = cmap.getLookupTable(0.0, 1.0, self.data_max_int, alpha=False)
+        lut = cmap.getLookupTable(0.0, 1.0, alpha=False)
         self.getImageItem().setLookupTable(lut)
-        self.getImageItem().setLevels([self.cm_min, float(min(self.cm_max, self.data_max_int))])  # set levels from min to max of image (may improve min here)
+        self.getImageItem().setLevels([0.0, 1.0])
 
     @pyqtSlot(np.ndarray)
     def image_value_changed(self, new_image):
         """
         Callback invoked when the Image Channel value is changed.
+
         Reshape and display the new image.
 
         Parameters
@@ -153,23 +154,35 @@ class PyDMImageView(ImageView, PyDMWidget):
         """
         if new_image is None:
             return
-        if len(new_image.shape) == 1:
-            if self.image_width == 0:
-                self.image_waveform = new_image
-                self._needs_reshape = True
-                # We'll wait to draw the image until we get the width.
-                return
-            self.image_waveform = new_image.reshape((int(self.image_width), -1), order='F')
         elif len(new_image.shape) == 2:
             self.image_waveform = new_image
-        self.data_max_int = np.amax(self.image_waveform)  # take the max value of the recieved image
-        self.setColorMap()  # to update the colormap immediately
+        elif self._width_from_image_channel:
+            self.imageWidth = new_image[0]
+            image = new_image[1:]
+            self.image_waveform = self._reshapeImage(image)
+        elif self.imageWidth > 0:
+            self.image_waveform = self._reshapeImage(new_image)
+        elif self._widthchannel is not None:
+            self.image_waveform = new_image
+            # We'll wait to draw the image until we get the width from channel.
+            self._needs_reshape = True
+            return
+        else:
+            raise Exception('Image width is not defined.')
         self.redrawImage()
+
+    def _reshapeImage(self, image):
+        """Reshape the image according to the imageWidth and readingOrder."""
+        return image.reshape(
+                        (self.imageWidth, -1),
+                        order=self.readingorderdict[self._readingOrder]
+                        )
 
     @pyqtSlot(int)
     def image_width_changed(self, new_width):
         """
         Callback invoked when the Image Width Channel value is changed.
+
         Reshape the image data and triggers a ```redrawImage```
 
         Parameters
@@ -179,22 +192,236 @@ class PyDMImageView(ImageView, PyDMWidget):
         """
         if new_width is None:
             return
-        self.image_width = int(new_width)
+        self.imageWidth = new_width
         if self._needs_reshape:
-            self.image_waveform = self.image_waveform.reshape((int(self.image_width), -1), order='F')
+            self.image_waveform = self._reshapeImage(self.image_waveform)
             self._needs_reshape = False
         self.redrawImage()
 
     def redrawImage(self):
+        """Set the image data into the ImageItem."""
+        if len(self.image_waveform) <= 0 or self.imageWidth <= 0:
+            return
+        if self._normalize_data:
+            mini = self.image_waveform.min()
+            maxi = self.image_waveform.max()
+        else:
+            mini = self.cm_min
+            maxi = self.cm_max
+        image = (self.image_waveform - mini)/(maxi-mini)
+        self.getImageItem().setImage(
+            image,
+            autoLevels=False,
+            autoHistogramRange=False)
+
+    def setColorMapLimits(self, mn, mx):
+        """Set the limit values for the colormap.
+
+        Parameters
+        ----------
+        mn : int
+            The lower limit
+        mx : int
+            The upper limit
         """
-        Set the image data into the ImageItem
-        """
-        if len(self.image_waveform) > 0 and self.image_width > 0:
-            self.getImageItem().setImage(self.image_waveform, autoLevels=False,
-                          autoHistogramRange=False, xvals=[0, 1])
+        if mn >= mx:
+            return
+        self.cm_max = float(mx)
+        self.cm_min = float(mn)
+        self.setColorMap()
 
     def keyPressEvent(self, ev):
+        """Handle keypress events."""
         return
+
+    @pyqtProperty(bool)
+    def widthFromImageChannel(self):
+        """Whether to retrieve width from the imageChannel first element.
+
+        Returns
+        -------
+        bool
+        """
+        return self._width_from_image_channel
+
+    @widthFromImageChannel.setter
+    def widthFromImageChannel(self, new_bool):
+        """Define if width is retrieved from the imageChannel first element.
+
+        Parameters
+        ----------
+        new_bool: bool
+        """
+        self._width_from_image_channel = bool(new_bool)
+
+    @pyqtProperty(int)
+    def imageWidth(self):
+        """Return the width of the image.
+
+        Returns
+        ----------
+        int
+        """
+        return self._image_width
+
+    @imageWidth.setter
+    def imageWidth(self, new_width):
+        """Set the width of the image.
+
+        Can be overridden by :attr:`widthChannel`
+        or :attr:`widthFromImageChannel`.
+
+        Parameters
+        ----------
+        new_width: int
+        """
+        if self._image_width != int(new_width) and self._widthchannel is None:
+            self._image_width = int(new_width)
+
+    @pyqtProperty(str)
+    def widthChannel(self):
+        """
+        The channel address in use for the image width .
+
+        Returns
+        -------
+        str
+            Channel address
+        """
+        return str(self._widthchannel)
+
+    @widthChannel.setter
+    def widthChannel(self, value):
+        """
+        The channel address in use for the image width .
+
+        Parameters
+        ----------
+        value : str
+            Channel address
+        """
+        if self._widthchannel != value:
+            self._widthchannel = str(value)
+
+    @pyqtProperty(colormapMap)
+    def colormap(self):
+        """Return the index of the colormap to be used.
+
+        Returns
+        ----------
+        int
+        """
+        return self._colormapindex
+
+    @colormap.setter
+    def colormap(self, new_colormapindex):
+        """Set the index of the colormap to be used.
+
+        Parameters
+        ----------
+        new_colormapindex: int
+        """
+        if self._colormapindex != new_colormapindex:
+            self._colormapindex = new_colormapindex
+            self._cm_colors = self.colormapdict[self._colormapindex]
+            self.setColorMap()
+
+    @pyqtProperty(bool)
+    def normalizeData(self):
+        """Return True if the colors are relative to data maximum and minimum.
+
+        Returns
+        ----------
+        bool
+        """
+        return self._normalize_data
+
+    @normalizeData.setter
+    @pyqtSlot(bool)
+    def normalizeData(self, new_norm):
+        """Define if the colors are relative to maximum and minimum of data.
+
+        Parameters
+        ----------
+        new_norm: bool
+        """
+        if self._normalize_data == new_norm:
+            return
+        self._normalize_data = new_norm
+        self.redrawImage()
+
+    @pyqtProperty(int)
+    def colorMapMin(self):
+        """Minimum value to be considered for color scale definition.
+
+        Returns
+        -------
+        float
+            minimum value of the color scale.
+        """
+        return self.cm_min
+
+    @colorMapMin.setter
+    @pyqtSlot(int)
+    def colorMapMin(self, new_min):
+        """Set the minimum value to be considered for color scale definition.
+
+        Parameters
+        -------
+        new_min: float
+        """
+        if self.cm_min == new_min or new_min > self.cm_max:
+            return
+        self.cm_min = float(new_min)
+        self.setColorMap()
+
+    @pyqtProperty(int)
+    def colorMapMax(self):
+        """Maximum value to be considered for color scale definition.
+
+        Returns
+        -------
+        float
+            maximum value of the color scale.
+        """
+        return self.cm_max
+
+    @colorMapMax.setter
+    @pyqtSlot(int)
+    def colorMapMax(self, new_max):
+        """Set the maximum value to be considered for color scale definition.
+
+        Parameters
+        -------
+        new_max: float
+        """
+        if self.cm_max == new_max or new_max < self.cm_min:
+            return
+        self.cm_max = float(new_max)
+        self.setColorMap()
+
+    @pyqtProperty(readingOrderMap)
+    def readingOrder(self):
+        """Reading order of the :attr:`imageChannel` array.
+
+        Returns
+        -------
+        int
+            0 if the reading order is Fortranlike or 1 if it is Clike.
+        """
+        return self._readingOrder
+
+    @readingOrder.setter
+    def readingOrder(self, new_order):
+        """Set reading order of the :attr:`imageChannel` array.
+
+        Parameters
+        ----------
+        new_order: int
+            0 if the reading order is Fortranlike or 1 if it is Clike.
+        """
+        if self._readingOrder != new_order:
+            self._readingOrder = int(new_order)
 
     @pyqtProperty(str)
     def imageChannel(self):

--- a/pydm/widgets/image.py
+++ b/pydm/widgets/image.py
@@ -23,10 +23,6 @@ class PyDMImageView(ImageView, PyDMWidget):
     If there is no :attr:`channelWidth` it is possible to define the width of
     the image with the :attr:`width` property.
 
-    If the :attr:`imageChannel` contains the width of the image in the first
-    element of the array, set :attr:`widthFromImageChannel` to true and it will
-    overright the :attr:`widthChannel` property and the :attr:`width` property.
-
     The :attr:`normalizeData` property defines if the colors of the images are
     relative to the :attr:`colorMapMin` and :attr:`colorMapMax` property or to
     the minimum and maximum values of the image.
@@ -76,7 +72,6 @@ class PyDMImageView(ImageView, PyDMWidget):
         self._widthchannel = width_channel
         self.image_waveform = np.zeros(0)
         self._image_width = 0
-        self._width_from_image_channel = False
         self._normalize_data = False
 
         # Hide some itens of the widget
@@ -156,10 +151,6 @@ class PyDMImageView(ImageView, PyDMWidget):
             return
         elif len(new_image.shape) == 2:
             self.image_waveform = new_image
-        elif self._width_from_image_channel:
-            self.imageWidth = new_image[0]
-            image = new_image[1:]
-            self.image_waveform = self._reshapeImage(image)
         elif self.imageWidth > 0:
             self.image_waveform = self._reshapeImage(new_image)
         elif self._widthchannel is not None:
@@ -234,26 +225,6 @@ class PyDMImageView(ImageView, PyDMWidget):
         """Handle keypress events."""
         return
 
-    @pyqtProperty(bool)
-    def widthFromImageChannel(self):
-        """Whether to retrieve width from the imageChannel first element.
-
-        Returns
-        -------
-        bool
-        """
-        return self._width_from_image_channel
-
-    @widthFromImageChannel.setter
-    def widthFromImageChannel(self, new_bool):
-        """Define if width is retrieved from the imageChannel first element.
-
-        Parameters
-        ----------
-        new_bool: bool
-        """
-        self._width_from_image_channel = bool(new_bool)
-
     @pyqtProperty(int)
     def imageWidth(self):
         """Return the width of the image.
@@ -268,8 +239,7 @@ class PyDMImageView(ImageView, PyDMWidget):
     def imageWidth(self, new_width):
         """Set the width of the image.
 
-        Can be overridden by :attr:`widthChannel`
-        or :attr:`widthFromImageChannel`.
+        Can be overridden by :attr:`widthChannel`.
 
         Parameters
         ----------


### PR DESCRIPTION
Improve PyDMImageView adding pyqtproperties:
 - normalizeData: attribute to define if the colors are defined relative
to minimum and maximum of array or to a fixed scale;
 - width: user defined width, in case there is no EPICS info about it
(is overridden by widthChannel and widthFromImageChannel).
 - colorMapMin and colorMapMax: pyqt properties to set limits of colors
in colormap.
 - colormap: set the colormap to be used.
 - readingOrder: if the data should be read in Fortran or C style.