### PR TITLE
Handle errors when disconnecting from connection signals.

### DIFF
--- a/pydm/data_plugins/plugin.py
+++ b/pydm/data_plugins/plugin.py
@@ -20,6 +20,7 @@ class PyDMConnection(QObject):
         self.listener_count = self.listener_count + 1
         if channel.connection_slot is not None:
             self.connection_state_signal.connect(channel.connection_slot, Qt.QueuedConnection)
+            
         if channel.value_slot is not None:
             try:
                 self.new_value_signal[int].connect(channel.value_slot, Qt.QueuedConnection)
@@ -61,7 +62,11 @@ class PyDMConnection(QObject):
       
     def remove_listener(self, channel):
         if channel.connection_slot is not None:
-            self.connection_state_signal.disconnect(channel.connection_slot)
+            try:
+                self.connection_state_signal.disconnect(channel.connection_slot)
+            except TypeError:
+                pass
+            
         if channel.value_slot is not None:
             try:
                 self.new_value_signal[int].disconnect(channel.value_slot)


### PR DESCRIPTION
#173 introduced a crash when closing a display which contains an embedded display window.  When the display is being torn down, the application traverses all the widgets and disconnects all channels they use.  For some reason, if you have an embedded window, the widgets inside that window get traversed twice.  When pyqtSignal.disconnect() gets called for the second time, it sees that there were no connections, and throws a TypeError.

This PR just handles the TypeError, and doesn't try to figure out why widgets are getting called twice, which seems to be a peculiarity with how QWidget.findChildWidgets() works.