### PR TITLE
Implement sizeHint on drawing widgets.

### DIFF
--- a/pydm/widgets/drawing.py
+++ b/pydm/widgets/drawing.py
@@ -1,6 +1,6 @@
 import math
 from ..PyQt.QtGui import QApplication, QWidget, QColor, QPainter, QBrush, QPen, QPolygon, QPixmap, QStyle, QStyleOption
-from ..PyQt.QtCore import pyqtProperty, Qt, QPoint
+from ..PyQt.QtCore import pyqtProperty, Qt, QPoint, QSize
 from .base import PyDMWidget
 
 def deg_to_qt(deg):
@@ -63,6 +63,9 @@ class PyDMDrawing(QWidget, PyDMWidget):
         self._pen_style = Qt.NoPen
         self._pen_width = 0
         self._pen_color = QColor(0, 0, 0)
+
+    def sizeHint(self):
+        return QSize(100,100)
 
     def paintEvent(self, _):
         """
@@ -453,6 +456,11 @@ class PyDMDrawingImage(PyDMDrawing):
                 pass
             self._pixmap = QPixmap(path_relative_to_ui_file)
             self.update()
+
+    def sizeHint(self):
+        if self._pixmap.size().isEmpty():
+            return super(PyDMDrawingImage, self).sizeHint()
+        return self._pixmap.size()
 
     @pyqtProperty(Qt.AspectRatioMode)
     def aspectRatioMode(self):


### PR DESCRIPTION
Now all drawing widgets start with a sizeHint of QSize(100,100).  Image drawing widgets get a sizeHint equal to the size of the loaded image.  This prevents layouts from shrinking the drawing widgets down to zero when an expanding item is also in the layout.