### PR TITLE
Fixed bug in the value_changed method of the PyDMEnumComboBox

### DIFF
--- a/pydm/widgets/enum_combo_box.py
+++ b/pydm/widgets/enum_combo_box.py
@@ -105,7 +105,7 @@ class PyDMEnumComboBox(QFrame, PyDMWritableWidget):
         new_value : str, int, float, bool or np.ndarray
             The new value from the channel. The type depends on the channel.
         """
-        if new_val:
+        if new_val is not None:
             super(PyDMEnumComboBox, self).value_changed(new_val)
             self.combo_box.setCurrentIndex(new_val)
 


### PR DESCRIPTION
When a callback is issued and the PyDMEnumComboBox value_changed method is called, it doesn't update the widget value if new_val is equal to 0.