### PR TITLE
Fix access rules file location for testing IOC.

### DIFF
--- a/examples/testing_ioc/pydm-testing-ioc
+++ b/examples/testing_ioc/pydm-testing-ioc
@@ -136,7 +136,7 @@ if __name__ == '__main__':
         print('Starting testing-ioc')
         print('To start processing records do: caput '+prefix+'Run 1')
         server = SimpleServer()
-        server.initAccessSecurityFile(os.path.join(os.path.dirname(os.path.realpath(__file__)),'../data/access_rules.as'), P=prefix)
+        server.initAccessSecurityFile(os.path.join(os.path.dirname(os.path.realpath(__file__)),'access_rules.as'), P=prefix)
         server.createPV(prefix, pvdb)
         driver = myDriver()
         #Manually set the ReadOnly PV to force access rule calculation.


### PR DESCRIPTION
Tell the testing IOC to look for the access rules in the same directory in which it lives.  Fixes #207.