### PR TITLE
Add property table to tab widget docs.

### DIFF
--- a/docs/source/widgets/tab_widget.rst
+++ b/docs/source/widgets/tab_widget.rst
@@ -15,6 +15,19 @@ Using the PyDM Tab Widget in Designer
 
 In designer, drag a tab widget from the widget list onto your display, and resize it appropriately.  You can use the property editor to give the current tab a label (the 'currentTabText' property), a name (the 'currentTabName' property - this is what you will use to refer to this tab in code), and an alarm channel ('currentTabAlarmChannel').  To add a new tab to the tab widget, right click on the widget and select 'Insert Page'.  You can choose to insert before or after the current tab.  To remove a tab, right click on the tab widget, and select 'Page X of Y' -> Delete.
 
+
+Widget Properties
+=================
+
+======================  ====  ===========
+Property                Type  Description
+======================  ====  ===========
+currentTabAlarmChannel  str   A channel to use for the alarm indicator on the current tab.
+currentTabText          str   The label to use for the current tab. 
+currentTabName          str   A name for the tab.  This is how you will refer to the tab in python code.
+======================  ====  ===========
+
+
 API Documentation
 =================
 


### PR DESCRIPTION
Small pull request to add a table of properties to the tab widget.  The idea is that this widget's documentation becomes the template to use for all other widgets as part of the ongoing effort towards better user-level documentation.