### PR TITLE
FIX: Make the Context Menu Great Again

### DIFF
--- a/pydm/application.py
+++ b/pydm/application.py
@@ -635,7 +635,8 @@ class PyDMApplication(QApplication):
                 temp_name = str(uuid.uuid4())
 
                 module = imp.load_source(temp_name, tool)
-                classes = [obj for _, obj in inspect.getmembers(module) if inspect.isclass(obj) and issubclass(obj, ExternalTool) and obj != ExternalTool]
+                classes = [obj for _, obj in inspect.getmembers(module)
+                           if inspect.isclass(obj) and issubclass(obj, ExternalTool) and obj != ExternalTool]
                 if len(classes) == 0:
                     raise ValueError("Invalid File Format. {} has no class inheriting from ExternalTool. Nothing to open at this time.".format(tool))
                 obj = [c() for c in classes]
@@ -655,11 +656,11 @@ class PyDMApplication(QApplication):
 
             reorder_tools_dict()
             kwargs = {'channels': None, 'sender': self.main_window}
-            self.assemble_tools_menu(self.main_window.ui.menuTools, **kwargs)
+            self.assemble_tools_menu(self.main_window.ui.menuTools, clear_menu=True, **kwargs)
         except Exception as e:
             print("Failed to load External Tool: ", tool, ". Exception was: ", str(e))
 
-    def assemble_tools_menu(self, parent_menu, widget_only=False, **kwargs):
+    def assemble_tools_menu(self, parent_menu, clear_menu=False, widget_only=False, **kwargs):
         """
         Assemble the Tools menu for a given parent menu.
 
@@ -667,6 +668,8 @@ class PyDMApplication(QApplication):
         ----------
         parent_menu : QMenu
             The main menu item to hold the tools menu tree.
+        clear_menu : bool
+            Whether of not we should clear the menu before adding the tools.
         widget_only : bool
             Whether or not generate only the menu for widgets compatible
             tools. This should be True when creating the menu for the
@@ -677,16 +680,18 @@ class PyDMApplication(QApplication):
             is a list and `sender` which is a QWidget.
 
         """
-
         def assemble_action(menu, tool_obj):
             if tool_obj.icon is not None:
-                action = QAction(tool_obj.icon, tool_obj.name, menu)
+                action = menu.addAction(tool_obj.name)
+                action.setIcon(tool_obj.icon)
             else:
-                action = QAction(tool_obj.name, menu)
+                action = menu.addAction(tool_obj.name)
             action.triggered.connect(partial(tool_obj.call, **kwargs))
-            menu.addAction(action)
 
-        parent_menu.clear()
+        if clear_menu:
+            parent_menu.clear()
+        else:
+            parent_menu.addSeparator()
 
         for k, v in self.tools.items():
             if isinstance(v, dict):

--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -202,8 +202,19 @@ class PyDMWidget(PyDMPrimitiveWidget):
             self.alarmSeverityChanged(self.ALARM_DISCONNECTED)
             self.check_enable_state()
 
-            self.setContextMenuPolicy(Qt.CustomContextMenu)
-            self.customContextMenuRequested.connect(self.open_context_menu)
+        self.setContextMenuPolicy(Qt.CustomContextMenu)
+        self.customContextMenuRequested.connect(self.open_context_menu)
+
+    def widget_ctx_menu(self):
+        """
+        Fetch the Widget specific context menu which will be populated with additional tools by `assemble_tools_menu`.
+
+        Returns
+        -------
+        QMenu or None
+            If the return of this method is None a new QMenu will be created by `assemble_tools_menu`.
+        """
+        return None
 
     def context_menu(self):
         """
@@ -215,7 +226,10 @@ class PyDMWidget(PyDMPrimitiveWidget):
         -------
         QMenu
         """
-        menu = QMenu(self)
+        menu = self.widget_ctx_menu()
+        if menu is None:
+            menu = QMenu(parent=self)
+
         kwargs = {'channels': self.channels_for_tools(), 'sender': self}
         self.app.assemble_tools_menu(menu, widget_only=True, **kwargs)
         return menu

--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -202,8 +202,8 @@ class PyDMWidget(PyDMPrimitiveWidget):
             self.alarmSeverityChanged(self.ALARM_DISCONNECTED)
             self.check_enable_state()
 
-        self.setContextMenuPolicy(Qt.CustomContextMenu)
-        self.customContextMenuRequested.connect(self.open_context_menu)
+        self.setContextMenuPolicy(Qt.DefaultContextMenu)
+        self.contextMenuEvent = self.open_context_menu
 
     def widget_ctx_menu(self):
         """
@@ -216,7 +216,7 @@ class PyDMWidget(PyDMPrimitiveWidget):
         """
         return None
 
-    def context_menu(self):
+    def generate_context_menu(self):
         """
         Generates the custom context menu, and populates it with any external
         tools that have been loaded.  PyDMWidget subclasses should override
@@ -234,16 +234,16 @@ class PyDMWidget(PyDMPrimitiveWidget):
         self.app.assemble_tools_menu(menu, widget_only=True, **kwargs)
         return menu
 
-    def open_context_menu(self, position):
+    def open_context_menu(self, ev):
         """
-        Handler for when the Custom Context Menu is requested.
+        Handler for when the Default Context Menu is requested.
 
         Parameters
         ----------
-        position : QPoint
+        ev : QEvent
         """
-        menu = self.context_menu()
-        menu.exec_(self.mapToGlobal(position))
+        menu = self.generate_context_menu()
+        action = menu.exec_(self.mapToGlobal(ev.pos()))
         del menu
 
     def init_for_designer(self):

--- a/pydm/widgets/enum_combo_box.py
+++ b/pydm/widgets/enum_combo_box.py
@@ -1,5 +1,5 @@
 from ..PyQt.QtGui import QFrame, QComboBox, QHBoxLayout
-from ..PyQt.QtCore import pyqtSignal, pyqtSlot
+from ..PyQt.QtCore import pyqtSignal, pyqtSlot, Qt
 from .base import PyDMWritableWidget
 from pydm.utilities import is_pydm_app
 
@@ -45,6 +45,8 @@ class PyDMEnumComboBox(QFrame, PyDMWritableWidget):
         self.combo_box.currentIndexChanged[str].connect(self.internal_combo_box_index_changed_str)
         self.combo_box.highlighted[int].connect(self.internal_combo_box_highlighted_int)
         self.combo_box.highlighted[str].connect(self.internal_combo_box_highlighted_str)
+        self.combo_box.setContextMenuPolicy(Qt.DefaultContextMenu)
+        self.combo_box.contextMenuEvent = self.open_context_menu
 
     # Internal methods
     def set_items(self, enums):

--- a/pydm/widgets/line_edit.py
+++ b/pydm/widgets/line_edit.py
@@ -197,10 +197,17 @@ class PyDMLineEdit(QLineEdit, PyDMWritableWidget, DisplayFormat):
             print('Warning: Attempting to convert PyDMLineEdit unit, but {:} '\
                            'can not be converted to {:}'.format(self._units, unit))
 
-    def context_menu(self):
-        menu = super(PyDMLineEdit, self).context_menu()
-        if len(menu.findChildren(QAction)) > 0:
-            menu.addSeparator()
+    def widget_ctx_menu(self):
+        """
+        Fetch the Widget specific context menu which will be populated with additional tools by `assemble_tools_menu`.
+
+        Returns
+        -------
+        QMenu or None
+            If the return of this method is None a new QMenu will be created by `assemble_tools_menu`.
+        """
+        menu = self.createStandardContextMenu()
+        menu.addSeparator()
         menu.addMenu(self.unitMenu)
         return menu
 

--- a/pydm/widgets/spinbox.py
+++ b/pydm/widgets/spinbox.py
@@ -51,8 +51,15 @@ class PyDMSpinbox(QDoubleSpinBox, PyDMWritableWidget):
         else:
             super(PyDMSpinbox, self).keyPressEvent(ev)
 
-    def contextMenuEvent(self, ev):
-        """Increment LineEdit menu to toggle the display of the step size."""
+    def widget_ctx_menu(self):
+        """
+        Fetch the Widget specific context menu which will be populated with additional tools by `assemble_tools_menu`.
+
+        Returns
+        -------
+        QMenu or None
+            If the return of this method is None a new QMenu will be created by `assemble_tools_menu`.
+        """
         def toogle():
             self.showStepExponent = not self.showStepExponent
 
@@ -60,7 +67,7 @@ class PyDMSpinbox(QDoubleSpinBox, PyDMWritableWidget):
         menu.addSeparator()
         ac = menu.addAction('Toggle Show Step Size')
         ac.triggered.connect(toogle)
-        menu.exec_(ev.globalPos())
+        return menu
 
     def update_step_size(self):
         """

--- a/pydm/widgets/spinbox.py
+++ b/pydm/widgets/spinbox.py
@@ -1,4 +1,4 @@
-from ..PyQt.QtGui import QDoubleSpinBox, QApplication
+from ..PyQt.QtGui import QDoubleSpinBox, QApplication, QMenu
 from ..PyQt.QtCore import pyqtProperty, QEvent, Qt
 from .base import PyDMWritableWidget
 


### PR DESCRIPTION
This PR supersedes #242 and #243 by implementing the fix in a more general way.
Widgets that have a custom menu should implement `widget_ctx_menu` to return their menu which will be modified to add the Tools if present. 

@anacso17 and @fernandohds564 here is the fix for the issues that we discussed with Context Menus.
Would you mind to give it a try and confirm to me that it works?
I tested locally and all seems fine.