### PR TITLE
BLD: Development Requirements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,9 +67,11 @@ after_success:
   - codecov
   - |
     if [[ $TRAVIS_PULL_REQUEST == false && $TRAVIS_REPO_SLUG == $OFFICIAL_REPO && $TRAVIS_BRANCH == $TRAVIS_TAG  && $TRAVIS_TAG != '' && $CONDA_UPLOAD_TOKEN_TAG != '' ]]; then
-      conda build . -c defaults -c conda-forge -c gsecars --token $CONDA_UPLOAD_TOKEN_TAG --python $TRAVIS_PYTHON_VERSION
+      export ANACONDA_API_TOKEN=$CONDA_UPLOAD_TOKEN_TAG  
+      anaconda upload bld-dir/linux-64/*.tar.bz2
     fi
   - |
     if [[ $TRAVIS_PULL_REQUEST == false && $TRAVIS_REPO_SLUG == $OFFICIAL_REPO && $TRAVIS_BRANCH == 'master' && $TRAVIS_TAG == '' && $CONDA_UPLOAD_TOKEN_DEV != '' ]]; then
-      conda build . -c defaults -c conda-forge -c gsecars --token $CONDA_UPLOAD_TOKEN_DEV --python $TRAVIS_PYTHON_VERSION
+      export ANACONDA_API_TOKEN=$CONDA_UPLOAD_TOKEN_DEV  
+      anaconda upload bld-dir/linux-64/*.tar.bz2
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,6 @@ before_install:
   - conda update -q conda conda-build
   # Add the channels needed for install
   - conda config --append channels conda-forge
-  - conda config --append channels gsecars
   # Build the recipe and use it the local build for install
   - conda build -q conda-recipe --python=$TRAVIS_PYTHON_VERSION --output-folder bld-dir
   - conda config --add channels "file://`pwd`/bld-dir"

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,9 +33,14 @@ before_install:
   - conda config --set always_yes yes
   - conda install conda-build anaconda-client
   - conda update -q conda conda-build
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION pyqt=$PYQT_VERSION pip numpy scipy six psutil pyqtgraph -c conda-forge
+  # Add the channels needed for install
+  - conda config --append channels conda-forge
+  - conda config --append channels gsecars
+  # Build the recipe and use it the local build for install
+  - conda build -q conda-recipe --python=$TRAVIS_PYTHON_VERSION --output-folder bld-dir
+  - conda config --add channels "file://`pwd`/bld-dir"
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION pydm --file dev-requirements.txt
   - source activate test-environment
-  - pip install requests pyepics coverage codecov coveralls pytest pytest-qt pytest-cov versioneer
 
 install:
   # Debug information

--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ will make all the PyDM widgets available to the Qt Designer.
 
 ### Most Recent Development Build
 ```sh
-conda install -c pydm-dev -c gsecars -c conda-forge pydm
+conda install -c pydm-dev -c conda-forge pydm
 ```
 ### Most Recent Tagged Build
 ```sh
-conda install -c pydm-tag -c gsecars -c conda-forge pydm
+conda install -c pydm-tag -c conda-forge pydm
 ```

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,4 @@
+codecov
+pytest
+pytest-qt
+pytest-cov


### PR DESCRIPTION
## Description 
* I noticed after #285 that there was no `dev-requirements` file that allowed users to install the requirements needed to run the testing suite. I added these into a single file for convenience to be installed with `pip -r` or `conda --file` 
* In general I think it best to test using only  the conda-recipe and the `-requirements` files. This means you avoid the struggle of remembering to add the same dependency in multiple places.
* If you build the package locally with Conda (thus checking the recipe) you can quickly upload this to Anaconda. This solves the unwanted surprise of "my tests passed on Travis why can't I build it for the Anaconda release". 

### Side Note
We now are building `pyepics` and `pcaspy` on the Conda channel `pcds-tag`. Just throwing out the idea of using that rather than the `gsecars` channel. The only complication I see is that we are also building `pydm` there. (We only want to have one channel for all PCDS packages). Still
`conda install pydm -c pydm-tag -c pcds-tag` would work fine. I left the CI build using `gsecars` for now 😉 