### PR TITLE
FIX: Prevent gui from crashing when shell command goes wrong

### DIFF
--- a/pydm/widgets/shell_command.py
+++ b/pydm/widgets/shell_command.py
@@ -98,6 +98,9 @@ class PyDMShellCommand(QPushButton, PyDMPrimitiveWidget):
 
         if (self.process is None or self.process.poll() is not None) or self._allow_multiple:
             args = shlex.split(self._command)
-            self.process = subprocess.Popen(args)
+            try:
+                self.process = subprocess.Popen(args)
+            except Exception as exc:
+                print("Error in command: ", exc)
         else:
             print("Command already active.")


### PR DESCRIPTION
Very simple proposal: protect the users from themselves. If a python exception is raised while executing a shell command, such as a file not found or permission error, the GUI should not crash. Use a simple try/except block to achieve this.