### PR TITLE
Make PyQt.Qt module available through PyDM

### DIFF
--- a/pydm/PyQt/Qt.py
+++ b/pydm/PyQt/Qt.py
@@ -1,0 +1,6 @@
+from . import qtlib
+QT_LIB = qtlib.QT_LIB
+if QT_LIB == 'PyQt4':
+    from PyQt4.Qt import *
+elif QT_LIB == 'PyQt5':
+    from PyQt5.Qt import *


### PR DESCRIPTION
Hi,

In pull request #194 I needed to make the following import:
`from pydm.PyQt.Qt import QWIDGETSIZE_MAX `

However, I got:
`ModuleNotFoundError: No module named 'pydm.PyQt.Qt'`

I tried to import QWIDGETSIZE_MAX from other modules but it did not work. So I throught it could be interesting to add Qt module to pydm in other to not import it directly from PyQt5.
What do you thing about this?

Thanks,
Laís. 
  
  