### PR TITLE
ENH: Open in Designer now also opens the PY file associated with the screen.

### DIFF
--- a/examples/code_only/code_only.py
+++ b/examples/code_only/code_only.py
@@ -1,0 +1,21 @@
+from pydm import Display
+from pydm.PyQt.QtGui import QLabel, QVBoxLayout, QHBoxLayout
+
+class MyDisplay(Display):
+    def __init__(self, parent=None, args=[]):
+        super(MyDisplay, self).__init__(parent=parent, args=args)
+        self.setup_ui()
+    
+    def setup_ui(self):
+        main = QHBoxLayout()
+        sub = QVBoxLayout()
+        for i in range(10):
+            sub.addWidget(QLabel(str(i)))
+        main.addLayout(sub)
+        self.setLayout(main)
+    
+    def ui_filename(self):
+        return None
+    
+    def ui_filepath(self):
+        return None

--- a/examples/home.ui
+++ b/examples/home.ui
@@ -76,8 +76,8 @@
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>216</width>
-             <height>782</height>
+             <width>213</width>
+             <height>560</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_3">
@@ -95,7 +95,7 @@
               <property name="whatsThis">
                <string/>
               </property>
-              <property name="text" stdset="0">
+              <property name="text">
                <string>Byte Indicator</string>
               </property>
               <property name="displayFilename" stdset="0">
@@ -117,7 +117,7 @@
               <property name="whatsThis">
                <string/>
               </property>
-              <property name="text" stdset="0">
+              <property name="text">
                <string>Checkbox</string>
               </property>
               <property name="displayFilename" stdset="0">
@@ -139,7 +139,7 @@
               <property name="whatsThis">
                <string/>
               </property>
-              <property name="text" stdset="0">
+              <property name="text">
                <string>Drawing Widgets</string>
               </property>
               <property name="displayFilename" stdset="0">
@@ -161,7 +161,7 @@
               <property name="whatsThis">
                <string/>
               </property>
-              <property name="text" stdset="0">
+              <property name="text">
                <string>Embedded Display</string>
               </property>
               <property name="displayFilename" stdset="0">
@@ -183,7 +183,7 @@
               <property name="whatsThis">
                <string/>
               </property>
-              <property name="text" stdset="0">
+              <property name="text">
                <string>Enum Combo Box</string>
               </property>
               <property name="displayFilename" stdset="0">
@@ -205,7 +205,7 @@
               <property name="whatsThis">
                <string/>
               </property>
-              <property name="text" stdset="0">
+              <property name="text">
                <string>Image View</string>
               </property>
               <property name="displayFilename" stdset="0">
@@ -227,7 +227,7 @@
               <property name="whatsThis">
                <string/>
               </property>
-              <property name="text" stdset="0">
+              <property name="text">
                <string>Label</string>
               </property>
               <property name="displayFilename" stdset="0">
@@ -249,7 +249,7 @@
               <property name="whatsThis">
                <string/>
               </property>
-              <property name="text" stdset="0">
+              <property name="text">
                <string>Line Edit</string>
               </property>
               <property name="displayFilename" stdset="0">
@@ -265,7 +265,7 @@
               <property name="whatsThis">
                <string/>
               </property>
-              <property name="text" stdset="0">
+              <property name="text">
                <string>Push Button</string>
               </property>
               <property name="displayFilename" stdset="0">
@@ -281,7 +281,7 @@
               <property name="whatsThis">
                <string/>
               </property>
-              <property name="text" stdset="0">
+              <property name="text">
                <string>Related Display Button</string>
               </property>
               <property name="displayFilename" stdset="0">
@@ -297,7 +297,7 @@
               <property name="whatsThis">
                <string/>
               </property>
-              <property name="text" stdset="0">
+              <property name="text">
                <string>Shell Command Button</string>
               </property>
               <property name="displayFilename" stdset="0">
@@ -313,7 +313,7 @@
               <property name="whatsThis">
                <string/>
               </property>
-              <property name="text" stdset="0">
+              <property name="text">
                <string>Slider</string>
               </property>
               <property name="displayFilename" stdset="0">
@@ -329,7 +329,7 @@
               <property name="whatsThis">
                <string/>
               </property>
-              <property name="text" stdset="0">
+              <property name="text">
                <string>Spinbox</string>
               </property>
               <property name="displayFilename" stdset="0">
@@ -345,7 +345,7 @@
               <property name="whatsThis">
                <string/>
               </property>
-              <property name="text" stdset="0">
+              <property name="text">
                <string>Symbol</string>
               </property>
               <property name="displayFilename" stdset="0">
@@ -361,7 +361,7 @@
               <property name="whatsThis">
                <string/>
               </property>
-              <property name="text" stdset="0">
+              <property name="text">
                <string>Time Plot</string>
               </property>
               <property name="displayFilename" stdset="0">
@@ -377,7 +377,7 @@
               <property name="whatsThis">
                <string/>
               </property>
-              <property name="text" stdset="0">
+              <property name="text">
                <string>Waveform Plot</string>
               </property>
               <property name="displayFilename" stdset="0">
@@ -393,7 +393,7 @@
               <property name="whatsThis">
                <string/>
               </property>
-              <property name="text" stdset="0">
+              <property name="text">
                <string>Waveform Table</string>
               </property>
               <property name="displayFilename" stdset="0">
@@ -436,7 +436,7 @@
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>358</width>
+             <width>366</width>
              <height>443</height>
             </rect>
            </property>
@@ -458,7 +458,7 @@
               <property name="whatsThis">
                <string/>
               </property>
-              <property name="text" stdset="0">
+              <property name="text">
                <string>Macro Variables in Embedded Displays</string>
               </property>
               <property name="displayFilename" stdset="0">
@@ -480,7 +480,7 @@
               <property name="whatsThis">
                <string/>
               </property>
-              <property name="text" stdset="0">
+              <property name="text">
                <string>Macro Variables and Related Display Buttons</string>
               </property>
               <property name="displayFilename" stdset="0">
@@ -502,7 +502,7 @@
               <property name="whatsThis">
                <string/>
               </property>
-              <property name="text" stdset="0">
+              <property name="text">
                <string>Nested Embedded Displays</string>
               </property>
               <property name="displayFilename" stdset="0">
@@ -524,7 +524,7 @@
               <property name="whatsThis">
                <string/>
               </property>
-              <property name="text" stdset="0">
+              <property name="text">
                <string>Python-based Display: Image Processing</string>
               </property>
               <property name="displayFilename" stdset="0">
@@ -546,7 +546,7 @@
               <property name="whatsThis">
                <string/>
               </property>
-              <property name="text" stdset="0">
+              <property name="text">
                <string>Python-based Display: Camera View Application</string>
               </property>
               <property name="displayFilename" stdset="0">
@@ -581,7 +581,7 @@
  <customwidgets>
   <customwidget>
    <class>PyDMRelatedDisplayButton</class>
-   <extends>QFrame</extends>
+   <extends>QPushButton</extends>
    <header>pydm.widgets.related_display_button</header>
   </customwidget>
  </customwidgets>

--- a/pydm/application.py
+++ b/pydm/application.py
@@ -7,6 +7,7 @@ our PyDMMainWindow class with navigation logic.
 import os
 import imp
 import sys
+import uuid
 import signal
 import subprocess
 import re
@@ -250,7 +251,12 @@ class PyDMApplication(QApplication):
             main_window.move(main_window.x() + 10, main_window.y() + 10)
 
     def close_window(self, window):
-        del self.windows[window]
+        try:
+            del self.windows[window]
+        except KeyError:
+            # If window is no longer at self.windows
+            # it means that we already closed it.
+            pass
 
     def load_ui_file(self, uifile, macros=None):
         """
@@ -310,9 +316,10 @@ class PyDMApplication(QApplication):
         # Add the intelligence module directory to the python path, so that submodules can be loaded.    Eventually, this should go away, and intelligence modules should behave as real python modules.
         module_dir = os.path.dirname(os.path.abspath(pyfile))
         sys.path.append(module_dir)
+        temp_name = str(uuid.uuid4())
 
         # Now load the intelligence module.
-        module = imp.load_source('intelclass', pyfile)
+        module = imp.load_source(temp_name, pyfile)
         self.__sanity_check_pyqt(module)
         if hasattr(module, 'intelclass'):
             cls = module.intelclass

--- a/pydm/display_module.py
+++ b/pydm/display_module.py
@@ -18,7 +18,7 @@ class Display(QWidget):
     def load_ui(self, parent=None, macros=None):
         if self.ui:
             return self.ui
-        if self.ui_filepath() is not None:
+        if self.ui_filepath() is not None and self.ui_filepath() != "":
             if macros is not None:
                 f = macro.substitute_in_file(self.ui_filepath(), macros)
             else:

--- a/pydm/display_module.py
+++ b/pydm/display_module.py
@@ -18,8 +18,9 @@ class Display(QWidget):
     def load_ui(self, parent=None, macros=None):
         if self.ui:
             return self.ui
-        if macros is not None:
-            f = macro.substitute_in_file(self.ui_filepath(), macros)
-        else:
-            f = self.ui_filepath()
-        self.ui = uic.loadUi(f, baseinstance=self)
+        if self.ui_filepath() is not None:
+            if macros is not None:
+                f = macro.substitute_in_file(self.ui_filepath(), macros)
+            else:
+                f = self.ui_filepath()
+            self.ui = uic.loadUi(f, baseinstance=self)


### PR DESCRIPTION
With this new enhancement the `Edit in Designer...` behaves in the following way:
- UI only:
Open the Designer if available with the UI file.
- Python only:
Open the default editor for `.py` files according to what is configured on the system.
- Python & UI:
You guessed right... it does both! 😆 

I need some help testing this with Windows & Linux...
After merged this closes #156 .