### PR TITLE
ENH: Log Widget

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ before_script:
   - sleep 1
 
 script:
-  - python run_tests.py
+  - python run_tests.py --show-cov
   #Build docs
   - set -e
   - |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -48,7 +48,7 @@ install:
   - activate test-environment
 
 test_script:
-  - python run_tests.py
+  - python run_tests.py --show-cov
 
 after_test:
   - codecov

--- a/examples/log_display/log_display.ui
+++ b/examples/log_display/log_display.ui
@@ -39,8 +39,11 @@
     parent : QObject, optional
     </string>
      </property>
+     <property name="logLevel" stdset="0">
+      <enum>PyDMLogDisplay::INFO</enum>
+     </property>
      <property name="logname" stdset="0">
-      <string>main_window</string>
+      <string>root</string>
      </property>
     </widget>
    </item>

--- a/examples/log_display/log_display.ui
+++ b/examples/log_display/log_display.ui
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>417</width>
+    <height>337</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QHBoxLayout" name="horizontalLayout">
+   <item>
+    <widget class="PyDMLogDisplay" name="PyDMLogDisplay">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="whatsThis">
+      <string>
+    Standard display for Log Output
+
+    This widget handles instantating a ``GuiHandler`` and displaying log
+    messages to a ``QPlainTextEdit``. The level of the log can be changed from
+    inside the widget itself, allowing users to select from any of the
+    ``.levels`` specified by the widget.
+
+    Parameters
+    ----------
+    logname : str
+        Name of log to display in widget
+
+    level : logging.Level
+        Initial level of log display
+
+    parent : QObject, optional
+    </string>
+     </property>
+     <property name="logname" stdset="0">
+      <string>main_window</string>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>PyDMLogDisplay</class>
+   <extends>QWidget</extends>
+   <header>pydm.widgets.logdisplay</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/pydm/tests/widgets/test_logdisplay.py
+++ b/pydm/tests/widgets/test_logdisplay.py
@@ -1,0 +1,33 @@
+import pytest
+import logging
+
+from pydm.widgets.logdisplay import PyDMLogDisplay
+
+
+@pytest.fixture(scope='module')
+def log():
+    log = logging.getLogger('log_test.pydm')
+    return log
+
+
+def test_write(qtbot, log):
+    logd = PyDMLogDisplay(log.name, level=logging.INFO)
+    logd.show()
+    # Watch our error message show up in the log
+    err_msg = 'This is a test of the emergency broadcast system'
+    log.error(err_msg)
+    assert err_msg in logd.text.toPlainText()
+    # Debug shouldn't show up
+    debug_msg = 'Pay no attention to the man behind the curtain'
+    log.debug(debug_msg)
+    assert debug_msg not in logd.text.toPlainText()
+    # Change the level so debug does show up
+    logd.set_level('DEBUG')
+    assert logd.handler.level == logging.DEBUG
+    log.debug(debug_msg)
+    assert debug_msg in logd.text.toPlainText()
+    # Change the name and make sure we still see what we need
+    logd.logname = 'log_test'
+    info_msg = 'The more things change the more they stay the same'
+    log.info(info_msg)
+    assert info_msg in logd.text.toPlainText()

--- a/pydm/tests/widgets/test_logdisplay.py
+++ b/pydm/tests/widgets/test_logdisplay.py
@@ -11,7 +11,7 @@ def log():
 
 
 def test_write(qtbot, log):
-    logd = PyDMLogDisplay(log.name, level=logging.INFO)
+    logd = PyDMLogDisplay(parent=None, logname=log.name, level=logging.INFO)
     logd.show()
     # Watch our error message show up in the log
     err_msg = 'This is a test of the emergency broadcast system'

--- a/pydm/tests/widgets/test_logdisplay.py
+++ b/pydm/tests/widgets/test_logdisplay.py
@@ -12,6 +12,7 @@ def log():
 
 def test_write(qtbot, log):
     logd = PyDMLogDisplay(parent=None, logname=log.name, level=logging.INFO)
+    qtbot.addWidget(logd)
     logd.show()
     # Watch our error message show up in the log
     err_msg = 'This is a test of the emergency broadcast system'
@@ -24,6 +25,7 @@ def test_write(qtbot, log):
     # Change the level so debug does show up
     logd.set_level('DEBUG')
     assert logd.handler.level == logging.DEBUG
+    assert logd.log.level <= logging.DEBUG
     log.debug(debug_msg)
     assert debug_msg in logd.text.toPlainText()
     # Change the name and make sure we still see what we need

--- a/pydm/tests/widgets/test_logdisplay.py
+++ b/pydm/tests/widgets/test_logdisplay.py
@@ -23,7 +23,7 @@ def test_write(qtbot, log):
     log.debug(debug_msg)
     assert debug_msg not in logd.text.toPlainText()
     # Change the level so debug does show up
-    logd.set_level('DEBUG')
+    logd.setLevel('DEBUG')
     assert logd.handler.level == logging.DEBUG
     assert logd.log.level <= logging.DEBUG
     log.debug(debug_msg)

--- a/pydm/widgets/logdisplay.py
+++ b/pydm/widgets/logdisplay.py
@@ -35,7 +35,8 @@ class GuiHandler(QObject, logging.Handler):
     message = pyqtSignal(str)
 
     def __init__(self, level=logging.NOTSET, parent=None):
-        super().__init__(level=level)
+        logging.Handler.__init__(self, level=level)
+        QObject.__init__(self)
         # Set the parent widget
         self.setParent(parent)
 
@@ -69,7 +70,7 @@ class PyDMLogDisplay(QWidget):
     default_level = logging.INFO
 
     def __init__(self, logname=None, level=logging.NOTSET, parent=None):
-        super().__init__(parent=parent)
+        QWidget.__init__(self, parent=parent)
         # Create Widgets
         self.label = QLabel('Minimum displayed log level: ')
         self.combo = QComboBox()

--- a/pydm/widgets/logdisplay.py
+++ b/pydm/widgets/logdisplay.py
@@ -1,0 +1,143 @@
+import logging
+
+from pydm.PyQt.QtCore import QObject, pyqtSlot, pyqtSignal, pyqtProperty
+from pydm.PyQt.QtGui import (QWidget, QPlainTextEdit, QComboBox, QLabel,
+                             QHBoxLayout, QVBoxLayout)
+
+logger = logging.getLogger(__name__)
+
+
+class GuiHandler(QObject, logging.Handler):
+    """
+    Handler for PyDM Applications
+
+    A composite of a QObject and a logging handler. This can be added to a
+    ``logging.Logger`` object just like any standard ``logging.Handler`` and
+    will emit logging messages as pyqtSignals
+
+    .. code:: python
+
+        # Create a log and GuiHandler
+        logger = logging.getLogger()
+        ui_handler = GuiHandler(level=logging.INFO)
+        # Attach our handler to the log
+        logger.addHandler(ui_handler)
+        # Publish log message via pyqtSignal
+        ui_handler.message.connect(mySlot)
+
+    Parameters
+    ----------
+    level: int
+        Level of Handler
+
+    parent: QObject, optional
+    """
+    message = pyqtSignal(str)
+
+    def __init__(self, level=logging.NOTSET, parent=None):
+        super().__init__(level=level)
+        # Set the parent widget
+        self.setParent(parent)
+
+    def emit(self, record):
+        """Emit formatted log messages when received"""
+        self.message.emit(self.format(record))
+
+
+class PyDMLogDisplay(QWidget):
+    """
+    Standard display for Log Output
+
+    This widget handles instantating a ``GuiHandler`` and displaying log
+    messages to a ``QPlainTextEdit``. The level of the log can be changed from
+    inside the widget itself, allowing users to select from any of the
+    ``.levels`` specified by the widget.
+
+    Parameters
+    ----------
+    logname : str
+        Name of log to display in widget
+
+    level : logging.Level
+        Initial level of log display
+
+    parent : QObject, optional
+    """
+    terminator = '\n'
+    levels = ['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']
+    default_format = '%(asctime)s %(message)s'
+    default_level = logging.INFO
+
+    def __init__(self, logname=None, level=logging.NOTSET, parent=None):
+        super().__init__(parent=parent)
+        # Create Widgets
+        self.label = QLabel('Minimum displayed log level: ')
+        self.combo = QComboBox()
+        self.text = QPlainTextEdit()
+        # Create layout
+        layout = QVBoxLayout()
+        level_control = QHBoxLayout()
+        level_control.addWidget(self.label)
+        level_control.addWidget(self.combo)
+        layout.addLayout(level_control)
+        layout.addWidget(self.text)
+        self.setLayout(layout)
+        # Allow QCombobox to control log level
+        self.combo.addItems(self.levels)
+        self.combo.currentIndexChanged[str].connect(self.set_level)
+        # Create a handler with the default format
+        self.handler = GuiHandler(level=level, parent=self)
+        self.logformat = self.default_format
+        self.handler.message.connect(self.write)
+        # Create logger. Either as a root or given logname
+        self.log = None
+        self.logname = logname or ''
+
+    @pyqtProperty(str)
+    def logname(self):
+        """Name of associated log"""
+        return self.log.name
+
+    @logname.setter
+    def logname(self, name):
+        # Disconnect prior log from handler
+        if self.log:
+            self.log.removeHandler(self.handler)
+        # Reattach handler to new handler
+        self.log = logging.getLogger(name)
+        # Ensure that the log matches level of handler
+        self.log.setLevel(self.handler.level)
+        # Attach preconfigured handler
+        self.log.addHandler(self.handler)
+
+    @pyqtProperty(str)
+    def logformat(self):
+        """Format for log messages"""
+        return self.handler.formatter._fmt
+
+    @logformat.setter
+    def logformat(self, fmt):
+        self.handler.setFormatter(logging.Formatter(fmt))
+
+    @pyqtSlot(str)
+    def write(self, message):
+        """Write a message to the log display"""
+        # We split the incoming message by new lines. In prior iterations of
+        # this widget it was discovered that large blocks of text cause issues
+        # at the Qt level.
+        for msg in message.split(self.terminator):
+            self.text.appendPlainText(msg)
+
+    @pyqtSlot(str)
+    def set_level(self, level):
+        """Set the level of the contained logger"""
+        # Get the level from the incoming string specification
+        try:
+            level = getattr(logging, level.upper())
+        except AttributeError as exc:
+            logger.exception("Invalid logging level specified %s",
+                             level.upper())
+        else:
+            # Set the existing handler and logger to this level
+            self.log.setLevel(level)
+            self.handler.setLevel(level)

--- a/pydm/widgets/logdisplay.py
+++ b/pydm/widgets/logdisplay.py
@@ -120,17 +120,17 @@ class PyDMLogDisplay(QWidget, LogLevels):
         # Allow QCombobox to control log level
         for log_level, value in LogLevels.as_dict().items():
             self.combo.addItem(log_level, value)
-        self.combo.currentIndexChanged[str].connect(self.set_level)
+        self.combo.currentIndexChanged[str].connect(self.setLevel)
         # Allow QPushButton to clear log text
         self.clear_btn.clicked.connect(self.clear)
         # Create a handler with the default format
         self.handler = GuiHandler(level=level, parent=self)
-        self.logformat = self.default_format
+        self.logFormat = self.default_format
         self.handler.message.connect(self.write)
         # Create logger. Either as a root or given logname
         self.log = None
         self.level = None
-        self.logname = logname or ''
+        self.logName = logname or ''
         self.logLevel = level
 
     @pyqtProperty(LogLevels)
@@ -145,12 +145,12 @@ class PyDMLogDisplay(QWidget, LogLevels):
             self.combo.setCurrentIndex(idx)
 
     @pyqtProperty(str)
-    def logname(self):
+    def logName(self):
         """Name of associated log"""
         return self.log.name
 
-    @logname.setter
-    def logname(self, name):
+    @logName.setter
+    def logName(self, name):
         # Disconnect prior log from handler
         if self.log:
             self.log.removeHandler(self.handler)
@@ -164,12 +164,12 @@ class PyDMLogDisplay(QWidget, LogLevels):
         self.log.addHandler(self.handler)
 
     @pyqtProperty(str)
-    def logformat(self):
+    def logFormat(self):
         """Format for log messages"""
         return self.handler.formatter._fmt
 
-    @logformat.setter
-    def logformat(self, fmt):
+    @logFormat.setter
+    def logFormat(self, fmt):
         self.handler.setFormatter(logging.Formatter(fmt))
 
     @pyqtSlot(str)
@@ -187,7 +187,7 @@ class PyDMLogDisplay(QWidget, LogLevels):
         self.text.clear()
 
     @pyqtSlot(str)
-    def set_level(self, level):
+    def setLevel(self, level):
         """Set the level of the contained logger"""
         # Get the level from the incoming string specification
         try:

--- a/pydm/widgets/logdisplay.py
+++ b/pydm/widgets/logdisplay.py
@@ -56,20 +56,21 @@ class PyDMLogDisplay(QWidget):
 
     Parameters
     ----------
+    parent : QObject, optional
+
     logname : str
         Name of log to display in widget
 
     level : logging.Level
         Initial level of log display
 
-    parent : QObject, optional
     """
     terminator = '\n'
     levels = ['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']
     default_format = '%(asctime)s %(message)s'
     default_level = logging.INFO
 
-    def __init__(self, logname=None, level=logging.NOTSET, parent=None):
+    def __init__(self, parent=None, logname=None, level=logging.NOTSET):
         QWidget.__init__(self, parent=parent)
         # Create Widgets
         self.label = QLabel('Minimum displayed log level: ')

--- a/pydm/widgets/qtplugins.py
+++ b/pydm/widgets/qtplugins.py
@@ -14,6 +14,7 @@ from .frame import PyDMFrame
 from .image import PyDMImageView
 from .label import PyDMLabel
 from .line_edit import PyDMLineEdit
+from .logdisplay import PyDMLogDisplay
 from .pushbutton import PyDMPushButton
 from .related_display_button import PyDMRelatedDisplayButton
 from .shell_command import PyDMShellCommand
@@ -76,6 +77,9 @@ PyDMLabelPlugin = qtplugin_factory(PyDMLabel, group=WidgetCategory.DISPLAY)
 
 # Line Edit plugin
 PyDMLineEditPlugin = qtplugin_factory(PyDMLineEdit, group=WidgetCategory.INPUT)
+
+# Log Viewer
+PyDMLogDisplayPlugin = qtplugin_factory(PyDMLogDisplay, group=WidgetCategory.DISPLAY)
 
 # Push Button plugin
 PyDMPushButtonPlugin = qtplugin_factory(PyDMPushButton, group=WidgetCategory.INPUT)

--- a/pydm_launcher/main.py
+++ b/pydm_launcher/main.py
@@ -43,7 +43,8 @@ def main():
     parser.add_argument(
         '--log_level',
         help='Configure level of log display',
-        default=logging.INFO
+        choices=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'],
+        default='INFO'
         )
     parser.add_argument(
         '-m', '--macro',
@@ -58,6 +59,7 @@ def main():
              ' (which is a QApplication subclass).',
         nargs=argparse.REMAINDER
         )
+
     pydm_args = parser.parse_args()
     macros = None
     if pydm_args.macro is not None:
@@ -66,10 +68,14 @@ def main():
         except ValueError:
             raise ValueError("Could not parse macro argument as JSON.")
 
-    logging.basicConfig(
-        level=pydm_args.log_level,
-        format='[%(asctime)s] - %(message)s'
-        )
+    logger = logging.getLogger('')
+    handler = logging.StreamHandler()
+    formatter = logging.Formatter('[%(asctime)s] [%(levelname)-8s] - %(message)s')
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+    if pydm_args.log_level:
+        logger.setLevel(pydm_args.log_level)
+        handler.setLevel(pydm_args.log_level)
 
     app = PyDMApplication(
         ui_file=pydm_args.displayfile,

--- a/run_tests.py
+++ b/run_tests.py
@@ -5,11 +5,16 @@ import pytest
 if __name__ == '__main__':
     # Show output results from every test function
     # Show the message output for skipped and expected failures
-    args = ['-v', '-vrxs', '--cov=pydm', '--cov-report', 'term-missing']
+    args = ['-v', '-vrxs']
 
     # Add extra arguments
     if len(sys.argv) > 1:
         args.extend(sys.argv[1:])
+
+    # Show coverage
+    if '--show-cov' in args:
+        args.extend(['--cov=pydm', '--cov-report', 'term-missing'])
+        args.remove('--show-cov')
 
     print('pytest arguments: {}'.format(args))
 


### PR DESCRIPTION
## Description
Generalized way to show logging output in PyDM

This adds:
* GuiHandler -> A `QObject` `logging.Handler` hybrid that emits log messages from a signal
* `PyDMLogDisplay` -> A `QPlainTextEdit` with a `QComboBox` that allows the operator to select the level of the log. The format of the log can also be selected by the user using the same syntax as a `logging.Formatter`


### Planned but not included
* QtDesigner Plugin
* Add as a utility pop-up available in `PyDMMainWindow`. Allows for live debugging of the `PyDM` system.

### In Addition
* The coverage display is very verbose. It made it hard to see the output of my failed tests. I added an option to `run_tests.py` that allows you to show the coverage `--show-cov`, but I did not have it do this by default. I think we should have a button for turning this on or off but I'm not convinced if we want to show the results of the coverage by default. Please advise!

## Motivation
Discussed https://github.com/pcdshub/typhon/issues/16

## Screenshot
<img width="380" alt="screen shot 2018-04-20 at 2 29 56 pm" src="https://user-images.githubusercontent.com/25753048/39074717-6625e234-44a7-11e8-87c6-263e79ad1809.png">
