### PR TITLE
Pr bugfix numeric locale

### DIFF
--- a/pydm/widgets/label.py
+++ b/pydm/widgets/label.py
@@ -1,3 +1,4 @@
+import locale
 from .base import PyDMWidget
 from ..PyQt.QtGui import QLabel, QApplication
 from ..PyQt.QtCore import Qt, pyqtProperty, Q_ENUMS
@@ -73,7 +74,7 @@ class PyDMLabel(QLabel, PyDMWidget, DisplayFormat):
         # If the value is a number (float or int), display it using a
         # format string if necessary.
         if isinstance(new_value, (int, float)):
-            self.setText(self.format_string.format(new_value))
+            self.setText(self.format_string.format(new_value).replace('.', locale.localeconv()['decimal_point']))
             return
         # If you made it this far, just turn whatever the heck the value
         # is into a string and display it.

--- a/pydm/widgets/line_edit.py
+++ b/pydm/widgets/line_edit.py
@@ -241,7 +241,7 @@ class PyDMLineEdit(QLineEdit, PyDMWritableWidget, DisplayFormat):
 
         if self._display_format_type == DisplayFormat.Default:
             if isinstance(new_value, (int, float)):
-                self._display = str(self.format_string.format(new_value))
+                self._display = str(self.format_string.format(new_value)).replace('.', locale.localeconv()['decimal_point'])
                 self.setText(self._display)
                 return
 


### PR DESCRIPTION
This PR addresses the issue #229.

The changes were made in the set_display module of the _PyDMLineEdit_ and _PyDMLabel_ widgets.

The change consists of simply replacing the standard decimal separator '.' by the one defined in the locale settings.

Perhaps a more elegant solution would be to make this changes in the the PyDMWidget's _update_format_string_ method, since that would affect all widgets with a similar behavior. However, at this time I could not think of an easy way to implement this changes, as that would entail having to use the locale module formatter instead of the .format currently being used.

Anyhow it seems to be working.

cheers,
Guilherme