### PR TITLE
ENH: Add PyDMFrame plugin.

### DIFF
--- a/examples/frame/frame.ui
+++ b/examples/frame/frame.ui
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>454</width>
+    <height>42</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_2">
+   <property name="spacing">
+    <number>0</number>
+   </property>
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item>
+    <widget class="PyDMFrame" name="PyDMFrame">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="whatsThis">
+      <string>
+    QFrame with support for alarms
+    This class inherits from QFrame and PyDMWidget.
+
+    Parameters
+    ----------
+    parent : QWidget
+        The parent widget for the Label
+    init_channel : str, optional
+        The channel to be used by the widget.
+    </string>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">PyDMFrame {
+border-radius: 15px;
+background-color: green;
+margin-bottom: 0px;
+padding-bottom: 0px;
+border-bottom: 0px;
+}</string>
+     </property>
+     <property name="lineWidth">
+      <number>0</number>
+     </property>
+     <property name="alarmSensitiveContent" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="alarmSensitiveBorder" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="channel" stdset="0">
+      <string>ca://MTEST:Float</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <spacer name="verticalSpacer">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>40</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QPushButton" name="pushButton">
+        <property name="autoFillBackground">
+         <bool>true</bool>
+        </property>
+        <property name="styleSheet">
+         <string notr="true"/>
+        </property>
+        <property name="text">
+         <string>PushButton</string>
+        </property>
+        <property name="default">
+         <bool>false</bool>
+        </property>
+        <property name="flat">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>PyDMFrame</class>
+   <extends>QFrame</extends>
+   <header>pydm.widgets.frame</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/pydm/tests/test_plugins_import.py
+++ b/pydm/tests/test_plugins_import.py
@@ -32,6 +32,11 @@ def test_import_embedded_display_plugin():
     from ..widgets.embedded_display import PyDMEmbeddedDisplay
     PyDMEmbeddedDisplayPlugin = qtplugin_factory(PyDMEmbeddedDisplay)
 
+def test_import_frame_plugin():
+    # Frame plugin
+    from ..widgets.frame import PyDMFrame
+    PyDMFramePlugin = qtplugin_factory(PyDMFrame, is_container=True)
+
 def test_import_combobox_plugin():
     # Enum Combobox plugin
     from ..widgets.enum_combo_box import PyDMEnumComboBox

--- a/pydm/widgets/frame.py
+++ b/pydm/widgets/frame.py
@@ -1,0 +1,46 @@
+from ..PyQt.QtGui import QFrame
+from .base import PyDMWidget, compose_stylesheet
+
+
+class PyDMFrame(QFrame, PyDMWidget):
+    """
+    QFrame with support for alarms
+    This class inherits from QFrame and PyDMWidget.
+
+    Parameters
+    ----------
+    parent : QWidget
+        The parent widget for the Label
+    init_channel : str, optional
+        The channel to be used by the widget.
+    """
+    def __init__(self, parent=None, init_channel=None):
+        QFrame.__init__(self, parent)
+        PyDMWidget.__init__(self, init_channel=init_channel)
+        self.alarmSensitiveBorder = False
+
+    def alarm_severity_changed(self, new_alarm_severity):
+        """
+        Callback invoked when the Channel alarm severity is changed.
+        This callback is not processed if the widget has no channel
+        associated with it.
+        This callback handles the composition of the stylesheet to be
+        applied and the call
+        to update to redraw the widget with the needed changes for the
+        new state.
+
+        Parameters
+        ----------
+        new_alarm_severity : int
+            The new severity where 0 = NO_ALARM, 1 = MINOR, 2 = MAJOR
+            and 3 = INVALID
+        """
+        self._alarm_state = new_alarm_severity
+        original_style = str(self.styleSheet()).replace(compose_stylesheet(style=self._style, obj=self), "")
+        self._style = dict(self.alarm_style_sheet_map[self._alarm_flags][new_alarm_severity])
+        if "color" in self._style and self._alarm_state != 0:
+            self._style["background-color"] = self._style["color"]
+            del self._style["color"]
+        style = compose_stylesheet(style=self._style, obj=self)
+        self.setStyleSheet(original_style + style)
+        self.update()

--- a/pydm/widgets/qtplugins.py
+++ b/pydm/widgets/qtplugins.py
@@ -10,6 +10,7 @@ from .drawing import (PyDMDrawingLine, PyDMDrawingRectangle, PyDMDrawingTriangle
 
 from .embedded_display import PyDMEmbeddedDisplay
 from .enum_combo_box import PyDMEnumComboBox
+from .frame import PyDMFrame
 from .image import PyDMImageView
 from .indicator import PyDMIndicator
 from .label import PyDMLabel
@@ -64,6 +65,8 @@ PyDMEmbeddedDisplayPlugin = qtplugin_factory(PyDMEmbeddedDisplay, group=WidgetCa
 # Enum Combobox plugin
 PyDMEnumComboBoxPlugin = qtplugin_factory(PyDMEnumComboBox, group=WidgetCategory.INPUT)
 
+# Frame plugin
+PyDMFramePlugin = qtplugin_factory(PyDMFrame, group=WidgetCategory.DISPLAY, is_container=True)
 
 # Image plugin
 PyDMImageViewPlugin = qtplugin_factory(PyDMImageView, group=WidgetCategory.DISPLAY)


### PR DESCRIPTION
Add a PyDMFrame widget with alarm capabilities.
One can now group widgets and have a Frame around which will respond to alarms in border (alarmSensitiveBorder) & background-color (alarmSensitiveContent).
Updated the smoke test for widgets imports.