### PR TITLE
ENH: Anaconda recipe for PyDM.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,10 @@ language: python
 
 env:
   global:
-    # Variables jut to silence pcaspy setup.
+    # Variables just to silence pcaspy setup.
     - EPICS_BASE=~
     - EPICS_HOST_ARCH=linux-x86_64
+    - OFFICIAL_REPO="slaclab/pydm"
     - secure: "g7JqJMMB4LL0bM0h1rUN8bR2/CWt+jHLW+nknroyU6+kZc2oi6WLw7FSapCV23nJkyzoBZrvHokKBz/hml/lhp4wBuxWfm4E9h8qdyZgkA7OzWkJ2SxNvChi3mASLfvavkuIS/yCDxdhlcQsSNr3kdwkTRQuuKPqWuLzYLFHesCYOtWtRTn/9bzEPsvLp5/3ul+PY8ZsAdcdUEEJPgeW8P+JS960Jf4JsQ2QEl3ZOS3+l4SF7Z72yr0exmrWp8dt2rVuPXDLVHVos08Wx1tTL5Xwp8v33sAt9SHR40li+Q5KNHyA6ZC6Jgz7ZeDyxu39V7QvA55sF5+1J9UG0SrStmChbJ5lTeOx9wgxq6Ha8hrcsTaMPuk5eKcLvfZliSZ4lXxlSf8R/+HFrZNnS9DvrulWY/MVI4AdrON9RF9RDPGtfMyit8CKYOKp9XzKPDHeGFGZCfE9F0isLK/2YqIem63FwB1uFew6cFyRHIM1Ygtb7dzm/AE+dJhkY4iwR8jVnQF9qy7DwAAjbRohL40KvjcrZmn5rxH/VpPjxbifArEhtymYMgTGPfSgQAJO17yOcJdNKODZ/40qghlh0dv1loMxGPM73S9VLdsHqDQaaIptpQi2Z/y7pGVoiMPbZueQcSIkC04YKwJzKB1iCs2OQJ0g+kUdV4fFweMnUwa4umU="
 
 matrix:
@@ -15,7 +16,6 @@ matrix:
       env: PYQT_VERSION=5
     - python: 3.6
       env: PYQT_VERSION=5 BUILD_DOCS=1
-
 
 before_install:
   - sudo apt-get update
@@ -58,3 +58,12 @@ script:
       doctr deploy . --built-docs docs/build/html --deploy-branch-name gh-pages
     fi
 
+after_success:
+  - |
+    if [[ $TRAVIS_PULL_REQUEST == false && $TRAVIS_REPO_SLUG == $OFFICIAL_REPO && $TRAVIS_BRANCH == $TRAVIS_TAG  && $TRAVIS_TAG != '' && $CONDA_UPLOAD_TOKEN_TAG != '' ]]; then
+      conda build . -c defaults -c conda-forge -c gsecars --token $CONDA_UPLOAD_TOKEN_TAG --python $TRAVIS_PYTHON_VERSION
+    fi
+  - |
+    if [[ $TRAVIS_PULL_REQUEST == false && $TRAVIS_REPO_SLUG == $OFFICIAL_REPO && $TRAVIS_BRANCH == 'master' && $TRAVIS_TAG == '' && $CONDA_UPLOAD_TOKEN_DEV != '' ]]; then
+      conda build . -c defaults -c conda-forge -c gsecars --token $CONDA_UPLOAD_TOKEN_DEV --python $TRAVIS_PYTHON_VERSION
+    fi

--- a/conda-recipe/build.sh
+++ b/conda-recipe/build.sh
@@ -1,0 +1,1 @@
+$PYTHON setup.py install

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,0 +1,43 @@
+{% set data = load_setup_py_data() %}
+
+package:
+    name    : pydm 
+    version : {{ data.get('version') }}
+
+source:
+    path: ..
+
+requirements:
+    build:
+      - python
+      - setuptools
+      - six
+      - numpy >=1.11.0
+      - scipy >=0.12.0
+      - pyepics >=3.2.7
+      - requests >=1.1.0
+      - pyqt >=5
+      - pyqtgraph
+
+    run:
+      - six
+      - python
+      - numpy >=1.11.0
+      - scipy >=0.12.0
+      - pyepics >=3.2.7
+      - requests >=1.1.0
+      - psutil
+      - pyqt >=5
+      - pyqtgraph
+
+test:
+    imports:
+      - pydm 
+
+    requires: 
+      - pytest
+
+about:
+  home: https://github.com/slaclab/pydm
+  license: SLAC Open License
+  summary: Python Display Manager

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ numpy>=1.11.0
 scipy>=0.12.0
 pyepics>=3.2.7
 requests>=1.1.0
-pcaspy>=0.6.3
+pyqtgraph>=0.10.0

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open(path.join(cur_dir, 'requirements.txt')) as f:
     requirements = f.read().split()
 
 # Remove the 'optional' requirements
-optional = ('PyQt5', 'PySide', 'psutil', 'pcaspy', 'pyepics', 'pyqtgraph')
+optional = ('PyQt5', 'PySide', 'psutil', 'pcaspy', 'pyepics')
 for package in optional:
     if package in requirements:
         requirements.remove(package)
@@ -27,14 +27,13 @@ extras_require = {
 
 if "CONDA_PREFIX" not in environ:
     extras_require['PyQt5'] = ['PyQt5']
-    extras_require['pyqtgraph'] = ['pyqtgraph']
 else:
     print("******************************************************************")
     print("*                              WARNING                           *") 
     print("******************************************************************")
     print("Installing at an Anaconda Environment, to avoid naming conflicts ")
     print("make sure you do:")
-    print("conda install pyqt=5 pyqtgraph")
+    print("conda install pyqt=5")
     print("******************************************************************")
     print("For more info please check: ")
     print("https://github.com/ContinuumIO/anaconda-issues/issues/1554")


### PR DESCRIPTION
MAINT: Removed pcaspy from requirements list as it is only used at the testing-ioc.
MAINT: Added back pyqtgraph to the requirements list as it was not causing the issues with PyQt vs pyqt naming.

Attn. @teddyrendahl

```bash
conda install pydm -c pydm-dev -c gsecars -c conda-forge
```

GSECARS channel is needed for pyepics.
