### PR TITLE
FIX: Clean up signal/slot connections in plugins

### DIFF
--- a/pydm/data_plugins/epics_plugins/psp_plugin.py
+++ b/pydm/data_plugins/epics_plugins/psp_plugin.py
@@ -380,6 +380,26 @@ class Connection(PyDMConnection):
             except KeyError:
                 pass
 
+    def remove_listener(self, channel):
+        if channel.value_signal is not None:
+            try:
+                channel.value_signal[str].disconnect(self.put_value)
+            except KeyError:
+                pass
+            try:
+                channel.value_signal[int].disconnect(self.put_value)
+            except KeyError:
+                pass
+            try:
+                channel.value_signal[float].disconnect(self.put_value)
+            except KeyError:
+                pass
+            try:
+                channel.value_signal[np.ndarray].disconnect(self.put_value)
+            except KeyError:
+                pass
+        super(Connection, self).remove_listener(channel)
+
     def close(self):
         """
         Clean up.

--- a/pydm/data_plugins/epics_plugins/pyepics_plugin.py
+++ b/pydm/data_plugins/epics_plugins/pyepics_plugin.py
@@ -124,6 +124,27 @@ class Connection(PyDMConnection):
             except KeyError:
                 pass
 
+    def remove_listener(self, channel):
+        if channel.value_signal is not None:
+            try:
+                channel.value_signal[str].disconnect(self.put_value)
+            except KeyError:
+                pass
+            try:
+                channel.value_signal[int].disconnect(self.put_value)
+            except KeyError:
+                pass
+            try:
+                channel.value_signal[float].disconnect(self.put_value)
+            except KeyError:
+                pass
+            try:
+                channel.value_signal[np.ndarray].disconnect(self.put_value)
+            except KeyError:
+                pass
+
+        super(Connection, self).remove_listener(channel)
+
     def close(self):
         self.pv.disconnect()
 

--- a/pydm/data_plugins/plugin.py
+++ b/pydm/data_plugins/plugin.py
@@ -59,7 +59,48 @@ class PyDMConnection(QObject):
         if channel.prec_slot is not None:
             self.prec_signal.connect(channel.prec_slot, Qt.QueuedConnection)
       
-    def remove_listener(self):
+    def remove_listener(self, channel):
+        if channel.connection_slot is not None:
+            self.connection_state_signal.disconnect(channel.connection_slot)
+        if channel.value_slot is not None:
+            try:
+                self.new_value_signal[int].disconnect(channel.value_slot)
+            except TypeError:
+                pass
+            try:
+                self.new_value_signal[float].disconnect(channel.value_slot)
+            except TypeError:
+                pass
+            try:
+                self.new_value_signal[str].disconnect(channel.value_slot)
+            except TypeError:
+                pass
+            try:
+                self.new_value_signal[ndarray].disconnect(channel.value_slot)
+            except TypeError:
+                pass
+
+        if channel.severity_slot is not None:
+            self.new_severity_signal.disconnect(channel.severity_slot)
+
+        if channel.write_access_slot is not None:
+            self.write_access_signal.disconnect(channel.write_access_slot)
+
+        if channel.enum_strings_slot is not None:
+            self.enum_strings_signal.disconnect(channel.enum_strings_slot)
+
+        if channel.unit_slot is not None:
+            self.unit_signal.disconnect(channel.unit_slot)
+
+        if channel.upper_ctrl_limit_slot is not None:
+            self.upper_ctrl_limit_signal.disconnect(channel.upper_ctrl_limit_slot)
+
+        if channel.lower_ctrl_limit_slot is not None:
+            self.lower_ctrl_limit_signal.disconnect(channel.lower_ctrl_limit_slot)
+
+        if channel.prec_slot is not None:
+            self.prec_signal.disconnect(channel.prec_slot)
+ 
         self.listener_count = self.listener_count - 1
         if self.listener_count < 1:
             self.close()
@@ -86,6 +127,6 @@ class PyDMPlugin(object):
     def remove_connection(self, channel):
         address = self.get_address(channel)
         if address in self.connections:
-            self.connections[address].remove_listener()
+            self.connections[address].remove_listener(channel)
             if self.connections[address].listener_count < 1:
                 del self.connections[address]


### PR DESCRIPTION
In current pydm, channel signals are never explicitly disconnected from the plugin slots, so they remain connected after `remove_connection` until the garbage collector catches up. This causes problems in the app we're currently working on because we are often changing the channel of various widgets. This results in oddities like two image PVs competing to update the same image widget, which is visually confusing and spikes the cpu load.

Here, I've simply added signal disconnect calls to the `remove_listener` routines. This changes the `remove_listener` API to require a `channel` argument, but this doesn't appear to break anything.