### PR TITLE
MAINT: Refactor Plugin Loading

### DIFF
--- a/docs/source/add_data_plugins.rst
+++ b/docs/source/add_data_plugins.rst
@@ -1,0 +1,24 @@
+Including Data Plugins
+######################
+PyDM is built with a flexible architecture such that information from multiple
+sources can be displayed without changing widget code. This allows widgets to
+be agnostic of the data source that updates them and focus on the logic of
+displaying information.  PyDM will always import the built-in plugins found in
+the ``data_plugins`` folder,  but some advanced users may want to include
+custom data plugins as well. A mapping of ``protocol`` to ``PyDMPlugin`` is
+kept within ``pydm.data_plugins.plugin_modules`` and mirrored in
+:attr:`.PyDMApplication.plugins`. This is where the ``PyDMApplication`` will
+determine which plugin to use when you provided it with a channel.
+
+If you would like add a library of plugins from a specific folder for every
+session, PyDM will check all paths provided by the environment variable
+``$PYDM_DATA_PLUGINS_PATH``. This folder will be searched for files that fit
+the name ``{}_plugin.py`` and attempt to load the contained plugin. Each of
+these files should contain a single ``PyDMPlugin``. For those searching for a
+more programmatic approach the API is documented below. Take note that all
+plugins should be registered before the ``PyDMApplication`` is launched,
+otherwise they will not be registered in time for connections to be made.
+
+.. autofunction:: pydm.data_plugins.add_plugin
+
+.. autofunction:: pydm.data_plugins.load_plugins_from_path

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -25,6 +25,7 @@ as well as a straightforward python framework to build complex applications.
    :caption: User & API Documentation
 
    widgets/index.rst
+   add_data_plugins.rst
    application.rst
    channel.rst
    utilities/index.rst

--- a/pydm/application.py
+++ b/pydm/application.py
@@ -78,7 +78,7 @@ class PyDMApplication(QApplication):
         create a PyDMMainWindow in the initialization (Default is True).
     """
     # Instantiate our plugins.
-    plugins = {plugin.protocol: plugin() for plugin in data_plugins.plugin_modules}
+    plugins = data_plugins.plugin_modules
     tools = dict()
 
     # HACK. To be replaced with some stylesheet stuff eventually.

--- a/pydm/data_plugins/__init__.py
+++ b/pydm/data_plugins/__init__.py
@@ -48,7 +48,7 @@ def load_plugins_from_path(locations, token):
     Returns
     -------
     plugins: dict
-        Dictionary of plugins
+        Dictionary of plugins add from this folder
     """
     added_plugins = dict()
     for loc in locations:

--- a/pydm/data_plugins/__init__.py
+++ b/pydm/data_plugins/__init__.py
@@ -79,12 +79,6 @@ def load_plugins_from_path(locations, token):
                     classes = list(set(classes))
                     for plugin in classes:
                         if plugin.protocol is not None:
-                            if plugin_modules.get(plugin.protocol, plugin) != plugin:
-                                logger.warning("More than one plugin is "
-                                               "attempting to register the %s "
-                                               "protocol. Which plugin will get "
-                                               "called to handle this protocol "
-                                               "is undefined.", plugin.protocol)
                             # Add to global plugin list
                             add_plugin(plugin)
                             # Add to return dictionary of added plugins

--- a/pydm/data_plugins/__init__.py
+++ b/pydm/data_plugins/__init__.py
@@ -59,7 +59,7 @@ def load_plugins_from_path(locations, token):
 
             logger.info("Looking for PyDM Data Plugins at: {}".format(root))
             for name in files:
-                if name.endswith(DATA_PLUGIN_TOKEN):
+                if name.endswith(token):
                     try:
                         logger.info("\tTrying to load {}...".format(name))
                         sys.path.append(root)

--- a/pydm/data_plugins/__init__.py
+++ b/pydm/data_plugins/__init__.py
@@ -9,7 +9,6 @@ import inspect
 import logging
 import imp
 import uuid
-import warnings
 from .plugin import PyDMPlugin
 
 logger = logging.getLogger(__name__)
@@ -66,11 +65,10 @@ def load_plugins_from_path(locations, token):
                         module = imp.load_source(temp_name,
                                                  os.path.join(root, name))
                     except Exception as e:
-                        warnings.warn("Unable to import plugin file {}."
-                                      "This plugin will be skipped."
-                                      "The exception raised was: {}"
-                                      "".format(name, e),
-                                      RuntimeWarning, stacklevel=2)
+                        logger.exception("Unable to import plugin file {}."
+                                         "This plugin will be skipped."
+                                         "The exception raised was: {}",
+                                         name, e)
                     classes = [obj for name, obj in inspect.getmembers(module)
                                if (inspect.isclass(obj)
                                    and issubclass(obj, PyDMPlugin)
@@ -80,24 +78,18 @@ def load_plugins_from_path(locations, token):
                     if len(classes) == 0:
                         continue
                     if len(classes) > 1:
-                        warnings.warn("More than one PyDMPlugin subclass "
-                                      "in file {}. The first occurrence "
-                                      "(in alphabetical order) will be "
-                                      "opened: {}"
-                                      "".format(name, classes[0].__name__),
-                                      RuntimeWarning,
-                                      stacklevel=0)
+                        logger.warning("More than one PyDMPlugin subclass "
+                                       "in file {}. The first occurrence "
+                                       "(in alphabetical order) will be "
+                                       "opened: {}", name, classes[0].__name__)
                     plugin = classes[0]
                     if plugin.protocol is not None:
                         if plugin_modules.get(plugin.protocol) != plugin:
-                            warnings.warn("More than one plugin is attempting "
-                                          "to register the {protocol} "
-                                          "protocol. Which plugin will get "
-                                          "called to handle this protocol "
-                                          "is undefined."
-                                          "".format(protocol=plugin.protocol,
-                                                    plugin=plugin.__name__),
-                                          RuntimeWarning, stacklevel=0)
+                            logger.warning("More than one plugin is "
+                                           "attempting to register the %s "
+                                           "protocol. Which plugin will get "
+                                           "called to handle this protocol "
+                                           "is undefined.", plugin.protocol)
                         add_plugin(plugin)
 
 

--- a/pydm/data_plugins/__init__.py
+++ b/pydm/data_plugins/__init__.py
@@ -16,7 +16,7 @@ from .plugin import PyDMPlugin
 
 logger = logging.getLogger(__name__)
 plugin_dir = os.path.dirname(os.path.realpath(__file__))
-plugin_modules = []
+plugin_modules = {}
 
 """
 Loads all the data plugins available at the given
@@ -37,6 +37,23 @@ locations.insert(0, plugin_dir)
 logger.info("*"*80)
 logger.info("* Loading PyDM Data Plugins")
 logger.info("*"*80)
+
+
+def add_plugin(plugin):
+    """
+    Add a PyDM plugin to the global registry of protocol vs. plugins
+
+    Parameters
+    ----------
+    plugin: PyDMPlugin
+    """
+    # Warn users if we are overwriting a protocol which already has a plugin
+    if plugin.protocol in plugin_modules:
+        logger.warning("Replacing %s plugin with %s for use with protocol %s",
+                       plugin, plugin_modules[plugin.protocol],
+                       plugin.protocol)
+    plugin_modules[plugin.protocol] = plugin
+
 
 for loc in locations:
     for root, _, files in os.walk(loc):

--- a/pydm/data_plugins/__init__.py
+++ b/pydm/data_plugins/__init__.py
@@ -71,6 +71,7 @@ def load_plugins_from_path(locations, token):
                                          "This plugin will be skipped."
                                          "The exception raised was: {}",
                                          name, e)
+                        continue
                     classes = [obj for name, obj in inspect.getmembers(module)
                                if (inspect.isclass(obj)
                                    and issubclass(obj, PyDMPlugin)

--- a/pydm/data_plugins/__init__.py
+++ b/pydm/data_plugins/__init__.py
@@ -22,13 +22,14 @@ def add_plugin(plugin):
     Parameters
     ----------
     plugin: PyDMPlugin
+        The class of plugin to instantiate
     """
     # Warn users if we are overwriting a protocol which already has a plugin
     if plugin.protocol in plugin_modules:
         logger.warning("Replacing %s plugin with %s for use with protocol %s",
                        plugin, plugin_modules[plugin.protocol],
                        plugin.protocol)
-    plugin_modules[plugin.protocol] = plugin
+    plugin_modules[plugin.protocol] = plugin()
 
 
 def load_plugins_from_path(locations, token):

--- a/pydm/data_plugins/__init__.py
+++ b/pydm/data_plugins/__init__.py
@@ -77,25 +77,18 @@ def load_plugins_from_path(locations, token):
                                    and obj is not PyDMPlugin)]
                     # De-duplicate classes.
                     classes = list(set(classes))
-                    if len(classes) == 0:
-                        continue
-                    if len(classes) > 1:
-                        logger.warning("More than one PyDMPlugin subclass "
-                                       "in file {}. The first occurrence "
-                                       "(in alphabetical order) will be "
-                                       "opened: {}", name, classes[0].__name__)
-                    plugin = classes[0]
-                    if plugin.protocol is not None:
-                        if plugin_modules.get(plugin.protocol, plugin) != plugin:
-                            logger.warning("More than one plugin is "
-                                           "attempting to register the %s "
-                                           "protocol. Which plugin will get "
-                                           "called to handle this protocol "
-                                           "is undefined.", plugin.protocol)
-                        # Add to global plugin list
-                        add_plugin(plugin)
-                        # Add to return dictionary of added plugins
-                        added_plugins[plugin.protocol] = plugin
+                    for plugin in classes:
+                        if plugin.protocol is not None:
+                            if plugin_modules.get(plugin.protocol, plugin) != plugin:
+                                logger.warning("More than one plugin is "
+                                               "attempting to register the %s "
+                                               "protocol. Which plugin will get "
+                                               "called to handle this protocol "
+                                               "is undefined.", plugin.protocol)
+                            # Add to global plugin list
+                            add_plugin(plugin)
+                            # Add to return dictionary of added plugins
+                            added_plugins[plugin.protocol] = plugin
     return added_plugins
 
 

--- a/pydm/data_plugins/__init__.py
+++ b/pydm/data_plugins/__init__.py
@@ -50,6 +50,7 @@ def load_plugins_from_path(locations, token):
     plugins: dict
         Dictionary of plugins
     """
+    added_plugins = dict()
     for loc in locations:
         for root, _, files in os.walk(loc):
             if root.split(os.path.sep)[-1].startswith("__"):
@@ -90,7 +91,11 @@ def load_plugins_from_path(locations, token):
                                            "protocol. Which plugin will get "
                                            "called to handle this protocol "
                                            "is undefined.", plugin.protocol)
+                        # Add to global plugin list
                         add_plugin(plugin)
+                        # Add to return dictionary of added plugins
+                        added_plugins[plugin.protocol] = plugin
+    return added_plugins
 
 
 # Load the data plugins from PYDM_DATA_PLUGINS_PATH

--- a/pydm/data_plugins/__init__.py
+++ b/pydm/data_plugins/__init__.py
@@ -86,7 +86,7 @@ def load_plugins_from_path(locations, token):
                                        "opened: {}", name, classes[0].__name__)
                     plugin = classes[0]
                     if plugin.protocol is not None:
-                        if plugin_modules.get(plugin.protocol) != plugin:
+                        if plugin_modules.get(plugin.protocol, plugin) != plugin:
                             logger.warning("More than one plugin is "
                                            "attempting to register the %s "
                                            "protocol. Which plugin will get "

--- a/pydm/tests/test_data_plugins_import.py
+++ b/pydm/tests/test_data_plugins_import.py
@@ -1,8 +1,8 @@
-import os.path
-import tempfile
+import os
 
 from pydm.data_plugins import (add_plugin, PyDMPlugin, plugin_modules,
                                load_plugins_from_path)
+
 
 def test_data_plugin_add(qapp):
     # Create test PyDMPlugin with mock protocol
@@ -14,15 +14,17 @@ def test_data_plugin_add(qapp):
     assert isinstance(qapp.plugins['tst'], test_plug)
 
 
-def test_plugin_directroy_loading(qapp):
+def test_plugin_directory_loading(qapp):
     # Create a fake file
-    with tempfile.NamedTemporaryFile(mode='w+', suffix='.py') as tmp:
-        tmp.write(fake_file)
-        tmp.flush()
-        dirname = os.path.dirname(tmp.name)
-        load_plugins_from_path([dirname], '.py')
-        assert 'tst1' in plugin_modules
-        assert 'tst2' in plugin_modules
+    cur_dir = os.getcwd()
+    with open(os.path.join(cur_dir, 'plugin_foo.py'), 'w+') as handle:
+        handle.write(fake_file)
+        handle.flush()
+    # Load plugins
+    load_plugins_from_path([cur_dir], 'foo.py')
+    assert 'tst1' in plugin_modules
+    assert 'tst2' in plugin_modules
+    os.remove(os.path.join(cur_dir, 'plugin_foo.py'))
 
 
 fake_file = """\
@@ -36,4 +38,3 @@ class TestPlugin1(PyDMPlugin):
 class TestPlugin2(PyDMPlugin):
     protocol = 'tst2'
 """
-

--- a/pydm/tests/test_data_plugins_import.py
+++ b/pydm/tests/test_data_plugins_import.py
@@ -3,12 +3,12 @@ from pydm.data_plugins import add_plugin, PyDMPlugin, plugin_modules
 
 def test_data_plugin_add(qapp):
     # Create test PyDMPlugin with mock protocol
-    test_plug = PyDMPlugin()
+    test_plug = PyDMPlugin
     test_plug.protocol = 'tst'
     # Check that adding this after import will be reflected in PyDMApp
     add_plugin(test_plug)
-    assert plugin_modules['tst'] == test_plug
-    assert qapp.plugins['tst'] == test_plug
+    assert isinstance(plugin_modules['tst'], test_plug)
+    assert isinstance(qapp.plugins['tst'], test_plug)
 
 
 def test_default_plugin_loading(qapp):

--- a/pydm/tests/test_data_plugins_import.py
+++ b/pydm/tests/test_data_plugins_import.py
@@ -1,5 +1,8 @@
-from pydm.data_plugins import add_plugin, PyDMPlugin, plugin_modules
+import os.path
+import tempfile
 
+from pydm.data_plugins import (add_plugin, PyDMPlugin, plugin_modules,
+                               load_plugins_from_path)
 
 def test_data_plugin_add(qapp):
     # Create test PyDMPlugin with mock protocol
@@ -11,7 +14,26 @@ def test_data_plugin_add(qapp):
     assert isinstance(qapp.plugins['tst'], test_plug)
 
 
-def test_default_plugin_loading(qapp):
-    # Making assumption we will always have a ca plugin in standard lib
-    assert 'ca' in plugin_modules
-    assert 'ca' in qapp.plugins
+def test_plugin_directroy_loading(qapp):
+    # Create a fake file
+    with tempfile.NamedTemporaryFile(mode='w+', suffix='.py') as tmp:
+        tmp.write(fake_file)
+        tmp.flush()
+        dirname = os.path.dirname(tmp.name)
+        load_plugins_from_path([dirname], '.py')
+        assert 'tst1' in plugin_modules
+        assert 'tst2' in plugin_modules
+
+
+fake_file = """\
+from pydm.data_plugins import PyDMPlugin
+
+
+class TestPlugin1(PyDMPlugin):
+    protocol = 'tst1'
+
+
+class TestPlugin2(PyDMPlugin):
+    protocol = 'tst2'
+"""
+

--- a/pydm/tests/test_data_plugins_import.py
+++ b/pydm/tests/test_data_plugins_import.py
@@ -1,0 +1,17 @@
+from pydm.data_plugins import add_plugin, PyDMPlugin, plugin_modules
+
+
+def test_data_plugin_add(qapp):
+    # Create test PyDMPlugin with mock protocol
+    test_plug = PyDMPlugin()
+    test_plug.protocol = 'tst'
+    # Check that adding this after import will be reflected in PyDMApp
+    add_plugin(test_plug)
+    assert plugin_modules['tst'] == test_plug
+    assert qapp.plugins['tst'] == test_plug
+
+
+def test_default_plugin_loading(qapp):
+    # Making assumption we will always have a ca plugin in standard lib
+    assert 'ca' in plugin_modules
+    assert 'ca' in qapp.plugins


### PR DESCRIPTION
## Description
Refactored the way plugins are loaded. There are now two methods:

* ``add_plugin``
     - Add a plugin to the global registry
* ``load_plugins_from_path``
     -  Searches a list of directories for valid `PyDMPlugin`objects. This is automatically called in `pydm/data_plugins` as well as any directories listed in`$PYDM_DATA_PLUGIN_PATH`.


Finally, the last major change is now instead of constructing the mapping of protocol vs. plugins in the `PyDMApplication` itself, `PyDMApplication.plugins` is just linked to `data_plugins.plugin_modules`. `plugin_modules` was formerly a `list` is now a `dict`. This allows plugins to be added after `PyDMApplication` is imported. This is explicitly tested now in `test_add_plugin`.

### Question
The way this was loading plugins before enforced a few restrictions:
1. Can not overwrite existing protocols
2. Can not have multiple plugins come from a single.

I find both of these to be kind of arbitrary. The first seems like it could be reasonable to want i.e different facilities have different `arch` data plugins. As long as there is a proper warning generated it seems like this should be tolerated. Second, just seems like a strange thing to check for and deleting that might clean the code up.

## Motivation
Closes #307 

## Documentation
I couldn't find a page about how these plugins are loaded so added one myself. Please let me know if this is in the correct location.

## Tests
Created `test_data_plugins_import`. These are slightly unnecessary because if plugin loading fails we'll see a cascade of errors in other tests but still fine for completeness. 