### PR TITLE
ENH: Icon & Cursor at Button Widgets (Related Display, Shell Command)

### DIFF
--- a/examples/buttons/buttons.ui
+++ b/examples/buttons/buttons.ui
@@ -1,0 +1,159 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>472</width>
+    <height>97</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QGridLayout" name="gridLayout">
+     <item row="0" column="0">
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>PyDMPushButton</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QLabel" name="label_2">
+       <property name="text">
+        <string>PyDMShellCommand</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="2">
+      <widget class="QLabel" name="label_3">
+       <property name="text">
+        <string>PyDMRelatedDisplayButton</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="PyDMPushButton" name="PyDMPushButton">
+       <property name="enabled">
+        <bool>true</bool>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="whatsThis">
+        <string>
+    Basic PushButton to send a fixed value.
+
+    The PyDMPushButton is meant to hold a specific value, and send that value
+    to a channel when it is clicked, much like the MessageButton does in EDM.
+    The PyDMPushButton works in two different modes of operation, first, a
+    fixed value can be given to the :attr:`.pressValue` attribute, whenever the
+    button is clicked a signal containing this value will be sent to the
+    connected channel. This is the default behavior of the button. However, if
+    the :attr:`.relativeChange` is set to True, the fixed value will be added
+    to the current value of the channel. This means that the button will
+    increment a channel by a fixed amount with every click, a consistent
+    relative move
+
+    Parameters
+    ----------
+    parent : QObject, optional
+        Parent of PyDMPushButton
+
+    label : str, optional
+        String to place on button
+
+    icon : QIcon, optional
+        An Icon to display on the PyDMPushButton
+
+    pressValue : int, float, str
+        Value to be sent when the button is clicked
+
+    relative : bool, optional
+        Choice to have the button perform a relative put, instead of always
+        setting to an absolute value
+
+    init_channel : str, optional
+        ID of channel to manipulate
+
+    </string>
+       </property>
+       <property name="text">
+        <string>Click Me!</string>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://BLAH</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="2">
+      <widget class="PyDMRelatedDisplayButton" name="PyDMRelatedDisplayButton">
+       <property name="mouseTracking">
+        <bool>false</bool>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="whatsThis">
+        <string>
+    A QPushButton capable of opening a new Display at the same of at a
+    new window.
+
+    Parameters
+    ----------
+    init_channel : str, optional
+        The channel to be used by the widget.
+
+    filename : str, optional
+        The file to be opened
+    </string>
+       </property>
+       <property name="text" stdset="0">
+        <string>Open Display</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="PyDMShellCommand" name="PyDMShellCommand">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="whatsThis">
+        <string>
+    A QPushButton capable of execute shell commands.
+    </string>
+       </property>
+       <property name="text">
+        <string>Run Command</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>PyDMPushButton</class>
+   <extends>QPushButton</extends>
+   <header>pydm.widgets.pushbutton</header>
+  </customwidget>
+  <customwidget>
+   <class>PyDMRelatedDisplayButton</class>
+   <extends>QFrame</extends>
+   <header>pydm.widgets.related_display_button</header>
+  </customwidget>
+  <customwidget>
+   <class>PyDMShellCommand</class>
+   <extends>QPushButton</extends>
+   <header>pydm.widgets.shell_command</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/pydm/application.py
+++ b/pydm/application.py
@@ -385,7 +385,7 @@ class PyDMApplication(QApplication):
         else:
             self.directory_stack.pop()
             self.macro_stack.pop()
-            raise ValueError("invalid file type: {}".format(extension))
+            raise ValueError("Invalid file type: {}".format(extension))
         self.establish_widget_connections(widget)
         self.directory_stack.pop()
         self.macro_stack.pop()

--- a/pydm/utilities/iconfont.py
+++ b/pydm/utilities/iconfont.py
@@ -10,56 +10,73 @@ from ..PyQt.QtGui import QFontDatabase, QIconEngine, QPixmap, QPainter, QColor, 
 from ..PyQt.QtCore import Qt, QRect, QPoint, qRound
 if sys.version_info[0] == 3:
     unichr = chr
-    
+
+
 class IconFont(object):
     """IconFont represents an icon font.  Users will generally want
     to use IconFont.icon() to get a QIcon object for the character they want."""
+    __instance = None
+
     def __init__(self):
-        self.font_file = "fontawesome.ttf" #specify these relative to this file.
+        if self.__initialized:
+            return
+        self.font_file = "fontawesome.ttf"  # specify these relative to this file.
         self.charmap_file = "fontawesome-charmap.json"
         self.font_name = None
         self.char_map = None
         self.load_font(self.font_file, self.charmap_file)
-        
+        self.__initialized = True
+
+    def __new__(cls, *args, **kwargs):
+        if cls.__instance is None:
+            cls.__instance = object.__new__(IconFont)
+            cls.__instance.__initialized = False
+        return cls.__instance
+
     def load_font(self, ttf_filename, charmap_filename):
-        font_id = QFontDatabase.addApplicationFont(os.path.join(os.path.dirname(os.path.realpath(__file__)), ttf_filename))
-        font_families = QFontDatabase.applicationFontFamilies(font_id)
-        if font_families:
-            self.font_name = font_families[0]
-        else:
-            raise IOError("Could not load ttf file for icon font.")
+
         def hook(obj):
             result = {}
             for key in obj:
                 result[key] = unichr(int(obj[key], 16))
             return result
-        with open(os.path.join(os.path.dirname(os.path.realpath(__file__)), charmap_filename), 'r') as codes:
-            self.char_map = json.load(codes, object_hook=hook)
-    
+
+        if self.char_map is None:
+            font_id = QFontDatabase.addApplicationFont(os.path.join(os.path.dirname(os.path.realpath(__file__)), ttf_filename))
+            font_families = QFontDatabase.applicationFontFamilies(font_id)
+            if font_families:
+                self.font_name = font_families[0]
+            else:
+                raise IOError("Could not load ttf file for icon font.")
+            with open(os.path.join(os.path.dirname(os.path.realpath(__file__)), charmap_filename), 'r') as codes:
+                self.char_map = json.load(codes, object_hook=hook)
+
     def get_char_for_name(self, name):
         if name in self.char_map:
             return self.char_map[name]
         else:
             print(self.char_map)
             raise ValueError("Invalid icon name for font.")
-    
+
     def font(self, size):
         font = QFont(self.font_name)
         font.setPixelSize(size)
         return font
-    
+
     def icon(self, name):
         char = self.get_char_for_name(name)
         engine = CharIconEngine(self, char)
         return QIcon(engine)
-        
+
+
 class CharIconEngine(QIconEngine):
     """Subclass of QIconEngine that is designed to draw characters from icon fonts."""
+
     def __init__(self, icon_font, char):
         super(CharIconEngine, self).__init__()
         self.icon_font = icon_font
         self.char = char
-    
+
     def paint(self, painter, rect, mode, state):
         painter.save()
         if mode == QIcon.Disabled:
@@ -73,7 +90,7 @@ class CharIconEngine(QIconEngine):
         painter.setOpacity(1.0)
         painter.drawText(rect, Qt.AlignCenter | Qt.AlignVCenter, self.char)
         painter.restore()
-    
+
     def pixmap(self, size, mode, state):
         pm = QPixmap(size)
         pm.fill(Qt.transparent)

--- a/pydm/widgets/related_display_button.py
+++ b/pydm/widgets/related_display_button.py
@@ -1,9 +1,11 @@
-from ..PyQt.QtGui import QPushButton, QApplication, QFrame, QVBoxLayout, QSizePolicy, QLayout
-from ..PyQt.QtCore import pyqtSlot, pyqtProperty, Qt
+from ..PyQt.QtGui import QPushButton, QCursor
+from ..PyQt.QtCore import pyqtSlot, pyqtProperty, Qt, QSize
 import json
-from .base import PyDMWidget, compose_stylesheet
+from .base import PyDMPrimitiveWidget
+from ..utilities import IconFont
 
-class PyDMRelatedDisplayButton(QFrame, PyDMWidget):
+
+class PyDMRelatedDisplayButton(QPushButton, PyDMPrimitiveWidget):
     """
     A QPushButton capable of opening a new Display at the same of at a
     new window.
@@ -20,54 +22,22 @@ class PyDMRelatedDisplayButton(QFrame, PyDMWidget):
     EXISTING_WINDOW = 0;
     NEW_WINDOW = 1;
 
-    def __init__(self, parent=None, init_channel=None, filename=None):
-        QFrame.__init__(self, parent)
-        PyDMWidget.__init__(self, init_channel=init_channel)
-        self._layout = QVBoxLayout(self)
-        self._layout.setSpacing(0)
-        self._layout.setContentsMargins(0, 0, 0, 0)
-        self._layout.setSizeConstraint(QLayout.SetMaximumSize)
+    def __init__(self, parent=None, filename=None):
+        QPushButton.__init__(self, parent)
+        PyDMPrimitiveWidget.__init__(self)
+        self.mouseReleaseEvent = self.push_button_release_event
 
-        self.push_button = QPushButton(self)
-        self.push_button.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
-        self.push_button.mouseReleaseEvent = self.push_button_release_event
+        make_cursor(icon="", include_arrow=False)
+        self.iconFont = IconFont()
+        icon = self.iconFont.icon("file")
+        self.setIconSize(QSize(16, 16))
+        self.setIcon(icon)
 
-        self._layout.addWidget(self.push_button)
-
-        self.setLayout(self._layout)
-        self.setFrameShape(QFrame.NoFrame)
-        self.setLineWidth(0)
+        self.setCursor(QCursor(icon.pixmap(16, 16)))
 
         self._display_filename = filename
         self._macro_string = None
         self._open_in_new_window = False
-        self.app = QApplication.instance()
-
-    def alarm_severity_changed(self, new_alarm_severity):
-        """
-        Callback invoked when the Channel alarm severity is changed.
-        This callback is not processed if the widget has no channel
-        associated with it.
-        This callback handles the composition of the stylesheet to be
-        applied and the call
-        to update to redraw the widget with the needed changes for the
-        new state.
-
-        Parameters
-        ----------
-        new_alarm_severity : int
-            The new severity where 0 = NO_ALARM, 1 = MINOR, 2 = MAJOR
-            and 3 = INVALID
-        """
-        PyDMWidget.alarm_severity_changed(self, new_alarm_severity)
-        if self._channels is not None:
-            self._alarm_state = new_alarm_severity
-            self._style = dict(self.alarm_style_sheet_map[self._alarm_flags][new_alarm_severity])
-            if 'border' in self._style:
-                del self._style['border']
-            style = compose_stylesheet(style=self._style, obj=self.push_button)
-            self.push_button.setStyleSheet(style)
-            self.push_button.update()
 
     def check_enable_state(self):
         """
@@ -75,28 +45,6 @@ class PyDMRelatedDisplayButton(QFrame, PyDMWidget):
         status, the widget is never disabled by connection state.
         """
         self.setEnabled(True)
-
-    @pyqtProperty(str)
-    def text(self):
-        """
-        The QPushButton text property
-
-        Returns
-        -------
-        str
-        """
-        return self.push_button.text()
-
-    @text.setter
-    def text(self, txt):
-        """
-        The QPushButton text property
-
-        Parameters
-        ----------
-        txt : str
-        """
-        self.push_button.setText(txt)
 
     @pyqtProperty(str)
     def displayFilename(self):
@@ -188,11 +136,15 @@ class PyDMRelatedDisplayButton(QFrame, PyDMWidget):
         mouse_event : QMouseEvent
 
         """
-        if mouse_event.modifiers() == Qt.ShiftModifier or self._open_in_new_window:
-            self.open_display(target=self.NEW_WINDOW)
-        else:
-            self.open_display()
-        super(PyDMRelatedDisplayButton, self).mouseReleaseEvent(mouse_event)
+        try:
+            if mouse_event.modifiers() == Qt.ShiftModifier or self._open_in_new_window:
+                self.open_display(target=self.NEW_WINDOW)
+            else:
+                self.open_display()
+        except:
+            pass
+        finally:
+            super(PyDMRelatedDisplayButton, self).mouseReleaseEvent(mouse_event)
 
     @pyqtSlot()
     def open_display(self, target=EXISTING_WINDOW):

--- a/pydm/widgets/related_display_button.py
+++ b/pydm/widgets/related_display_button.py
@@ -27,7 +27,6 @@ class PyDMRelatedDisplayButton(QPushButton, PyDMPrimitiveWidget):
         PyDMPrimitiveWidget.__init__(self)
         self.mouseReleaseEvent = self.push_button_release_event
 
-        make_cursor(icon="", include_arrow=False)
         self.iconFont = IconFont()
         icon = self.iconFont.icon("file")
         self.setIconSize(QSize(16, 16))

--- a/pydm/widgets/shell_command.py
+++ b/pydm/widgets/shell_command.py
@@ -1,7 +1,9 @@
-from ..PyQt.QtGui import QPushButton
-from ..PyQt.QtCore import pyqtSlot, pyqtProperty
+from ..PyQt.QtGui import QPushButton, QCursor
+from ..PyQt.QtCore import pyqtSlot, pyqtProperty, QSize
 import shlex, subprocess
 from .base import PyDMPrimitiveWidget
+from ..utilities import IconFont
+
 
 class PyDMShellCommand(QPushButton, PyDMPrimitiveWidget):
     """
@@ -11,6 +13,12 @@ class PyDMShellCommand(QPushButton, PyDMPrimitiveWidget):
     def __init__(self, parent=None, command=None):
         QPushButton.__init__(self, parent)
         PyDMPrimitiveWidget.__init__(self)
+        self.iconFont = IconFont()
+        icon = self.iconFont.icon("cog")
+        self.setIconSize(QSize(16, 16))
+        self.setIcon(icon)
+        self.setCursor(QCursor(icon.pixmap(16, 16)))
+
         self._command = command
         self.process = None
 


### PR DESCRIPTION
The three button widgets at PyDM (PushButton, Related Display & Shell Command) were exactly the same for a user standpoint and as pointed out, it can cause confusion for the users.
Keeping in mind that some developers and users may like it, this change can be reverted by code and also using the Designer to remove the Icon & cursor if desired.

Here is a GIF showing how the buttons are looking like now:
![pydm_buttons](https://user-images.githubusercontent.com/8185425/33627147-78f7a2f0-d9b1-11e7-8bf1-c4a2761e073b.gif)

The PushButton was left unchanged as it can perform way more operations than a simple write to a PV.
Also on this PR, the Related Display button no longer inherits from QFrame and PyDMWidget but now from QPushButton and PyDMPrimitiveWidget since it has no need for channels.
In order to add Alarm behavior to the widget we strongly recommend that you add this widget to the new PyDMFrame which will perform the alarm handling better than before.