### PR TITLE
MAINT: QPlainTextEdit should not be user write-able

### DIFF
--- a/pydm/widgets/logdisplay.py
+++ b/pydm/widgets/logdisplay.py
@@ -107,6 +107,7 @@ class PyDMLogDisplay(QWidget, LogLevels):
         self.label = QLabel('Minimum displayed log level: ', parent=self)
         self.combo = QComboBox(parent=self)
         self.text = QPlainTextEdit(parent=self)
+        self.text.setReadOnly(True)
         self.clear_btn = QPushButton("Clear", parent=self)
         # Create layout
         layout = QVBoxLayout()

--- a/pydm/widgets/logdisplay.py
+++ b/pydm/widgets/logdisplay.py
@@ -3,7 +3,7 @@ import logging
 from collections import OrderedDict
 
 from pydm.PyQt.QtCore import (QObject, pyqtSlot, pyqtSignal, pyqtProperty,
-                              Q_ENUMS)
+                              Q_ENUMS, QSize)
 from pydm.PyQt.QtGui import (QWidget, QPlainTextEdit, QComboBox, QLabel,
                              QPushButton, QHBoxLayout, QVBoxLayout)
 
@@ -133,6 +133,9 @@ class PyDMLogDisplay(QWidget, LogLevels):
         self.level = None
         self.logName = logname or ''
         self.logLevel = level
+
+    def sizeHint(self):
+        return QSize(400, 300)
 
     @pyqtProperty(LogLevels)
     def logLevel(self):


### PR DESCRIPTION
## Details
An operator can currently write to the `QPlainTextEdit` that displays the logs. I thought we had this set to read-only internally, but I guess it didn't make it in the final PR. 

