### PR TITLE
PR: improve PyDMSpinbox

### DIFF
--- a/pydm/widgets/spinbox.py
+++ b/pydm/widgets/spinbox.py
@@ -26,6 +26,7 @@ class PyDMSpinbox(QDoubleSpinBox, PyDMWritableWidget):
 
         self.valueChanged.connect(self.send_value)  # signal from spinbox
         self.setKeyboardTracking(False)
+        self.setAccelerated(True)
 
     def event(self, event):
         """

--- a/pydm/widgets/spinbox.py
+++ b/pydm/widgets/spinbox.py
@@ -172,4 +172,4 @@ class PyDMSpinbox(QDoubleSpinBox, PyDMWritableWidget):
         val : bool
         """
         self._show_step_exponent = val
-        self.update()
+        self.update_format_string()

--- a/pydm/widgets/spinbox.py
+++ b/pydm/widgets/spinbox.py
@@ -23,55 +23,33 @@ class PyDMSpinbox(QDoubleSpinBox, PyDMWritableWidget):
         self.step_exponent = 0
         self.setDecimals(0)
         self.app = QApplication.instance()
-
         self.setAccelerated(True)
 
-    def event(self, event):
+    def keyPressEvent(self, ev):
         """
-        Method invoked when an event of any nature happens on the
-        QDoubleSpinBox.
+        Method invoked when a key press event happens on the QDoubleSpinBox.
 
         For PyDMSpinBox we are interested on the Keypress events for:
-        - CTRL + Left/Right : Increase or Decrease the step exponent
-        - Up / Down : Add or Remove `singleStep` units to the value
-        - Return : Send the value to the channel using the `send_value_signal`
+        - CTRL + Left/Right : Increase or Decrease the step exponent;
+        - Up / Down : Add or Remove `singleStep` units to the value;
+        - PageUp / PageDown : Add or Remove 10 times `singleStep` units
+          to the value;
+        - Return or Enter : Send the value to the channel using the
+          `send_value_signal`.
 
         Parameters
         ----------
-        event : QEvent
+        ev : QEvent
         """
-        if (event.type() == QEvent.KeyPress):
-            ctrl_hold = self.app.queryKeyboardModifiers() == Qt.ControlModifier
-
-            if ctrl_hold and (event.key() == Qt.Key_Left):
-                self.step_exponent = self.step_exponent + 1
-                self.update_step_size()
-                return True
-
-            if ctrl_hold and (event.key() == Qt.Key_Right):
-                self.step_exponent = self.step_exponent - 1
-
-                if self.step_exponent < -self.decimals():
-                    self.step_exponent = -self.decimals()
-
-                self.update_step_size()
-                return True
-
-            if (event.key() == Qt.Key_Up):
-                self.setValue(self.value + self.singleStep())
-                self.send_value()
-                return True
-
-            if (event.key() == Qt.Key_Down):
-                self.setValue(self.value - self.singleStep())
-                self.send_value()
-                return True
-
-            if (event.key() == Qt.Key_Return):
-                self.send_value()
-                return True
-
-        return super(PyDMSpinbox, self).event(event)
+        ctrl_hold = self.app.queryKeyboardModifiers() == Qt.ControlModifier
+        if ctrl_hold and (ev.key() in (Qt.Key_Left, Qt.Key_Right)):
+            self.step_exponent += 1 if ev.key() == Qt.Key_Left else -1
+            self.step_exponent = max(-self.decimals(), self.step_exponent)
+            self.update_step_size()
+        elif ev.key() in (Qt.Key_Return, Qt.Key_Enter):
+            self.send_value()
+        else:
+            super(PyDMSpinbox, self).keyPressEvent(ev)
 
     def contextMenuEvent(self, ev):
         """Increment LineEdit menu to toggle the display of the step size."""

--- a/pydm/widgets/spinbox.py
+++ b/pydm/widgets/spinbox.py
@@ -24,6 +24,9 @@ class PyDMSpinbox(QDoubleSpinBox, PyDMWritableWidget):
         self.setDecimals(0)
         self.app = QApplication.instance()
 
+        self.valueChanged.connect(self.send_value)  # signal from spinbox
+        self.setKeyboardTracking(False)
+
     def event(self, event):
         """
         Method invoked when an event of any nature happens on the
@@ -53,20 +56,6 @@ class PyDMSpinbox(QDoubleSpinBox, PyDMWritableWidget):
                     self.step_exponent = -self.decimals()
 
                 self.update_step_size()
-                return True
-
-            if (event.key() == Qt.Key_Up):
-                self.setValue(self.value + self.singleStep())
-                self.send_value()
-                return True
-
-            if (event.key() == Qt.Key_Down):
-                self.setValue(self.value - self.singleStep())
-                self.send_value()
-                return True
-
-            if (event.key() == Qt.Key_Return):
-                self.send_value()
                 return True
 
         return super(PyDMSpinbox, self).event(event)
@@ -114,12 +103,11 @@ class PyDMSpinbox(QDoubleSpinBox, PyDMWritableWidget):
         self.setValue(new_val)
         self.valueBeingSet = False
 
-    def send_value(self):
+    def send_value(self, value):
         """
         Method invoked to send the current value on the QDoubleSpinBox to
         the channel using the `send_value_signal`.
         """
-        value = float(self.cleanText())
         if not self.valueBeingSet:
             self.send_value_signal[float].emit(value)
 

--- a/pydm/widgets/spinbox.py
+++ b/pydm/widgets/spinbox.py
@@ -28,8 +28,6 @@ class PyDMSpinbox(QDoubleSpinBox, PyDMWritableWidget):
         self.setKeyboardTracking(False)
         self.setAccelerated(True)
 
-        self.lineEdit().setToolTip('Step: 1E{0:+d}'.format(self.step_exponent))
-
     def event(self, event):
         """
         Method invoked when an event of any nature happens on the
@@ -93,12 +91,14 @@ class PyDMSpinbox(QDoubleSpinBox, PyDMWritableWidget):
         else:
             units = ""
 
-        self.lineEdit().setToolTip('Step: 1E{0:+d}'.format(self.step_exponent))
         if self._show_step_exponent:
             self.setSuffix("{units} Step: 1E{exp}".format(
                 units=units, exp=self.step_exponent))
+            self.lineEdit().setToolTip("")
         else:
             self.setSuffix(units)
+            self.lineEdit().setToolTip(
+                            'Step: 1E{0:+d}'.format(self.step_exponent))
 
     def value_changed(self, new_val):
         """

--- a/pydm/widgets/spinbox.py
+++ b/pydm/widgets/spinbox.py
@@ -42,20 +42,16 @@ class PyDMSpinbox(QDoubleSpinBox, PyDMWritableWidget):
         ----------
         event : QEvent
         """
-        if (event.type() == QEvent.KeyPress):
-            ctrl_hold = self.app.queryKeyboardModifiers() == Qt.ControlModifier
+        if event.type() == QEvent.KeyPress and \
+           self.app.queryKeyboardModifiers() == Qt.ControlModifier:
 
-            if ctrl_hold and (event.key() == Qt.Key_Left):
+            if event.key() == Qt.Key_Left:
                 self.step_exponent = self.step_exponent + 1
                 self.update_step_size()
                 return True
-
-            if ctrl_hold and (event.key() == Qt.Key_Right):
-                self.step_exponent = self.step_exponent - 1
-
-                if self.step_exponent < -self.decimals():
-                    self.step_exponent = -self.decimals()
-
+            elif event.key() == Qt.Key_Right:
+                self.step_exponent = max(self.step_exponent - 1,
+                                         -self.decimals())
                 self.update_step_size()
                 return True
 

--- a/pydm/widgets/spinbox.py
+++ b/pydm/widgets/spinbox.py
@@ -28,6 +28,8 @@ class PyDMSpinbox(QDoubleSpinBox, PyDMWritableWidget):
         self.setKeyboardTracking(False)
         self.setAccelerated(True)
 
+        self.lineEdit().setToolTip('Step: 1E{0:+d}'.format(self.step_exponent))
+
     def event(self, event):
         """
         Method invoked when an event of any nature happens on the
@@ -91,6 +93,7 @@ class PyDMSpinbox(QDoubleSpinBox, PyDMWritableWidget):
         else:
             units = ""
 
+        self.lineEdit().setToolTip('Step: 1E{0:+d}'.format(self.step_exponent))
         if self._show_step_exponent:
             self.setSuffix("{units} Step: 1E{exp}".format(
                 units=units, exp=self.step_exponent))

--- a/pydm/widgets/spinbox.py
+++ b/pydm/widgets/spinbox.py
@@ -57,6 +57,17 @@ class PyDMSpinbox(QDoubleSpinBox, PyDMWritableWidget):
 
         return super(PyDMSpinbox, self).event(event)
 
+    def contextMenuEvent(self, ev):
+        """Increment LineEdit menu to toggle the display of the step size."""
+        def toogle():
+            self.showStepExponent = not self.showStepExponent
+
+        menu = self.lineEdit().createStandardContextMenu()
+        menu.addSeparator()
+        ac = menu.addAction('Toggle Show Step Size')
+        ac.triggered.connect(toogle)
+        menu.exec_(ev.globalPos())
+
     def update_step_size(self):
         """
         Update the Single Step size on the QDoubleSpinBox.


### PR DESCRIPTION
Bug fixes and new functionality to `PyDMSpinbox`:

 - Use of keyboard arrows was triggering float conversion errors for Locale's configuration where comma is used instead of dots. The solution delegates to the `QDoubleSpinBox` class the float conversions.
 - The text in `lineEdit` was not updated when `showStepExponent` was changed.
 - Creation of `contextMenu` entry to toggle display of `stepSize` in `lineEdit` text.
 - Creation of `lineEdit` tooltip to show `stepSize` when it is not show in the text.