### PR TITLE
BUG: set buffer size when adds new curve on Timeplot

### DIFF
--- a/pydm/widgets/timeplot.py
+++ b/pydm/widgets/timeplot.py
@@ -164,6 +164,7 @@ class PyDMTimePlot(BasePlot):
                                       color=color,
                                       **plot_opts)
         new_curve.setUpdatesAsynchronously(self.updatesAsynchronously)
+        new_curve.setBufferSize(self._bufferSize)
         self.update_timer.timeout.connect(new_curve.asyncUpdate)
         self.addCurve(new_curve, curve_color=color)
         self.redraw_timer.start()


### PR DESCRIPTION
There was a bug when add a new curve on execution, the curve buffer size
keeps default buffer size (1200). To fix this the addYChannel was
changed to set buffer size to curve.