### PR TITLE
CI: Add single-version-externally-managed to build scripts for Anaconda.

### DIFF
--- a/conda-recipe/bld.bat
+++ b/conda-recipe/bld.bat
@@ -1,1 +1,1 @@
-"%PYTHON%" setup.py install
+"%PYTHON%" setup.py install --single-version-externally-managed --record=record.txt

--- a/conda-recipe/build.sh
+++ b/conda-recipe/build.sh
@@ -1,5 +1,5 @@
 # Install the package
-$PYTHON setup.py install
+$PYTHON setup.py install --single-version-externally-managed --record=record.txt
 
 # Create auxiliary dirs
 mkdir -p $PREFIX/etc/conda/activate.d


### PR DESCRIPTION
Bumped into https://github.com/conda/conda/issues/508.
