### PR TITLE
Pr py dm application without window

### DIFF
--- a/pydm/application.py
+++ b/pydm/application.py
@@ -116,8 +116,6 @@ class PyDMApplication(QApplication):
         self.hide_status_bar = hide_status_bar
         self.__read_only = read_only
         # Open a window if one was provided.
-        self.make_main_window()
-
         if ui_file is not None:
             self.make_window(ui_file, macros, command_line_args)
             self.had_file = True

--- a/pydm_launcher/main.py
+++ b/pydm_launcher/main.py
@@ -50,7 +50,7 @@ def main():
         help='Specify macro replacements to use, in JSON object format.' +
              '    Reminder: JSON requires double quotes for strings, ' +
              'so you should wrap this whole argument in single quotes.' +
-             '  Example: -m \'{"sector": "LI25", "facility": "LCLS"}'
+             '  Example: -m \'{"sector": "LI25", "facility": "LCLS"}\''
         )
     parser.add_argument(
         'display_args',

--- a/pydm_launcher/main.py
+++ b/pydm_launcher/main.py
@@ -7,15 +7,57 @@ import logging
 
 def main():
     parser = argparse.ArgumentParser(description="Python Display Manager")
-    parser.add_argument('displayfile', help='A PyDM file to display.    Can be either a Qt .ui file, or a Python file.', nargs='?', default=None)
-    parser.add_argument('--perfmon', action='store_true', help='Enable performance monitoring, and print CPU usage to the terminal.')
-    parser.add_argument('--hide-nav-bar', action='store_true', help='Start PyDM with the navigation bar hidden.')
-    parser.add_argument('--hide-menu-bar', action='store_true', help='Start PyDM with the menu bar hidden.')
-    parser.add_argument('--hide-status-bar', action='store_true', help='Start PyDM with the status bar hidden.')
-    parser.add_argument('--read-only', action='store_true', help='Start PyDM in a Read-Only mode.')
-    parser.add_argument('--log_level', help='Configure level of log display', default=logging.INFO)
-    parser.add_argument('-m', '--macro', help='Specify macro replacements to use, in JSON object format.    Reminder: JSON requires double quotes for strings, so you should wrap this whole argument in single quotes.  Example: -m \'{"sector": "LI25", "facility": "LCLS"}')
-    parser.add_argument('display_args', help='Arguments to be passed to the PyDM client application (which is a QApplication subclass).', nargs=argparse.REMAINDER)
+    parser.add_argument(
+        'displayfile',
+        help='A PyDM file to display.' +
+             '    Can be either a Qt .ui file, or a Python file.',
+        nargs='?',
+        default=None
+        )
+    parser.add_argument(
+        '--perfmon',
+        action='store_true',
+        help='Enable performance monitoring,' +
+             ' and print CPU usage to the terminal.'
+        )
+    parser.add_argument(
+        '--hide-nav-bar',
+        action='store_true',
+        help='Start PyDM with the navigation bar hidden.'
+        )
+    parser.add_argument(
+        '--hide-menu-bar',
+        action='store_true',
+        help='Start PyDM with the menu bar hidden.'
+        )
+    parser.add_argument(
+        '--hide-status-bar',
+        action='store_true',
+        help='Start PyDM with the status bar hidden.'
+        )
+    parser.add_argument(
+        '--read-only',
+        action='store_true',
+        help='Start PyDM in a Read-Only mode.'
+        )
+    parser.add_argument(
+        '--log_level',
+        help='Configure level of log display',
+        default=logging.INFO
+        )
+    parser.add_argument(
+        '-m', '--macro',
+        help='Specify macro replacements to use, in JSON object format.' +
+             '    Reminder: JSON requires double quotes for strings, ' +
+             'so you should wrap this whole argument in single quotes.' +
+             '  Example: -m \'{"sector": "LI25", "facility": "LCLS"}'
+        )
+    parser.add_argument(
+        'display_args',
+        help='Arguments to be passed to the PyDM client application' +
+             ' (which is a QApplication subclass).',
+        nargs=argparse.REMAINDER
+        )
     pydm_args = parser.parse_args()
     macros = None
     if pydm_args.macro is not None:
@@ -24,17 +66,25 @@ def main():
         except ValueError:
             raise ValueError("Could not parse macro argument as JSON.")
 
-    logging.basicConfig(level=pydm_args.log_level, format='[%(asctime)s] - %(message)s')
+    logging.basicConfig(
+        level=pydm_args.log_level,
+        format='[%(asctime)s] - %(message)s'
+        )
+
+    app = PyDMApplication(
+        ui_file=pydm_args.displayfile,
+        command_line_args=pydm_args.display_args,
+        perfmon=pydm_args.perfmon,
+        hide_nav_bar=pydm_args.hide_nav_bar,
+        hide_menu_bar=pydm_args.hide_menu_bar,
+        hide_status_bar=pydm_args.hide_status_bar,
+        read_only=pydm_args.read_only,
+        macros=macros
+        )
+
     if pydm_args.displayfile is None:
         app.make_main_window()
 
-    app = PyDMApplication(ui_file=pydm_args.displayfile, command_line_args=pydm_args.display_args,
-                          perfmon=pydm_args.perfmon,
-                          hide_nav_bar=pydm_args.hide_nav_bar,
-                          hide_menu_bar=pydm_args.hide_menu_bar,
-                          hide_status_bar=pydm_args.hide_status_bar,
-                          read_only=pydm_args.read_only,
-                          macros=macros)
     sys.exit(app.exec_())
 
 

--- a/pydm_launcher/main.py
+++ b/pydm_launcher/main.py
@@ -25,6 +25,8 @@ def main():
             raise ValueError("Could not parse macro argument as JSON.")
 
     logging.basicConfig(level=pydm_args.log_level, format='[%(asctime)s] - %(message)s')
+    if pydm_args.displayfile is None:
+        app.make_main_window()
 
     app = PyDMApplication(ui_file=pydm_args.displayfile, command_line_args=pydm_args.display_args,
                           perfmon=pydm_args.perfmon,


### PR DESCRIPTION
Hi Guys!

In our applications we generally do not use `PyDMMainWindow` for our interfaces, we only create an instance of `PyDMApplication` to manage our windows, whch in turn use PyDM widgets.

With PR #290, every time we create an instance of the class `PyDMApplication`, a `PyDMMainWindow` is created and there is no way to change this behavior.

This PR tries to fix this while maintaining the behavior defined in #290 of opening an instance of `PyDMMainWindow` when `pydm` is called from the command line without arguments.

This PR also have a commit to fix the style of the `main` module of `pydm_launcher`.