### PR TITLE
fix context menu of spinbox.

### DIFF
--- a/pydm/widgets/spinbox.py
+++ b/pydm/widgets/spinbox.py
@@ -51,7 +51,7 @@ class PyDMSpinbox(QDoubleSpinBox, PyDMWritableWidget):
         else:
             super(PyDMSpinbox, self).keyPressEvent(ev)
 
-    def contextMenuEvent(self, ev):
+    def context_menu(self):
         """Increment LineEdit menu to toggle the display of the step size."""
         def toogle():
             self.showStepExponent = not self.showStepExponent
@@ -60,7 +60,7 @@ class PyDMSpinbox(QDoubleSpinBox, PyDMWritableWidget):
         menu.addSeparator()
         ac = menu.addAction('Toggle Show Step Size')
         ac.triggered.connect(toogle)
-        menu.exec_(ev.globalPos())
+        return menu
 
     def update_step_size(self):
         """


### PR DESCRIPTION
A context menu entry to toggle display of step size in the `lineEdit` of `PyDMSpinbox` was created in PR #143.

This behavior was broken by PR #213, with the creation of the methods `open_context_menu` and `context_menu` in the `PyDMWidget` Class.

This PR solves this problem changing the name of `PyDMSpinbox` method `contextMenuEvent` to `context_menu` and returning the menu created instead of executing it.