### PR TITLE
FIX: Prevent overwrite of QPixmap after filename __init__

### DIFF
--- a/pydm/widgets/drawing.py
+++ b/pydm/widgets/drawing.py
@@ -419,9 +419,9 @@ class PyDMDrawingImage(PyDMDrawing):
     """
     def __init__(self, parent=None, init_channel=None, filename=""):
         super(PyDMDrawingImage, self).__init__(parent, init_channel)
-        self.filename = filename
         self._pixmap = QPixmap()
         self._aspect_ratio_mode = Qt.KeepAspectRatio
+        self.filename = filename
         if not is_pydm_app():
             designer_window = self.get_designer_window()
             if designer_window is not None:


### PR DESCRIPTION
## Description
I think the order of operations were slightly off when you pass in a `filename` at `__init__`.  In the current setup, you set the filename, which creates a new `QPixmap` with your image, then you initialize a new one, overwriting the correct one.

## Solution
I moved the `filename` set all the way to the end of the base `__init__` operations. That way we don't overwrite our `QPixmap`, and we also have the base aspect ratio when call `update` for the first time at the end of `filename.setter`

## Tests
Tested locally