### PR TITLE
Add Scatter Plot Widget

### DIFF
--- a/docs/source/widgets/index.rst
+++ b/docs/source/widgets/index.rst
@@ -16,6 +16,7 @@ PyDM comes with a set of widgets useful for operating a control system.
     line_edit.rst
     pushbutton.rst
     related_display_button.rst
+    scatterplot.rst
     shell_command.rst
     slider.rst
     spinbox.rst

--- a/docs/source/widgets/scatterplot.rst
+++ b/docs/source/widgets/scatterplot.rst
@@ -1,0 +1,6 @@
+###############
+PyDMScatterPlot
+###############
+
+.. autoclass:: pydm.widgets.scatterplot.PyDMScatterPlot
+   :members:

--- a/examples/scatterplot/scatterplot.ui
+++ b/examples/scatterplot/scatterplot.ui
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="PyDMScatterPlot" name="PyDMScatterPlot">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="whatsThis">
+      <string>
+    PyDMScatterPlot is a widget to plot one scalar value against another.
+    Multiple scalar pairs can be plotted on the same plot.  Each pair has
+    a buffer which stores previous values.  All values in the buffer are
+    drawn.  The buffer size for each pair is user configurable.
+
+    Parameters
+    ----------
+    parent : optional
+        The parent of this widget.
+    init_x_channels: optional
+        init_x_channels can be a string with the address for a channel, or a list of
+        strings, each containing an address for a channel.  If not specified, y-axis
+        waveforms will be plotted against their indices.  If a list is specified for
+        both init_x_channels and init_y_channels, they both must have the same length.
+        If a single x channel was specified, and a list of y channels are specified, all
+        y channels will be plotted against the same x channel.
+    init_y_channels: optional
+        init_y_channels can be a string with the address for a channel, or a list of
+        strings, each containing an address for a channel.  If a list is specified for
+        both init_x_channels and init_y_channels, they both must have the same length.
+        If a single x channel was specified, and a list of y channels are specified, all
+        y channels will be plotted against the same x channel.
+    background: optional
+        The background color for the plot.  Accepts any arguments that pyqtgraph.mkColor
+        will accept.
+    </string>
+     </property>
+     <property name="curves">
+      <stringlist>
+       <string>{&quot;y_channel&quot;: &quot;ca://MTEST:SinVal&quot;, &quot;x_channel&quot;: &quot;ca://MTEST:CosVal&quot;, &quot;name&quot;: &quot;CircularData&quot;, &quot;color&quot;: &quot;white&quot;, &quot;lineStyle&quot;: 0, &quot;lineWidth&quot;: 1, &quot;symbol&quot;: &quot;o&quot;, &quot;symbolSize&quot;: 10, &quot;redraw_mode&quot;: 3}</string>
+      </stringlist>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>PyDMScatterPlot</class>
+   <extends>QGraphicsView</extends>
+   <header>pydm.widgets.scatterplot</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/pydm/widgets/qtplugins.py
+++ b/pydm/widgets/qtplugins.py
@@ -28,6 +28,8 @@ from .timeplot_qtplugin import PyDMTimePlotPlugin
 # Waveform Plot plugin
 from .waveformplot_qtplugin import PyDMWaveformPlotPlugin
 
+# Scatter Plot plugin
+from .scatterplot_qtplugin import PyDMScatterPlotPlugin
 # Byte plugin
 PyDMByteIndicatorPlugin = qtplugin_factory(PyDMByteIndicator, group=WidgetCategory.DISPLAY)
 

--- a/pydm/widgets/scatterplot.py
+++ b/pydm/widgets/scatterplot.py
@@ -1,0 +1,644 @@
+from ..PyQt.QtGui import QColor
+from ..PyQt.QtCore import pyqtSignal, pyqtSlot, pyqtProperty, Qt
+from pyqtgraph import ViewBox, AxisItem, PlotDataItem, mkPen
+import numpy as np
+import json
+import itertools
+from collections import OrderedDict
+from .baseplot import BasePlot
+from .channel import PyDMChannel
+from .. import utilities
+from .base import PyDMPrimitiveWidget
+
+class ScatterPlotCurveItem(PlotDataItem):
+    REDRAW_ON_X, REDRAW_ON_Y, REDRAW_ON_EITHER, REDRAW_ON_BOTH = range(4)
+    symbols = OrderedDict([('None', None),
+                           ('Circle', 'o'),
+                           ('Square', 's'),
+                           ('Triangle', 't'),
+                           ('Star', 'star'),
+                           ('Pentagon', 'p'),
+                           ('Hexagon', 'h'),
+                           ('X', 'x'),
+                           ('Diamond', 'd'),
+                           ('Plus', '+')])
+    lines = OrderedDict([('NoLine', Qt.NoPen),
+                         ('Solid', Qt.SolidLine),
+                         ('Dash', Qt.DashLine),
+                         ('Dot', Qt.DotLine),
+                         ('DashDot', Qt.DashDotLine),
+                         ('DashDotDot', Qt.DashDotDotLine)])
+    data_changed = pyqtSignal()
+    def __init__(self, y_addr, x_addr, color=None, lineStyle=None,
+                 lineWidth=None, redraw_mode=REDRAW_ON_EITHER, **kws):
+        self.x_channel = None
+        self.y_channel = None
+        self.x_address = x_addr
+        self.y_address = y_addr
+        self.x_connected = False
+        self.y_connected = False
+        #If a name wasn't specified, use the addresses to make one.
+        if kws.get('name') is None:
+            if y_addr is None and x_addr is None:
+                kws['name'] = ""
+            else:
+                y_name = utilities.remove_protocol(y_addr if y_addr is not None else "")
+                x_name = utilities.remove_protocol(x_addr if x_addr is not None else "")
+                kws['name'] = "{y} vs. {x}".format(y=y_name, x=x_name)
+        self.redraw_mode = redraw_mode
+        self._bufferSize = 1200
+        self.data_buffer = np.zeros((2, self._bufferSize), order='f', dtype=float)
+        self.points_accumulated = 0
+        self.latest_x_value = None
+        self.latest_y_value = None
+        self._color = QColor('white')
+        self._pen = mkPen(self._color)
+        if lineWidth is not None:
+            self._pen.setWidth(lineWidth)
+        if lineStyle is not None:
+            self._pen.setStyle(lineStyle)
+        kws['pen'] = self._pen
+        super(ScatterPlotCurveItem, self).__init__(**kws)
+        self.setSymbolBrush(None)
+        if color is not None:
+            self.color = color
+
+    def to_dict(self):
+        """
+        Returns an OrderedDict representation with values for all properties
+        needed to recreate this curve.
+
+        Returns
+        -------
+        OrderedDict
+        """
+        return OrderedDict([("y_channel", self.y_address),
+                            ("x_channel", self.x_address),
+                            ("name", self.name()),
+                            ("color", self.color_string),
+                            ("lineStyle", self.lineStyle),
+                            ("lineWidth", self.lineWidth),
+                            ("symbol", self.symbol),
+                            ("symbolSize", self.symbolSize),
+                            ("redraw_mode", self.redraw_mode)])
+
+    @property
+    def x_address(self):
+        """
+        The address of the channel used to get the x axis data.
+
+        Returns
+        -------
+        str
+        """
+        if self.x_channel is None:
+            return None
+        return self.x_channel.address
+
+    @x_address.setter
+    def x_address(self, new_address):
+        """
+        The address of the channel used to get the x axis data.
+
+        Parameters
+        -------
+        new_address: str
+        """
+        if new_address is None or len(str(new_address)) < 1:
+            self.x_channel = None
+            return
+        self.x_channel = PyDMChannel(address=new_address, connection_slot=self.xConnectionStateChanged, value_slot=self.receiveXValue)
+
+    @property
+    def y_address(self):
+        """
+        The address of the channel used to get the y axis data.
+
+        Returns
+        -------
+        str
+        """
+        if self.y_channel is None:
+            return None
+        return self.y_channel.address
+
+    @y_address.setter
+    def y_address(self, new_address):
+        """
+        The address of the channel used to get the y axis data.
+
+        Parameters
+        ----------
+        new_address: str
+        """
+        if new_address is None or len(str(new_address)) < 1:
+            self.y_channel = None
+            return
+        self.y_channel = PyDMChannel(address=new_address, connection_slot=self.yConnectionStateChanged, value_slot=self.receiveYValue)
+
+    @property
+    def color_string(self):
+        """
+        A string representation of the color used for the curve.  This string
+        will be a hex color code, like #FF00FF, or an SVG spec color name, if
+        a name exists for the color.
+
+        Returns
+        -------
+        str
+        """
+        return str(utilities.colors.svg_color_from_hex(self.color.name(), hex_on_fail=True))
+
+    @color_string.setter
+    def color_string(self, new_color_string):
+        """
+        A string representation of the color used for the curve.  This string
+        will be a hex color code, like #FF00FF, or an SVG spec color name, if
+        a name exists for the color.
+
+        Parameters
+        -------
+        new_color_string: int
+            The new string to use for the curve color.
+        """
+        self.color = QColor(str(new_color_string))
+
+    @property
+    def color(self):
+        """
+        The color used for the curve.
+
+        Returns
+        -------
+        QColor
+        """
+        return self._color
+
+    @color.setter
+    def color(self, new_color):
+        """
+        The color used for the curve.
+
+        Parameters
+        -------
+        new_color: QColor or str
+            The new color to use for the curve.
+            Strings are passed to ScatterPlotCurveItem.color_string.
+        """
+        if isinstance(new_color, str):
+            self.color_string = new_color
+            return
+        self._color = new_color
+        self._pen.setColor(self._color)
+        self.setPen(self._pen)
+        self.setSymbolPen(self._color)
+
+    @property
+    def symbol(self):
+        """
+        The single-character code for the symbol drawn at each datapoint.
+
+        See the documentation for pyqtgraph.PlotDataItem for possible values.
+
+        Returns
+        -------
+        str or None
+        """
+        return self.opts['symbol']
+
+    @symbol.setter
+    def symbol(self, new_symbol):
+        """
+        The single-character code for the symbol drawn at each datapoint.
+
+        See the documentation for pyqtgraph.PlotDataItem for possible values.
+
+        Parameters
+        -------
+        new_symbol: str or None
+        """
+        if new_symbol in self.symbols.values():
+            self.setSymbol(new_symbol)
+            self.setSymbolPen(self._color)
+
+    @property
+    def symbolSize(self):
+        """
+        Return the size of the symbol to represent the data.
+
+        Returns
+        -------
+        int
+        """
+        return self.opts['symbolSize']
+
+    @symbolSize.setter
+    def symbolSize(self, new_size):
+        """
+        Set the size of the symbol to represent the data.
+
+        Parameters
+        -------
+        new_size: int
+        """
+        self.setSymbolSize(int(new_size))
+
+    @property
+    def lineWidth(self):
+        """
+        Return the width of the line connecting the data points.
+
+        Returns
+        -------
+        int
+        """
+        return self._pen.width()
+
+    @lineWidth.setter
+    def lineWidth(self, new_width):
+        """
+        Set the width of the line connecting the data points.
+
+        Parameters
+        -------
+        new_width: int
+        """
+        self._pen.setWidth(int(new_width))
+        self.setPen(self._pen)
+        
+    @property
+    def lineStyle(self):
+        """
+        Return the style of the line connecting the data points.
+        Must be a value from the Qt::PenStyle enum (see http://doc.qt.io/qt-5/qt.html#PenStyle-enum).
+
+        Returns
+        -------
+        int
+        """
+        return self._pen.style()
+
+    @lineStyle.setter
+    def lineStyle(self, new_style):
+        """
+        Set the style of the line connecting the data points.
+        Must be a value from the Qt::PenStyle enum (see http://doc.qt.io/qt-5/qt.html#PenStyle-enum).
+
+        Parameters
+        -------
+        new_style: int
+        """
+        if new_style in self.lines.values():
+            self._pen.setStyle(new_style)
+            self.setPen(self._pen)
+    
+    @pyqtSlot(bool)
+    def xConnectionStateChanged(self, connected):
+        self.x_connected = connected
+
+    @pyqtSlot(bool)
+    def yConnectionStateChanged(self, connected):
+        self.y_connected = connected
+
+    @pyqtSlot(int)
+    @pyqtSlot(float)
+    def receiveXValue(self, new_x):
+        """
+        Handler for new x data.
+        """
+        if new_x is None:
+            return
+        self.latest_x_value = new_x
+        self.needs_new_x = False
+        self.update_buffer()
+
+    @pyqtSlot(int)
+    @pyqtSlot(float)
+    def receiveYValue(self, new_y):
+        """
+        Handler for new y data.
+        """
+        if new_y is None:
+            return
+        self.latest_y_value = new_y
+        self.needs_new_y = False
+        self.update_buffer()
+
+    def update_buffer(self):
+        """
+        This is called whenever new data is received for X or Y.
+        Based on the value of the redraw_mode attribute, it decides whether
+        we are ready to shift the data buffer by one and add the latest data.
+        """
+        #If we haven't gotten values for X and Y yet, can't redraw.
+        if self.latest_y_value is None or self.latest_x_value is None:
+            return
+    
+        if self.redraw_mode == self.REDRAW_ON_EITHER:
+            #no matter which channel updates, add a pair with the two most recent values
+            pass 
+        elif self.redraw_mode == self.REDRAW_ON_X:
+            #If we only redraw when X updates, make sure new X data has arrived since the last time we drew the plot.
+            if self.needs_new_x:
+                return
+        elif self.redraw_mode == self.REDRAW_ON_Y:
+            #If we only redraw when Y updates, make sure new Y data has arrived since the last time we drew the plot.
+            if self.needs_new_y:
+                return
+        elif self.redraw_mode == self.REDRAW_ON_BOTH:
+            #Make sure both X and Y have received new data since the last time we drew the plot.
+            if self.needs_new_y or self.needs_new_x:
+                return
+        #If you get this far, we are OK to add the latest data to the buffer.
+        self.data_buffer = np.roll(self.data_buffer, -1)
+        self.data_buffer[0, -1] = self.latest_x_value
+        self.data_buffer[1, -1] = self.latest_y_value
+        if self.points_accumulated < self._bufferSize:
+            self.points_accumulated = self.points_accumulated + 1
+        self.data_changed.emit()
+
+    def initialize_buffer(self):
+        self.points_accumulated = 0
+        self.data_buffer = np.zeros((2, self._bufferSize), order='f', dtype=float)
+
+    def getBufferSize(self):
+        return int(self._bufferSize)
+
+    def setBufferSize(self, value):
+        if self._bufferSize != int(value):
+            self._bufferSize = max(int(value), 1)
+            self.initialize_buffer()
+
+    def resetBufferSize(self):
+        if self._bufferSize != 1200:
+            self._bufferSize = 1200
+            self.initialize_buffer()
+
+    def redrawCurve(self):
+        """
+        redrawCurve is called by the curve's parent plot whenever the curve needs to be
+        re-drawn with new data.
+        """
+        self.setData(x=self.data_buffer[1, -self.points_accumulated:], y=self.data_buffer[0, -self.points_accumulated:])
+        self.needs_new_x = True
+        self.needs_new_y = True
+        
+    def limits(self):
+        """
+        Limits of the data for this curve.
+        Returns a nested tuple of limits: ((xmin, xmax), (ymin, ymax))
+
+        Returns
+        -------
+        tuple
+        """
+        if self.points_accumulated == 0:
+            raise NoDataError("Curve has no data, cannot determine limits.")
+        x_data = self.data_buffer[0, -self.points_accumulated:]
+        y_data = self.data_buffer[1, -self.points_accumulated:]
+        return ((np.amin(x_data), np.amax(x_data)), (np.amin(y_data), np.amax(y_data)))
+        
+class PyDMScatterPlot(BasePlot):
+    """
+    PyDMScatterPlot is a widget to plot one scalar value against another.
+    Multiple scalar pairs can be plotted on the same plot.  Each pair has
+    a buffer which stores previous values.  All values in the buffer are
+    drawn.  The buffer size for each pair is user configurable.
+
+    Parameters
+    ----------
+    parent : optional
+        The parent of this widget.
+    init_x_channels: optional
+        init_x_channels can be a string with the address for a channel, or a list of
+        strings, each containing an address for a channel.  If not specified, y-axis
+        waveforms will be plotted against their indices.  If a list is specified for
+        both init_x_channels and init_y_channels, they both must have the same length.
+        If a single x channel was specified, and a list of y channels are specified, all
+        y channels will be plotted against the same x channel.
+    init_y_channels: optional
+        init_y_channels can be a string with the address for a channel, or a list of
+        strings, each containing an address for a channel.  If a list is specified for
+        both init_x_channels and init_y_channels, they both must have the same length.
+        If a single x channel was specified, and a list of y channels are specified, all
+        y channels will be plotted against the same x channel.
+    background: optional
+        The background color for the plot.  Accepts any arguments that pyqtgraph.mkColor
+        will accept.
+    """
+    def __init__(self, parent=None, init_x_channels=[], init_y_channels=[], background='default'):
+        super(PyDMScatterPlot, self).__init__(parent, background)
+        #If the user supplies a single string instead of a list, wrap it in a list.
+        if isinstance(init_x_channels, str):
+            init_x_channels = [init_x_channels]
+        if isinstance(init_y_channels, str):
+            init_y_channels = [init_y_channels]
+        if len(init_x_channels) == 0:
+            init_x_channels = list(itertools.repeat(None, len(init_y_channels)))
+        if len(init_x_channels) != len(init_y_channels):
+            raise ValueError("If lists are provided for both X and Y channels, they must be the same length.")
+        #self.channel_pairs is an ordered dictionary that is keyed on a (x_channel, y_channel) tuple, with ScatterPlotCurveItem values.
+        #It gets populated in self.addChannel().
+        self.channel_pairs = OrderedDict()
+        init_channel_pairs = zip(init_x_channels, init_y_channels)
+        for (x_chan, y_chan) in init_channel_pairs:
+            self.addChannel(y_chan, x_channel=x_chan)
+
+    def addChannel(self, y_channel=None, x_channel=None, name=None,
+                   color=None, lineStyle=None, lineWidth=None,
+                   symbol=None, symbolSize=None, redraw_mode=None):
+        """
+        Add a new curve to the plot.  In addition to the arguments below,
+        all other keyword arguments are passed to the underlying
+        pyqtgraph.PlotDataItem used to draw the curve.
+
+        Parameters
+        ----------
+        y_channel: str
+            The address for the y channel for the curve.
+        x_channel: str, optional
+            The address for the x channel for the curve.
+        name: str, optional
+            A name for this curve.  The name will be used in the plot legend.
+        color: str or QColor, optional
+            A color for the line of the curve.  If not specified, the plot will
+            automatically assign a unique color from a set of default colors.
+        lineStyle: int, optional
+            Style of the line connecting the data points.
+            0 means no line (scatter plot).
+        lineWidth: int, optional
+            Width of the line connecting the data points.
+        redraw_mode: int, optional
+            Must be one four values:
+            ScatterPlotCurveItem.REDRAW_ON_EITHER: (Default) The curve will be redrawn after either X or Y receives new data.
+            ScatterPlotCurveItem.REDRAW_ON_X: The curve will only be redrawn after X receives new data.
+            ScatterPlotCurveItem.REDRAW_ON_Y: The curve will only be redrawn after Y receives new data.
+            ScatterPlotCurveItem.REDRAW_ON_BOTH: The curve will only be redrawn after both X and Y receive new data.
+        symbol: str or None, optional
+            Which symbol to use to represent the data.
+        symbol: int, optional
+            Size of the symbol.
+        """
+        plot_opts = {}
+        plot_opts['symbol'] = symbol
+        if symbolSize is not None:
+            plot_opts['symbolSize'] = symbolSize
+        if lineStyle is not None:
+            plot_opts['lineStyle'] = lineStyle
+        if lineWidth is not None:
+            plot_opts['lineWidth'] = lineWidth
+        if redraw_mode is not None:
+            plot_opts['redraw_mode'] = redraw_mode
+        curve = ScatterPlotCurveItem(y_addr=y_channel,
+                                  x_addr=x_channel,
+                                  name=name,
+                                  color=color,
+                                  **plot_opts)
+        curve.data_changed.connect(self.redrawPlot)
+        self.channel_pairs[(y_channel, x_channel)] = curve
+        self.addCurve(curve, curve_color=color)
+
+    def removeChannel(self, curve):
+        """
+        Remove a curve from the plot.
+
+        Parameters
+        ----------
+        curve: ScatterPlotCurveItem
+            The curve to remove.
+        """
+        curve.data_changed.disconnect(self.redrawPlot)
+        self.removeCurve(curve)
+
+    def removeChannelAtIndex(self, index):
+        """
+        Remove a curve from the plot, given an index
+        for a curve.
+
+        Parameters
+        ----------
+        index: int
+            Index for the curve to remove.
+        """
+        curve = self._curves[index]
+        self.removeChannel(curve)
+
+    def updateAxes(self):
+        """
+        Update the X and Y axes for the plot to fit all data in
+        all curves for the plot.
+        """
+        plot_xmin = None
+        plot_xmax = None
+        plot_ymin = None
+        plot_ymax = None
+        for curve in self._curves:
+            try:
+                ((curve_xmin, curve_xmax), (curve_ymin, curve_ymax)) = curve.limits()
+            except NoDataError:
+                continue
+            if plot_xmin is None or curve_xmin < plot_xmin:
+                plot_xmin = curve_xmin
+            if plot_xmax is None or curve_xmax > plot_xmax:
+                plot_xmax = curve_xmax
+            if plot_ymin is None or curve_ymin < plot_ymin:
+                plot_ymin = curve_ymin
+            if plot_ymax is None or curve_ymax > plot_ymax:
+                plot_ymax = curve_ymax
+        self.plotItem.setLimits(xMin=plot_xmin, xMax=plot_xmax, yMin=plot_ymin, yMax=plot_ymax)
+
+    @pyqtSlot()
+    def redrawPlot(self):
+        """
+        Request a redraw from each curve in the plot.
+        Called by curves when they get new data.
+        """
+        self.updateAxes()
+        for curve in self._curves:
+            curve.redrawCurve()
+
+    def clearCurves(self):
+        """
+        Remove all curves from the plot.
+        """
+        super(PyDMScatterPlot, self).clear()
+
+    def getCurves(self):
+        """
+        Get a list of json representations for each curve.
+        """
+        return [json.dumps(curve.to_dict()) for curve in self._curves]
+
+    def setCurves(self, new_list):
+        """
+        Replace all existing curves with new ones.  This function
+        is mostly used as a way to load curves from a .ui file, and
+        almost all users will want to add curves through addChannel,
+        not this method.
+
+        Parameters
+        ----------
+        new_list: list
+            A list of json strings representing each curve in the plot.
+        """
+        try:
+            new_list = [json.loads(str(i)) for i in new_list]
+        except ValueError as e:
+            print("Error parsing curve json data: {}".format(e))
+            return
+        self.clearCurves()
+        for d in new_list:
+            color = d.get('color')
+            if color:
+                color = QColor(color)
+            self.addChannel(d['y_channel'], d['x_channel'],
+                            name=d.get('name'), color=color,
+                            lineStyle=d.get('lineStyle'),
+                            lineWidth=d.get('lineWidth'),
+                            symbol=d.get('symbol'),
+                            symbolSize=d.get('symbolSize'),
+                            redraw_mode=d.get('redraw_mode'))
+
+    curves = pyqtProperty("QStringList", getCurves, setCurves)
+
+    def channels(self):
+        """
+        Returns the list of channels used by all curves in the plot.
+
+        Returns
+        -------
+        list
+        """
+        chans = []
+        chans.extend([curve.y_channel for curve in self._curves])
+        chans.extend([curve.x_channel for curve in self._curves])
+        return chans
+
+    # The methods for autoRangeX, minXRange, maxXRange, autoRangeY, minYRange, and maxYRange are
+    # all defined in BasePlot, but we don't expose them as properties there, because not all plot
+    # subclasses necessarily want them to be user-configurable in Designer.
+    autoRangeX = pyqtProperty(bool, BasePlot.getAutoRangeX, BasePlot.setAutoRangeX, BasePlot.resetAutoRangeX, doc="""
+    Whether or not the X-axis automatically rescales to fit the data.  If true, the
+    values in minXRange and maxXRange are ignored.
+    """)
+
+    minXRange = pyqtProperty(float, BasePlot.getMinXRange, BasePlot.setMinXRange, doc="""
+    Minimum X-axis value visible on the plot.
+    """)
+
+    maxXRange = pyqtProperty(float, BasePlot.getMaxXRange, BasePlot.setMaxXRange, doc="""
+    Maximum X-axis value visible on the plot.
+    """)
+
+    autoRangeY = pyqtProperty(bool, BasePlot.getAutoRangeY, BasePlot.setAutoRangeY, BasePlot.resetAutoRangeY, doc="""
+    Whether or not the Y-axis automatically rescales to fit the data.  If true, the
+    values in minYRange and maxYRange are ignored.
+    """)
+
+    minYRange = pyqtProperty(float, BasePlot.getMinYRange, BasePlot.setMinYRange, doc="""
+    Minimum Y-axis value visible on the plot.
+    """)
+
+    maxYRange = pyqtProperty(float, BasePlot.getMaxYRange, BasePlot.setMaxYRange, doc="""
+    Maximum Y-axis value visible on the plot.
+    """)

--- a/pydm/widgets/scatterplot.py
+++ b/pydm/widgets/scatterplot.py
@@ -29,7 +29,7 @@ class ScatterPlotCurveItem(PlotDataItem):
                          ('DashDot', Qt.DashDotLine),
                          ('DashDotDot', Qt.DashDotDotLine)])
     data_changed = pyqtSignal()
-    def __init__(self, y_addr, x_addr, color=None, lineStyle=None,
+    def __init__(self, y_addr, x_addr, color=None, lineStyle=Qt.NoPen,
                  lineWidth=None, redraw_mode=REDRAW_ON_EITHER, **kws):
         self.x_channel = None
         self.y_channel = None
@@ -60,6 +60,7 @@ class ScatterPlotCurveItem(PlotDataItem):
         kws['pen'] = self._pen
         super(ScatterPlotCurveItem, self).__init__(**kws)
         self.setSymbolBrush(None)
+        self.setSymbol('o')
         if color is not None:
             self.color = color
 

--- a/pydm/widgets/scatterplot_curve_editor.py
+++ b/pydm/widgets/scatterplot_curve_editor.py
@@ -1,0 +1,181 @@
+from ..PyQt.QtGui import QDialog, QVBoxLayout, QHBoxLayout, QTableView, QAbstractItemView, QSpacerItem, QSizePolicy, QDialogButtonBox, QPushButton, QItemSelection, QComboBox, QStyledItemDelegate, QColorDialog
+from ..PyQt.QtCore import Qt, pyqtSlot, QModelIndex
+from ..PyQt.QtDesigner import QDesignerFormWindowInterface
+from .scatterplot_table_model import PyDMScatterPlotCurvesModel
+from .scatterplot import ScatterPlotCurveItem
+from collections import OrderedDict
+
+class ScatterPlotCurveEditorDialog(QDialog):
+    """ScatterPlotCurveEditorDialog is a QDialog that is used in Qt Designer to
+    edit the properties of the curves in a waveform plot.  This dialog is shown
+    when you double-click the plot, or when you right click it and choose 'edit curves'.
+
+    This thing is mostly just a wrapper for a table view, with a couple buttons to add and
+    remove curves, and a button to save the changes.
+    """
+    def __init__(self, plot, parent=None):
+        super(ScatterPlotCurveEditorDialog, self).__init__(parent)
+        self.plot = plot
+        self.setup_ui()
+        self.column_names = ("Y Channel", "X Channel",
+                             "Label", "Color",
+                             "Line Style", "Line Width",
+                             "Symbol", "Symbol Size",
+                             "Redraw Mode")
+        self.table_model = PyDMScatterPlotCurvesModel(self.plot)
+        self.table_view.setModel(self.table_model)
+        self.table_model.plot = plot
+        #self.table_view.resizeColumnsToContents()
+        self.add_button.clicked.connect(self.addCurve)
+        self.remove_button.clicked.connect(self.removeSelectedCurve)
+        self.remove_button.setEnabled(False)
+        symbol_delegate = SymbolColumnDelegate(self)
+        self.table_view.setItemDelegateForColumn(6, symbol_delegate)
+        line_delegate = LineColumnDelegate(self)
+        self.table_view.setItemDelegateForColumn(4, line_delegate)
+        color_delegate = ColorColumnDelegate(self)
+        self.table_view.setItemDelegateForColumn(3, color_delegate)
+        redraw_mode_delegate = RedrawModeColumnDelegate(self)
+        self.table_view.setItemDelegateForColumn(8, redraw_mode_delegate)
+        self.table_view.selectionModel().selectionChanged.connect(self.handleSelectionChange)
+        self.table_view.doubleClicked.connect(self.handleDoubleClick)
+
+    def setup_ui(self):
+        self.resize(800, 300)
+        self.vertical_layout = QVBoxLayout(self)
+        self.table_view = QTableView(self)
+        self.table_view.setEditTriggers(QAbstractItemView.DoubleClicked)
+        self.table_view.setProperty("showDropIndicator", False)
+        self.table_view.setDragDropOverwriteMode(False)
+        self.table_view.setSelectionMode(QAbstractItemView.SingleSelection)
+        self.table_view.setSelectionBehavior(QAbstractItemView.SelectRows)
+        self.table_view.setSortingEnabled(False)
+        self.table_view.horizontalHeader().setStretchLastSection(True)
+        self.table_view.verticalHeader().setVisible(False)
+        self.table_view.setColumnWidth(0, 160)
+        self.table_view.setColumnWidth(1, 160)
+        self.table_view.setColumnWidth(2, 160)
+        self.table_view.setColumnWidth(3, 20)
+        self.vertical_layout.addWidget(self.table_view)
+        self.add_remove_layout = QHBoxLayout()
+        spacer = QSpacerItem(40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
+        self.add_remove_layout.addItem(spacer)
+        self.add_button = QPushButton("Add Curve", self)
+        self.add_remove_layout.addWidget(self.add_button)
+        self.remove_button = QPushButton("Remove Curve", self)
+        self.add_remove_layout.addWidget(self.remove_button)
+        self.vertical_layout.addLayout(self.add_remove_layout)
+        self.button_box = QDialogButtonBox(self)
+        self.button_box.setOrientation(Qt.Horizontal)
+        self.button_box.addButton("Done", QDialogButtonBox.AcceptRole)
+        self.vertical_layout.addWidget(self.button_box)
+        self.button_box.accepted.connect(self.saveChanges)
+        self.button_box.rejected.connect(self.reject)
+        self.setWindowTitle("Scatter Plot Curve Editor")
+
+    @pyqtSlot()
+    def addCurve(self):
+        self.table_model.append()
+
+    @pyqtSlot()
+    def removeSelectedCurve(self):
+        self.table_model.removeAtIndex(self.table_view.currentIndex())
+
+    @pyqtSlot(QItemSelection, QItemSelection)
+    def handleSelectionChange(self, selected, deselected):
+        self.remove_button.setEnabled(self.table_view.selectionModel().hasSelection())
+
+    @pyqtSlot(QModelIndex)
+    def handleDoubleClick(self, index):
+        if self.table_model.needsColorDialog(index):
+            #The table model returns a QBrush for BackgroundRole, not a QColor.
+            init_color = self.table_model.data(index, Qt.BackgroundRole).color()
+            color = QColorDialog.getColor(init_color, self)
+            if color.isValid():
+                self.table_model.setData(index, color, role=Qt.EditRole)
+
+    @pyqtSlot()
+    def saveChanges(self):
+        formWindow = QDesignerFormWindowInterface.findFormWindow(self.plot)
+        if formWindow:
+            formWindow.cursor().setProperty("curves", self.plot.curves)
+        self.accept()
+
+
+class ColorColumnDelegate(QStyledItemDelegate):
+    """The ColorColumnDelegate is an item delegate that is installed on the
+    color column of the table view.  Its only job is to ensure that the default
+    editor widget (a line edit) isn't displayed for items in the color column."""
+    def createEditor(self, parent, option, index):
+        return None
+
+
+class LineColumnDelegate(QStyledItemDelegate):
+    """LineColumnDelegate draws a QComboBox in the Line Style column, so that users
+    can pick the styles they want to display from a list, instead of needing to
+    remember the PyQtGraph character codes."""
+    def createEditor(self, parent, option, index):
+        editor = QComboBox(parent)
+        editor.addItems(ScatterPlotCurveItem.lines.keys())
+        return editor
+
+    def setEditorData(self, editor, index):
+        val = str(index.model().data(index, Qt.EditRole))
+        editor.setCurrentText(val)
+
+    def setModelData(self, editor, model, index):
+        val = ScatterPlotCurveItem.lines[editor.currentText()]
+        model.setData(index, val, Qt.EditRole)
+
+    def updateEditorGeometry(self, editor, option, index):
+        editor.setGeometry(option.rect)
+
+
+class SymbolColumnDelegate(QStyledItemDelegate):
+    """SymbolColumnDelegate draws a QComboBox in the Symbol column, so that users
+    can pick the symbol they want to display from a list, instead of needing to
+    remember the PyQtGraph character codes."""
+    def createEditor(self, parent, option, index):
+        editor = QComboBox(parent)
+        editor.addItems(ScatterPlotCurveItem.symbols.keys())
+        return editor
+
+    def setEditorData(self, editor, index):
+        val = str(index.model().data(index, Qt.EditRole))
+        editor.setCurrentText(val)
+
+    def setModelData(self, editor, model, index):
+        val = ScatterPlotCurveItem.symbols[editor.currentText()]
+        model.setData(index, val, Qt.EditRole)
+
+    def updateEditorGeometry(self, editor, option, index):
+        editor.setGeometry(option.rect)
+
+
+class RedrawModeColumnDelegate(QStyledItemDelegate):
+    """RedrawModeColumnDelegate draws a QComboBox in the Redraw Mode column, so
+    that users can pick the redraw mode from a list."""
+    choices = OrderedDict([('X or Y updates', ScatterPlotCurveItem.REDRAW_ON_EITHER),
+                            ('Y updates', ScatterPlotCurveItem.REDRAW_ON_Y),
+                            ('X updates', ScatterPlotCurveItem.REDRAW_ON_X),
+                            ('Both update', ScatterPlotCurveItem.REDRAW_ON_BOTH)])
+    text_for_choices = {v: k for k, v in choices.items()}
+
+    def displayText(self, value, locale):
+        return self.text_for_choices[value]
+
+    def createEditor(self, parent, option, index):
+        editor = QComboBox(parent)
+        editor.addItems(self.choices.keys())
+        return editor
+
+    def setEditorData(self, editor, index):
+        val = self.text_for_choices[index.model().data(index, Qt.EditRole)]
+        editor.setCurrentText(val)
+
+    def setModelData(self, editor, model, index):
+        val = self.choices[editor.currentText()]
+        model.setData(index, val, Qt.EditRole)
+
+    def updateEditorGeometry(self, editor, option, index):
+        editor.setGeometry(option.rect)

--- a/pydm/widgets/scatterplot_curve_editor.py
+++ b/pydm/widgets/scatterplot_curve_editor.py
@@ -21,7 +21,7 @@ class ScatterPlotCurveEditorDialog(QDialog):
                              "Label", "Color",
                              "Line Style", "Line Width",
                              "Symbol", "Symbol Size",
-                             "Redraw Mode")
+                             "Redraw Mode", "Buffer Size")
         self.table_model = PyDMScatterPlotCurvesModel(self.plot)
         self.table_view.setModel(self.table_model)
         self.table_model.plot = plot

--- a/pydm/widgets/scatterplot_qtplugin.py
+++ b/pydm/widgets/scatterplot_qtplugin.py
@@ -1,0 +1,62 @@
+from ..PyQt.QtDesigner import QExtensionFactory, QPyDesignerTaskMenuExtension
+from ..PyQt.QtGui import QAction
+from ..PyQt.QtCore import pyqtSlot
+from .qtplugin_base import PyDMDesignerPlugin, WidgetCategory
+from .scatterplot import PyDMScatterPlot
+from .scatterplot_curve_editor import ScatterPlotCurveEditorDialog
+
+class PyDMScatterPlotPlugin(PyDMDesignerPlugin):
+    def __init__(self):
+        super(PyDMScatterPlotPlugin, self).__init__(PyDMScatterPlot, group=WidgetCategory.PLOT)
+        self.factory = None
+        
+    def initialize(self, core):
+        """
+        Override this function if you need special initialization instructions.
+        Make sure you don't neglect to set the self.initialized flag to True
+        after a successful initialization.
+
+        :param core: form editor interface to use in the initialization
+        :type core:  QDesignerFormEditorInterface
+        """
+        if self.initialized:
+            return
+        manager = core.extensionManager()
+        if manager:
+            self.factory = PyDMScatterPlotExtensionFactory(manager)
+            manager.registerExtensions(self.factory, 'org.qt-project.Qt.Designer.TaskMenu') #Qt5
+            manager.registerExtensions(self.factory, 'com.trolltech.Qt.Designer.TaskMenu') #Qt4
+        self.initialized = True
+
+
+class PyDMScatterPlotExtensionFactory(QExtensionFactory):
+    def __init__(self, parent=None):
+        super(PyDMScatterPlotExtensionFactory, self).__init__(parent)
+
+    def createExtension(self, obj, iid, parent):
+        #Shouldn't have to check iid because we registered this factor for only this iid type.
+        #if (str(iid) != 'org.qt-project.Qt.Designer.TaskMenu') or (str(iid) != 'com.trolltech.Qt.Designer.TaskMenu'):
+        #  print("Extension id didn't match TaskMenu type.")
+        #  return None
+        if isinstance(obj, PyDMScatterPlot):
+            return PyDMScatterPlotTaskMenuExtension(obj, parent)
+        return None
+
+class PyDMScatterPlotTaskMenuExtension(QPyDesignerTaskMenuExtension):
+    def __init__(self, scatter_plot, parent):
+        super(PyDMScatterPlotTaskMenuExtension, self).__init__(parent)
+        self.scatter_plot = scatter_plot
+        self.edit_curves_action = QAction("Edit Curves...", self)
+        self.edit_curves_action.triggered.connect(self.edit_curves)
+
+    @pyqtSlot()
+    def edit_curves(self):
+        edit_curves_dialog = ScatterPlotCurveEditorDialog(self.scatter_plot)
+        edit_curves_dialog.exec_()
+
+    def preferredEditAction(self):
+        return self.edit_curves_action
+
+    def taskActions(self):
+        return [self.edit_curves_action]
+

--- a/pydm/widgets/scatterplot_table_model.py
+++ b/pydm/widgets/scatterplot_table_model.py
@@ -18,7 +18,7 @@ class PyDMScatterPlotCurvesModel(QAbstractTableModel):
                               "Label", "Color",
                               "Line Style", "Line Width",
                               "Symbol", "Symbol Size",
-                              "Redraw Mode")
+                              "Redraw Mode", "Buffer Size")
 
     @property
     def plot(self):
@@ -82,6 +82,8 @@ class PyDMScatterPlotCurvesModel(QAbstractTableModel):
                 return str(curve.symbolSize)
             elif column_name == "Redraw Mode":
                 return curve.redraw_mode
+            elif column_name == "Buffer Size":
+                return curve.getBufferSize()
         elif role == Qt.BackgroundRole and column_name == "Color":
             return QBrush(curve.color)
         elif role == Qt.CheckStateRole and column_name == "Connect Points":
@@ -125,6 +127,8 @@ class PyDMScatterPlotCurvesModel(QAbstractTableModel):
                 curve.symbolSize = int(value)
             elif column_name == "Redraw Mode":
                 curve.redraw_mode = int(value)
+            elif column_name == "Buffer Size":
+                curve.setBufferSize(int(value))
             else:
                 return False
         else:

--- a/pydm/widgets/scatterplot_table_model.py
+++ b/pydm/widgets/scatterplot_table_model.py
@@ -1,0 +1,158 @@
+from ..PyQt.QtCore import QAbstractTableModel, Qt, QModelIndex, QVariant
+from ..PyQt.QtGui import QBrush, QColor
+from operator import itemgetter
+from .. import utilities
+from .scatterplot import ScatterPlotCurveItem
+
+class PyDMScatterPlotCurvesModel(QAbstractTableModel):
+    name_for_symbol = {v: k for k, v in ScatterPlotCurveItem.symbols.items()}
+    name_for_line = {v: k for k, v in ScatterPlotCurveItem.lines.items()}
+    """ This is the data model used by the waveform plot curve editor.
+    It basically acts as a go-between for the curves in a plot, and
+    QTableView items.
+    """
+    def __init__(self, plot, parent=None):
+        super(PyDMScatterPlotCurvesModel, self).__init__(parent=parent)
+        self._plot = plot
+        self._column_names = ("Y Channel", "X Channel",
+                              "Label", "Color",
+                              "Line Style", "Line Width",
+                              "Symbol", "Symbol Size",
+                              "Redraw Mode")
+
+    @property
+    def plot(self):
+        return self._plot
+
+    @plot.setter
+    def plot(self, new_plot):
+        self.beginResetModel()
+        self._plot = new_plot
+        self.endResetModel()
+
+    #QAbstractItemModel Implementation
+    def clear(self):
+        self.plot.clearCurves()
+
+    def flags(self, index):
+        column_name = self._column_names[index.column()]
+        if column_name == "Color":
+            return Qt.ItemIsSelectable | Qt.ItemIsEnabled
+        return Qt.ItemIsSelectable | Qt.ItemIsEnabled | Qt.ItemIsEditable
+
+    def rowCount(self, parent=None):
+        if parent is not None and parent.isValid():
+            return 0
+        return len(self.plot._curves)
+
+    def columnCount(self, parent=None):
+        return len(self._column_names)
+
+    def data(self, index, role=Qt.DisplayRole):
+        if not index.isValid():
+            return QVariant()
+        if index.row() >= self.rowCount():
+            return QVariant()
+        if index.column() >= self.columnCount():
+            return QVariant()
+        column_name = self._column_names[index.column()]
+        curve = self.plot._curves[index.row()]
+        if role == Qt.DisplayRole or role == Qt.EditRole:
+            if column_name == "Y Channel":
+                if curve.y_address is None:
+                    return QVariant()
+                return str(curve.y_address)
+            elif column_name == "X Channel":
+                if curve.x_address is None:
+                    return QVariant()
+                return str(curve.x_address)
+            elif column_name == "Label":
+                if curve.name() is None:
+                    return QVariant()
+                return str(curve.name())
+            elif column_name == "Color":
+                return curve.color_string
+            elif column_name == "Line Style":
+                return self.name_for_line[curve.lineStyle]
+            elif column_name == "Line Width":
+                return str(curve.lineWidth)
+            elif column_name == "Symbol":
+                return self.name_for_symbol[curve.symbol]
+            elif column_name == "Symbol Size":
+                return str(curve.symbolSize)
+            elif column_name == "Redraw Mode":
+                return curve.redraw_mode
+        elif role == Qt.BackgroundRole and column_name == "Color":
+            return QBrush(curve.color)
+        elif role == Qt.CheckStateRole and column_name == "Connect Points":
+            if curve.connect_points:
+                return Qt.Checked
+            else:
+                return Qt.Unchecked
+        else:
+            return QVariant()
+
+    def setData(self, index, value, role=Qt.EditRole):
+        if not index.isValid():
+            return False
+        if index.row() >= self.rowCount():
+            return False
+        if index.column() >= self.columnCount():
+            return False
+        column_name = self._column_names[index.column()]
+        curve = self.plot._curves[index.row()]
+        if role == Qt.EditRole:
+            if isinstance(value, QVariant):
+                value = value.toString()
+            if column_name == "Y Channel":
+                curve.y_address = str(value)
+            elif column_name == "X Channel":
+                curve.x_address = str(value)
+            elif column_name == "Label":
+                curve.setData(name=str(value))
+            elif column_name == "Color":
+                curve.color = value
+            elif column_name == "Line Style":
+                curve.lineStyle = int(value)
+            elif column_name == "Line Width":
+                curve.lineWidth = int(value)
+            elif column_name == "Symbol":
+                if value is None:
+                    curve.symbol = None
+                else:
+                    curve.symbol = str(value)
+            elif column_name == "Symbol Size":
+                curve.symbolSize = int(value)
+            elif column_name == "Redraw Mode":
+                curve.redraw_mode = int(value)
+            else:
+                return False
+        else:
+            return False
+        self.dataChanged.emit(index, index)
+        return True
+
+    def headerData(self, section, orientation, role=Qt.DisplayRole):
+        if role != Qt.DisplayRole:
+            return super(PyDMScatterPlotCurvesModel, self).headerData(section, orientation, role)
+        if orientation == Qt.Horizontal and section < self.columnCount():
+            return str(self._column_names[section])
+        elif orientation == Qt.Vertical and section < self.rowCount():
+            return section
+    #End QAbstractItemModel implementation.
+
+    def append(self, y_address=None, x_address=None, name=None, color=None):
+        self.beginInsertRows(QModelIndex(), len(self._plot._curves), len(self._plot._curves))
+        self._plot.addChannel(y_address, x_address, name, color)
+        self.endInsertRows()
+
+    def removeAtIndex(self, index):
+        self.beginRemoveRows(QModelIndex(), index.row(), index.row())
+        self._plot.removeChannelAtIndex(index.row())
+        self.endRemoveRows()
+
+    def needsColorDialog(self, index):
+        column_name = self._column_names[index.column()]
+        if column_name == "Color":
+            return True
+        return False

--- a/pydm/widgets/waveformplot.py
+++ b/pydm/widgets/waveformplot.py
@@ -295,7 +295,7 @@ class WaveformCurveItem(PlotDataItem):
     @y_address.setter
     def y_address(self, new_address):
         """
-        The address of the channel used to get the x axis wavefor data.
+        The address of the channel used to get the y axis waveform data.
 
         Parameters
         -------

--- a/scripts/pydm-testing-ioc
+++ b/scripts/pydm-testing-ioc
@@ -80,6 +80,7 @@ class myDriver(Driver):
         x = numpy.linspace(-5.0,5.0,IMAGE_SIZE)
         y = numpy.linspace(-5.0,5.0,IMAGE_SIZE)
         xgrid,ygrid = numpy.meshgrid(x,y)
+        i=0
         while True:
             run = self.getParam('Run')
             updateTime = self.getParam('UpdateTime')
@@ -112,7 +113,7 @@ class myDriver(Driver):
             cos_data = NUM_DIVISIONS/2.0 + yScale * (cos_data + voltOffset)
             self.setParam('Waveform',  data)
             self.setParam('Cosine', cos_data)
-            i = numpy.random.randint(0,MAX_POINTS)
+            i = (i+1) % MAX_POINTS
             self.setParam('SinVal', data[i])
             self.setParam('CosVal', cos_data[i])
             #Generate the image data

--- a/scripts/pydm-testing-ioc
+++ b/scripts/pydm-testing-ioc
@@ -18,7 +18,7 @@ pvdb = {
                                 'enums': ['STOP', 'RUN'], 'asg'  : 'default'},
         'ReadOnly'     : { 'type' : 'enum',
                                 'enums': ['FALSE', 'TRUE'], 'value': 0 },
-        'UpdateTime'       : { 'prec' : 3, 'unit' : 's', 'value' : 1, 'asg' : 'default'     },
+        'UpdateTime'       : { 'prec' : 3, 'unit' : 's', 'value' : 0.03, 'asg' : 'default'     },
         'TimePerDivision'  : { 'prec' : 5, 'unit' : 's', 'value' : 0.001, 'asg' : 'default' },
         'TriggerDelay'     : { 'prec' : 5, 'unit' : 's', 'value' : 0.0005, 'asg' : 'default'},
         'VoltsPerDivision' : { 'prec' : 3, 'unit' : 'V', 'value' : 0.2, 'asg' : 'default'   },
@@ -42,7 +42,9 @@ pvdb = {
         'ImageWidth'       : { 'type' : 'int', 'value' : IMAGE_SIZE, 'asg' : 'default' },
         'String'           : { 'type' : 'string', 'value': "Test String", 'asg' : 'default'},
         'Float'            : { 'type' : 'float', 'value': 0.0, 'lolim': -1.2, 'lolo': -1.0, 'low': -0.8, 'high': 0.8, 'hihi': 1.0, 'hilim': 1.2, 'unit': 'mJ', 'prec': 3, 'asg' : 'default' },
-        'StatusBits'       : { 'type' : 'int', 'value': 0b101010, 'lolim': 0, 'hilim': 32, 'asg' : 'default' }
+        'StatusBits'       : { 'type' : 'int', 'value': 0b101010, 'lolim': 0, 'hilim': 32, 'asg' : 'default' },
+        'SinVal'           : { 'type' : 'float', 'value': 0.0, 'asg': 'default' },
+        'CosVal'           : { 'type' : 'float', 'value': 0.0, 'asg': 'default' }
 }
 
 def double_gaussian_2d(x, y, x0, y0, xsig, ysig):
@@ -97,9 +99,9 @@ class myDriver(Driver):
             timeStart = triggerDelay
             timeStep  = timePerDivision * NUM_DIVISIONS / MAX_POINTS
             timeWave  = timeStart + numpy.arange(MAX_POINTS) * timeStep 
-            noise  = noiseAmplitude * numpy.random.random(MAX_POINTS)
-            data = AMPLITUDE * numpy.sin(timeWave * FREQUENCY * 2 * numpy.pi) + noise
-            cos_data = AMPLITUDE * numpy.cos(timeWave * FREQUENCY * 2 * numpy.pi) + noise
+            #noise  = noiseAmplitude * numpy.random.random(MAX_POINTS)
+            data = AMPLITUDE * numpy.sin(timeWave * FREQUENCY * 2 * numpy.pi) + (noiseAmplitude * numpy.random.random(MAX_POINTS))
+            cos_data = AMPLITUDE * numpy.cos(timeWave * FREQUENCY * 2 * numpy.pi) + (noiseAmplitude * numpy.random.random(MAX_POINTS))
             # calculate statistics
             self.setParam('MinValue',  data.min())
             self.setParam('MaxValue',  data.max())
@@ -110,6 +112,9 @@ class myDriver(Driver):
             cos_data = NUM_DIVISIONS/2.0 + yScale * (cos_data + voltOffset)
             self.setParam('Waveform',  data)
             self.setParam('Cosine', cos_data)
+            i = numpy.random.randint(0,MAX_POINTS)
+            self.setParam('SinVal', data[i])
+            self.setParam('CosVal', cos_data[i])
             #Generate the image data
             x0 = 0.5*(numpy.random.rand()-0.5) + self.getParam('XPos')
             y0 = 0.5*(numpy.random.rand()-0.5) - self.getParam('YPos')
@@ -138,6 +143,6 @@ if __name__ == '__main__':
         driver.setParam('ReadOnly', 0)
         # process CA transactions
         while True:
-            server.process(0.1)
+            server.process(0.03)
     except KeyboardInterrupt:
         print('\nInterrupted... finishing testing-ioc')


### PR DESCRIPTION
This adds a third plot type: Scatter Plot.  PyDMScatterPlot is a widget to plot one scalar value against another.  Multiple scalar pairs can be plotted on the same plot.  Each pair has a buffer which stores previous values.  All values in the buffer are drawn.  The buffer size for each pair is user configurable.

This PR will close #158.