### PR TITLE
Fix bug with alarm borders

### DIFF
--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -100,14 +100,14 @@ class PyDMWidget(PyDMPrimitiveWidget):
             ALARM_DISCONNECTED: {"color": "white"}
         },
         ALARM_BORDER: {
-            ALARM_NONE: {"border": "2px transparent"},
+            ALARM_NONE: {"border": "2px solid transparent"},
             ALARM_MINOR: {"border": "2px solid yellow"},
             ALARM_MAJOR: {"border": "2px solid red"},
             ALARM_INVALID: {"border": "2px solid purple"},
             ALARM_DISCONNECTED: {"border": "2px solid white"}
         },
         ALARM_CONTENT | ALARM_BORDER: {
-            ALARM_NONE: {"color": "black", "border": "2px transparent"},
+            ALARM_NONE: {"color": "black", "border": "2px solid transparent"},
             ALARM_MINOR: {"color": "yellow", "border": "2px solid yellow"},
             ALARM_MAJOR: {"color": "red", "border": "2px solid red"},
             ALARM_INVALID: {"color": "purple", "border": "2px solid purple"},


### PR DESCRIPTION
Apparently PR #136 did not fix the widget area being constant irrespectively of alarm state. Needed to use "solid transparent" color to achieve it.