### PR TITLE
Pyepics plugin race condition in send_access_state callback

### DIFF
--- a/pydm/data_plugins/epics_plugins/pyepics_plugin_component.py
+++ b/pydm/data_plugins/epics_plugins/pyepics_plugin_component.py
@@ -22,11 +22,11 @@ class Connection(PyDMConnection):
 
     def __init__(self, channel, pv, protocol=None, parent=None):
         super(Connection, self).__init__(channel, pv, protocol, parent)
+        self.app = QApplication.instance()
         self.pv = epics.PV(pv, connection_callback=self.send_connection_state, form='ctrl', auto_monitor=True, access_callback=self.send_access_state)
         self.pv.add_callback(self.send_new_value, with_ctrlvars=True)
         self.add_listener(channel)
 
-        self.app = QApplication.instance()
         self._severity = None
         self._precision = None
         self._enum_strs = None


### PR DESCRIPTION
`self.send_access_state` needs `self.app` to exist, else it will raise an exception. If we create `self.app` before creating the `PV` object, we can avoid this issue.

I'm surprised I'm the first to have this issue, as it makes this plugin unusable for me. Has everyone moved over to only using the psp plugin, or am I just lucky with race conditions?