### PR TITLE
FIX: Do not assume widget has populated channels

### DIFF
--- a/pydm/application.py
+++ b/pydm/application.py
@@ -531,6 +531,9 @@ class PyDMApplication(QApplication):
     # Not sure if showing the tooltip should be the job of the app,
     # may want to revisit this.
     def show_address_tooltip(self, obj, event):
+        if not len(obj.channels()):
+            logger.warning("Object %r has no PyDM Channels", obj)
+            return
         addr = obj.channels()[0].address
         QToolTip.showText(event.globalPos(), addr)
         # If the address has a protocol, and it is the default protocol, strip it out before putting it on the clipboard.


### PR DESCRIPTION
## Description
The `show_address_tooltip` function assumes that there are `PyDMChannels` on the widget. This crashes the application with an `IndexError` when there are no channels on a widget. This patch checks that there are objects in the list if before grabbing the zero-th channel to display.