### PR TITLE
PyDMDrawing Filename

### DIFF
--- a/pydm/tests/widgets/test_drawing.py
+++ b/pydm/tests/widgets/test_drawing.py
@@ -1,6 +1,6 @@
 # Unit Tests for the PyDM drawing widgets
 
-
+import os
 from logging import ERROR
 import pytest
 
@@ -503,6 +503,17 @@ def test_pydmdrawingimage_construct(qtbot):
 
     if not is_pydm_app():
         assert pydm_drawingimage.get_designer_window()
+
+    base_path = os.path.dirname(__file__)
+    test_file = os.path.join(base_path, '..', '..', '..', 'examples', 'drawing', 'SLAC_logo.jpeg')
+    pydm_drawingimage2 = PyDMDrawingImage(filename=test_file)
+    qtbot.addWidget(pydm_drawingimage2)
+
+    pydm_drawingimage3 = PyDMDrawingImage(filename=os.path.abspath(test_file))
+    qtbot.addWidget(pydm_drawingimage3)
+
+    pydm_drawingimage4 = PyDMDrawingImage(filename="foo")
+    qtbot.addWidget(pydm_drawingimage4)
 
 
 def test_pydmdrawingimage_get_designer_window(qtbot):

--- a/pydm/widgets/drawing.py
+++ b/pydm/widgets/drawing.py
@@ -431,6 +431,8 @@ class PyDMDrawingImage(PyDMDrawing):
     init_channel : str, optional
         The channel to be used by the widget.
     """
+    null_color = Qt.gray
+
     def __init__(self, parent=None, init_channel=None, filename=""):
         super(PyDMDrawingImage, self).__init__(parent, init_channel)
         self._pixmap = QPixmap()
@@ -501,7 +503,19 @@ class PyDMDrawingImage(PyDMDrawing):
             except Exception:
                 logger.exception("Unable to find full filepath for %s",
                                  self._file)
-        self._pixmap = QPixmap(path_relative_to_ui_file)
+        # Check that the path exists
+        if os.path.isfile(abs_path):
+            pixmap = QPixmap(abs_path)
+        # Return a blank image if we don't have a valid path
+        else:
+            # Warn the user loudly if their file does not exist, but avoid
+            # doing this in Designer as this spams the user as they are typing
+            if is_app:
+                logger.error("Image file  %r does not exist", abs_path)
+            pixmap = QPixmap(self.sizeHint())
+            pixmap.fill(self.null_color)
+        # Update the display
+        self._pixmap = pixmap
         self.update()
 
     def sizeHint(self):

--- a/pydm/widgets/drawing.py
+++ b/pydm/widgets/drawing.py
@@ -435,7 +435,12 @@ class PyDMDrawingImage(PyDMDrawing):
         super(PyDMDrawingImage, self).__init__(parent, init_channel)
         self._pixmap = QPixmap()
         self._aspect_ratio_mode = Qt.KeepAspectRatio
-        self.filename = filename
+        # Make sure we don't set a non-existant file
+        if filename:
+            self.filename = filename
+        # But we always have an internal value to reference
+        else:
+            self._file = filename
         if not is_pydm_app():
             designer_window = self.get_designer_window()
             if designer_window is not None:

--- a/pydm/widgets/drawing.py
+++ b/pydm/widgets/drawing.py
@@ -484,15 +484,20 @@ class PyDMDrawingImage(PyDMDrawing):
             The filename to be used
         """
         self._file = new_file
-        path_relative_to_ui_file = self._file
-        if not os.path.isabs(self._file):                
+        abs_path = self._file
+        is_app = is_pydm_app()
+        # Find the absolute path relative to UI
+        if not os.path.isabs(self._file):
             try:
-                if is_pydm_app():
-                    path_relative_to_ui_file = QApplication.instance().get_path(self._file)
+                # Based on the QApplication
+                if is_app:
+                    abs_path = QApplication.instance().get_path(self._file)
+                # Based on the QtDesigner
                 else:
                     p = self.get_designer_window()
                     if p is not None:
-                        path_relative_to_ui_file = os.path.join(p.absoluteDir().absolutePath(), self._file)
+                        ui_dir = p.absoluteDir().absolutePath()
+                        abs_path = os.path.join(ui_dir, self._file)
             except Exception:
                 logger.exception("Unable to find full filepath for %s",
                                  self._file)

--- a/pydm/widgets/drawing.py
+++ b/pydm/widgets/drawing.py
@@ -421,7 +421,7 @@ class PyDMDrawingLine(PyDMDrawing):
 
 class PyDMDrawingImage(PyDMDrawing):
     """
-    Renders an image given by the ```filename``` property.
+    Renders an image given by the ``filename`` property.
     This class inherits from PyDMDrawing.
 
     Parameters
@@ -430,6 +430,11 @@ class PyDMDrawingImage(PyDMDrawing):
         The parent widget for the Label
     init_channel : str, optional
         The channel to be used by the widget.
+
+    Attributes
+    ----------
+    null_color : Qt.Color
+        QColor to fill the image if the filename is not found.
     """
     null_color = Qt.gray
 
@@ -478,7 +483,10 @@ class PyDMDrawingImage(PyDMDrawing):
     def filename(self, new_file):
         """
         The filename of the image to be displayed.
-        This can be an absolute or relative path to the display file.
+
+        This file can be either relative to the ``.ui`` file or absolute. If
+        the path does not exist, a shape of ``.null_color`` will be displayed
+        instead.
 
         Parameters
         -------

--- a/pydm/widgets/drawing.py
+++ b/pydm/widgets/drawing.py
@@ -440,7 +440,9 @@ class PyDMDrawingImage(PyDMDrawing):
 
     def __init__(self, parent=None, init_channel=None, filename=""):
         super(PyDMDrawingImage, self).__init__(parent, init_channel)
-        self._pixmap = QPixmap()
+        hint = super(PyDMDrawingImage, self).sizeHint()
+        self._pixmap = QPixmap(hint)
+        self._pixmap.fill(self.null_color)
         self._aspect_ratio_mode = Qt.KeepAspectRatio
         # Make sure we don't set a non-existant file
         if filename:
@@ -493,21 +495,22 @@ class PyDMDrawingImage(PyDMDrawing):
         new_file : str
             The filename to be used
         """
+        # Expand user (~ or ~user) and environment variables.
         self._file = new_file
-        abs_path = self._file
+        abs_path = os.path.expanduser(os.path.expandvars(self._file))
         is_app = is_pydm_app()
         # Find the absolute path relative to UI
-        if not os.path.isabs(self._file):
+        if not os.path.isabs(abs_path):
             try:
                 # Based on the QApplication
                 if is_app:
-                    abs_path = QApplication.instance().get_path(self._file)
+                    abs_path = QApplication.instance().get_path(abs_path)
                 # Based on the QtDesigner
                 else:
                     p = self.get_designer_window()
                     if p is not None:
                         ui_dir = p.absoluteDir().absolutePath()
-                        abs_path = os.path.join(ui_dir, self._file)
+                        abs_path = os.path.join(ui_dir, abs_path)
             except Exception:
                 logger.exception("Unable to find full filepath for %s",
                                  self._file)

--- a/pydm/widgets/drawing.py
+++ b/pydm/widgets/drawing.py
@@ -1,14 +1,15 @@
 import math
 import os
-
 import logging
-logger = logging.getLogger(__name__)
 
 from ..PyQt.QtGui import QApplication, QWidget, QColor, QPainter, QBrush, QPen, QPolygon, QPixmap, QStyle, QStyleOption
 from ..PyQt.QtCore import pyqtProperty, Qt, QPoint, QSize, pyqtSlot
 from ..PyQt.QtDesigner import QDesignerFormWindowInterface
 from .base import PyDMWidget
 from ..utilities import is_pydm_app
+
+logger = logging.getLogger(__name__)
+
 
 def deg_to_qt(deg):
     """
@@ -487,8 +488,9 @@ class PyDMDrawingImage(PyDMDrawing):
                     p = self.get_designer_window()
                     if p is not None:
                         path_relative_to_ui_file = os.path.join(p.absoluteDir().absolutePath(), self._file)
-            except Exception as e:
-                print(e)
+            except Exception:
+                logger.exception("Unable to find full filepath for %s",
+                                 self._file)
         self._pixmap = QPixmap(path_relative_to_ui_file)
         self.update()
 

--- a/pydm/widgets/drawing.py
+++ b/pydm/widgets/drawing.py
@@ -534,6 +534,13 @@ class PyDMDrawingImage(PyDMDrawing):
         x, y, w, h = self.get_bounds(maxsize=True, force_no_pen=True)
         _scaled = self._pixmap.scaled(w, h, self._aspect_ratio_mode,
                                       Qt.SmoothTransformation)
+        # Make sure the image is centered if smaller than the widget itself
+        if w > _scaled.width():
+            logger.debug("Centering image horizontally ...")
+            x += (w-_scaled.width())/2
+        if h > _scaled.height():
+            logger.debug("Centering image vertically ...")
+            y += (h - _scaled.height())/2
         self._painter.drawPixmap(x, y, _scaled)
 
 


### PR DESCRIPTION
# Description
Some minor adjustments to the `PyDMDrawingImage` widget.

* When using `Qt.KeepAspectRatio` you can wind up with the situation where one dimension of the image is much smaller than the widget. The prior implementation always drew this in the upper left hand corner but I think it is better to center the image inside the widget.

* When you typed in the Designer the shell would barf error messages about setting a null `QPixmap` this is because it was trying to creating a `QPixmap` from a path that doesn't exist. We now check whether this path exists before drawing

* The widget would silently fail if the image you added does not exist (besides the  null QPixmap warning). Now if a `QApplication` is active we broadcast an error message saying we can't find your image. If we are in Designer this error message is muted because it tries the load the image after every letter you type.

* Because we are not setting `null` Pixmaps anymore we instead create an image filled with `null_color` to take the place of the widget. This way operators will still see their widget and the accompanying error code and not just a cryptic error messages about Pixmaps. If we don't fill the QPixmap it displays a crazy streaked image which I think is it just displaying a random piece of memory 😆 

## Screenshots
##### Before
![unbalanced_image](https://user-images.githubusercontent.com/25753048/40260958-a2031648-5ab2-11e8-9267-a203968b18ca.png)
##### After
![after_change](https://user-images.githubusercontent.com/25753048/40260963-a921fd68-5ab2-11e8-9b75-f400849badc7.png)

