### PR TITLE
FIX: PyDMImageView bug on reshaping image for Clike reading order.

### DIFF
--- a/pydm/widgets/image.py
+++ b/pydm/widgets/image.py
@@ -32,12 +32,11 @@ class PyDMImageView(ImageView, PyDMWidget, PyDMColorMap, ReadingOrder):
         The channel to be used by the widget to receive the image width
         information
     """
+    ReadingOrder = ReadingOrder
 
     Q_ENUMS(ReadingOrder)
     Q_ENUMS(PyDMColorMap)
 
-    reading_orders = {ReadingOrder.Fortranlike: 'F',
-                      ReadingOrder.Clike: 'C'}
     color_maps = cmaps
 
     def __init__(self, parent=None, image_channel=None, width_channel=None):
@@ -297,13 +296,11 @@ class PyDMImageView(ImageView, PyDMWidget, PyDMColorMap, ReadingOrder):
                 # We don't have a width for this image yet, so we can't draw it
                 return
             if self.readingOrder == ReadingOrder.Clike:
-                img = self.image_waveform.reshape(
-                    (-1, self.imageWidth),
-                    order=self.reading_orders[self._reading_order])
+                img = self.image_waveform.reshape((-1, self.imageWidth),
+                                                  order='C')
             else:
-                img = self.image_waveform.reshape(
-                    (self.imageWidth, -1),
-                    order=self.reading_orders[self._reading_order])
+                img = self.image_waveform.reshape((self.imageWidth, -1),
+                                                  order='F')
         else:
             img = self.image_waveform
 

--- a/pydm/widgets/image.py
+++ b/pydm/widgets/image.py
@@ -148,7 +148,6 @@ class PyDMImageView(ImageView, PyDMWidget, PyDMColorMap, ReadingOrder):
             self.cm_min = new_min
             if self.cm_min > self.cm_max:
                 self.cm_max = self.cm_min
-            self.setColorMap()
 
     @pyqtProperty(float)
     def colorMapMax(self):
@@ -175,7 +174,6 @@ class PyDMImageView(ImageView, PyDMWidget, PyDMColorMap, ReadingOrder):
             self.cm_max = new_max
             if self.cm_max < self.cm_min:
                 self.cm_min = self.cm_max
-            self.setColorMap()
 
     def setColorMapLimits(self, mn, mx):
         """
@@ -192,7 +190,6 @@ class PyDMImageView(ImageView, PyDMWidget, PyDMColorMap, ReadingOrder):
             return
         self.cm_max = mx
         self.cm_min = mn
-        self.setColorMap()
 
     @pyqtProperty(PyDMColorMap)
     def colorMap(self):

--- a/pydm/widgets/image.py
+++ b/pydm/widgets/image.py
@@ -22,6 +22,13 @@ class PyDMImageView(ImageView, PyDMWidget, PyDMColorMap, ReadingOrder):
     """
     A PyQtGraph ImageView with support for Channels and more from PyDM.
 
+    If there is no :attr:`channelWidth` it is possible to define the width of
+    the image with the :attr:`width` property.
+
+    The :attr:`normalizeData` property defines if the colors of the images are
+    relative to the :attr:`colorMapMin` and :attr:`colorMapMax` property or to
+    the minimum and maximum values of the image.
+
     Parameters
     ----------
     parent : QWidget
@@ -32,6 +39,7 @@ class PyDMImageView(ImageView, PyDMWidget, PyDMColorMap, ReadingOrder):
         The channel to be used by the widget to receive the image width
         information
     """
+
     ReadingOrder = ReadingOrder
 
     Q_ENUMS(ReadingOrder)

--- a/pydm/widgets/image.py
+++ b/pydm/widgets/image.py
@@ -296,9 +296,14 @@ class PyDMImageView(ImageView, PyDMWidget, PyDMColorMap, ReadingOrder):
             if self.imageWidth < 1:
                 # We don't have a width for this image yet, so we can't draw it
                 return
-            img = self.image_waveform.reshape(
-                self.imageWidth, -1,
-                order=self.reading_orders[self._reading_order])
+            if self.readingOrder == ReadingOrder.Clike:
+                img = self.image_waveform.reshape(
+                    (-1, self.imageWidth),
+                    order=self.reading_orders[self._reading_order])
+            else:
+                img = self.image_waveform.reshape(
+                    (self.imageWidth, -1),
+                    order=self.reading_orders[self._reading_order])
         else:
             img = self.image_waveform
 


### PR DESCRIPTION
Hey guys! This PR fixes a bug that I noticed when using an image of non-square dimensions (that is why none of us noticed before, because the `pydm-testing-ioc` generates a square image).