### PR TITLE
MNT: Add CONTAINER to Widget Category

### DIFF
--- a/docs/source/widgets/frame.rst
+++ b/docs/source/widgets/frame.rst
@@ -1,0 +1,6 @@
+#######################
+PyDMFrame
+#######################
+
+.. autoclass:: pydm.widgets.frame.PyDMFrame
+   :members:

--- a/docs/source/widgets/index.rst
+++ b/docs/source/widgets/index.rst
@@ -16,7 +16,6 @@ Display Widgets
    related_display_button.rst
    scale.rst
    symbol.rst
-   waveformtable.rst
 
 Input Widgets
 -------------
@@ -30,6 +29,7 @@ Input Widgets
    shell_command.rst
    slider.rst
    spinbox.rst
+   waveformtable.rst
 
 Plot Widgets
 ------------

--- a/docs/source/widgets/index.rst
+++ b/docs/source/widgets/index.rst
@@ -3,25 +3,55 @@ Widgets
 ============================
 PyDM comes with a set of widgets useful for operating a control system.
 
-.. toctree::
-    :maxdepth: 1
 
-    byte.rst
-    checkbox.rst
-    drawing.rst
-    embedded_display.rst
-    enum_combo_box.rst
-    image.rst
-    label.rst
-    line_edit.rst
-    pushbutton.rst
-    related_display_button.rst
-    scatterplot.rst
-    shell_command.rst
-    slider.rst
-    spinbox.rst
-    symbol.rst
-    tab_widget.rst
-    timeplot.rst
-    waveformplot.rst
-    waveformtable.rst
+Display Widgets
+---------------
+.. toctree::
+   :maxdepth: 1
+
+   byte.rst
+   image.rst
+   label.rst
+   log.rst
+   related_display_button.rst
+   scale.rst
+   symbol.rst
+   waveformtable.rst
+
+Input Widgets
+-------------
+.. toctree::
+   :maxdepth: 1
+
+   checkbox.rst
+   enum_combo_box.rst
+   line_edit.rst
+   pushbutton.rst
+   shell_command.rst
+   slider.rst
+   spinbox.rst
+
+Plot Widgets
+------------
+.. toctree::
+   :maxdepth: 1
+
+   scatterplot.rst
+   timeplot.rst
+   waveformplot.rst
+
+Container Widgets
+-----------------
+.. toctree::
+   :maxdepth: 1
+
+   embedded_display.rst
+   frame.rst
+   tab_widget.rst
+
+Drawing Widgets
+---------------
+.. toctree::
+   :maxdepth: 1
+
+   drawing.rst

--- a/docs/source/widgets/log.rst
+++ b/docs/source/widgets/log.rst
@@ -1,0 +1,6 @@
+#######################
+PyDMLogDisplay
+#######################
+
+.. autoclass:: pydm.widgets.logdisplay.PyDMLogDisplay
+   :members:

--- a/docs/source/widgets/scale.rst
+++ b/docs/source/widgets/scale.rst
@@ -1,0 +1,6 @@
+#######################
+PyDMScaleIndicator
+#######################
+
+.. autoclass:: pydm.widgets.scale.PyDMScaleIndicator
+   :members:

--- a/pydm/widgets/qtplugin_base.py
+++ b/pydm/widgets/qtplugin_base.py
@@ -21,6 +21,7 @@ from ..PyQt import QtGui, QtDesigner
 #       for the almost dead and agonizing Python 2.7
 #       <pitchforks> Death to Python 2.7! </ pitchforks>
 class WidgetCategory(object):
+    CONTAINER = "PyDM Container Widgets"
     DISPLAY = "PyDM Display Widgets"
     INPUT = "PyDM Input Widgets"
     PLOT = "PyDM Plot Widgets"

--- a/pydm/widgets/qtplugins.py
+++ b/pydm/widgets/qtplugins.py
@@ -105,7 +105,7 @@ PyDMScaleIndicatorPlugin = qtplugin_factory(PyDMScaleIndicator, group=WidgetCate
 PyDMSymbolPlugin = qtplugin_factory(PyDMSymbol, group=WidgetCategory.DISPLAY)
 
 # Waveform Table plugin
-PyDMWaveformTablePlugin = qtplugin_factory(PyDMWaveformTable, group=WidgetCategory.DISPLAY)
+PyDMWaveformTablePlugin = qtplugin_factory(PyDMWaveformTable, group=WidgetCategory.INPUT)
 
 # Tab Widget plugin
 PyDMTabWidgetPlugin = TabWidgetPlugin()

--- a/pydm/widgets/qtplugins.py
+++ b/pydm/widgets/qtplugins.py
@@ -61,13 +61,13 @@ PyDMDrawingRectanglePlugin = qtplugin_factory(PyDMDrawingRectangle, group=Widget
 PyDMDrawingTrianglePlugin = qtplugin_factory(PyDMDrawingTriangle, group=WidgetCategory.DRAWING)
 
 # Embedded Display plugin
-PyDMEmbeddedDisplayPlugin = qtplugin_factory(PyDMEmbeddedDisplay, group=WidgetCategory.DISPLAY)
+PyDMEmbeddedDisplayPlugin = qtplugin_factory(PyDMEmbeddedDisplay, group=WidgetCategory.CONTAINER)
 
 # Enum Combobox plugin
 PyDMEnumComboBoxPlugin = qtplugin_factory(PyDMEnumComboBox, group=WidgetCategory.INPUT)
 
 # Frame plugin
-PyDMFramePlugin = qtplugin_factory(PyDMFrame, group=WidgetCategory.DISPLAY, is_container=True)
+PyDMFramePlugin = qtplugin_factory(PyDMFrame, group=WidgetCategory.CONTAINER, is_container=True)
 
 # Image plugin
 PyDMImageViewPlugin = qtplugin_factory(PyDMImageView, group=WidgetCategory.DISPLAY)

--- a/pydm/widgets/tab_bar_qtplugin.py
+++ b/pydm/widgets/tab_bar_qtplugin.py
@@ -7,7 +7,7 @@ class TabWidgetPlugin(PyDMDesignerPlugin):
     TabClass = PyDMTabWidget
     def __init__(self):
         super(TabWidgetPlugin, self).__init__(self.TabClass,
-                                             group=WidgetCategory.DISPLAY)
+                                             group=WidgetCategory.CONTAINER)
 
     def domXml(self):
         """
@@ -32,4 +32,4 @@ class TabWidgetPlugin(PyDMDesignerPlugin):
                 " </attribute>\n"
                 "</widget>\n"
                 "</widget>"
-               ).format(self.name(), self.toolTip(), self.whatsThis()) 
+               ).format(self.name(), self.toolTip(), self.whatsThis())


### PR DESCRIPTION
As we talked offline, this PR reorganize some of the widgets in a new category named Container so it makes more sense. This PR also add some widgets that were left behind on the documentation part, it is still not perfect but it is better than nothing.
We will revisit those widgets documentation in the near future.

Attn. @teddyrendahl, @mattgibbs and @hmbui 