### PR TITLE
ENH: Display Format option for Label and Line Edit

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,19 @@ pydm widgets are written in Python, and are loaded into Qt Designer via the PyQt
 If you want to use the pydm widgets in Qt Designer, add the pydm directory (which holds designer_plugin.py) to your PYQTDESIGNERPATH environment variable.  Eventually, this will happen automatically in some kind of setup script.
 
 # Easy Installing PyDM
-
+## Using the source code
 ```sh
 git clone https://github.com/slaclab/pydm.git
 cd pydm
 pip install .[all]
+```
+
+## Using Anaconda
+### Most Recent Development Build
+```sh
+conda install -c pydm-dev -c gsecars -c conda-forge pydm
+```
+### Most Recent Tagged Build
+```sh
+conda install -c pydm-tag -c gsecars -c conda-forge pydm
 ```

--- a/examples/display_format/display_format.ui
+++ b/examples/display_format/display_format.ui
@@ -495,7 +495,7 @@
             <bool>false</bool>
            </property>
            <property name="showUnits" stdset="0">
-            <bool>false</bool>
+            <bool>true</bool>
            </property>
            <property name="channel" stdset="0">
             <string>ca://MTEST:UpdateTime</string>
@@ -522,6 +522,9 @@
         The channel to be used by the widget.
     </string>
            </property>
+           <property name="showUnits" stdset="0">
+            <bool>true</bool>
+           </property>
            <property name="channel" stdset="0">
             <string>ca://MTEST:UpdateTime</string>
            </property>
@@ -546,6 +549,9 @@
     init_channel : str, optional
         The channel to be used by the widget.
     </string>
+           </property>
+           <property name="showUnits" stdset="0">
+            <bool>true</bool>
            </property>
            <property name="channel" stdset="0">
             <string>ca://MTEST:UpdateTime</string>
@@ -575,6 +581,9 @@
         The channel to be used by the widget.
     </string>
            </property>
+           <property name="showUnits" stdset="0">
+            <bool>true</bool>
+           </property>
            <property name="channel" stdset="0">
             <string>ca://MTEST:UpdateTime</string>
            </property>
@@ -602,6 +611,9 @@
     init_channel : str, optional
         The channel to be used by the widget.
     </string>
+           </property>
+           <property name="showUnits" stdset="0">
+            <bool>true</bool>
            </property>
            <property name="channel" stdset="0">
             <string>ca://MTEST:UpdateTime</string>
@@ -631,6 +643,9 @@
         The channel to be used by the widget.
     </string>
            </property>
+           <property name="showUnits" stdset="0">
+            <bool>true</bool>
+           </property>
            <property name="channel" stdset="0">
             <string>ca://MTEST:UpdateTime</string>
            </property>
@@ -658,6 +673,9 @@
     init_channel : str, optional
         The channel to be used by the widget.
     </string>
+           </property>
+           <property name="showUnits" stdset="0">
+            <bool>true</bool>
            </property>
            <property name="channel" stdset="0">
             <string>ca://MTEST:UpdateTime</string>

--- a/examples/display_format/display_format.ui
+++ b/examples/display_format/display_format.ui
@@ -425,42 +425,42 @@
          <item row="3" column="0">
           <widget class="QLabel" name="label_19">
            <property name="text">
-            <string>Float (Default):</string>
+            <string>Update Time (Default):</string>
            </property>
           </widget>
          </item>
          <item row="4" column="0">
           <widget class="QLabel" name="label_20">
            <property name="text">
-            <string>Float (String):</string>
+            <string>Update Time (String):</string>
            </property>
           </widget>
          </item>
          <item row="5" column="0">
           <widget class="QLabel" name="label_21">
            <property name="text">
-            <string>Float (Decimal):</string>
+            <string>Update Time (Decimal):</string>
            </property>
           </widget>
          </item>
          <item row="6" column="0">
           <widget class="QLabel" name="label_22">
            <property name="text">
-            <string>Float (Exponential):</string>
+            <string>Update Time (Exponential):</string>
            </property>
           </widget>
          </item>
          <item row="7" column="0">
           <widget class="QLabel" name="label_23">
            <property name="text">
-            <string>Float (Hex):</string>
+            <string>Update Time (Hex):</string>
            </property>
           </widget>
          </item>
          <item row="8" column="0">
           <widget class="QLabel" name="label_24">
            <property name="text">
-            <string>Float (Binary):</string>
+            <string>Update Time (Binary):</string>
            </property>
           </widget>
          </item>

--- a/examples/label/test_enum.ui
+++ b/examples/label/test_enum.ui
@@ -6,38 +6,392 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>400</width>
-    <height>300</height>
+    <width>539</width>
+    <height>399</height>
    </rect>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>500</width>
+    <height>330</height>
+   </size>
   </property>
   <property name="windowTitle">
    <string>Dialog</string>
   </property>
-  <widget class="PyDMLabel" name="PyDMLabel">
-   <property name="geometry">
-    <rect>
-     <x>180</x>
-     <y>70</y>
-     <width>69</width>
-     <height>16</height>
-    </rect>
-   </property>
-   <property name="toolTip">
-    <string/>
-   </property>
-   <property name="whatsThis">
-    <string/>
-   </property>
-   <property name="displayFormat" stdset="0">
-    <enum>PyDMLabel::Exponential</enum>
-   </property>
-  </widget>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QVBoxLayout" name="verticalLayout_2">
+     <item>
+      <layout class="QFormLayout" name="formLayout_2">
+       <item row="3" column="0">
+        <widget class="QLabel" name="label_12">
+         <property name="text">
+          <string>Float (Default):</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="1">
+        <widget class="PyDMLabel" name="PyDMLabel_11">
+         <property name="toolTip">
+          <string/>
+         </property>
+         <property name="whatsThis">
+          <string/>
+         </property>
+         <property name="alarmSensitiveBorder" stdset="0">
+          <bool>false</bool>
+         </property>
+         <property name="channel" stdset="0">
+          <string>ca://MTEST:Float</string>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="0">
+        <widget class="QLabel" name="label_13">
+         <property name="text">
+          <string>Float (String):</string>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="1">
+        <widget class="PyDMLabel" name="PyDMLabel_12">
+         <property name="toolTip">
+          <string/>
+         </property>
+         <property name="whatsThis">
+          <string/>
+         </property>
+         <property name="alarmSensitiveBorder" stdset="0">
+          <bool>false</bool>
+         </property>
+         <property name="channel" stdset="0">
+          <string>ca://MTEST:Float</string>
+         </property>
+         <property name="displayFormat" stdset="0">
+          <enum>PyDMLabel::String</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="0">
+        <widget class="QLabel" name="label_14">
+         <property name="text">
+          <string>Float (Decimal):</string>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="1">
+        <widget class="PyDMLabel" name="PyDMLabel_13">
+         <property name="toolTip">
+          <string/>
+         </property>
+         <property name="whatsThis">
+          <string/>
+         </property>
+         <property name="alarmSensitiveBorder" stdset="0">
+          <bool>false</bool>
+         </property>
+         <property name="channel" stdset="0">
+          <string>ca://MTEST:Float</string>
+         </property>
+         <property name="displayFormat" stdset="0">
+          <enum>PyDMLabel::Decimal</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="6" column="0">
+        <widget class="QLabel" name="label_15">
+         <property name="text">
+          <string>Float (Exponential):</string>
+         </property>
+        </widget>
+       </item>
+       <item row="6" column="1">
+        <widget class="PyDMLabel" name="PyDMLabel_14">
+         <property name="toolTip">
+          <string/>
+         </property>
+         <property name="whatsThis">
+          <string/>
+         </property>
+         <property name="alarmSensitiveBorder" stdset="0">
+          <bool>false</bool>
+         </property>
+         <property name="channel" stdset="0">
+          <string>ca://MTEST:Float</string>
+         </property>
+         <property name="displayFormat" stdset="0">
+          <enum>PyDMLabel::Exponential</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="7" column="0">
+        <widget class="QLabel" name="label_16">
+         <property name="text">
+          <string>Float (Hex):</string>
+         </property>
+        </widget>
+       </item>
+       <item row="7" column="1">
+        <widget class="PyDMLabel" name="PyDMLabel_15">
+         <property name="toolTip">
+          <string/>
+         </property>
+         <property name="whatsThis">
+          <string/>
+         </property>
+         <property name="alarmSensitiveBorder" stdset="0">
+          <bool>false</bool>
+         </property>
+         <property name="channel" stdset="0">
+          <string>ca://MTEST:Float</string>
+         </property>
+         <property name="displayFormat" stdset="0">
+          <enum>PyDMLabel::Hex</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="8" column="0">
+        <widget class="QLabel" name="label_17">
+         <property name="text">
+          <string>Float (Binary):</string>
+         </property>
+        </widget>
+       </item>
+       <item row="8" column="1">
+        <widget class="PyDMLabel" name="PyDMLabel_16">
+         <property name="toolTip">
+          <string/>
+         </property>
+         <property name="whatsThis">
+          <string/>
+         </property>
+         <property name="alarmSensitiveBorder" stdset="0">
+          <bool>false</bool>
+         </property>
+         <property name="channel" stdset="0">
+          <string>ca://MTEST:Float</string>
+         </property>
+         <property name="displayFormat" stdset="0">
+          <enum>PyDMLabel::Binary</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QLabel" name="label_18">
+         <property name="text">
+          <string>Float:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="PyDMLineEdit" name="PyDMLineEdit_2">
+         <property name="toolTip">
+          <string/>
+         </property>
+         <property name="whatsThis">
+          <string>
+    A QLineEdit (writable text field) with support for Channels and more
+    from PyDM.
+    This widget offers an unit conversion menu when users Right Click
+    into it.
+
+    Parameters
+    ----------
+    parent : QWidget
+        The parent widget for the Label
+    init_channel : str, optional
+        The channel to be used by the widget.
+    </string>
+         </property>
+         <property name="alarmSensitiveBorder" stdset="0">
+          <bool>false</bool>
+         </property>
+         <property name="channel" stdset="0">
+          <string>ca://MTEST:Float</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="Line" name="line">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QFormLayout" name="formLayout">
+     <item row="0" column="0">
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>Message (Default):</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="PyDMLabel" name="PyDMLabel">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="whatsThis">
+        <string/>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://MTEST:Message</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="label_2">
+       <property name="text">
+        <string>Message (String):</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="PyDMLabel" name="PyDMLabel_2">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="whatsThis">
+        <string/>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://MTEST:Message</string>
+       </property>
+       <property name="displayFormat" stdset="0">
+        <enum>PyDMLabel::String</enum>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="label_3">
+       <property name="text">
+        <string>Message (Decimal):</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="0">
+      <widget class="QLabel" name="label_4">
+       <property name="text">
+        <string>Message (Exponential):</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="0">
+      <widget class="QLabel" name="label_5">
+       <property name="text">
+        <string>Message (Hex):</string>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="0">
+      <widget class="QLabel" name="label_6">
+       <property name="text">
+        <string>Message (Binary):</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="PyDMLabel" name="PyDMLabel_3">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="whatsThis">
+        <string/>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://MTEST:Message</string>
+       </property>
+       <property name="displayFormat" stdset="0">
+        <enum>PyDMLabel::Decimal</enum>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="1">
+      <widget class="PyDMLabel" name="PyDMLabel_4">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="whatsThis">
+        <string/>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://MTEST:Message</string>
+       </property>
+       <property name="displayFormat" stdset="0">
+        <enum>PyDMLabel::Exponential</enum>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="1">
+      <widget class="PyDMLabel" name="PyDMLabel_5">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="whatsThis">
+        <string/>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://MTEST:Message</string>
+       </property>
+       <property name="displayFormat" stdset="0">
+        <enum>PyDMLabel::Hex</enum>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="1">
+      <widget class="PyDMLabel" name="PyDMLabel_6">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="whatsThis">
+        <string/>
+       </property>
+       <property name="alarmSensitiveBorder" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://MTEST:Message</string>
+       </property>
+       <property name="displayFormat" stdset="0">
+        <enum>PyDMLabel::Binary</enum>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
  </widget>
  <customwidgets>
   <customwidget>
    <class>PyDMLabel</class>
    <extends>QLabel</extends>
    <header>pydm.widgets.label</header>
+  </customwidget>
+  <customwidget>
+   <class>PyDMLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header>pydm.widgets.line_edit</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/examples/label/test_enum.ui
+++ b/examples/label/test_enum.ui
@@ -16,14 +16,11 @@
   <widget class="PyDMLabel" name="PyDMLabel">
    <property name="geometry">
     <rect>
-     <x>60</x>
-     <y>80</y>
+     <x>180</x>
+     <y>70</y>
      <width>69</width>
      <height>16</height>
     </rect>
-   </property>
-   <property name="focusPolicy">
-    <enum>Qt::StrongFocus</enum>
    </property>
    <property name="toolTip">
     <string/>
@@ -31,14 +28,8 @@
    <property name="whatsThis">
     <string/>
    </property>
-   <property name="alarmSensitiveContent" stdset="0">
-    <bool>true</bool>
-   </property>
-   <property name="channel" stdset="0">
-    <string>ca://MTEST:Float</string>
-   </property>
    <property name="displayFormat" stdset="0">
-    <enum>PyDMLabel::String</enum>
+    <enum>PyDMLabel::Exponential</enum>
    </property>
   </widget>
  </widget>

--- a/examples/label/test_enum.ui
+++ b/examples/label/test_enum.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>539</width>
-    <height>399</height>
+    <width>937</width>
+    <height>501</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -21,176 +21,202 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <layout class="QVBoxLayout" name="verticalLayout_2">
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <property name="leftMargin">
+      <number>10</number>
+     </property>
+     <property name="topMargin">
+      <number>10</number>
+     </property>
+     <property name="rightMargin">
+      <number>10</number>
+     </property>
+     <property name="bottomMargin">
+      <number>10</number>
+     </property>
      <item>
-      <layout class="QFormLayout" name="formLayout_2">
-       <item row="3" column="0">
-        <widget class="QLabel" name="label_12">
-         <property name="text">
-          <string>Float (Default):</string>
-         </property>
-        </widget>
-       </item>
-       <item row="3" column="1">
-        <widget class="PyDMLabel" name="PyDMLabel_11">
-         <property name="toolTip">
-          <string/>
-         </property>
-         <property name="whatsThis">
-          <string/>
-         </property>
-         <property name="alarmSensitiveBorder" stdset="0">
-          <bool>false</bool>
-         </property>
-         <property name="channel" stdset="0">
-          <string>ca://MTEST:Float</string>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="0">
-        <widget class="QLabel" name="label_13">
-         <property name="text">
-          <string>Float (String):</string>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="1">
-        <widget class="PyDMLabel" name="PyDMLabel_12">
-         <property name="toolTip">
-          <string/>
-         </property>
-         <property name="whatsThis">
-          <string/>
-         </property>
-         <property name="alarmSensitiveBorder" stdset="0">
-          <bool>false</bool>
-         </property>
-         <property name="channel" stdset="0">
-          <string>ca://MTEST:Float</string>
-         </property>
-         <property name="displayFormat" stdset="0">
-          <enum>PyDMLabel::String</enum>
-         </property>
-        </widget>
-       </item>
-       <item row="5" column="0">
-        <widget class="QLabel" name="label_14">
-         <property name="text">
-          <string>Float (Decimal):</string>
-         </property>
-        </widget>
-       </item>
-       <item row="5" column="1">
-        <widget class="PyDMLabel" name="PyDMLabel_13">
-         <property name="toolTip">
-          <string/>
-         </property>
-         <property name="whatsThis">
-          <string/>
-         </property>
-         <property name="alarmSensitiveBorder" stdset="0">
-          <bool>false</bool>
-         </property>
-         <property name="channel" stdset="0">
-          <string>ca://MTEST:Float</string>
-         </property>
-         <property name="displayFormat" stdset="0">
-          <enum>PyDMLabel::Decimal</enum>
-         </property>
-        </widget>
-       </item>
-       <item row="6" column="0">
-        <widget class="QLabel" name="label_15">
-         <property name="text">
-          <string>Float (Exponential):</string>
-         </property>
-        </widget>
-       </item>
-       <item row="6" column="1">
-        <widget class="PyDMLabel" name="PyDMLabel_14">
-         <property name="toolTip">
-          <string/>
-         </property>
-         <property name="whatsThis">
-          <string/>
-         </property>
-         <property name="alarmSensitiveBorder" stdset="0">
-          <bool>false</bool>
-         </property>
-         <property name="channel" stdset="0">
-          <string>ca://MTEST:Float</string>
-         </property>
-         <property name="displayFormat" stdset="0">
-          <enum>PyDMLabel::Exponential</enum>
-         </property>
-        </widget>
-       </item>
-       <item row="7" column="0">
-        <widget class="QLabel" name="label_16">
-         <property name="text">
-          <string>Float (Hex):</string>
-         </property>
-        </widget>
-       </item>
-       <item row="7" column="1">
-        <widget class="PyDMLabel" name="PyDMLabel_15">
-         <property name="toolTip">
-          <string/>
-         </property>
-         <property name="whatsThis">
-          <string/>
-         </property>
-         <property name="alarmSensitiveBorder" stdset="0">
-          <bool>false</bool>
-         </property>
-         <property name="channel" stdset="0">
-          <string>ca://MTEST:Float</string>
-         </property>
-         <property name="displayFormat" stdset="0">
-          <enum>PyDMLabel::Hex</enum>
-         </property>
-        </widget>
-       </item>
-       <item row="8" column="0">
-        <widget class="QLabel" name="label_17">
-         <property name="text">
-          <string>Float (Binary):</string>
-         </property>
-        </widget>
-       </item>
-       <item row="8" column="1">
-        <widget class="PyDMLabel" name="PyDMLabel_16">
-         <property name="toolTip">
-          <string/>
-         </property>
-         <property name="whatsThis">
-          <string/>
-         </property>
-         <property name="alarmSensitiveBorder" stdset="0">
-          <bool>false</bool>
-         </property>
-         <property name="channel" stdset="0">
-          <string>ca://MTEST:Float</string>
-         </property>
-         <property name="displayFormat" stdset="0">
-          <enum>PyDMLabel::Binary</enum>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="0">
-        <widget class="QLabel" name="label_18">
-         <property name="text">
-          <string>Float:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="1">
-        <widget class="PyDMLineEdit" name="PyDMLineEdit_2">
-         <property name="toolTip">
-          <string/>
-         </property>
-         <property name="whatsThis">
-          <string>
+      <layout class="QVBoxLayout" name="verticalLayout_4">
+       <property name="leftMargin">
+        <number>10</number>
+       </property>
+       <property name="topMargin">
+        <number>10</number>
+       </property>
+       <property name="rightMargin">
+        <number>10</number>
+       </property>
+       <property name="bottomMargin">
+        <number>10</number>
+       </property>
+       <item>
+        <layout class="QFormLayout" name="formLayout_5">
+         <item row="3" column="0">
+          <widget class="QLabel" name="label_27">
+           <property name="text">
+            <string>Float (Default):</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="1">
+          <widget class="PyDMLabel" name="PyDMLabel_25">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="whatsThis">
+            <string/>
+           </property>
+           <property name="alarmSensitiveBorder" stdset="0">
+            <bool>false</bool>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://MTEST:Float</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="0">
+          <widget class="QLabel" name="label_28">
+           <property name="text">
+            <string>Float (String):</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="1">
+          <widget class="PyDMLabel" name="PyDMLabel_26">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="whatsThis">
+            <string/>
+           </property>
+           <property name="alarmSensitiveBorder" stdset="0">
+            <bool>false</bool>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://MTEST:Float</string>
+           </property>
+           <property name="displayFormat" stdset="0">
+            <enum>PyDMLabel::String</enum>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="0">
+          <widget class="QLabel" name="label_29">
+           <property name="text">
+            <string>Float (Decimal):</string>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="1">
+          <widget class="PyDMLabel" name="PyDMLabel_27">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="whatsThis">
+            <string/>
+           </property>
+           <property name="alarmSensitiveBorder" stdset="0">
+            <bool>false</bool>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://MTEST:Float</string>
+           </property>
+           <property name="displayFormat" stdset="0">
+            <enum>PyDMLabel::Decimal</enum>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="0">
+          <widget class="QLabel" name="label_30">
+           <property name="text">
+            <string>Float (Exponential):</string>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="1">
+          <widget class="PyDMLabel" name="PyDMLabel_28">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="whatsThis">
+            <string/>
+           </property>
+           <property name="alarmSensitiveBorder" stdset="0">
+            <bool>false</bool>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://MTEST:Float</string>
+           </property>
+           <property name="displayFormat" stdset="0">
+            <enum>PyDMLabel::Exponential</enum>
+           </property>
+          </widget>
+         </item>
+         <item row="7" column="0">
+          <widget class="QLabel" name="label_31">
+           <property name="text">
+            <string>Float (Hex):</string>
+           </property>
+          </widget>
+         </item>
+         <item row="7" column="1">
+          <widget class="PyDMLabel" name="PyDMLabel_29">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="whatsThis">
+            <string/>
+           </property>
+           <property name="alarmSensitiveBorder" stdset="0">
+            <bool>false</bool>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://MTEST:Float</string>
+           </property>
+           <property name="displayFormat" stdset="0">
+            <enum>PyDMLabel::Hex</enum>
+           </property>
+          </widget>
+         </item>
+         <item row="8" column="0">
+          <widget class="QLabel" name="label_32">
+           <property name="text">
+            <string>Float (Binary):</string>
+           </property>
+          </widget>
+         </item>
+         <item row="8" column="1">
+          <widget class="PyDMLabel" name="PyDMLabel_30">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="whatsThis">
+            <string/>
+           </property>
+           <property name="alarmSensitiveBorder" stdset="0">
+            <bool>false</bool>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://MTEST:Float</string>
+           </property>
+           <property name="displayFormat" stdset="0">
+            <enum>PyDMLabel::Binary</enum>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="label_33">
+           <property name="text">
+            <string>Float:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="PyDMLineEdit" name="PyDMLineEdit_4">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="whatsThis">
+            <string>
     A QLineEdit (writable text field) with support for Channels and more
     from PyDM.
     This widget offers an unit conversion menu when users Right Click
@@ -203,180 +229,701 @@
     init_channel : str, optional
         The channel to be used by the widget.
     </string>
-         </property>
-         <property name="alarmSensitiveBorder" stdset="0">
-          <bool>false</bool>
-         </property>
-         <property name="channel" stdset="0">
-          <string>ca://MTEST:Float</string>
+           </property>
+           <property name="alarmSensitiveBorder" stdset="0">
+            <bool>false</bool>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://MTEST:Float</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <widget class="Line" name="line_2">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
          </property>
         </widget>
        </item>
+       <item>
+        <layout class="QFormLayout" name="formLayout_6">
+         <item row="0" column="0">
+          <widget class="QLabel" name="label_12">
+           <property name="text">
+            <string>Message (Default):</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="PyDMLabel" name="PyDMLabel_11">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="whatsThis">
+            <string/>
+           </property>
+           <property name="alarmSensitiveBorder" stdset="0">
+            <bool>false</bool>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://MTEST:Message</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="label_13">
+           <property name="text">
+            <string>Message (String):</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="PyDMLabel" name="PyDMLabel_12">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="whatsThis">
+            <string/>
+           </property>
+           <property name="alarmSensitiveBorder" stdset="0">
+            <bool>false</bool>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://MTEST:Message</string>
+           </property>
+           <property name="displayFormat" stdset="0">
+            <enum>PyDMLabel::String</enum>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="label_14">
+           <property name="text">
+            <string>Message (Decimal):</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="0">
+          <widget class="QLabel" name="label_15">
+           <property name="text">
+            <string>Message (Exponential):</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="0">
+          <widget class="QLabel" name="label_16">
+           <property name="text">
+            <string>Message (Hex):</string>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="0">
+          <widget class="QLabel" name="label_34">
+           <property name="text">
+            <string>Message (Binary):</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="PyDMLabel" name="PyDMLabel_13">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="whatsThis">
+            <string/>
+           </property>
+           <property name="alarmSensitiveBorder" stdset="0">
+            <bool>false</bool>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://MTEST:Message</string>
+           </property>
+           <property name="displayFormat" stdset="0">
+            <enum>PyDMLabel::Decimal</enum>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="1">
+          <widget class="PyDMLabel" name="PyDMLabel_14">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="whatsThis">
+            <string/>
+           </property>
+           <property name="alarmSensitiveBorder" stdset="0">
+            <bool>false</bool>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://MTEST:Message</string>
+           </property>
+           <property name="displayFormat" stdset="0">
+            <enum>PyDMLabel::Exponential</enum>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="1">
+          <widget class="PyDMLabel" name="PyDMLabel_31">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="whatsThis">
+            <string/>
+           </property>
+           <property name="alarmSensitiveBorder" stdset="0">
+            <bool>false</bool>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://MTEST:Message</string>
+           </property>
+           <property name="displayFormat" stdset="0">
+            <enum>PyDMLabel::Hex</enum>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="1">
+          <widget class="PyDMLabel" name="PyDMLabel_32">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="whatsThis">
+            <string/>
+           </property>
+           <property name="alarmSensitiveBorder" stdset="0">
+            <bool>false</bool>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://MTEST:Message</string>
+           </property>
+           <property name="displayFormat" stdset="0">
+            <enum>PyDMLabel::Binary</enum>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
       </layout>
      </item>
-    </layout>
-   </item>
-   <item>
-    <widget class="Line" name="line">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <layout class="QFormLayout" name="formLayout">
-     <item row="0" column="0">
-      <widget class="QLabel" name="label">
-       <property name="text">
-        <string>Message (Default):</string>
+     <item>
+      <layout class="QVBoxLayout" name="verticalLayout_3">
+       <property name="leftMargin">
+        <number>10</number>
        </property>
-      </widget>
-     </item>
-     <item row="0" column="1">
-      <widget class="PyDMLabel" name="PyDMLabel">
-       <property name="toolTip">
-        <string/>
+       <property name="topMargin">
+        <number>10</number>
        </property>
-       <property name="whatsThis">
-        <string/>
+       <property name="rightMargin">
+        <number>10</number>
        </property>
-       <property name="alarmSensitiveBorder" stdset="0">
-        <bool>false</bool>
+       <property name="bottomMargin">
+        <number>10</number>
        </property>
-       <property name="channel" stdset="0">
-        <string>ca://MTEST:Message</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="label_2">
-       <property name="text">
-        <string>Message (String):</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="1">
-      <widget class="PyDMLabel" name="PyDMLabel_2">
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="whatsThis">
-        <string/>
-       </property>
-       <property name="alarmSensitiveBorder" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://MTEST:Message</string>
-       </property>
-       <property name="displayFormat" stdset="0">
-        <enum>PyDMLabel::String</enum>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="0">
-      <widget class="QLabel" name="label_3">
-       <property name="text">
-        <string>Message (Decimal):</string>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="0">
-      <widget class="QLabel" name="label_4">
-       <property name="text">
-        <string>Message (Exponential):</string>
-       </property>
-      </widget>
-     </item>
-     <item row="4" column="0">
-      <widget class="QLabel" name="label_5">
-       <property name="text">
-        <string>Message (Hex):</string>
-       </property>
-      </widget>
-     </item>
-     <item row="5" column="0">
-      <widget class="QLabel" name="label_6">
-       <property name="text">
-        <string>Message (Binary):</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="1">
-      <widget class="PyDMLabel" name="PyDMLabel_3">
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="whatsThis">
-        <string/>
-       </property>
-       <property name="alarmSensitiveBorder" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://MTEST:Message</string>
-       </property>
-       <property name="displayFormat" stdset="0">
-        <enum>PyDMLabel::Decimal</enum>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="1">
-      <widget class="PyDMLabel" name="PyDMLabel_4">
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="whatsThis">
-        <string/>
-       </property>
-       <property name="alarmSensitiveBorder" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://MTEST:Message</string>
-       </property>
-       <property name="displayFormat" stdset="0">
-        <enum>PyDMLabel::Exponential</enum>
-       </property>
-      </widget>
-     </item>
-     <item row="4" column="1">
-      <widget class="PyDMLabel" name="PyDMLabel_5">
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="whatsThis">
-        <string/>
-       </property>
-       <property name="alarmSensitiveBorder" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://MTEST:Message</string>
-       </property>
-       <property name="displayFormat" stdset="0">
-        <enum>PyDMLabel::Hex</enum>
-       </property>
-      </widget>
-     </item>
-     <item row="5" column="1">
-      <widget class="PyDMLabel" name="PyDMLabel_6">
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="whatsThis">
-        <string/>
-       </property>
-       <property name="alarmSensitiveBorder" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://MTEST:Message</string>
-       </property>
-       <property name="displayFormat" stdset="0">
-        <enum>PyDMLabel::Binary</enum>
-       </property>
-      </widget>
+       <item>
+        <layout class="QFormLayout" name="formLayout_3">
+         <item row="3" column="0">
+          <widget class="QLabel" name="label_19">
+           <property name="text">
+            <string>Float (Default):</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="0">
+          <widget class="QLabel" name="label_20">
+           <property name="text">
+            <string>Float (String):</string>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="0">
+          <widget class="QLabel" name="label_21">
+           <property name="text">
+            <string>Float (Decimal):</string>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="0">
+          <widget class="QLabel" name="label_22">
+           <property name="text">
+            <string>Float (Exponential):</string>
+           </property>
+          </widget>
+         </item>
+         <item row="7" column="0">
+          <widget class="QLabel" name="label_23">
+           <property name="text">
+            <string>Float (Hex):</string>
+           </property>
+          </widget>
+         </item>
+         <item row="8" column="0">
+          <widget class="QLabel" name="label_24">
+           <property name="text">
+            <string>Float (Binary):</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="label_25">
+           <property name="text">
+            <string>Update Time:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="PyDMLineEdit" name="PyDMLineEdit_3">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="whatsThis">
+            <string>
+    A QLineEdit (writable text field) with support for Channels and more
+    from PyDM.
+    This widget offers an unit conversion menu when users Right Click
+    into it.
+
+    Parameters
+    ----------
+    parent : QWidget
+        The parent widget for the Label
+    init_channel : str, optional
+        The channel to be used by the widget.
+    </string>
+           </property>
+           <property name="alarmSensitiveBorder" stdset="0">
+            <bool>false</bool>
+           </property>
+           <property name="showUnits" stdset="0">
+            <bool>false</bool>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://MTEST:UpdateTime</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="1">
+          <widget class="PyDMLineEdit" name="PyDMLineEdit">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="whatsThis">
+            <string>
+    A QLineEdit (writable text field) with support for Channels and more
+    from PyDM.
+    This widget offers an unit conversion menu when users Right Click
+    into it.
+
+    Parameters
+    ----------
+    parent : QWidget
+        The parent widget for the Label
+    init_channel : str, optional
+        The channel to be used by the widget.
+    </string>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://MTEST:UpdateTime</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="1">
+          <widget class="PyDMLineEdit" name="PyDMLineEdit_2">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="whatsThis">
+            <string>
+    A QLineEdit (writable text field) with support for Channels and more
+    from PyDM.
+    This widget offers an unit conversion menu when users Right Click
+    into it.
+
+    Parameters
+    ----------
+    parent : QWidget
+        The parent widget for the Label
+    init_channel : str, optional
+        The channel to be used by the widget.
+    </string>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://MTEST:UpdateTime</string>
+           </property>
+           <property name="displayFormat" stdset="0">
+            <enum>PyDMLineEdit::String</enum>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="1">
+          <widget class="PyDMLineEdit" name="PyDMLineEdit_5">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="whatsThis">
+            <string>
+    A QLineEdit (writable text field) with support for Channels and more
+    from PyDM.
+    This widget offers an unit conversion menu when users Right Click
+    into it.
+
+    Parameters
+    ----------
+    parent : QWidget
+        The parent widget for the Label
+    init_channel : str, optional
+        The channel to be used by the widget.
+    </string>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://MTEST:UpdateTime</string>
+           </property>
+           <property name="displayFormat" stdset="0">
+            <enum>PyDMLineEdit::Decimal</enum>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="1">
+          <widget class="PyDMLineEdit" name="PyDMLineEdit_6">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="whatsThis">
+            <string>
+    A QLineEdit (writable text field) with support for Channels and more
+    from PyDM.
+    This widget offers an unit conversion menu when users Right Click
+    into it.
+
+    Parameters
+    ----------
+    parent : QWidget
+        The parent widget for the Label
+    init_channel : str, optional
+        The channel to be used by the widget.
+    </string>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://MTEST:UpdateTime</string>
+           </property>
+           <property name="displayFormat" stdset="0">
+            <enum>PyDMLineEdit::Exponential</enum>
+           </property>
+          </widget>
+         </item>
+         <item row="7" column="1">
+          <widget class="PyDMLineEdit" name="PyDMLineEdit_7">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="whatsThis">
+            <string>
+    A QLineEdit (writable text field) with support for Channels and more
+    from PyDM.
+    This widget offers an unit conversion menu when users Right Click
+    into it.
+
+    Parameters
+    ----------
+    parent : QWidget
+        The parent widget for the Label
+    init_channel : str, optional
+        The channel to be used by the widget.
+    </string>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://MTEST:UpdateTime</string>
+           </property>
+           <property name="displayFormat" stdset="0">
+            <enum>PyDMLineEdit::Hex</enum>
+           </property>
+          </widget>
+         </item>
+         <item row="8" column="1">
+          <widget class="PyDMLineEdit" name="PyDMLineEdit_8">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="whatsThis">
+            <string>
+    A QLineEdit (writable text field) with support for Channels and more
+    from PyDM.
+    This widget offers an unit conversion menu when users Right Click
+    into it.
+
+    Parameters
+    ----------
+    parent : QWidget
+        The parent widget for the Label
+    init_channel : str, optional
+        The channel to be used by the widget.
+    </string>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://MTEST:UpdateTime</string>
+           </property>
+           <property name="displayFormat" stdset="0">
+            <enum>PyDMLineEdit::Binary</enum>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <widget class="Line" name="line">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <layout class="QFormLayout" name="formLayout_4">
+         <item row="0" column="0">
+          <widget class="QLabel" name="label_7">
+           <property name="text">
+            <string>Message (Default):</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="label_8">
+           <property name="text">
+            <string>Message (String):</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="label_9">
+           <property name="text">
+            <string>Message (Decimal):</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="0">
+          <widget class="QLabel" name="label_10">
+           <property name="text">
+            <string>Message (Exponential):</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="0">
+          <widget class="QLabel" name="label_11">
+           <property name="text">
+            <string>Message (Hex):</string>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="0">
+          <widget class="QLabel" name="label_26">
+           <property name="text">
+            <string>Message (Binary):</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="PyDMLineEdit" name="PyDMLineEdit_9">
+           <property name="minimumSize">
+            <size>
+             <width>200</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="whatsThis">
+            <string>
+    A QLineEdit (writable text field) with support for Channels and more
+    from PyDM.
+    This widget offers an unit conversion menu when users Right Click
+    into it.
+
+    Parameters
+    ----------
+    parent : QWidget
+        The parent widget for the Label
+    init_channel : str, optional
+        The channel to be used by the widget.
+    </string>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://MTEST:Message</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="PyDMLineEdit" name="PyDMLineEdit_10">
+           <property name="minimumSize">
+            <size>
+             <width>200</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="whatsThis">
+            <string>
+    A QLineEdit (writable text field) with support for Channels and more
+    from PyDM.
+    This widget offers an unit conversion menu when users Right Click
+    into it.
+
+    Parameters
+    ----------
+    parent : QWidget
+        The parent widget for the Label
+    init_channel : str, optional
+        The channel to be used by the widget.
+    </string>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://MTEST:Message</string>
+           </property>
+           <property name="displayFormat" stdset="0">
+            <enum>PyDMLineEdit::String</enum>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="PyDMLineEdit" name="PyDMLineEdit_11">
+           <property name="minimumSize">
+            <size>
+             <width>200</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="whatsThis">
+            <string>
+    A QLineEdit (writable text field) with support for Channels and more
+    from PyDM.
+    This widget offers an unit conversion menu when users Right Click
+    into it.
+
+    Parameters
+    ----------
+    parent : QWidget
+        The parent widget for the Label
+    init_channel : str, optional
+        The channel to be used by the widget.
+    </string>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://MTEST:Message</string>
+           </property>
+           <property name="displayFormat" stdset="0">
+            <enum>PyDMLineEdit::Decimal</enum>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="1">
+          <widget class="PyDMLineEdit" name="PyDMLineEdit_12">
+           <property name="minimumSize">
+            <size>
+             <width>200</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="whatsThis">
+            <string>
+    A QLineEdit (writable text field) with support for Channels and more
+    from PyDM.
+    This widget offers an unit conversion menu when users Right Click
+    into it.
+
+    Parameters
+    ----------
+    parent : QWidget
+        The parent widget for the Label
+    init_channel : str, optional
+        The channel to be used by the widget.
+    </string>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://MTEST:Message</string>
+           </property>
+           <property name="displayFormat" stdset="0">
+            <enum>PyDMLineEdit::Exponential</enum>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="1">
+          <widget class="PyDMLineEdit" name="PyDMLineEdit_13">
+           <property name="minimumSize">
+            <size>
+             <width>200</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="whatsThis">
+            <string>
+    A QLineEdit (writable text field) with support for Channels and more
+    from PyDM.
+    This widget offers an unit conversion menu when users Right Click
+    into it.
+
+    Parameters
+    ----------
+    parent : QWidget
+        The parent widget for the Label
+    init_channel : str, optional
+        The channel to be used by the widget.
+    </string>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://MTEST:Message</string>
+           </property>
+           <property name="displayFormat" stdset="0">
+            <enum>PyDMLineEdit::Hex</enum>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="1">
+          <widget class="PyDMLineEdit" name="PyDMLineEdit_14">
+           <property name="minimumSize">
+            <size>
+             <width>200</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="whatsThis">
+            <string>
+    A QLineEdit (writable text field) with support for Channels and more
+    from PyDM.
+    This widget offers an unit conversion menu when users Right Click
+    into it.
+
+    Parameters
+    ----------
+    parent : QWidget
+        The parent widget for the Label
+    init_channel : str, optional
+        The channel to be used by the widget.
+    </string>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://MTEST:Message</string>
+           </property>
+           <property name="displayFormat" stdset="0">
+            <enum>PyDMLineEdit::Binary</enum>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+      </layout>
      </item>
     </layout>
    </item>

--- a/examples/testing_ioc/pydm-testing-ioc
+++ b/examples/testing_ioc/pydm-testing-ioc
@@ -11,6 +11,7 @@ AMPLITUDE       = 1.0
 NUM_DIVISIONS   = 10
 MIN_UPDATE_TIME = 0.001
 IMAGE_SIZE      = 512
+MESSAGE         = "PyDM Rocks!"
 
 prefix = 'MTEST:'
 pvdb = {
@@ -41,6 +42,7 @@ pvdb = {
         'TwoSpotImage'     : { 'type' : 'char', 'count': IMAGE_SIZE**2, 'value': numpy.zeros(IMAGE_SIZE**2,dtype=numpy.uint8), 'asg' : 'default' },
         'ImageWidth'       : { 'type' : 'int', 'value' : IMAGE_SIZE, 'asg' : 'default' },
         'String'           : { 'type' : 'string', 'value': "Test String", 'asg' : 'default'},
+        'Message'          : { 'type' : 'char', 'count': 100, 'value': MESSAGE},
         'Float'            : { 'type' : 'float', 'value': 0.0, 'lolim': -1.2, 'lolo': -1.0, 'low': -0.8, 'high': 0.8, 'hihi': 1.0, 'hilim': 1.2, 'unit': 'mJ', 'prec': 3, 'asg' : 'default' },
         'StatusBits'       : { 'type' : 'int', 'value': 0b101010, 'lolim': 0, 'hilim': 32, 'asg' : 'default' },
         'SinVal'           : { 'type' : 'float', 'value': 0.0, 'asg': 'default' },

--- a/pydm/application.py
+++ b/pydm/application.py
@@ -124,6 +124,9 @@ class PyDMApplication(QApplication):
             self.perf_timer.timeout.connect(self.get_CPU_usage)
             self.perf_timer.start()
 
+    def get_string_encoding(self):
+        return os.getenv("PYDM_STRING_ENCODING", "utf_8")
+
     def exec_(self):
         """
         Execute the QApplication.

--- a/pydm/data_plugins/epics_plugins/pyepics_plugin.py
+++ b/pydm/data_plugins/epics_plugins/pyepics_plugin.py
@@ -42,14 +42,20 @@ class Connection(PyDMConnection):
         self._upper_ctrl_limit = None
         self._lower_ctrl_limit = None
 
-    def send_new_value(self, value=None, char_value=None, count=None, ftype=None, *args, **kws):
+    def send_new_value(self, value=None, char_value=None, count=None, ftype=None, type=None, *args, **kws):
         self.update_ctrl_vars(**kws)
         if value is not None:
             if isinstance(value, np.ndarray):
                 self.new_value_signal[np.ndarray].emit(value)
             else:
                 if ftype in int_types:
-                    self.new_value_signal[int].emit(int(value))
+                    try:
+                        self.new_value_signal[int].emit(int(value))
+                    except ValueError:  # This happens when a string is empty
+                        # HACK since looks like for PyEpics a 1 element array
+                        # is in fact a scalar. =( I will try to address this
+                        # with Matt Newville
+                        self.new_value_signal[str].emit(char_value)
                 elif ftype in float_types:
                     self.new_value_signal[float].emit(float(value))
                 else:

--- a/pydm/widgets/display_format.py
+++ b/pydm/widgets/display_format.py
@@ -22,6 +22,7 @@ def parse_value_for_display(new_value, display_format_type, precision, widget):
         return new_value
     elif display_format_type == DisplayFormat.String:
         if isinstance(new_value, np.ndarray):
+            new_value = new_value[new_value > 0]
             fmt_string = "{}"*len(new_value)
             r = fmt_string.format(*[unichr(x) for x in new_value])
             return r

--- a/pydm/widgets/display_format.py
+++ b/pydm/widgets/display_format.py
@@ -1,12 +1,6 @@
 import math
 import numpy as np
 
-try:
-    # unichr is not available on Py3+
-    unichr(1)
-except NameError:
-    unichr = chr
-
 
 class DisplayFormat(object):
     Default = 0
@@ -17,40 +11,42 @@ class DisplayFormat(object):
     Binary = 5
 
 
-def parse_value_for_display(new_value, display_format_type, precision, widget):
+def parse_value_for_display(value, precision, display_format_type=DisplayFormat.Default, string_encoding="utf_8", widget=None):
     if display_format_type == DisplayFormat.Default:
-        return new_value
+        return value
     elif display_format_type == DisplayFormat.String:
-        if isinstance(new_value, np.ndarray):
-            new_value = new_value[new_value > 0]
-            fmt_string = "{}"*len(new_value)
-            r = fmt_string.format(*[unichr(x) for x in new_value])
+        if isinstance(value, np.ndarray):
+            try:
+                r = value.tobytes().decode(string_encoding)
+                print("Could not decode {} using {} at widget named '{}'.".format(value, string_encoding, widget.objectName()))
+            except:
+                return value
             return r
         else:
-            return new_value
+            return value
     elif display_format_type == DisplayFormat.Decimal:
         # This case is taken care by the current string formatting
         # routine
-        return new_value
+        return value
     elif display_format_type == DisplayFormat.Exponential:
         fmt_string = "{" + ":.{}e".format(precision) + "}"
         try:
-            r = fmt_string.format(new_value)
+            r = fmt_string.format(value)
         except (ValueError, TypeError):
-            print("Could not display value {} using displayFormat 'Exponential' at widget named '{}'.".format(new_value, widget.objectName()))
-            r = new_value
+            print("Could not display value {} using displayFormat 'Exponential' at widget named '{}'.".format(value, widget.objectName()))
+            r = value
         return r
     elif display_format_type == DisplayFormat.Hex:
         try:
-            r = hex(math.floor(new_value))
+            r = hex(math.floor(value))
         except (ValueError, TypeError):
-            print("Could not display value {} using displayFormat 'Hex' at widget named '{}'.".format(new_value, widget.objectName()))
-            r = new_value
+            print("Could not display value {} using displayFormat 'Hex' at widget named '{}'.".format(value, widget.objectName()))
+            r = value
         return r
     elif display_format_type == DisplayFormat.Binary:
         try:
-            r = bin(math.floor(new_value))
+            r = bin(math.floor(value))
         except (ValueError, TypeError):
-            print("Could not display value {} using displayFormat 'Binary' at widget named '{}'.".format(new_value, widget.objectName()))
-            r = new_value
+            print("Could not display value {} using displayFormat 'Binary' at widget named '{}'.".format(value, widget.objectName()))
+            r = value
         return r

--- a/pydm/widgets/display_format.py
+++ b/pydm/widgets/display_format.py
@@ -1,0 +1,55 @@
+import math
+import numpy as np
+
+try:
+    # unichr is not available on Py3+
+    unichr(1)
+except NameError:
+    unichr = chr
+
+
+class DisplayFormat(object):
+    Default = 0
+    String = 1
+    Decimal = 2
+    Exponential = 3
+    Hex = 4
+    Binary = 5
+
+
+def parse_value_for_display(new_value, display_format_type, precision, widget):
+    if display_format_type == DisplayFormat.Default:
+        return new_value
+    elif display_format_type == DisplayFormat.String:
+        if isinstance(new_value, np.ndarray):
+            fmt_string = "{}"*len(new_value)
+            r = fmt_string.format(*[unichr(x) for x in new_value])
+            return r
+        else:
+            return new_value
+    elif display_format_type == DisplayFormat.Decimal:
+        # This case is taken care by the current string formatting
+        # routine
+        return new_value
+    elif display_format_type == DisplayFormat.Exponential:
+        fmt_string = "{" + ":.{}e".format(precision) + "}"
+        try:
+            r = fmt_string.format(new_value)
+        except (ValueError, TypeError):
+            print("Could not display value {} using displayFormat 'Exponential' at widget named '{}'.".format(new_value, widget.objectName()))
+            r = new_value
+        return r
+    elif display_format_type == DisplayFormat.Hex:
+        try:
+            r = hex(math.floor(new_value))
+        except (ValueError, TypeError):
+            print("Could not display value {} using displayFormat 'Hex' at widget named '{}'.".format(new_value, widget.objectName()))
+            r = new_value
+        return r
+    elif display_format_type == DisplayFormat.Binary:
+        try:
+            r = bin(math.floor(new_value))
+        except (ValueError, TypeError):
+            print("Could not display value {} using displayFormat 'Binary' at widget named '{}'.".format(new_value, widget.objectName()))
+            r = new_value
+        return r

--- a/pydm/widgets/label.py
+++ b/pydm/widgets/label.py
@@ -10,7 +10,7 @@ try:
 except NameError:
     unichr = chr
 
-class DisplayFormat:
+class DisplayFormat(object):
     Default = 0
     String = 1
     Decimal = 2
@@ -19,8 +19,8 @@ class DisplayFormat:
     Binary = 5
 
 class PyDMLabel(QLabel, PyDMWidget, DisplayFormat):
-    DisplayFormat = DisplayFormat        
     Q_ENUMS(DisplayFormat)
+    DisplayFormat = DisplayFormat
     """
     A QLabel with support for Channels and more from PyDM
 

--- a/pydm/widgets/label.py
+++ b/pydm/widgets/label.py
@@ -2,6 +2,7 @@ from .base import PyDMWidget
 from ..PyQt.QtGui import QLabel
 from ..PyQt.QtCore import Qt, pyqtProperty, Q_ENUMS, QObject
 import numpy as np
+import math
 
 try:
     # unichr is not available on Py3+
@@ -46,7 +47,6 @@ class PyDMLabel(QLabel, PyDMWidget, DisplayFormat):
 
     @displayFormat.setter
     def displayFormat(self, new_type):
-        print("Display Format : ", new_type)
         if self._display_format_type != new_type:
             self._display_format_type = new_type
 
@@ -63,22 +63,27 @@ class PyDMLabel(QLabel, PyDMWidget, DisplayFormat):
         elif self._display_format_type == DisplayFormat.Decimal:
             # This case is taken care by the current string formatting 
             # routine
-            return r
+            return new_value
         elif self._display_format_type == DisplayFormat.Exponential:
             fmt_string = "{"+":.{}e".format(self._prec)+"}"
             try:
                 r = fmt_string.format(new_value)
-            except ValueError:
-                print("Could not format value {} to exponential.".format(new_value))
+            except (ValueError, TypeError):
+                print("Could not display value {} using displayFormat 'Exponential' at widget named '{}'.".format(new_value, self.objectName()))
                 r = new_value
             return r
         elif self._display_format_type == DisplayFormat.Hex:
-            # TODO: Implement Hexadecimal formating
-            fmt_string = "{:#0X}"
             try:
-                r = fmt_string.format(new_value)
-            except ValueError:
-                print("Could not format value {} to hex.".format(new_value))
+                r = hex(math.floor(new_value))
+            except (ValueError, TypeError):
+                print("Could not display value {} using displayFormat 'Hex' at widget named '{}'.".format(new_value, self.objectName()))
+                r = new_value
+            return r
+        elif self._display_format_type == DisplayFormat.Binary:
+            try:
+                r = bin(math.floor(new_value))
+            except (ValueError, TypeError):
+                print("Could not display value {} using displayFormat 'Binary' at widget named '{}'.".format(new_value, self.objectName()))
                 r = new_value
             return r
 

--- a/pydm/widgets/label.py
+++ b/pydm/widgets/label.py
@@ -1,8 +1,24 @@
 from .base import PyDMWidget
 from ..PyQt.QtGui import QLabel
-from ..PyQt.QtCore import Qt
+from ..PyQt.QtCore import Qt, pyqtProperty, Q_ENUMS
+
+try:
+    # unichr is not available on Py3+
+    unichr(1)
+except NameError:
+    unichr = chr
 
 class PyDMLabel(QLabel, PyDMWidget):
+    class DisplayFormat:
+        DEFAULT = 0
+        STRING = 1
+        DECIMAL = 2
+        EXPONENTIAL = 3
+        HEX = 4
+        BINARY = 5
+    
+    Q_ENUMS(DisplayFormat)
+    
     """
     A QLabel with support for Channels and more from PyDM
 
@@ -19,6 +35,47 @@ class PyDMLabel(QLabel, PyDMWidget):
         self.setTextFormat(Qt.PlainText)
         self.setTextInteractionFlags(Qt.NoTextInteraction)
         self.setText("PyDMLabel")
+        self._display_format_type = self.DisplayFormat.DEFAULT
+
+    @pyqtProperty(DisplayFormat)
+    def displayFormat(self):
+        return self._display_format_type
+
+    @displayFormat.setter
+    def displayFormat(self, new_type):
+        if self._display_format_type != new_type:
+            self._display_format_type = new_type
+
+    def parse_value_for_display(self, new_value):
+        if self._display_format_type == self.DisplayFormat.DEFAULT:
+            return new_value
+        elif self._display_format_type == self.DisplayFormat.STRING:
+            if isinstance(new_value, str):
+                return new_value
+            fmt_string = "{}"*len(new_value)
+            r = fmt_string.format(*[unichr(x) for x in new_value])
+            return r
+        elif self._display_format_type == self.DisplayFormat.DECIMAL:
+            # This case is taken care by the current string formatting 
+            # routine
+            return r
+        elif self._display_format_type == self.DisplayFormat.EXPONENTIAL:
+            fmt_string = "{"+":.{}e".format(self._prec)+"}"
+            try:
+                r = fmt_string.format(new_value)
+            except ValueError:
+                print("Could not format value {} to exponential.".format(new_value))
+                r = new_value
+            return r
+        elif self._display_format_type == self.DisplayFormat.HEX:
+            # TODO: Implement Hexadecimal formating
+            fmt_string = "{:#0X}"
+            try:
+                r = fmt_string.format(new_value)
+            except ValueError:
+                print("Could not format value {} to hex.".format(new_value))
+                r = new_value
+            return r
 
     def value_changed(self, new_value):
         """

--- a/pydm/widgets/label.py
+++ b/pydm/widgets/label.py
@@ -1,7 +1,9 @@
 from .base import PyDMWidget
-from ..PyQt.QtGui import QLabel
+from ..PyQt.QtGui import QLabel, QApplication
 from ..PyQt.QtCore import Qt, pyqtProperty, Q_ENUMS
 from .display_format import DisplayFormat, parse_value_for_display
+from pydm.utilities import is_pydm_app
+
 
 class PyDMLabel(QLabel, PyDMWidget, DisplayFormat):
     Q_ENUMS(DisplayFormat)
@@ -16,14 +18,18 @@ class PyDMLabel(QLabel, PyDMWidget, DisplayFormat):
     init_channel : str, optional
         The channel to be used by the widget.
     """
-    
+
     def __init__(self, parent=None, init_channel=None):
         QLabel.__init__(self, parent)
         PyDMWidget.__init__(self, init_channel=init_channel)
+        self.app = QApplication.instance()
         self.setTextFormat(Qt.PlainText)
         self.setTextInteractionFlags(Qt.NoTextInteraction)
         self.setText("PyDMLabel")
         self._display_format_type = self.DisplayFormat.Default
+        self._string_encoding = "utf_8"
+        if is_pydm_app():
+            self._string_encoding = self.app.get_string_encoding()
 
     @pyqtProperty(DisplayFormat)
     def displayFormat(self):
@@ -47,7 +53,10 @@ class PyDMLabel(QLabel, PyDMWidget, DisplayFormat):
             The new value from the channel. The type depends on the channel.
         """
         super(PyDMLabel, self).value_changed(new_value)
-        new_value = parse_value_for_display(new_value, self._display_format_type, self._prec, self)
+        new_value = parse_value_for_display(value=new_value, precision=self._prec,
+                                             display_format_type=self._display_format_type,
+                                             string_encoding=self._string_encoding,
+                                             widget=self)
         # If the value is a string, just display it as-is, no formatting
         # needed.
         if isinstance(new_value, str):

--- a/pydm/widgets/line_edit.py
+++ b/pydm/widgets/line_edit.py
@@ -1,6 +1,6 @@
 import locale
 from functools import partial
-from ..PyQt.QtGui import QLineEdit, QMenu
+from ..PyQt.QtGui import QLineEdit, QMenu, QApplication
 from ..PyQt.QtCore import Qt, pyqtProperty, Q_ENUMS
 from .. import utilities
 from .base import PyDMWritableWidget
@@ -29,6 +29,7 @@ class PyDMLineEdit(QLineEdit, PyDMWritableWidget, DisplayFormat):
     def __init__(self, parent=None, init_channel=None):
         QLineEdit.__init__(self, parent)
         PyDMWritableWidget.__init__(self, init_channel=init_channel)
+        self.app = QApplication.instance()
         self._display = None
         self._scale = 1
 
@@ -42,6 +43,9 @@ class PyDMLineEdit(QLineEdit, PyDMWritableWidget, DisplayFormat):
         self.unitMenu = self.menu.addMenu('Convert Units')
         self.create_unit_options()
         self._display_format_type = self.DisplayFormat.Default
+        self._string_encoding = "utf_8"
+        if utilities.is_pydm_app():
+            self._string_encoding = self.app.get_string_encoding()
 
     @pyqtProperty(DisplayFormat)
     def displayFormat(self):
@@ -236,7 +240,10 @@ class PyDMLineEdit(QLineEdit, PyDMWritableWidget, DisplayFormat):
                 except TypeError:
                     print("Cannot convert channel: {} with type: {}", self._channel, self.channeltype)
 
-        new_value = parse_value_for_display(new_value, self._display_format_type, self._prec, self)
+        new_value = parse_value_for_display(value=new_value,  precision=self._prec,
+                                             display_format_type=self._display_format_type,
+                                             string_encoding=self._string_encoding,
+                                             widget=self)
 
         self._display = str(new_value)
 

--- a/pydm/widgets/line_edit.py
+++ b/pydm/widgets/line_edit.py
@@ -79,16 +79,15 @@ class PyDMLineEdit(QLineEdit, PyDMWritableWidget, DisplayFormat):
         ReturnPressed signal of the PyDMLineEdit
         """
         send_value = str(self.text())
-
         # Clean text of unit string
-        if self._show_units:
+        if self._show_units and self._unit in send_value:
             send_value = send_value[:-len(self._unit)].strip()
-
         try:
             if self.channeltype not in [str, np.ndarray]:
                 scale = self._scale
                 if scale is None or scale == 0:
                     scale = 1.0
+
                 if self._display_format_type in [DisplayFormat.Default, DisplayFormat.String]:
                     if self.channeltype == float:
                         num_value = locale.atof(send_value)


### PR DESCRIPTION
This PR adds a new property to the PyDMLabel and PyDMLineEdit to enable the setup of a display format between the available options:
- Default = 0
- String = 1
- Decimal = 2
- Exponential = 3
- Hex = 4
- Binary = 5

The LineEdit is tricky because we also need to take care of doing the reverse conversion when the user sets the data back into it.

Here is a screenshot of the formats being used:
<img width="945" alt="screen shot 2017-12-15 at 11 08 06 am" src="https://user-images.githubusercontent.com/8185425/34056546-443b885e-e188-11e7-9e9f-534ed2b05b3c.png">

After merged this PR closes #106 and #107.
**TODO:**
- [x] Test the line edit with the units.