### PR TITLE
ENH: Add support for PYDM_DISPLAYS_PATH variable.

### DIFF
--- a/pydm/application.py
+++ b/pydm/application.py
@@ -25,7 +25,7 @@ from .PyQt.QtGui import QApplication, QColor, QWidget, QToolTip, QClipboard, QAc
 from .PyQt import uic
 from .main_window import PyDMMainWindow
 from .tools import ExternalTool
-from .utilities import macro, which, path_info
+from .utilities import macro, which, path_info, find_display_in_path
 from . import data_plugins
 
 logger = logging.getLogger(__name__)
@@ -459,6 +459,11 @@ class PyDMApplication(QApplication):
         really only used by embedded displays.
         """
         full_path = self.get_path(ui_file)
+
+        if not os.path.exists(full_path):
+            new_fname = find_display_in_path(ui_file)
+            if new_fname is not None and new_fname != "":
+                full_path = new_fname
         return self.open_file(full_path, macros=macros,
                               command_line_args=command_line_args,
                               establish_connection=establish_connection)

--- a/pydm/main_window.py
+++ b/pydm/main_window.py
@@ -2,7 +2,7 @@ import os
 from os import path
 from .PyQt.QtGui import QApplication, QMainWindow, QFileDialog, QWidget, QAction
 from .PyQt.QtCore import Qt, QTimer, pyqtSlot, QSize, QLibraryInfo
-from .utilities import IconFont
+from .utilities import IconFont, find_display_in_path
 from .pydm_ui import Ui_MainWindow
 from .display_module import Display
 from .connection_inspector import ConnectionInspector
@@ -113,7 +113,10 @@ class PyDMMainWindow(QMainWindow):
         filename = self.join_to_current_file_path(ui_file)
         try:
             if not os.path.exists(filename):
-                raise IOError("File {} not found".format(filename))
+                new_fname = find_display_in_path(ui_file)
+                if new_fname is None or new_fname == "":
+                    raise IOError("File {} not found".format(filename))
+                filename = new_fname
             self.open_abs_file(filename, macros, command_line_args)
         except (IOError, OSError, ValueError, ImportError) as e:
             error_msg = "Cannot open file: '{0}'. Reason: '{1}'.".format(filename, e)
@@ -147,7 +150,9 @@ class PyDMMainWindow(QMainWindow):
         filename = self.join_to_current_file_path(ui_file)
         try:
             if not os.path.exists(filename):
-                raise IOError("File {} not found".format(filename))
+                new_fname = find_display_in_path(ui_file)
+                if new_fname is None or new_fname == "":
+                    raise IOError("File {} not found".format(filename))
             self.new_abs_window(filename, macros, command_line_args)
         except (IOError, OSError, ValueError, ImportError) as e:
             error_msg = "Cannot open file: '{0}'. Reason: '{1}'.".format(filename, e)

--- a/pydm/tests/utilities/test_utilities.py
+++ b/pydm/tests/utilities/test_utilities.py
@@ -1,6 +1,8 @@
+import os
 import platform
+import tempfile
 
-from ...utilities import is_pydm_app, path_info, which
+from ...utilities import is_pydm_app, path_info, which, find_display_in_path
 from ...PyQt import QtGui
 
 
@@ -23,6 +25,22 @@ def test_path_info():
     assert (file_name == 'ls')
     assert (args == [])
 
+
+def test_find_display_in_path():
+    temp, file_path = tempfile.mkstemp(suffix=".ui", prefix="display_")
+    print("temp.name: ", file_path)
+    direc, fname, _ = path_info(file_path)
+
+    # Try to find the file as is... is should not find it.
+    assert(find_display_in_path(fname) is None)
+
+    # Try to find the file passing the path
+    assert(find_display_in_path(fname, mode=None, path=direc) == file_path)
+
+    # Try to find the file passing the path but relative name
+    rel_name = ".{}{}".format(os.sep, fname)
+    expected = "{}{}{}".format(direc, os.sep, rel_name)
+    assert (find_display_in_path(rel_name, mode=None, path=direc) == expected)
 
 def test_which():
     if platform.system() == 'Windows':

--- a/pydm/tests/utilities/test_utilities.py
+++ b/pydm/tests/utilities/test_utilities.py
@@ -28,19 +28,26 @@ def test_path_info():
 
 def test_find_display_in_path():
     temp, file_path = tempfile.mkstemp(suffix=".ui", prefix="display_")
-    print("temp.name: ", file_path)
+    print("File Path: ", file_path)
     direc, fname, _ = path_info(file_path)
 
+    print("Direc: ", direc)
     # Try to find the file as is... is should not find it.
     assert(find_display_in_path(fname) is None)
 
     # Try to find the file passing the path
-    assert(find_display_in_path(fname, mode=None, path=direc) == file_path)
+    disp_path = find_display_in_path(fname, mode=None, path=direc)
+    print("Rel Name: {} | Expected: {} | Disp Path: {}".format(fname, direc,
+                                                             disp_path))
+    assert(disp_path == file_path)
 
     # Try to find the file passing the path but relative name
     rel_name = ".{}{}".format(os.sep, fname)
     expected = "{}{}{}".format(direc, os.sep, rel_name)
-    assert (find_display_in_path(rel_name, mode=None, path=direc) == expected)
+    disp_path = find_display_in_path(rel_name, mode=None, path=direc)
+    print("Rel Name: {} | Expected: {} | Disp Path: {}".format(rel_name, expected, disp_path))
+    assert (disp_path == expected)
+
 
 def test_which():
     if platform.system() == 'Windows':

--- a/pydm/utilities/__init__.py
+++ b/pydm/utilities/__init__.py
@@ -67,7 +67,7 @@ def find_display_in_path(file, mode=None, path=None):
     Look for a display file in a given path.
     This is basically a wrapper on top of the ``which``
     command defined below so we don't need to keep redefining
-    the PYDM_DISPLAYS_PATH variable.
+    the ``PYDM_DISPLAYS_PATH`` variable.
 
     Parameters
     ----------
@@ -85,7 +85,7 @@ def find_display_in_path(file, mode=None, path=None):
         Returns the full path to the file or None in case it was not found.
     """
     if path is None:
-        path = os.getenv("PYDM_DISPLAYS_PATH")
+        path = os.getenv("PYDM_DISPLAYS_PATH", None)
     if mode is None:
         mode = os.F_OK | os.R_OK
 

--- a/pydm/utilities/__init__.py
+++ b/pydm/utilities/__init__.py
@@ -62,7 +62,7 @@ def path_info(path_str):
     return dir_name, file_name, args
 
 
-def find_display_in_path(file, mode=None, path=None):
+def find_display_in_path(file, mode=None, path=None, pathext=None):
     """
     Look for a display file in a given path.
     This is basically a wrapper on top of the ``which``
@@ -84,15 +84,17 @@ def find_display_in_path(file, mode=None, path=None):
     str
         Returns the full path to the file or None in case it was not found.
     """
+    if pathext is None and sys.platform == "win32":
+        pathext = ".ui"
     if path is None:
         path = os.getenv("PYDM_DISPLAYS_PATH", None)
     if mode is None:
         mode = os.F_OK | os.R_OK
 
-    return which(file, mode, path)
+    return which(file, mode, path, pathext=pathext)
 
 
-def which(cmd, mode=os.F_OK | os.X_OK, path=None):
+def which(cmd, mode=os.F_OK | os.X_OK, path=None, pathext=None):
     """Given a command, mode, and a PATH string, return the path which
     conforms to the given mode on the PATH, or None if there is no such
     file.
@@ -131,7 +133,9 @@ def which(cmd, mode=os.F_OK | os.X_OK, path=None):
             path.insert(0, os.curdir)
 
         # PATHEXT is necessary to check on Windows.
-        pathext = os.environ.get("PATHEXT", "").split(os.pathsep)
+        if pathext is None:
+            pathext = os.environ.get("PATHEXT", "")
+        pathext = pathext.split(os.pathsep)
         # See if the given file matches any of the expected path
         # extensions. This will allow us to short circuit when given
         # "python.exe". If it does match, only test that one, otherwise we

--- a/pydm/utilities/__init__.py
+++ b/pydm/utilities/__init__.py
@@ -62,69 +62,96 @@ def path_info(path_str):
     return dir_name, file_name, args
 
 
-try:  # Forced testing
-    from shutil import which
-except ImportError:  # Forced testing
-    # Versions prior to Python 3.3 don't have shutil.which
+def find_display_in_path(file, mode=None, path=None):
+    """
+    Look for a display file in a given path.
+    This is basically a wrapper on top of the ``which``
+    command defined below so we don't need to keep redefining
+    the PYDM_DISPLAYS_PATH variable.
 
-    def which(cmd, mode=os.F_OK | os.X_OK, path=None):
-        """Given a command, mode, and a PATH string, return the path which
-        conforms to the given mode on the PATH, or None if there is no such
-        file.
-        `mode` defaults to os.F_OK | os.X_OK. `path` defaults to the result
-        of os.environ.get("PATH"), or can be overridden with a custom search
-        path.
-        Note: This function was backported from the Python 3 source code.
-        """
+    Parameters
+    ----------
+    file : str
+        The file name.
+    mode : int
+        The mode required for the file, defaults to os.F_OK | os.R_OK.
+        Which ensure that the file exists and we can read it.
+    path : str
+        The PATH string.
 
-        # Check that a given file can be accessed with the correct mode.
-        # Additionally check that `file` is not a directory, as on Windows
-        # directories pass the os.access check.
-        def _access_check(fn, mode):
-            return (os.path.exists(fn) and os.access(fn, mode) and
-                    not os.path.isdir(fn))
+    Returns
+    -------
+    str
+        Returns the full path to the file or None in case it was not found.
+    """
+    if path is None:
+        path = os.getenv("PYDM_DISPLAYS_PATH")
+    if mode is None:
+        mode = os.F_OK | os.R_OK
 
-        # If we're given a path with a directory part, look it up directly
-        # rather than referring to PATH directories. This includes checking
-        # relative to the current directory, e.g. ./script
-        if os.path.dirname(cmd):
-            if _access_check(cmd, mode):
-                return cmd
-            return None
+    return which(file, mode, path)
 
-        if path is None:
-            path = os.environ.get("PATH", os.defpath)
-        if not path:
-            return None
-        path = path.split(os.pathsep)
 
-        if sys.platform == "win32":
-            # The current directory takes precedence on Windows.
-            if os.curdir not in path:
-                path.insert(0, os.curdir)
+def which(cmd, mode=os.F_OK | os.X_OK, path=None):
+    """Given a command, mode, and a PATH string, return the path which
+    conforms to the given mode on the PATH, or None if there is no such
+    file.
+    `mode` defaults to os.F_OK | os.X_OK. `path` defaults to the result
+    of os.environ.get("PATH"), or can be overridden with a custom search
+    path.
+    Note: This function was backported from the Python 3 source code and modified
+    to deal with the case in which we WANT to look at the path even with a relative
+    path.
+    """
 
-            # PATHEXT is necessary to check on Windows.
-            pathext = os.environ.get("PATHEXT", "").split(os.pathsep)
-            # See if the given file matches any of the expected path
-            # extensions. This will allow us to short circuit when given
-            # "python.exe". If it does match, only test that one, otherwise we
-            # have to try others.
-            if any(cmd.lower().endswith(ext.lower()) for ext in pathext):
-                files = [cmd]
-            else:
-                files = [cmd + ext for ext in pathext]
-        else:
-            # On other platforms you don't have things like PATHEXT to tell you
-            # what file suffixes are executable, so just pass on cmd as-is.
-            files = [cmd]
+    # Check that a given file can be accessed with the correct mode.
+    # Additionally check that `file` is not a directory, as on Windows
+    # directories pass the os.access check.
+    def _access_check(fn, mode):
+        return (os.path.exists(fn) and os.access(fn, mode) and
+                not os.path.isdir(fn))
 
-        seen = set()
-        for dir_ in path:
-            normdir = os.path.normcase(dir_)
-            if normdir not in seen:
-                seen.add(normdir)
-                for thefile in files:
-                    name = os.path.join(dir_, thefile)
-                    if _access_check(name, mode):
-                        return name
+    # If we're given a path with a directory part, look it up directly
+    # rather than referring to PATH directories. This includes checking
+    # relative to the current directory, e.g. ./script
+    # if os.path.dirname(cmd):
+    #     if _access_check(cmd, mode):
+    #         return cmd
+    #     return None
+
+    if path is None:
+        path = os.environ.get("PATH", os.defpath)
+    if not path:
         return None
+    path = path.split(os.pathsep)
+
+    if sys.platform == "win32":
+        # The current directory takes precedence on Windows.
+        if os.curdir not in path:
+            path.insert(0, os.curdir)
+
+        # PATHEXT is necessary to check on Windows.
+        pathext = os.environ.get("PATHEXT", "").split(os.pathsep)
+        # See if the given file matches any of the expected path
+        # extensions. This will allow us to short circuit when given
+        # "python.exe". If it does match, only test that one, otherwise we
+        # have to try others.
+        if any(cmd.lower().endswith(ext.lower()) for ext in pathext):
+            files = [cmd]
+        else:
+            files = [cmd + ext for ext in pathext]
+    else:
+        # On other platforms you don't have things like PATHEXT to tell you
+        # what file suffixes are executable, so just pass on cmd as-is.
+        files = [cmd]
+
+    seen = set()
+    for dir_ in path:
+        normdir = os.path.normcase(dir_)
+        if normdir not in seen:
+            seen.add(normdir)
+            for thefile in files:
+                name = os.path.join(dir_, thefile)
+                if _access_check(name, mode):
+                    return name
+    return None


### PR DESCRIPTION
This adds another environment variable to PyDM: ``PYDM_DISPLAYS_PATH`` which will be useful to point PyDM in where to look for new files such as EDM, MEDM and other display manager do.
Users will be able to specify the filename or a relative path that will be first tried at the local folder and if not found we look at the PYDM_DISPLAYS_PATH for that...

I added a test for this case and all works fine. I also tested that locally with a UI file and it is working great.

The motivation for this implementation came from a comment from @markrivers and the explanation on why such functionality is important to generate and deliver UIs for modules such as AreaDetector.

This closes #348 