### PR TITLE
Improve image and plotting widget handling of extremely large update rates.

### DIFF
--- a/pydm/widgets/scatterplot.py
+++ b/pydm/widgets/scatterplot.py
@@ -183,7 +183,6 @@ class ScatterPlotCurveItem(BasePlotCurveItem):
         self.data_buffer[1, -1] = self.latest_y_value
         if self.points_accumulated < self._bufferSize:
             self.points_accumulated = self.points_accumulated + 1
-        self.data_changed.emit()
 
     def initialize_buffer(self):
         self.points_accumulated = 0
@@ -347,7 +346,6 @@ class PyDMScatterPlot(BasePlot):
                                      **plot_opts)
         if buffer_size is not None:
             curve.setBufferSize(buffer_size)
-        curve.data_changed.connect(self.redrawPlot)
         self.channel_pairs[(y_channel, x_channel)] = curve
         self.addCurve(curve, curve_color=color)
 
@@ -360,7 +358,6 @@ class PyDMScatterPlot(BasePlot):
         curve: ScatterPlotCurveItem
             The curve to remove.
         """
-        curve.data_changed.disconnect(self.redrawPlot)
         self.removeCurve(curve)
 
     def removeChannelAtIndex(self, index):

--- a/pydm/widgets/timeplot.py
+++ b/pydm/widgets/timeplot.py
@@ -133,9 +133,6 @@ class PyDMTimePlot(BasePlot):
         self.plotItem.disableAutoRange(ViewBox.XAxis)
         self.getViewBox().setMouseEnabled(x=False)
         self._bufferSize = 1200
-        self.redraw_timer = QTimer(self)
-        self.redraw_timer.setInterval(20)
-        self.redraw_timer.timeout.connect(self.redrawPlot)
         self.update_timer = QTimer(self)
         self._time_span = 5.0  # This is in seconds
         self._update_interval = 100
@@ -183,8 +180,6 @@ class PyDMTimePlot(BasePlot):
 
     @pyqtSlot()
     def redrawPlot(self):
-        if len(self._curves) == 0:
-            return
         self.updateXAxis()
         for curve in self._curves:
             curve.redrawCurve()


### PR DESCRIPTION
The PyDMImageView and PyDMBasePlot-based widgets now all have a 'maxRedrawRate' property, which controls the maximum rate at which the plots will redraw, regardless of the update rate of the underlying channel.  This greatly improves responsiveness in situations where the channel updates at very high rates (100 Hz or more) - previously, these constant redraws would hog the event loop, and bring all other activity in the window to a grinding halt.

Additionally, some refactoring was done to PyDMImageView to avoid unnecessary work, and simplify the flow of updating image data.