### PR TITLE
FIX: Create PyDMBitIndicator using self as parent.

### DIFF
--- a/pydm/widgets/byte.py
+++ b/pydm/widgets/byte.py
@@ -422,7 +422,7 @@ class PyDMByteIndicator(QWidget, PyDMWidget):
         self._num_bits = new_num_bits
         for indicator in self._indicators:
             indicator.deleteLater()
-        self._indicators = [PyDMBitIndicator() for i in range(0, self._num_bits)]
+        self._indicators = [PyDMBitIndicator(self) for i in range(0, self._num_bits)]
         old_labels = self.labels
         new_labels = ["Bit {}".format(i) for i in range(0, self._num_bits)]
         for i, old_label in enumerate(old_labels):

--- a/pydm/widgets/byte.py
+++ b/pydm/widgets/byte.py
@@ -476,7 +476,7 @@ class PyDMByteIndicator(QWidget, PyDMWidget):
         """
         for label in self._labels:
             label.deleteLater()
-        self._labels = [QLabel(text) for text in new_labels]
+        self._labels = [QLabel(text, parent=self) for text in new_labels]
         # Have to reset showLabels to hide or show all the new labels we just made.
         self.showLabels = self._show_labels
         self.rebuild_layout()


### PR DESCRIPTION
This is generating a weird flickering when using the Widget on Windows and it also creates a little delay in general. This small fix was tested locally by me at my mac.
Attn. @joaopmrod

So what happens is that:
- When creating a widget without a parent it shows up just *flying* on the screen on Windows... so you see a bunch of flickering screens before your real screen shows up
- Moreover, the creation of the widget without parent and later adding it to the layout generates an overhead on the system...