### PR TITLE
ENH: Read only option

### DIFF
--- a/pydm/application.py
+++ b/pydm/application.py
@@ -62,6 +62,8 @@ class PyDMApplication(QApplication):
     hide_status_bar: bool, optional
         Whether or not to display the status bar (general messages and errors)
         when the main window is first displayed.
+    read_only: bool, optional
+        Whether or not to launch PyDM in a read-only state.
     macros : dict, optional
         A dictionary of macro variables to be forwarded to the display class
         being loaded.

--- a/pydm/application.py
+++ b/pydm/application.py
@@ -83,7 +83,7 @@ class PyDMApplication(QApplication):
         True: QColor(0, 0, 0)
     }
 
-    def __init__(self, ui_file=None, command_line_args=[], display_args=[], perfmon=False, hide_nav_bar=False, hide_menu_bar=False, hide_status_bar=False, macros=None):
+    def __init__(self, ui_file=None, command_line_args=[], display_args=[], perfmon=False, hide_nav_bar=False, hide_menu_bar=False, hide_status_bar=False, read_only=False, macros=None):
         super(PyDMApplication, self).__init__(command_line_args)
         # Enable High DPI display, if available.
         if hasattr(Qt, 'AA_UseHighDpiPixmaps'):
@@ -103,6 +103,7 @@ class PyDMApplication(QApplication):
         self.hide_nav_bar = hide_nav_bar
         self.hide_menu_bar = hide_menu_bar
         self.hide_status_bar = hide_status_bar
+        self.__read_only = read_only
         # Open a window if one was provided.
         if ui_file is not None:
             self.make_window(ui_file, macros, command_line_args)
@@ -130,6 +131,9 @@ class PyDMApplication(QApplication):
         if not self.had_file:
             self.make_connections()
         return super(PyDMApplication, self).exec_()
+
+    def is_read_only(self):
+        return self.__read_only
 
     @pyqtSlot()
     def get_CPU_usage(self):

--- a/pydm/data_plugins/epics_plugins/pyepics_plugin.py
+++ b/pydm/data_plugins/epics_plugins/pyepics_plugin.py
@@ -2,30 +2,35 @@ import epics
 import numpy as np
 from ..plugin import PyDMPlugin, PyDMConnection
 from ...PyQt.QtCore import pyqtSlot, Qt
+from ...PyQt.QtGui import QApplication
+from ...utilities import is_pydm_app
 
-int_types = set((epics.dbr.INT, epics.dbr.CTRL_INT, epics.dbr.TIME_INT, 
-                 epics.dbr.ENUM, epics.dbr.CTRL_ENUM, epics.dbr.TIME_ENUM, 
-                 epics.dbr.TIME_LONG, epics.dbr.LONG, epics.dbr.CTRL_LONG, 
-                 epics.dbr.CHAR, epics.dbr.TIME_CHAR, epics.dbr.CTRL_CHAR, 
+int_types = set((epics.dbr.INT, epics.dbr.CTRL_INT, epics.dbr.TIME_INT,
+                 epics.dbr.ENUM, epics.dbr.CTRL_ENUM, epics.dbr.TIME_ENUM,
+                 epics.dbr.TIME_LONG, epics.dbr.LONG, epics.dbr.CTRL_LONG,
+                 epics.dbr.CHAR, epics.dbr.TIME_CHAR, epics.dbr.CTRL_CHAR,
                  epics.dbr.TIME_SHORT, epics.dbr.CTRL_SHORT))
 
-float_types = set((epics.dbr.CTRL_FLOAT, epics.dbr.FLOAT, epics.dbr.TIME_FLOAT, 
+float_types = set((epics.dbr.CTRL_FLOAT, epics.dbr.FLOAT, epics.dbr.TIME_FLOAT,
                    epics.dbr.CTRL_DOUBLE, epics.dbr.DOUBLE, epics.dbr.TIME_DOUBLE))
 
+
 class Connection(PyDMConnection):
+
     def __init__(self, channel, pv, parent=None):
         super(Connection, self).__init__(channel, pv, parent)
         self.pv = epics.PV(pv, connection_callback=self.send_connection_state, form='ctrl', auto_monitor=True, access_callback=self.send_access_state)
         self.pv.add_callback(self.send_new_value, with_ctrlvars=True)
         self.add_listener(channel)
 
+        self.app = QApplication.instance()
         self._severity = None
         self._precision = None
         self._enum_strs = None
         self._unit = None
         self._upper_ctrl_limit = None
         self._lower_ctrl_limit = None
-  
+
     def clear_cache(self):
         self._severity = None
         self._precision = None
@@ -46,7 +51,7 @@ class Connection(PyDMConnection):
                     self.new_value_signal[float].emit(float(value))
                 else:
                     self.new_value_signal[str].emit(char_value)
-    
+
     def update_ctrl_vars(self, units=None, enum_strs=None, severity=None, upper_ctrl_limit=None, lower_ctrl_limit=None, precision=None, *args, **kws):
         if severity is not None and self._severity != severity:
             self._severity = severity
@@ -68,15 +73,19 @@ class Connection(PyDMConnection):
             self.unit_signal.emit(units)
         if upper_ctrl_limit is not None and self._upper_ctrl_limit != upper_ctrl_limit:
             self._upper_ctrl_limit = upper_ctrl_limit
-            self.upper_ctrl_limit_signal.emit(upper_ctrl_limit)    
+            self.upper_ctrl_limit_signal.emit(upper_ctrl_limit)
         if lower_ctrl_limit is not None and self._lower_ctrl_limit != lower_ctrl_limit:
             self._lower_ctrl_limit = lower_ctrl_limit
-            self.lower_ctrl_limit_signal.emit(lower_ctrl_limit)    
+            self.lower_ctrl_limit_signal.emit(lower_ctrl_limit)
 
     def send_access_state(self, read_access, write_access, *args, **kws):
+        if is_pydm_app() and self.app.is_read_only():
+            self.write_access_signal.emit(False)
+            return
+
         if write_access is not None:
             self.write_access_signal.emit(write_access)
-    
+
     def reload_access_state(self):
         read_access = epics.ca.read_access(self.pv.chid)
         write_access = epics.ca.write_access(self.pv.chid)
@@ -95,9 +104,13 @@ class Connection(PyDMConnection):
     @pyqtSlot(str)
     @pyqtSlot(np.ndarray)
     def put_value(self, new_val):
+        if is_pydm_app() and self.app.is_read_only():
+            self.write_access_signal.emit(False)
+            return
+
         if self.pv.write_access:
             self.pv.put(new_val)
-    
+
     def add_listener(self, channel):
         super(Connection, self).add_listener(channel)
         # If we are adding a listener to an already existing PV, we need to
@@ -107,7 +120,7 @@ class Connection(PyDMConnection):
             self.pv.run_callbacks()
         else:
             self.send_connection_state(conn=False)
-        # If the channel is used for writing to PVs, hook it up to the 'put' methods.  
+        # If the channel is used for writing to PVs, hook it up to the 'put' methods.
         if channel.value_signal is not None:
             try:
                 channel.value_signal[str].connect(self.put_value, Qt.QueuedConnection)
@@ -149,6 +162,7 @@ class Connection(PyDMConnection):
 
     def close(self):
         self.pv.disconnect()
+
 
 class PyEPICSPlugin(PyDMPlugin):
     # NOTE: protocol is intentionally "None" to keep this plugin from getting directly imported.

--- a/pydm/data_plugins/epics_plugins/pyepics_plugin.py
+++ b/pydm/data_plugins/epics_plugins/pyepics_plugin.py
@@ -105,7 +105,6 @@ class Connection(PyDMConnection):
     @pyqtSlot(np.ndarray)
     def put_value(self, new_val):
         if is_pydm_app() and self.app.is_read_only():
-            self.write_access_signal.emit(False)
             return
 
         if self.pv.write_access:

--- a/pydm/data_plugins/plugin.py
+++ b/pydm/data_plugins/plugin.py
@@ -1,26 +1,27 @@
 from numpy import ndarray
-from ..PyQt.QtCore import pyqtSlot, pyqtSignal, QObject, Qt
+from ..PyQt.QtCore import pyqtSignal, QObject, Qt
+
 
 class PyDMConnection(QObject):
-    new_value_signal =        pyqtSignal([float],[int],[str], [ndarray])
+    new_value_signal = pyqtSignal([float], [int], [str], [ndarray])
     connection_state_signal = pyqtSignal(bool)
-    new_severity_signal =     pyqtSignal(int)
-    write_access_signal =     pyqtSignal(bool)
-    enum_strings_signal =     pyqtSignal(tuple)
-    unit_signal =             pyqtSignal(str)
-    prec_signal =             pyqtSignal(int)
-    upper_ctrl_limit_signal = pyqtSignal([float],[int])
-    lower_ctrl_limit_signal = pyqtSignal([float],[int])
+    new_severity_signal = pyqtSignal(int)
+    write_access_signal = pyqtSignal(bool)
+    enum_strings_signal = pyqtSignal(tuple)
+    unit_signal = pyqtSignal(str)
+    prec_signal = pyqtSignal(int)
+    upper_ctrl_limit_signal = pyqtSignal([float], [int])
+    lower_ctrl_limit_signal = pyqtSignal([float], [int])
 
     def __init__(self, channel, address, parent=None):
         super(PyDMConnection, self).__init__(parent)
         self.listener_count = 0
-  
+
     def add_listener(self, channel):
         self.listener_count = self.listener_count + 1
         if channel.connection_slot is not None:
             self.connection_state_signal.connect(channel.connection_slot, Qt.QueuedConnection)
-            
+
         if channel.value_slot is not None:
             try:
                 self.new_value_signal[int].connect(channel.value_slot, Qt.QueuedConnection)
@@ -59,14 +60,14 @@ class PyDMConnection(QObject):
 
         if channel.prec_slot is not None:
             self.prec_signal.connect(channel.prec_slot, Qt.QueuedConnection)
-      
+
     def remove_listener(self, channel):
         if channel.connection_slot is not None:
             try:
                 self.connection_state_signal.disconnect(channel.connection_slot)
             except TypeError:
                 pass
-            
+
         if channel.value_slot is not None:
             try:
                 self.new_value_signal[int].disconnect(channel.value_slot)
@@ -105,30 +106,32 @@ class PyDMConnection(QObject):
 
         if channel.prec_slot is not None:
             self.prec_signal.disconnect(channel.prec_slot)
- 
+
         self.listener_count = self.listener_count - 1
         if self.listener_count < 1:
             self.close()
-  
+
     def close(self):
         pass
+
 
 class PyDMPlugin(object):
     protocol = None
     connection_class = PyDMConnection
+
     def __init__(self):
         self.connections = {}
-    
+
     def get_address(self, channel):
         return str(channel.address.split(self.protocol + "://")[-1])
-    
-    def add_connection(self, channel):  
+
+    def add_connection(self, channel):
         address = self.get_address(channel)
         if address in self.connections:
             self.connections[address].add_listener(channel)
         else:
             self.connections[address] = self.connection_class(channel, address)
-  
+
     def remove_connection(self, channel):
         address = self.get_address(channel)
         if address in self.connections:

--- a/pydm/main_window.py
+++ b/pydm/main_window.py
@@ -224,9 +224,14 @@ class PyDMMainWindow(QMainWindow):
 
     def update_window_title(self):
         if self.showing_file_path_in_title_bar:
-            self.setWindowTitle(self.current_file() + " - PyDM")
+            title = self.current_file()
         else:
-            self.setWindowTitle(self._display_widget.windowTitle() + " - PyDM")
+            title = self._display_widget.windowTitle()
+        title += " - PyDM"
+        if self.app.is_read_only():
+            title += " [Read Only Mode]"
+        self.setWindowTitle(title)
+        
 
     @property
     def showing_file_path_in_title_bar(self):

--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -3,7 +3,6 @@ import numpy as np
 from ..PyQt.QtGui import QApplication, QColor, QCursor
 from ..PyQt.QtCore import Qt, QEvent, pyqtSignal, pyqtSlot, pyqtProperty
 from .channel import PyDMChannel
-from ..application import PyDMApplication
 from ..utilities import is_pydm_app
 
 
@@ -651,7 +650,7 @@ class PyDMWidget(PyDMPrimitiveWidget):
     def restore_original_tooltip(self):
         if self._tooltip is None:
             self._tooltip = self.toolTip()
-        return self._tooltip 
+        return self._tooltip
 
     @only_if_channel_set
     def check_enable_state(self):
@@ -732,6 +731,7 @@ class PyDMWritableWidget(PyDMWidget):
     def __init__(self, init_channel=None):
         self._write_access = False
         super(PyDMWritableWidget, self).__init__(init_channel=init_channel)
+        self.app = QApplication.instance()
         # We should  install the Event Filter only if we are running
         # and not at the Designer
         if is_pydm_app():
@@ -815,7 +815,10 @@ class PyDMWritableWidget(PyDMWidget):
             tooltip += "PV is disconnected."
         elif not self._write_access:
             if tooltip != '': tooltip += '\n'
-            tooltip += "Access denied by Channel Access Security."
+            if is_pydm_app() and self.app.is_read_only():
+                tooltip += "Running PyDM on Read-Only mode."
+            else:
+                tooltip += "Access denied by Channel Access Security."
         self.setToolTip(tooltip)
         self.setEnabled(status)
 

--- a/pydm/widgets/enum_combo_box.py
+++ b/pydm/widgets/enum_combo_box.py
@@ -1,6 +1,7 @@
 from ..PyQt.QtGui import QFrame, QComboBox, QHBoxLayout
 from ..PyQt.QtCore import pyqtSignal, pyqtSlot
 from .base import PyDMWritableWidget
+from pydm.utilities import is_pydm_app
 
 
 class PyDMEnumComboBox(QFrame, PyDMWritableWidget):
@@ -74,7 +75,10 @@ class PyDMEnumComboBox(QFrame, PyDMWritableWidget):
         if not self._connected:
             tooltip += "PV is disconnected."
         elif not self._write_access:
-            tooltip += "Access denied by Channel Access Security."
+            if is_pydm_app() and self.app.is_read_only():
+                tooltip += "Running PyDM on Read-Only mode."
+            else:
+                tooltip += "Access denied by Channel Access Security."
         elif not self._has_enums:
             tooltip += "Enums not available."
 

--- a/pydm_launcher/main.py
+++ b/pydm_launcher/main.py
@@ -11,6 +11,7 @@ def main():
     parser.add_argument('--hide-nav-bar', action='store_true', help='Start PyDM with the navigation bar hidden.')
     parser.add_argument('--hide-menu-bar', action='store_true', help='Start PyDM with the menu bar hidden.')
     parser.add_argument('--hide-status-bar', action='store_true', help='Start PyDM with the status bar hidden.')
+    parser.add_argument('--read-only', action='store_true', help='Start PyDM in a Read-Only mode.')
     parser.add_argument('-m', '--macro', help='Specify macro replacements to use, in JSON object format.    Reminder: JSON requires double quotes for strings, so you should wrap this whole argument in single quotes.  Example: -m \'{"sector": "LI25", "facility": "LCLS"}')
     parser.add_argument('display_args', help='Arguments to be passed to the PyDM client application (which is a QApplication subclass).', nargs=argparse.REMAINDER)
     pydm_args = parser.parse_args()
@@ -20,7 +21,13 @@ def main():
             macros = json.loads(pydm_args.macro)
         except ValueError:
             raise ValueError("Could not parse macro argument as JSON.")
-    app = PyDMApplication(ui_file=pydm_args.displayfile, command_line_args=pydm_args.display_args, perfmon=pydm_args.perfmon, hide_nav_bar=pydm_args.hide_nav_bar, hide_menu_bar=pydm_args.hide_menu_bar, hide_status_bar=pydm_args.hide_status_bar, macros=macros)
+    app = PyDMApplication(ui_file=pydm_args.displayfile, command_line_args=pydm_args.display_args,
+                          perfmon=pydm_args.perfmon,
+                          hide_nav_bar=pydm_args.hide_nav_bar,
+                          hide_menu_bar=pydm_args.hide_menu_bar,
+                          hide_status_bar=pydm_args.hide_status_bar,
+                          read_only=pydm_args.read_only,
+                          macros=macros)
     sys.exit(app.exec_())
 
 


### PR DESCRIPTION
This PR adds a `--read-only` option for when launching the PyDM application.

At this moment we don't see the need for a `read-only` option at the application menu but it can be easily added if needed by users.

This closes #21 .