### PR TITLE
FIX: Version Information at Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ matrix:
       env: PYQT_VERSION=5 BUILD_DOCS=1
 
 before_install:
+  # Make sure we have the tags no matter how far from them we are.
+  - git pull --unshallow
   - sudo apt-get update
   # We do this conditionally because it saves us some downloading if the
   # version is the same.

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,10 @@ before_install:
   - pip install requests pyepics coverage codecov coveralls pytest pytest-cov
 
 install:
+  # Debug information
+  - git describe --tags --dirty --always
+  - python setup.py version
+  # Do the proper install
   - python setup.py install
 
 script:
@@ -47,10 +51,6 @@ script:
   - |
     if [[ -n "$DOCTR_DEPLOY_ENCRYPTION_KEY" && $BUILD_DOCS ]]; then
       pip install -r docs-requirements.txt
-      # Install doctr from a custom branch until
-      # https://github.com/drdoctr/doctr/pull/190 is merged.
-      pip uninstall -y doctr
-      pip install git+https://github.com/danielballan/doctr@other-master
       pushd docs
       make html
       popd

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ before_install:
   # Useful for debugging any issues with conda
   - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION pyqt=$PYQT_VERSION pip numpy scipy six psutil pyqtgraph -c conda-forge
   - source activate test-environment
-  - pip install requests pyepics coverage codecov coveralls pytest pytest-cov
+  - pip install requests pyepics coverage codecov coveralls pytest pytest-cov versioneer
 
 install:
   # Debug information


### PR DESCRIPTION
The version information at Travis was behaving weirdly since a couple of commits back.
The issue is related to the fact that Travis runs the following command for checkout:
```
git clone --depth=50 ...
```
And since our last tag is more than 50 commits old the automated systems (versioneer and others) were not able to get the proper tag information from the history.
This PR solves this issue and also switch us back to use `doctr` from the official repo since the pull request was merged and the issue was solved.

Thank you @klauer for the help finding this bug on the `depth`.