### PR TITLE
FIX: Stop reading epics char waveforms at first zero (null) value for string conversion

### DIFF
--- a/pydm/tests/widgets/test_display_format.py
+++ b/pydm/tests/widgets/test_display_format.py
@@ -13,7 +13,7 @@ from pydm.widgets.display_format import  DisplayFormat, parse_value_for_display
 
 @pytest.mark.parametrize("value, precision, display_format, widget, expected", [
     (np.array([65, 66], dtype=np.uint8), 1, DisplayFormat.String, QWidget, "AB"),
-    (np.array([65, 66, 0, 199]), 0, DisplayFormat.String, QWidget, "AB"),
+    (np.array([65, 66, 0, 199], dtype=np.uint8), 1, DisplayFormat.String, QWidget, "AB"),
     ("abc", 0, DisplayFormat.Default, QWidget, "abc"),
     (123, 0, DisplayFormat.Default, QWidget, 123),
     (123.45, 0, DisplayFormat.Default, QWidget, 123.45),

--- a/pydm/tests/widgets/test_display_format.py
+++ b/pydm/tests/widgets/test_display_format.py
@@ -13,6 +13,7 @@ from pydm.widgets.display_format import  DisplayFormat, parse_value_for_display
 
 @pytest.mark.parametrize("value, precision, display_format, widget, expected", [
     (np.array([65, 66], dtype=np.uint8), 1, DisplayFormat.String, QWidget, "AB"),
+    (np.array([65, 66, 0, 199]), 0, DisplayFormat.String, QWidget, "AB"),
     ("abc", 0, DisplayFormat.Default, QWidget, "abc"),
     (123, 0, DisplayFormat.Default, QWidget, 123),
     (123.45, 0, DisplayFormat.Default, QWidget, 123.45),

--- a/pydm/widgets/display_format.py
+++ b/pydm/widgets/display_format.py
@@ -25,6 +25,11 @@ def parse_value_for_display(value, precision, display_format_type=DisplayFormat.
     elif display_format_type == DisplayFormat.String:
         if isinstance(value, np.ndarray):
             try:
+                # Stop at the first zero (EPICS convention)
+                # Assume the ndarray is one-dimensional
+                zeros = np.where(value == 0)[0]
+                if zeros.size > 0:
+                    value = value[:zeros[0]]
                 r = value.tobytes().decode(string_encoding)
             except:
                 logger.error("Could not decode {0} using {1} at widget named '{2}'.".format(


### PR DESCRIPTION
See for #332 for the full motivation

In short, the other display managers and client layers ignore all entries in the char waveforms after the first 0 value. Some IOCs assume that this is the case, and make no effort to clean junk values in the extra spaces. This PR shortens the array before decoding a string if there is a zero in it when the user asks for the data as a string.

I added one test case.

closes #332 