### PR TITLE
Overwrite context_menu method to return custom menu created in ImageView

### DIFF
--- a/pydm/widgets/image.py
+++ b/pydm/widgets/image.py
@@ -61,7 +61,17 @@ class PyDMImageView(ImageView, PyDMWidget, PyDMColorMap):
         self.redraw_timer.timeout.connect(self.redrawImage)
         self._redraw_rate = 30
         self.maxRedrawRate = self._redraw_rate
-        
+
+    def context_menu(self):
+        """
+        Return custom context menu created in ImageView.
+
+        Returns
+        -------
+        context_menu : ViewBoxMenu
+        """
+        return self.getView().getMenu(None)
+
     def changeColorMap(self, action):
         """
         Method invoked by the colormap Action Menu that changes the


### PR DESCRIPTION
There was a context menu entry to choose the `colormap` used on the `PyDMImageView`. 
PR #213, which creates a new `context_menu` in the `PyDMWidget` Class, broke this. 
The changes introduced here try to recover this behavior.