### PR TITLE
ENH: Make MainWindow visible when calling PyDM without arguments.

### DIFF
--- a/pydm/application.py
+++ b/pydm/application.py
@@ -105,6 +105,7 @@ class PyDMApplication(QApplication):
         # being called hierarchially (i.e., parent calls it first, then on down the ancestor tree, with no unrelated
         # calls in between).    If something crazy happens and PyDM somehow gains the ability to open files in a
         # multi-threaded way, for example, this system will fail.
+        self.main_window = None
         self.directory_stack = ['']
         self.macro_stack = [{}]
         self.windows = {}
@@ -114,6 +115,8 @@ class PyDMApplication(QApplication):
         self.hide_status_bar = hide_status_bar
         self.__read_only = read_only
         # Open a window if one was provided.
+        self.make_main_window()
+
         if ui_file is not None:
             self.make_window(ui_file, macros, command_line_args)
             self.had_file = True
@@ -236,12 +239,27 @@ class PyDMApplication(QApplication):
         # All new windows are spawned as new processes.
         self.new_pydm_process(ui_file, macros, command_line_args)
 
-    def make_window(self, ui_file, macros=None, command_line_args=None):
+    def make_main_window(self):
         """
         Instantiate a new PyDMMainWindow, add it to the application's
-        list of windows, and open the ui_file in the window.  Typically,
-        this function is only called as part of starting up a new process,
-        because PyDMApplications only have one window per process.
+        list of windows. Typically, this function is only called as part
+        of starting up a new process, because PyDMApplications only have
+        one window per process.
+        """
+        main_window = PyDMMainWindow(hide_nav_bar=self.hide_nav_bar,
+                                     hide_menu_bar=self.hide_menu_bar,
+                                     hide_status_bar=self.hide_status_bar)
+
+        self.main_window = main_window
+        main_window.show()
+        self.load_external_tools()
+        # If we are launching a new window, we don't want it to sit right on top of an existing window.
+        if len(self.windows) > 1:
+            main_window.move(main_window.x() + 10, main_window.y() + 10)
+
+    def make_window(self, ui_file, macros=None, command_line_args=None):
+        """
+        Open the ui_file in the window.
 
         Parameters
         ----------
@@ -256,17 +274,9 @@ class PyDMApplication(QApplication):
             to pass in extra arguments.  It is probably rare that code you
             write needs to use this argument.
         """
-        main_window = PyDMMainWindow(hide_nav_bar=self.hide_nav_bar,
-                                     hide_menu_bar=self.hide_menu_bar,
-                                     hide_status_bar=self.hide_status_bar)
-        main_window.open_file(ui_file, macros, command_line_args)
-        main_window.show()
-        self.main_window = main_window
-        self.load_external_tools()
-        self.windows[main_window] = path_info(ui_file)[0]
-        # If we are launching a new window, we don't want it to sit right on top of an existing window.
-        if len(self.windows) > 1:
-            main_window.move(main_window.x() + 10, main_window.y() + 10)
+        if ui_file is not None:
+            self.main_window.open_file(ui_file, macros, command_line_args)
+            self.windows[self.main_window] = path_info(ui_file)[0]
 
     def close_window(self, window):
         try:

--- a/pydm/application.py
+++ b/pydm/application.py
@@ -92,7 +92,8 @@ class PyDMApplication(QApplication):
         True: QColor(0, 0, 0)
     }
 
-    def __init__(self, ui_file=None, command_line_args=[], display_args=[], perfmon=False, hide_nav_bar=False, hide_menu_bar=False, hide_status_bar=False, read_only=False, macros=None):
+    def __init__(self, ui_file=None, command_line_args=[], display_args=[], perfmon=False, hide_nav_bar=False,
+                 hide_menu_bar=False, hide_status_bar=False, read_only=False, macros=None):
         super(PyDMApplication, self).__init__(command_line_args)
         # Enable High DPI display, if available.
         if hasattr(Qt, 'AA_UseHighDpiPixmaps'):

--- a/pydm/main_window.py
+++ b/pydm/main_window.py
@@ -187,6 +187,9 @@ class PyDMMainWindow(QMainWindow):
                 self.open_abs_file(filename=stack_item[0], macros=stack_item[1], command_line_args=stack_item[2])
 
     def home(self):
+        if self.home_file is None:
+            return
+
         if QApplication.keyboardModifiers() == Qt.ShiftModifier:
             self.new_abs_window(filename=self.home_file[0], macros=self.home_file[1], command_line_args=self.home_file[2])
         else:
@@ -269,7 +272,12 @@ class PyDMMainWindow(QMainWindow):
         self.ui.statusbar.setHidden(not checked)
 
     def get_files_in_display(self):
-        _, extension = path.splitext(self.current_file())
+        try:
+            curr_file = self.current_file()
+        except IndexError:
+            return None, None
+
+        _, extension = path.splitext(curr_file)
         if extension == '.ui':
             return self.current_file(), None
         else:
@@ -304,7 +312,12 @@ class PyDMMainWindow(QMainWindow):
     @pyqtSlot(bool)
     def open_file_action(self, checked):
         modifiers = QApplication.keyboardModifiers()
-        filename = QFileDialog.getOpenFileName(self, 'Open File...', os.path.dirname(self.current_file()), 'PyDM Display Files (*.ui *.py)')
+        try:
+            curr_file = self.current_file()
+        except IndexError:
+            curr_file = os.getcwd()
+
+        filename = QFileDialog.getOpenFileName(self, 'Open File...', os.path.dirname(curr_file), 'PyDM Display Files (*.ui *.py)')
         filename = filename[0] if isinstance(filename, (list, tuple)) else filename
 
         if filename:
@@ -327,6 +340,10 @@ class PyDMMainWindow(QMainWindow):
 
     @pyqtSlot(bool)
     def reload_display(self, checked):
+        try:
+            curr_file = self.current_file()
+        except IndexError:
+            return
         self.statusBar().showMessage("Reloading '{0}'...".format(self.current_file()), 5000)
         self.go_abs(self.current_file())
 

--- a/pydm/main_window.py
+++ b/pydm/main_window.py
@@ -277,7 +277,7 @@ class PyDMMainWindow(QMainWindow):
         try:
             curr_file = self.current_file()
         except IndexError:
-            logger.info("The display manager does not have a display loaded.")
+            logger.error("The display manager does not have a display loaded.")
             return None, None
 
         _, extension = path.splitext(curr_file)
@@ -347,7 +347,7 @@ class PyDMMainWindow(QMainWindow):
         try:
             curr_file = self.current_file()
         except IndexError:
-            logger.info("The display manager does not have a display loaded.")
+            logger.error("The display manager does not have a display loaded.")
             return
         self.statusBar().showMessage("Reloading '{0}'...".format(self.current_file()), 5000)
         self.go_abs(self.current_file())

--- a/pydm/main_window.py
+++ b/pydm/main_window.py
@@ -1,6 +1,5 @@
 import os
-from os import path, environ
-from functools import partial
+from os import path
 from .PyQt.QtGui import QApplication, QMainWindow, QFileDialog, QWidget, QAction
 from .PyQt.QtCore import Qt, QTimer, pyqtSlot, QSize, QLibraryInfo
 from .utilities import IconFont
@@ -10,6 +9,9 @@ from .connection_inspector import ConnectionInspector
 from .about_pydm import AboutWindow
 import subprocess
 import platform
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 class PyDMMainWindow(QMainWindow):
@@ -275,6 +277,7 @@ class PyDMMainWindow(QMainWindow):
         try:
             curr_file = self.current_file()
         except IndexError:
+            logger.info("The display manager does not have a display loaded.")
             return None, None
 
         _, extension = path.splitext(curr_file)
@@ -314,10 +317,11 @@ class PyDMMainWindow(QMainWindow):
         modifiers = QApplication.keyboardModifiers()
         try:
             curr_file = self.current_file()
+            folder = os.path.dirname(curr_file)
         except IndexError:
-            curr_file = os.getcwd()
+            folder = os.getcwd()
 
-        filename = QFileDialog.getOpenFileName(self, 'Open File...', os.path.dirname(curr_file), 'PyDM Display Files (*.ui *.py)')
+        filename = QFileDialog.getOpenFileName(self, 'Open File...', folder, 'PyDM Display Files (*.ui *.py)')
         filename = filename[0] if isinstance(filename, (list, tuple)) else filename
 
         if filename:
@@ -343,6 +347,7 @@ class PyDMMainWindow(QMainWindow):
         try:
             curr_file = self.current_file()
         except IndexError:
+            logger.info("The display manager does not have a display loaded.")
             return
         self.statusBar().showMessage("Reloading '{0}'...".format(self.current_file()), 5000)
         self.go_abs(self.current_file())

--- a/pydm_launcher/main.py
+++ b/pydm_launcher/main.py
@@ -2,6 +2,7 @@ import sys
 import argparse
 from pydm import PyDMApplication
 import json
+import logging
 
 
 def main():
@@ -12,6 +13,7 @@ def main():
     parser.add_argument('--hide-menu-bar', action='store_true', help='Start PyDM with the menu bar hidden.')
     parser.add_argument('--hide-status-bar', action='store_true', help='Start PyDM with the status bar hidden.')
     parser.add_argument('--read-only', action='store_true', help='Start PyDM in a Read-Only mode.')
+    parser.add_argument('--log_level', help='Configure level of log display', default=logging.INFO)
     parser.add_argument('-m', '--macro', help='Specify macro replacements to use, in JSON object format.    Reminder: JSON requires double quotes for strings, so you should wrap this whole argument in single quotes.  Example: -m \'{"sector": "LI25", "facility": "LCLS"}')
     parser.add_argument('display_args', help='Arguments to be passed to the PyDM client application (which is a QApplication subclass).', nargs=argparse.REMAINDER)
     pydm_args = parser.parse_args()
@@ -21,6 +23,9 @@ def main():
             macros = json.loads(pydm_args.macro)
         except ValueError:
             raise ValueError("Could not parse macro argument as JSON.")
+
+    logging.basicConfig(level=pydm_args.log_level, format='[%(asctime)s] - %(message)s')
+
     app = PyDMApplication(ui_file=pydm_args.displayfile, command_line_args=pydm_args.display_args,
                           perfmon=pydm_args.perfmon,
                           hide_nav_bar=pydm_args.hide_nav_bar,


### PR DESCRIPTION
It always bugged me the fact that we need to specify a file to be loaded.
This PR makes possible to just call `pydm` on the command line and get the Main Window to display so users can `Open File...` from the menu if they want.
It is a common mistake that happens mainly with new users but it is a nice "feature" to have.
