### PR TITLE
MAINT: Add try/except around pyepics caput

### DIFF
--- a/pydm/data_plugins/epics_plugins/pyepics_plugin.py
+++ b/pydm/data_plugins/epics_plugins/pyepics_plugin.py
@@ -1,9 +1,12 @@
 import epics
+import logging
 import numpy as np
 from ..plugin import PyDMPlugin, PyDMConnection
 from ...PyQt.QtCore import pyqtSlot, Qt
 from ...PyQt.QtGui import QApplication
 from ...utilities import is_pydm_app
+
+logger = logging.getLogger(__name__)
 
 int_types = set((epics.dbr.INT, epics.dbr.CTRL_INT, epics.dbr.TIME_INT,
                  epics.dbr.ENUM, epics.dbr.CTRL_ENUM, epics.dbr.TIME_ENUM,
@@ -108,7 +111,11 @@ class Connection(PyDMConnection):
             return
 
         if self.pv.write_access:
-            self.pv.put(new_val)
+            try:
+                self.pv.put(new_val)
+            except Exception:
+                logger.exception("Unable to put %s to %s",
+                                 new_val, self.pv.pvname)
 
     def add_listener(self, channel):
         super(Connection, self).add_listener(channel)

--- a/pydm/data_plugins/epics_plugins/pyepics_plugin.py
+++ b/pydm/data_plugins/epics_plugins/pyepics_plugin.py
@@ -113,9 +113,9 @@ class Connection(PyDMConnection):
         if self.pv.write_access:
             try:
                 self.pv.put(new_val)
-            except Exception:
-                logger.exception("Unable to put %s to %s",
-                                 new_val, self.pv.pvname)
+            except Exception as e:
+                logger.exception("Unable to put %s to %s.  Exception: %s",
+                                 new_val, self.pv.pvname, str(e))
 
     def add_listener(self, channel):
         super(Connection, self).add_listener(channel)


### PR DESCRIPTION
The `pyepics` plugin in has no try/except block around the `caput`. This means that if a user enters a comma instead of a period in their number the entire application goes down. 

I added a try/except block and the exception is logged. I noticed that in the `pyca` plugin that exceptions are caught, but they are printed. I believe the proper thing here is to log the exception, and if the user doesn't have a logger configured this goes to `stdout`  anyways. I can always switch my PR to a `print` or switch the `pyca` code to log for uniformity 

On another note, @ZLLentz did some work two weeks ago to make pyca work with Python 3.x. We also now package `psp` with `pyca` so that should make things a little nicer. Just wanted to let people know this is now an option in your Python 3.x environments.