### PR TITLE
ENH: Connection on PyDMWidget

### DIFF
--- a/examples/actions/actions2.ui
+++ b/examples/actions/actions2.ui
@@ -86,7 +86,7 @@
    <property name="geometry">
     <rect>
      <x>20</x>
-     <y>420</y>
+     <y>360</y>
      <width>41</width>
      <height>41</height>
     </rect>
@@ -161,35 +161,10 @@
    <property name="styleSheet">
     <string notr="true">color: rgba(255, 255, 000, 158);</string>
    </property>
-   <layout class="QHBoxLayout" name="horizontalLayout">
-    <item>
-     <widget class="PyDMLabel" name="PyDMLabel">
-      <property name="toolTip">
-       <string/>
-      </property>
-      <property name="whatsThis">
-       <string/>
-      </property>
-      <property name="autoFillBackground">
-       <bool>false</bool>
-      </property>
-      <property name="rules" stdset="0">
-       <string>[{&quot;name&quot;: &quot;Background Color Rule&quot;, &quot;property&quot;: &quot;StyleSheet&quot;, &quot;expression&quot;: &quot;\&quot;background-color: orange;\&quot; if ch[0] &gt; 1 else \&quot;background-color: lightblue\&quot; if ch[0] &lt; 1 and ch[0] &gt; -1 else \&quot;background-color: brown\&quot;&quot;, &quot;channels&quot;: [{&quot;channel&quot;: &quot;ca://MTEST:Float&quot;, &quot;trigger&quot;: true}]}]</string>
-      </property>
-      <property name="channel" stdset="0">
-       <string>ca://MTEST:Float</string>
-      </property>
-     </widget>
-    </item>
-   </layout>
+   <layout class="QHBoxLayout" name="horizontalLayout"/>
   </widget>
  </widget>
  <customwidgets>
-  <customwidget>
-   <class>PyDMLabel</class>
-   <extends>QLabel</extends>
-   <header>pydm.widgets.label</header>
-  </customwidget>
   <customwidget>
    <class>PyDMTimePlot</class>
    <extends>QGraphicsView</extends>

--- a/examples/camviewer/camviewer.py
+++ b/examples/camviewer/camviewer.py
@@ -29,14 +29,12 @@ class CamViewer(Display):
         # self.cameras = { "VCC": vcc_dict, "C-Iris": c_iris_dict, "Test": test_dict }
         self.cameras = {"Testing IOC Image": test_dict }
         self._channels = []
+        self.imageChannel = None
 
         # Populate the camera combo box
         self.ui.cameraComboBox.clear()
         for camera in self.cameras:
             self.ui.cameraComboBox.addItem(camera)
-
-        # Clear out any image data, reset width, get PVs ready for connection
-        self.initializeCamera(self.ui.cameraComboBox.currentText())
 
         # When the camera combo box changes, disconnect from PVs, re-initialize, then reconnect.
         self.ui.cameraComboBox.activated[str].connect(self.cameraChanged)
@@ -230,7 +228,7 @@ class CamViewer(Display):
         new_camera = str(new_camera)
         if self.imageChannel == self.cameras[new_camera]["image"]:
             return
-        remove_widget_connections(self)
+        close_widget_connections(self)
         self.disable_all_markers()
         self.initializeCamera(new_camera)
 

--- a/examples/camviewer/camviewer.py
+++ b/examples/camviewer/camviewer.py
@@ -1,11 +1,13 @@
 # import epics
 # from qtpy import uic
+import functools
 from qtpy.QtCore import Slot, Signal, QPointF, QRectF
 from qtpy.QtGui import QPen
 from qtpy.QtWidgets import QSizePolicy
 from os import path
 from pydm import Display
 from pydm.widgets.channel import PyDMChannel
+from pydm.widgets.base import widget_destroyed
 from pydm.widgets.colormaps import cmap_names
 from pydm.utilities import establish_widget_connections, close_widget_connections
 import numpy as np
@@ -131,6 +133,9 @@ class CamViewer(Display):
         # Set up ROI buttons
         self.ui.setROIButton.clicked.connect(self.setROI)
         self.ui.resetROIButton.clicked.connect(self.resetROI)
+
+        self.destroyed.connect(functools.partial(widget_destroyed, self.channels))
+
 
     @Slot()
     def zoomIn(self):

--- a/examples/camviewer/camviewer.py
+++ b/examples/camviewer/camviewer.py
@@ -7,6 +7,7 @@ from os import path
 from pydm import Display
 from pydm.widgets.channel import PyDMChannel
 from pydm.widgets.colormaps import cmap_names
+from pydm.utilities import establish_widget_connections, close_widget_connections
 import numpy as np
 from pyqtgraph import PlotWidget, mkPen
 from marker import ImageMarker
@@ -229,10 +230,9 @@ class CamViewer(Display):
         new_camera = str(new_camera)
         if self.imageChannel == self.cameras[new_camera]["image"]:
             return
-        self.display_manager_window.close_widget_connections(self)
+        remove_widget_connections(self)
         self.disable_all_markers()
         self.initializeCamera(new_camera)
-        self.display_manager_window.establish_widget_connections(self)
 
     def initializeCamera(self, new_camera):
         new_camera = str(new_camera)
@@ -277,6 +277,7 @@ class CamViewer(Display):
             self.ui.roiWLineEdit.setEnabled(False)
             self.ui.roiHLineEdit.clear()
             self.ui.roiHLineEdit.setEnabled(False)
+        establish_widget_connections(self)
 
     @Slot()
     def setROI(self):

--- a/examples/home.ui
+++ b/examples/home.ui
@@ -75,9 +75,9 @@
            <property name="geometry">
             <rect>
              <x>0</x>
-             <y>0</y>
-             <width>213</width>
-             <height>560</height>
+             <y>-125</y>
+             <width>230</width>
+             <height>582</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_3">
@@ -354,6 +354,22 @@
              </widget>
             </item>
             <item>
+             <widget class="PyDMRelatedDisplayButton" name="PyDMRelatedDisplayButton_24">
+              <property name="toolTip">
+               <string/>
+              </property>
+              <property name="whatsThis">
+               <string/>
+              </property>
+              <property name="text">
+               <string>Tab Widget</string>
+              </property>
+              <property name="displayFilename" stdset="0">
+               <string>tab_widget/tab_widget.ui</string>
+              </property>
+             </widget>
+            </item>
+            <item>
              <widget class="PyDMRelatedDisplayButton" name="PyDMRelatedDisplayButton_15">
               <property name="toolTip">
                <string/>
@@ -366,6 +382,22 @@
               </property>
               <property name="displayFilename" stdset="0">
                <string>timeplot/timeplot.ui</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="PyDMRelatedDisplayButton" name="PyDMRelatedDisplayButton_23">
+              <property name="toolTip">
+               <string/>
+              </property>
+              <property name="whatsThis">
+               <string/>
+              </property>
+              <property name="text">
+               <string>Scatter Plot</string>
+              </property>
+              <property name="displayFilename" stdset="0">
+               <string>scatterplot/scatterplot.ui</string>
               </property>
              </widget>
             </item>
@@ -436,11 +468,36 @@
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>366</width>
-             <height>443</height>
+             <width>358</width>
+             <height>457</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_5">
+            <item>
+             <widget class="PyDMRelatedDisplayButton" name="PyDMRelatedDisplayButton_25">
+              <property name="enabled">
+               <bool>true</bool>
+              </property>
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="toolTip">
+               <string/>
+              </property>
+              <property name="whatsThis">
+               <string/>
+              </property>
+              <property name="text">
+               <string>Widget Rules</string>
+              </property>
+              <property name="displayFilename" stdset="0">
+               <string>actions/actions2.ui</string>
+              </property>
+             </widget>
+            </item>
             <item>
              <widget class="PyDMRelatedDisplayButton" name="PyDMRelatedDisplayButton_18">
               <property name="enabled">

--- a/examples/macros/basics/embedded_display_with_macro.ui
+++ b/examples/macros/basics/embedded_display_with_macro.ui
@@ -36,7 +36,7 @@
   <customwidget>
    <class>PyDMEmbeddedDisplay</class>
    <extends>QFrame</extends>
-   <header>pydm.widgets.new_embedded_display</header>
+   <header>pydm.widgets.embedded_display</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/examples/tab_widget/tab_widget.ui
+++ b/examples/tab_widget/tab_widget.ui
@@ -113,19 +113,19 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>PyDMSlider</class>
-   <extends>QFrame</extends>
-   <header>pydm.widgets.slider</header>
-  </customwidget>
-  <customwidget>
-   <class>PyDMEnumComboBox</class>
-   <extends>QFrame</extends>
-   <header>pydm.widgets.enum_combo_box</header>
-  </customwidget>
-  <customwidget>
    <class>PyDMTabWidget</class>
    <extends>QTabWidget</extends>
    <header>pydm.widgets.tab_bar</header>
+  </customwidget>
+  <customwidget>
+   <class>PyDMEnumComboBox</class>
+   <extends>QComboBox</extends>
+   <header>pydm.widgets.enum_combo_box</header>
+  </customwidget>
+  <customwidget>
+   <class>PyDMSlider</class>
+   <extends>QFrame</extends>
+   <header>pydm.widgets.slider</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/pydm/__init__.py
+++ b/pydm/__init__.py
@@ -1,5 +1,6 @@
 from .application import PyDMApplication
 from .display_module import Display
+from .data_plugins import set_read_only
 from ._version import get_versions
 __version__ = get_versions()['version']
 del get_versions

--- a/pydm/application.py
+++ b/pydm/application.py
@@ -17,6 +17,7 @@ import warnings
 import platform
 import collections
 from functools import partial
+from . import config
 from .display_module import Display
 from qtpy.QtCore import Qt, QEvent, QTimer, Slot
 from qtpy.QtWidgets import QApplication, QWidget, QToolTip, QAction, QMenu

--- a/pydm/application.py
+++ b/pydm/application.py
@@ -112,6 +112,7 @@ class PyDMApplication(QApplication):
         # being called hierarchially (i.e., parent calls it first, then on down the ancestor tree, with no unrelated
         # calls in between).    If something crazy happens and PyDM somehow gains the ability to open files in a
         # multi-threaded way, for example, this system will fail.
+        data_plugins.set_read_only(read_only)
         self.main_window = None
         self.directory_stack = ['']
         self.macro_stack = [{}]
@@ -121,7 +122,6 @@ class PyDMApplication(QApplication):
         self.hide_menu_bar = hide_menu_bar
         self.hide_status_bar = hide_status_bar
         self.fullscreen = fullscreen
-        self.__read_only = read_only
 
         # Open a window if required.
         if ui_file is not None:
@@ -154,7 +154,9 @@ class PyDMApplication(QApplication):
         return super(PyDMApplication, self).exec_()
 
     def is_read_only(self):
-        return self.__read_only
+        warnings.warn("'PyDMApplication.is_read_only' is deprecated, "
+                      "use 'pydm.data_plugins.is_read_only' instead.")
+        return data_plugins.is_read_only()
 
     @Slot()
     def get_CPU_usage(self):

--- a/pydm/application.py
+++ b/pydm/application.py
@@ -403,6 +403,11 @@ class PyDMApplication(QApplication):
         -------
         QWidget
         """
+        if 'establish_connection' in kwargs:
+            logger.warning("Ignoring 'establish_connection' parameter at "
+                           "open_relative. The connection is now handled by the"
+                           " widgets.")
+
         # First split the ui_file string into a filepath and arguments
         args = command_line_args if command_line_args is not None else []
         dir_name, file_name, extra_args = path_info(ui_file)
@@ -463,6 +468,10 @@ class PyDMApplication(QApplication):
         open_relative opens a ui file with a relative path.  This is
         really only used by embedded displays.
         """
+        if 'establish_connection' in kwargs:
+            logger.warning("Ignoring 'establish_connection' parameter at "
+                           "open_relative. The connection is now handled by the"
+                           " widgets.")
         full_path = self.get_path(ui_file)
 
         if not os.path.exists(full_path):

--- a/pydm/application.py
+++ b/pydm/application.py
@@ -499,6 +499,7 @@ class PyDMApplication(QApplication):
         """
         warnings.warn("'PyDMApplication.add_connection' is deprecated, "
                       "use PyDMConnection.connect()")
+        channel.connect()
 
     def remove_connection(self, channel):
         """
@@ -510,6 +511,7 @@ class PyDMApplication(QApplication):
         """
         warnings.warn("'PyDMApplication.remove_connection' is deprecated, "
                       "use PyDMConnection.disconnect()")
+        channel.disconnect()
 
     def eventFilter(self, obj, event):
         warnings.warn("'PyDMApplication.eventFilter' is deprecated, "
@@ -567,7 +569,7 @@ class PyDMApplication(QApplication):
                 if hasattr(child_widget, 'rules'):
                     if child_widget.rules:
                         RulesDispatcher().unregister(child_widget)
-            except:
+            except Exception:
                 pass
 
     def load_external_tools(self):

--- a/pydm/application.py
+++ b/pydm/application.py
@@ -33,10 +33,6 @@ from . import data_plugins
 from .widgets.rules import RulesDispatcher
 
 logger = logging.getLogger(__name__)
-DEFAULT_PROTOCOL = os.getenv("PYDM_DEFAULT_PROTOCOL")
-if DEFAULT_PROTOCOL is not None:
-    # Get rid of the "://" part if it exists
-    DEFAULT_PROTOCOL = DEFAULT_PROTOCOL.split("://")[0]
 
 
 class PyDMApplication(QApplication):
@@ -493,29 +489,11 @@ class PyDMApplication(QApplication):
         -------
         PyDMPlugin
         """
+        warnings.warn("'PyDMApplication.plugin_for_channel' is deprecated, "
+                      "use 'pydm.data_plugins.plugin_for_address' instead.")
         if channel.address is None or channel.address == "":
             return None
-        protocol = None
-        match = re.match('.*://', channel.address)
-        if match:
-            protocol = match.group(0)[:-3]
-        elif DEFAULT_PROTOCOL is not None:
-            # If no protocol was specified, and the default protocol environment variable is specified, try to use that instead.
-            protocol = DEFAULT_PROTOCOL
-        if protocol:
-            try:
-                plugin_to_use = self.plugins[str(protocol)]
-                return plugin_to_use
-            except KeyError:
-                print("Couldn't find plugin for protocol: {0}".format(match.group(0)[:-3]))
-        #If you get this far, we didn't successfuly figure out what plugin to use for this channel.
-        logger.warning(
-            "Channel {addr} did not specify a valid protocol and no default "
-            "protocol is defined.  This channel will receive no data. To "
-            "specify a default protocol, set the PYDM_DEFAULT_PROTOCOL "
-            "environment variable.".format(addr=channel.address)
-        )
-        return None
+        return data_plugins.plugin_for_address(channel.address)
 
     def add_connection(self, channel):
         """

--- a/pydm/application.py
+++ b/pydm/application.py
@@ -510,7 +510,6 @@ class PyDMApplication(QApplication):
         warnings.warn("'PyDMApplication.remove_connection' is deprecated, "
                       "use PyDMConnection.disconnect()")
 
-
     def eventFilter(self, obj, event):
         warnings.warn("'PyDMApplication.eventFilter' is deprecated, "
                       " this function is now found on PyDMWidget")

--- a/pydm/application.py
+++ b/pydm/application.py
@@ -379,7 +379,7 @@ class PyDMApplication(QApplication):
             kwargs['macros'] = macros
         return cls(**kwargs)
 
-    def open_file(self, ui_file, macros=None, command_line_args=None):
+    def open_file(self, ui_file, macros=None, command_line_args=None, **kwargs):
         """
         Open a .ui or .py file, and return a widget from the loaded file.
         This method is the entry point for all opening of new displays,
@@ -457,7 +457,8 @@ class PyDMApplication(QApplication):
         full_path = os.path.join(dirname, str(ui_file))
         return full_path
 
-    def open_relative(self, ui_file, widget, macros=None, command_line_args=[]):
+    def open_relative(self, ui_file, widget, macros=None, command_line_args=[],
+                      **kwargs):
         """
         open_relative opens a ui file with a relative path.  This is
         really only used by embedded displays.

--- a/pydm/application.py
+++ b/pydm/application.py
@@ -27,6 +27,7 @@ from .tools import ExternalTool
 
 from .utilities import macro, which, path_info, find_display_in_path
 from .utilities.stylesheet import apply_stylesheet
+from .utilities import connection
 from . import data_plugins
 from .widgets.rules import RulesDispatcher
 
@@ -532,6 +533,7 @@ class PyDMApplication(QApplication):
         """
         warnings.warn("'PyDMApplication.establish_widget_connections' is deprecated, "
                       "this function is now found on `utilities.establish_widget_connections`.")
+        connection.establish_widget_connections(widget)
 
     def close_widget_connections(self, widget):
         """
@@ -545,6 +547,7 @@ class PyDMApplication(QApplication):
         warnings.warn(
             "'PyDMApplication.close_widget_connections' is deprecated, "
             "this function is now found on `utilities.close_widget_connections`.")
+        connection.close_widget_connections(widget)
 
     def unregister_widget_rules(self, widget):
         """

--- a/pydm/application.py
+++ b/pydm/application.py
@@ -579,12 +579,12 @@ class PyDMApplication(QApplication):
         EXT_TOOLS_TOKEN = "_tool.py"
         path = os.getenv("PYDM_TOOLS_PATH", None)
 
-        logger.info("*"*80)
-        logger.info("* Loading PyDM External Tools")
-        logger.info("*"*80)
+        logger.debug("*"*80)
+        logger.debug("* Loading PyDM External Tools")
+        logger.debug("*"*80)
 
         if path is not None:
-            logger.info("Looking for external tools at: {}".format(path))
+            logger.debug("Looking for external tools at: {}".format(path))
             if platform.system() == "Windows":
                 locations = path.split(";")
             else:
@@ -595,7 +595,7 @@ class PyDMApplication(QApplication):
                         if name.endswith(EXT_TOOLS_TOKEN):
                             self.install_external_tool(os.path.join(root, name))
         else:
-            logger.warning("External Tools not loaded. No External Tools Path specified.")
+            logger.debug("External Tools not loaded. No External Tools Path specified.")
 
     def install_external_tool(self, tool):
         """

--- a/pydm/application.py
+++ b/pydm/application.py
@@ -503,6 +503,8 @@ class PyDMApplication(QApplication):
         ----------
         channel : PyDMChannel
         """
+        warnings.warn("'PyDMApplication.add_connection' is deprecated, "
+                      "use PyDMConnection.connect()")
         plugin = self.plugin_for_channel(channel)
         if plugin:
             plugin.add_connection(channel)
@@ -520,33 +522,16 @@ class PyDMApplication(QApplication):
             plugin.remove_connection(channel)
 
     def eventFilter(self, obj, event):
-        # Override the eventFilter to capture all middle mouse button events,
-        # and show a tooltip if needed.
-        if event.type() == QEvent.MouseButtonPress:
-            if event.button() == Qt.MiddleButton:
-                self.show_address_tooltip(obj, event)
-                return True
-        return False
+        warnings.warn("'PyDMApplication.eventFilter' is deprecated, "
+                      " this function is now found on PyDMWidget")
+        obj.eventFilter(obj, event)
 
     # Not sure if showing the tooltip should be the job of the app,
     # may want to revisit this.
     def show_address_tooltip(self, obj, event):
-        if not len(obj.channels()):
-            logger.warning("Object %r has no PyDM Channels", obj)
-            return
-        addr = obj.channels()[0].address
-        QToolTip.showText(event.globalPos(), addr)
-        # If the address has a protocol, and it is the default protocol, strip it out before putting it on the clipboard.
-        m = re.match('(.+?):/{2,3}(.+?)$', addr)
-        if m is not None and DEFAULT_PROTOCOL is not None and m.group(1) == DEFAULT_PROTOCOL:
-            copy_text = m.group(2)
-        else:
-            copy_text = addr
-
-        clipboard = QApplication.clipboard()
-        clipboard.setText(copy_text)
-        event = QEvent(QEvent.Clipboard)
-        self.sendEvent(clipboard, event)
+        warnings.warn("'PyDMApplication.show_address_tooltip' is deprecated, "
+                      " this function is now found on PyDMWidget")
+        obj.show_address_tooltip(obj, event)
 
     def establish_widget_connections(self, widget):
         """
@@ -560,18 +545,8 @@ class PyDMApplication(QApplication):
         ----------
         widget : QWidget
         """
-        widgets = [widget]
-        widgets.extend(widget.findChildren(QWidget))
-        for child_widget in widgets:
-            try:
-                if hasattr(child_widget, 'channels'):
-                    for channel in child_widget.channels():
-                        self.add_connection(channel)
-                    # Take this opportunity to install a filter that intercepts middle-mouse clicks,
-                    # which we use to display a tooltip with the address of the widget's first channel.
-                    child_widget.installEventFilter(self)
-            except NameError:
-                pass
+        warnings.warn("'PyDMWidget now handles the creation of connection."
+                      "There should be no need to call this function.")
 
     def unregister_widget_rules(self, widget):
         """

--- a/pydm/config.py
+++ b/pydm/config.py
@@ -1,0 +1,10 @@
+import os
+
+__all__ = ['DEFAULT_PROTOCOL',
+           ]
+
+
+DEFAULT_PROTOCOL = os.getenv("PYDM_DEFAULT_PROTOCOL")
+if DEFAULT_PROTOCOL is not None:
+    # Get rid of the "://" part if it exists
+    DEFAULT_PROTOCOL = DEFAULT_PROTOCOL.split("://")[0]

--- a/pydm/config.py
+++ b/pydm/config.py
@@ -1,6 +1,7 @@
 import os
 
 __all__ = ['DEFAULT_PROTOCOL',
+           'DESIGNER_ONLINE'
            ]
 
 
@@ -8,3 +9,5 @@ DEFAULT_PROTOCOL = os.getenv("PYDM_DEFAULT_PROTOCOL")
 if DEFAULT_PROTOCOL is not None:
     # Get rid of the "://" part if it exists
     DEFAULT_PROTOCOL = DEFAULT_PROTOCOL.split("://")[0]
+
+DESIGNER_ONLINE = os.getenv("PYDM_DESIGNER_ONLINE", None) is not None

--- a/pydm/connection_inspector/connection_inspector.py
+++ b/pydm/connection_inspector/connection_inspector.py
@@ -1,10 +1,15 @@
-from qtpy.QtWidgets import QWidget, QTableView, QAbstractItemView, QHBoxLayout, QVBoxLayout, QAbstractScrollArea, QPushButton, QFileDialog, QMessageBox, QLabel
-from qtpy.QtCore import Qt, QSize, Slot
+from qtpy.QtWidgets import (QWidget, QTableView, QAbstractItemView, QHBoxLayout,
+                            QVBoxLayout, QAbstractScrollArea, QPushButton,
+                            QFileDialog, QMessageBox, QLabel)
+from qtpy.QtCore import Qt, QSize, Slot, QTimer
 from .connection_table_model import ConnectionTableModel
+from .. import data_plugins
+
 
 class ConnectionInspector(QWidget):
-    def __init__(self, connections=[], parent=None):
+    def __init__(self, parent=None):
         super(ConnectionInspector, self).__init__(parent, Qt.Window)
+        connections = self.fetch_data()
         self.table_view = ConnectionTableView(connections, self)
         self.setLayout(QVBoxLayout(self))
         self.layout().addWidget(self.table_view)
@@ -17,14 +22,33 @@ class ConnectionInspector(QWidget):
         self.save_button.setText("Save list to file...")
         self.save_button.clicked.connect(self.save_list_to_file)
         button_layout.addWidget(self.save_button)
+        self.update_timer = QTimer(parent=self)
+        self.update_timer.setInterval(1500)
+        self.update_timer.timeout.connect(self.update_data)
+        self.update_timer.start()
+
+    def update_data(self):
+        self.table_view.model().connections = self.fetch_data()
+
+    def fetch_data(self):
+        plugins = data_plugins.plugin_modules
+        conns = []
+        for p in plugins.values():
+            for connection in p.connections.values():
+                conns.append(connection)
+        return conns
 
     @Slot()
     def save_list_to_file(self):
-        filename, filters = QFileDialog.getSaveFileName(self, "Save connection list", "", "Text Files (*.txt)")
+        filename, filters = QFileDialog.getSaveFileName(self,
+                                                        "Save connection list",
+                                                        "",
+                                                        "Text Files (*.txt)")
         try:
             with open(filename, "w") as f:
                 for conn in self.table_view.model().connections:
-                    f.write("{p}://{a}\n".format(p=conn.protocol, a=conn.address))
+                    f.write(
+                        "{p}://{a}\n".format(p=conn.protocol, a=conn.address))
             self.save_status_label.setText("File saved to {}".format(filename))
         except Exception as e:
             msgBox = QMessageBox()
@@ -33,10 +57,12 @@ class ConnectionInspector(QWidget):
             msgBox.setStandardButtons(QMessageBox.Ok)
             msgBox.exec_()
 
+
 class ConnectionTableView(QTableView):
     def __init__(self, connections=[], parent=None):
         super(ConnectionTableView, self).__init__(parent)
-        self.setSizeAdjustPolicy(QAbstractScrollArea.AdjustToContentsOnFirstShow)
+        self.setSizeAdjustPolicy(
+            QAbstractScrollArea.AdjustToContentsOnFirstShow)
         self.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
         self.horizontalHeader().setStretchLastSection(True)
         self.setSelectionMode(QAbstractItemView.SingleSelection)

--- a/pydm/connection_inspector/connection_inspector.py
+++ b/pydm/connection_inspector/connection_inspector.py
@@ -32,11 +32,10 @@ class ConnectionInspector(QWidget):
 
     def fetch_data(self):
         plugins = data_plugins.plugin_modules
-        conns = []
-        for p in plugins.values():
-            for connection in p.connections.values():
-                conns.append(connection)
-        return conns
+        return [connection
+                for p in plugins.values()
+                for connection in p.connections.values()
+                ]
 
     @Slot()
     def save_list_to_file(self):

--- a/pydm/data_plugins/__init__.py
+++ b/pydm/data_plugins/__init__.py
@@ -153,9 +153,9 @@ def set_read_only(read_only):
 
 
 # Load the data plugins from PYDM_DATA_PLUGINS_PATH
-logger.info("*"*80)
-logger.info("* Loading PyDM Data Plugins")
-logger.info("*"*80)
+logger.debug("*"*80)
+logger.debug("* Loading PyDM Data Plugins")
+logger.debug("*"*80)
 
 DATA_PLUGIN_TOKEN = "_plugin.py"
 path = os.getenv("PYDM_DATA_PLUGINS_PATH", None)

--- a/pydm/data_plugins/__init__.py
+++ b/pydm/data_plugins/__init__.py
@@ -15,7 +15,7 @@ from ..utilities import protocol_and_address
 
 logger = logging.getLogger(__name__)
 plugin_modules = {}
-
+__read_only = False
 
 DEFAULT_PROTOCOL = os.getenv("PYDM_DEFAULT_PROTOCOL")
 if DEFAULT_PROTOCOL is not None:
@@ -126,6 +126,30 @@ def load_plugins_from_path(locations, token):
                             # Add to return dictionary of added plugins
                             added_plugins[plugin.protocol] = plugin
     return added_plugins
+
+
+def is_read_only():
+    """
+    Check whether or not the app is running with the read only flag set.
+
+    Returns
+    -------
+    bool
+        True if read only. False otherwise.
+    """
+    return __read_only
+
+
+def set_read_only(read_only):
+    """
+    Set the read only flag for the data plugins.
+
+    Parameters
+    ----------
+    read_only : bool
+    """
+    global __read_only
+    __read_only = read_only
 
 
 # Load the data plugins from PYDM_DATA_PLUGINS_PATH

--- a/pydm/data_plugins/__init__.py
+++ b/pydm/data_plugins/__init__.py
@@ -141,6 +141,8 @@ def set_read_only(read_only):
     """
     global __read_only
     __read_only = read_only
+    if read_only:
+        logger.info("Running PyDM in Read Only mode.")
 
 
 # Load the data plugins from PYDM_DATA_PLUGINS_PATH

--- a/pydm/data_plugins/__init__.py
+++ b/pydm/data_plugins/__init__.py
@@ -11,6 +11,7 @@ import logging
 import imp
 import uuid
 from .plugin import PyDMPlugin
+from ..utilities import protocol_and_address
 
 logger = logging.getLogger(__name__)
 plugin_modules = {}
@@ -28,12 +29,9 @@ def plugin_for_address(address):
     Find the correct PyDMPlugin for a channel
     """
     # Check for a configured protocol
-    match = re.match('.*://', address)
-    protocol = None
-    if match:
-        protocol = match.group(0)[:-3]
+    protocol, addr = protocol_and_address(address)
     # Use default protocol
-    elif DEFAULT_PROTOCOL is not None:
+    if protocol is None and DEFAULT_PROTOCOL is not None:
         logger.debug("Using default protocol %s for %s",
                      DEFAULT_PROTOCOL, address)
         # If no protocol was specified, and the default protocol

--- a/pydm/data_plugins/__init__.py
+++ b/pydm/data_plugins/__init__.py
@@ -41,7 +41,10 @@ def plugin_for_address(address):
     if protocol:
         try:
             # Provide proper protocol
-            return plugin_modules[str(protocol)]
+            try:
+                return plugin_modules[str(protocol)]
+            except KeyError:
+                pass # We will print the more complete message below.
         except KeyError as exc:
             logger.exception("Could not find protocol for %r", address)
     # Catch all in case of improper plugin specification

--- a/pydm/data_plugins/__init__.py
+++ b/pydm/data_plugins/__init__.py
@@ -4,7 +4,6 @@ environment variable and subfolders that follows the *_plugin.py and have
 classes that inherits from the pydm.data_plugins.PyDMPlugin class.
 """
 import os
-import re
 import sys
 import inspect
 import logging
@@ -89,11 +88,11 @@ def load_plugins_from_path(locations, token):
             if root.split(os.path.sep)[-1].startswith("__"):
                 continue
 
-            logger.info("Looking for PyDM Data Plugins at: %s", root)
+            logger.debug("Looking for PyDM Data Plugins at: %s", root)
             for name in files:
                 if name.endswith(token):
                     try:
-                        logger.info("Trying to load %s...", name)
+                        logger.debug("Trying to load %s...", name)
                         sys.path.append(root)
                         temp_name = str(uuid.uuid4())
                         module = imp.load_source(temp_name,

--- a/pydm/data_plugins/__init__.py
+++ b/pydm/data_plugins/__init__.py
@@ -35,11 +35,7 @@ def plugin_for_address(address):
     # Load proper plugin module
     if protocol:
         try:
-            # Provide proper protocol
-            try:
-                return plugin_modules[str(protocol)]
-            except KeyError:
-                pass # We will print the more complete message below.
+            return plugin_modules[str(protocol)]
         except KeyError as exc:
             logger.exception("Could not find protocol for %r", address)
     # Catch all in case of improper plugin specification

--- a/pydm/data_plugins/__init__.py
+++ b/pydm/data_plugins/__init__.py
@@ -12,16 +12,11 @@ import imp
 import uuid
 from .plugin import PyDMPlugin
 from ..utilities import protocol_and_address
+from .. import config
 
 logger = logging.getLogger(__name__)
 plugin_modules = {}
 __read_only = False
-
-DEFAULT_PROTOCOL = os.getenv("PYDM_DEFAULT_PROTOCOL")
-if DEFAULT_PROTOCOL is not None:
-    DEFAULT_PROTOCOL = DEFAULT_PROTOCOL.replace('://', '')
-    logger.info("Using default PyDM protocol %s",
-                DEFAULT_PROTOCOL)
 
 
 def plugin_for_address(address):
@@ -31,12 +26,12 @@ def plugin_for_address(address):
     # Check for a configured protocol
     protocol, addr = protocol_and_address(address)
     # Use default protocol
-    if protocol is None and DEFAULT_PROTOCOL is not None:
+    if protocol is None and config.DEFAULT_PROTOCOL is not None:
         logger.debug("Using default protocol %s for %s",
-                     DEFAULT_PROTOCOL, address)
+                     config.DEFAULT_PROTOCOL, address)
         # If no protocol was specified, and the default protocol
         # environment variable is specified, try to use that instead.
-        protocol = DEFAULT_PROTOCOL
+        protocol = config.DEFAULT_PROTOCOL
     # Load proper plugin module
     if protocol:
         try:

--- a/pydm/data_plugins/epics_plugins/psp_plugin_component.py
+++ b/pydm/data_plugins/epics_plugins/psp_plugin_component.py
@@ -450,26 +450,6 @@ class Connection(PyDMConnection):
             except KeyError:
                 pass
 
-    def remove_listener(self, channel):
-        if channel.value_signal is not None:
-            try:
-                channel.value_signal[str].disconnect(self.put_value)
-            except KeyError:
-                pass
-            try:
-                channel.value_signal[int].disconnect(self.put_value)
-            except KeyError:
-                pass
-            try:
-                channel.value_signal[float].disconnect(self.put_value)
-            except KeyError:
-                pass
-            try:
-                channel.value_signal[np.ndarray].disconnect(self.put_value)
-            except KeyError:
-                pass
-        super(Connection, self).remove_listener(channel)
-
     def close(self):
         """
         Clean up.

--- a/pydm/data_plugins/epics_plugins/psp_plugin_component.py
+++ b/pydm/data_plugins/epics_plugins/psp_plugin_component.py
@@ -6,8 +6,8 @@ import numpy as np
 import pyca
 from psp.Pv import Pv
 from qtpy.QtCore import Slot, Qt, QTimer
+from pydm import data_plugins
 from pydm.data_plugins.plugin import PyDMPlugin, PyDMConnection
-from pydm.utilities import is_pydm_app
 
 # Map how we will interpret EPICS types in python.
 type_map = dict(
@@ -330,7 +330,7 @@ class Connection(PyDMConnection):
         self.connection_state_signal.emit(conn)
 
     def send_access_state(self, read_access, write_access):
-        if is_pydm_app() and self.app.is_read_only():
+        if data_plugins.is_read_only():
             self.write_access_signal.emit(False)
             return
         self.write_access_signal.emit(write_access)

--- a/pydm/data_plugins/epics_plugins/pyepics_plugin_component.py
+++ b/pydm/data_plugins/epics_plugins/pyepics_plugin_component.py
@@ -1,10 +1,10 @@
 import epics
 import logging
 import numpy as np
+from pydm import data_plugins
 from pydm.data_plugins.plugin import PyDMPlugin, PyDMConnection
 from qtpy.QtCore import Slot, Qt
 from qtpy.QtWidgets import QApplication
-from pydm.utilities import is_pydm_app
 
 logger = logging.getLogger(__name__)
 
@@ -88,7 +88,7 @@ class Connection(PyDMConnection):
             self.lower_ctrl_limit_signal.emit(lower_ctrl_limit)
 
     def send_access_state(self, read_access, write_access, *args, **kws):
-        if is_pydm_app() and self.app.is_read_only():
+        if data_plugins.is_read_only():
             self.write_access_signal.emit(False)
             return
 
@@ -114,7 +114,7 @@ class Connection(PyDMConnection):
     @Slot(str)
     @Slot(np.ndarray)
     def put_value(self, new_val):
-        if is_pydm_app() and self.app.is_read_only():
+        if data_plugins.is_read_only():
             return
 
         if self.pv.write_access:

--- a/pydm/data_plugins/epics_plugins/pyepics_plugin_component.py
+++ b/pydm/data_plugins/epics_plugins/pyepics_plugin_component.py
@@ -1,7 +1,7 @@
 import epics
 import logging
 import numpy as np
-from pydm import data_plugins
+from pydm.data_plugins import is_read_only
 from pydm.data_plugins.plugin import PyDMPlugin, PyDMConnection
 from qtpy.QtCore import Slot, Qt
 from qtpy.QtWidgets import QApplication
@@ -88,7 +88,7 @@ class Connection(PyDMConnection):
             self.lower_ctrl_limit_signal.emit(lower_ctrl_limit)
 
     def send_access_state(self, read_access, write_access, *args, **kws):
-        if data_plugins.is_read_only():
+        if is_read_only():
             self.write_access_signal.emit(False)
             return
 
@@ -114,7 +114,7 @@ class Connection(PyDMConnection):
     @Slot(str)
     @Slot(np.ndarray)
     def put_value(self, new_val):
-        if data_plugins.is_read_only():
+        if is_read_only():
             return
 
         if self.pv.write_access:

--- a/pydm/data_plugins/epics_plugins/pyepics_plugin_component.py
+++ b/pydm/data_plugins/epics_plugins/pyepics_plugin_component.py
@@ -152,27 +152,6 @@ class Connection(PyDMConnection):
             except KeyError:
                 pass
 
-    def remove_listener(self, channel):
-        if channel.value_signal is not None:
-            try:
-                channel.value_signal[str].disconnect(self.put_value)
-            except (KeyError, TypeError):
-                pass
-            try:
-                channel.value_signal[int].disconnect(self.put_value)
-            except (KeyError, TypeError):
-                pass
-            try:
-                channel.value_signal[float].disconnect(self.put_value)
-            except (KeyError, TypeError):
-                pass
-            try:
-                channel.value_signal[np.ndarray].disconnect(self.put_value)
-            except (KeyError, TypeError):
-                pass
-
-        super(Connection, self).remove_listener(channel)
-
     def close(self):
         self.pv.disconnect()
 

--- a/pydm/data_plugins/fake_plugin.py
+++ b/pydm/data_plugins/fake_plugin.py
@@ -13,16 +13,18 @@ class Connection(PyDMConnection):
         self.timer = QTimer(self)
         self.timer.timeout.connect(self.send_new_value)
         self.timer.start(1000)
-        self.send_connection_state(True)
         self.connected = True
 
     def send_new_value(self):
         val_to_send = "{0}-{1}".format(self.value, random.randint(0, 9))
-        self.new_value_signal.emit(str(val_to_send))
+        self.new_value_signal[str].emit(str(val_to_send))
 
     def send_connection_state(self, conn):
         self.connection_state_signal.emit(conn)
 
+    def add_listener(self, widget):
+        super().add_listener(widget)
+        self.send_connection_state(True)
 
 class FakePlugin(PyDMPlugin):
     protocol = "fake"

--- a/pydm/data_plugins/fake_plugin.py
+++ b/pydm/data_plugins/fake_plugin.py
@@ -23,8 +23,9 @@ class Connection(PyDMConnection):
         self.connection_state_signal.emit(conn)
 
     def add_listener(self, widget):
-        super().add_listener(widget)
+        super(Connection, self).add_listener(widget)
         self.send_connection_state(True)
+
 
 class FakePlugin(PyDMPlugin):
     protocol = "fake"

--- a/pydm/main_window.py
+++ b/pydm/main_window.py
@@ -101,7 +101,6 @@ class PyDMMainWindow(QMainWindow):
         if self._display_widget is not None:
             self.setCentralWidget(QWidget())
             self.app.unregister_widget_rules(self._display_widget)
-            self.app.close_widget_connections(self._display_widget)
             self._display_widget.deleteLater()
             self._display_widget = None
             self.ui.actionEdit_in_Designer.setEnabled(False)
@@ -408,7 +407,7 @@ class PyDMMainWindow(QMainWindow):
 
     @Slot(bool)
     def show_connections(self, checked):
-        c = ConnectionInspector(self.app.list_all_connections(), self)
+        c = ConnectionInspector(self)
         c.show()
 
     @Slot(bool)

--- a/pydm/main_window.py
+++ b/pydm/main_window.py
@@ -7,6 +7,7 @@ from .pydm_ui import Ui_MainWindow
 from .display_module import Display
 from .connection_inspector import ConnectionInspector
 from .about_pydm import AboutWindow
+from . import data_plugins
 import subprocess
 import platform
 import logging
@@ -259,7 +260,7 @@ class PyDMMainWindow(QMainWindow):
         else:
             title = self._display_widget.windowTitle()
         title += " - PyDM"
-        if self.app.is_read_only():
+        if data_plugins.is_read_only():
             title += " [Read Only Mode]"
         self.setWindowTitle(title)
 

--- a/pydm/qtdesigner.py
+++ b/pydm/qtdesigner.py
@@ -1,3 +1,5 @@
+from qtpy.QtCore import QTimer
+from qtpy.QtWidgets import QApplication
 from .utilities import stylesheet
 
 
@@ -13,6 +15,7 @@ class DesignerHooks(object):
             return
         self.__form_editor = None
         self.__initialized = True
+        self.__timer = None
 
     def __new__(cls, *args, **kwargs):
         if cls.__instance is None:
@@ -37,6 +40,7 @@ class DesignerHooks(object):
 
     def setup_hooks(self):
         self.__set_stylesheet_hook()
+        self.__start_kicker()
 
     def __set_stylesheet_hook(self):
         if self.form_editor:
@@ -50,3 +54,12 @@ class DesignerHooks(object):
         style_data = stylesheet._get_style_data(None)
         widget = form_window_interface.formContainer()
         widget.setStyleSheet(style_data)
+
+    def __kick(self):
+        app = QApplication.instance()
+        app.processEvents()
+        self.__timer.singleShot(0.03, self.__kick)
+
+    def __start_kicker(self):
+        self.__timer = QTimer()
+        self.__timer.singleShot(0.01, self.__kick) # ~30Hz

--- a/pydm/qtdesigner.py
+++ b/pydm/qtdesigner.py
@@ -1,6 +1,4 @@
 from qtpy.QtCore import QTimer
-from qtpy.QtGui import QResizeEvent
-from qtpy.QtWidgets import QApplication
 from .utilities import stylesheet
 from . import data_plugins
 

--- a/pydm/qtdesigner.py
+++ b/pydm/qtdesigner.py
@@ -64,8 +64,7 @@ class DesignerHooks(object):
         if fwman:
             widget = fwman.activeFormWindow()
             if widget:
-                ev = QResizeEvent(widget.size(), widget.size())
-                QApplication.instance().sendEvent(widget, ev)
+                widget.update()
 
     def __start_kicker(self):
         self.__timer = QTimer()

--- a/pydm/qtdesigner.py
+++ b/pydm/qtdesigner.py
@@ -16,7 +16,6 @@ class DesignerHooks(object):
         self.__form_editor = None
         self.__initialized = True
         self.__timer = None
-        data_plugins.set_read_only(True)
 
     def __new__(cls, *args, **kwargs):
         if cls.__instance is None:
@@ -40,9 +39,9 @@ class DesignerHooks(object):
         self.setup_hooks()
 
     def setup_hooks(self):
-        self.__set_stylesheet_hook()
+        # Set PyDM to be read-only
+        data_plugins.set_read_only(True)
 
-    def __set_stylesheet_hook(self):
         if self.form_editor:
             fwman = self.form_editor.formWindowManager()
             if fwman:

--- a/pydm/qtdesigner.py
+++ b/pydm/qtdesigner.py
@@ -16,6 +16,7 @@ class DesignerHooks(object):
         self.__form_editor = None
         self.__initialized = True
         self.__timer = None
+        self.__start_kicker()
 
     def __new__(cls, *args, **kwargs):
         if cls.__instance is None:
@@ -40,7 +41,6 @@ class DesignerHooks(object):
 
     def setup_hooks(self):
         self.__set_stylesheet_hook()
-        self.__start_kicker()
 
     def __set_stylesheet_hook(self):
         if self.form_editor:

--- a/pydm/tests/conftest.py
+++ b/pydm/tests/conftest.py
@@ -13,6 +13,9 @@ import logging
 from qtpy.QtCore import QObject, Signal, Slot
 from ..application import PyDMApplication
 from ..widgets.base import PyDMWidget
+from pydm.data_plugins import PyDMPlugin, add_plugin
+
+pytest_plugins = 'pytester'
 
 logger = logging.getLogger(__name__)
 _, file_path = tempfile.mkstemp(suffix=".log")
@@ -114,3 +117,12 @@ def qapp(qapp_args):
         yield _qapp_instance
     else:
         yield app  # pragma: no cover
+
+
+@pytest.fixture(scope='session')
+def test_plugin():
+    # Create test PyDMPlugin with mock protocol
+    test_plug = PyDMPlugin
+    test_plug.protocol = 'tst'
+    add_plugin(test_plug)
+    return test_plug

--- a/pydm/tests/test_data_plugins_import.py
+++ b/pydm/tests/test_data_plugins_import.py
@@ -28,9 +28,7 @@ def test_plugin_for_address(test_plugin):
     # Get by protocol
     assert isinstance(plugin_for_address('tst://tst:this'),
                       test_plugin)
-    # Unspecified protocol
-    with pytest.raises(ValueError):
-        plugin_for_address('tst:this')
+    assert plugin_for_address('tst:this') is None
     # Default protocol
     pydm.data_plugins.DEFAULT_PROTOCOL = 'tst'
     assert isinstance(plugin_for_address('tst:this'),

--- a/pydm/tests/test_data_plugins_import.py
+++ b/pydm/tests/test_data_plugins_import.py
@@ -1,9 +1,9 @@
 import os
-import pytest
 
 import pydm.data_plugins
 from pydm.data_plugins import (plugin_modules, load_plugins_from_path,
                                plugin_for_address)
+from pydm import config
 
 def test_data_plugin_add(qapp, test_plugin):
     # Check that adding this after import will be reflected in PyDMApp
@@ -30,7 +30,7 @@ def test_plugin_for_address(test_plugin):
                       test_plugin)
     assert plugin_for_address('tst:this') is None
     # Default protocol
-    pydm.data_plugins.DEFAULT_PROTOCOL = 'tst'
+    config.DEFAULT_PROTOCOL = 'tst'
     assert isinstance(plugin_for_address('tst:this'),
                       test_plugin)
 

--- a/pydm/tests/test_data_plugins_import.py
+++ b/pydm/tests/test_data_plugins_import.py
@@ -2,17 +2,8 @@ import os
 import pytest
 
 import pydm.data_plugins
-from pydm.data_plugins import (add_plugin, PyDMPlugin, plugin_modules,
-                               load_plugins_from_path, plugin_for_address)
-
-@pytest.fixture(scope='module')
-def test_plugin():
-    # Create test PyDMPlugin with mock protocol
-    test_plug = PyDMPlugin
-    test_plug.protocol = 'tst'
-    add_plugin(test_plug)
-    return test_plug
-
+from pydm.data_plugins import (plugin_modules, load_plugins_from_path,
+                               plugin_for_address)
 
 def test_data_plugin_add(qapp, test_plugin):
     # Check that adding this after import will be reflected in PyDMApp

--- a/pydm/tests/utilities/test_utilities.py
+++ b/pydm/tests/utilities/test_utilities.py
@@ -2,7 +2,8 @@ import os
 import platform
 import tempfile
 
-from ...utilities import is_pydm_app, path_info, which, find_display_in_path
+from ...utilities import (is_pydm_app, path_info, which, find_display_in_path,
+                          is_qt_designer)
 from qtpy import QtWidgets
 
 
@@ -12,6 +13,10 @@ def test_is_pydm_app(qapp):
 
 def test_negative_is_pydm_app():
     assert not is_pydm_app(QtWidgets.QLabel())
+
+
+def test_is_qt_designer():
+    assert not is_qt_designer()
 
 
 def test_path_info():

--- a/pydm/tests/widgets/test_base.py
+++ b/pydm/tests/widgets/test_base.py
@@ -9,7 +9,7 @@ from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QMenu
 from qtpy.QtGui import QColor, QMouseEvent
 from ...utilities import is_pydm_app
-from ...application import PyDMApplication
+from ... import data_plugins
 from ...widgets.base import is_channel_valid, PyDMWidget
 from ...widgets.label import PyDMLabel
 from ...widgets.line_edit import PyDMLineEdit
@@ -489,7 +489,7 @@ def test_pydmwritablewidget_channels(qtbot):
         ("", False, False, False),
         (None, False, False, False),
     ])
-def test_pydmwritable_check_enable_state(qtbot, monkeypatch, channel_address,
+def test_pydmwritable_check_enable_state(qtbot, channel_address,
                                          connected, write_access,
                                          is_app_read_only):
     """
@@ -507,8 +507,6 @@ def test_pydmwritable_check_enable_state(qtbot, monkeypatch, channel_address,
     ----------
     qtbot : fixture
         Window for widget testing
-    monkeypatch : fixture
-        To override the default behavior of PyDMApplication.is_read_only()
     channel_address : str
         The channel address
     connected : bool
@@ -525,8 +523,7 @@ def test_pydmwritable_check_enable_state(qtbot, monkeypatch, channel_address,
     pydm_lineedit._connected = connected
     pydm_lineedit._write_access = write_access
 
-    monkeypatch.setattr(PyDMApplication, 'is_read_only',
-                        lambda *args: is_app_read_only)
+    data_plugins.set_read_only(is_app_read_only)
 
     original_tooltip = "Original Tooltip"
     pydm_lineedit.setToolTip(original_tooltip)
@@ -537,7 +534,7 @@ def test_pydmwritable_check_enable_state(qtbot, monkeypatch, channel_address,
         if not pydm_lineedit._connected:
             assert "PV is disconnected." in actual_tooltip
         elif not write_access:
-            if is_pydm_app() and pydm_lineedit.app.is_read_only():
+            if data_plugins.is_read_only():
                 assert "Running PyDM on Read-Only mode." in actual_tooltip
             else:
                 assert "Access denied by Channel Access Security." in actual_tooltip

--- a/pydm/tests/widgets/test_base.py
+++ b/pydm/tests/widgets/test_base.py
@@ -73,8 +73,11 @@ def test_pydmwidget_construct(qtbot, init_channel):
 
     assert pydm_label.app is None if not is_pydm_app else not None
     assert pydm_label._connected is not is_pydm_app
-    assert pydm_label._channel == init_channel
-    assert pydm_label._channels is None
+    assert pydm_label._color == test_local_connection_status_color_map[False]
+    if init_channel is None:
+        assert pydm_label.channels() is None
+    else:
+        assert len(pydm_label.channels()) == 1
     assert pydm_label._show_units is False
     assert pydm_label._alarm_sensitive_content is False
     assert pydm_label.alarmSensitiveBorder is True
@@ -369,7 +372,7 @@ def test_channels_for_tools(qtbot):
     qtbot : fixture
         Window for widget testing
     """
-    pydm_label = PyDMLabel()
+    pydm_label = PyDMLabel(init_channel='tst://This')
     qtbot.addWidget(pydm_label)
 
     assert all(x == y for x, y in
@@ -389,16 +392,14 @@ def test_pydmwidget_channel_change(qtbot):
     pydm_label = PyDMLabel()
     qtbot.addWidget(pydm_label)
     assert pydm_label._channel is None
-    assert pydm_label._channels is None
+    assert pydm_label.channels() is None
 
     pydm_label.channel = 'foo://bar'
     assert pydm_label._channel == 'foo://bar'
-    assert pydm_label._channels is None
     assert pydm_label.channels()[0].address == 'foo://bar'
 
     pydm_label.channel = 'abc://def'
     assert pydm_label._channel == 'abc://def'
-    assert pydm_label._channels is None
     assert pydm_label.channels()[0].address == 'abc://def'
 
 
@@ -420,8 +421,8 @@ def test_pydmwidget_channels(qtbot):
     qtbot.addWidget(pydm_label)
 
     assert pydm_label._channel is None
-    assert pydm_label._channels is None
-
+    assert pydm_label.channels() is None
+    pydm_label.channel = 'test://this'
     pydm_channels = pydm_label.channels()[0]
 
     default_pydm_channels = PyDMChannel(address=pydm_label.channel,
@@ -436,13 +437,6 @@ def test_pydmwidget_channels(qtbot):
                                         value_signal=None,
                                         write_access_slot=None)
     assert pydm_channels == default_pydm_channels
-
-    new_channel = PyDMChannel(address=pydm_label.channel,
-                              connection_slot=pydm_label.connectionStateChanged,
-                              upper_ctrl_limit_slot=None,
-                              lower_ctrl_limit_slot=None)
-    pydm_label._channels = [new_channel]
-    assert pydm_label.channels()[0] == new_channel
 
 
 def test_pydmwritablewidget_channels(qtbot):
@@ -464,8 +458,9 @@ def test_pydmwritablewidget_channels(qtbot):
     qtbot.addWidget(pydm_lineedit)
 
     assert pydm_lineedit._channel is None
-    assert pydm_lineedit._channels is None
+    assert pydm_lineedit.channels() is None
 
+    pydm_lineedit.channel = 'tst://this'
     pydm_channels = pydm_lineedit.channels()[0]
 
     default_pydm_channels = PyDMChannel(address=pydm_lineedit.channel,
@@ -480,13 +475,6 @@ def test_pydmwritablewidget_channels(qtbot):
                                         value_signal=pydm_lineedit.send_value_signal,
                                         write_access_slot=pydm_lineedit.writeAccessChanged)
     assert pydm_channels == default_pydm_channels
-
-    new_channel = PyDMChannel(address=pydm_lineedit.channel,
-                              connection_slot=pydm_lineedit.connectionStateChanged,
-                              upper_ctrl_limit_slot=None,
-                              lower_ctrl_limit_slot=None)
-    pydm_lineedit._channels = [new_channel]
-    assert pydm_lineedit.channels()[0] == new_channel
 
 
 @pytest.mark.parametrize(

--- a/pydm/tests/widgets/test_base.py
+++ b/pydm/tests/widgets/test_base.py
@@ -73,7 +73,6 @@ def test_pydmwidget_construct(qtbot, init_channel):
 
     assert pydm_label.app is None if not is_pydm_app else not None
     assert pydm_label._connected is not is_pydm_app
-    assert pydm_label._color == test_local_connection_status_color_map[False]
     if init_channel is None:
         assert pydm_label.channels() is None
     else:

--- a/pydm/tests/widgets/test_channel.py
+++ b/pydm/tests/widgets/test_channel.py
@@ -1,10 +1,8 @@
 # Unit Tests for the Channel widget class
 from ...widgets.label import PyDMLabel
 from ...widgets.line_edit import PyDMLineEdit
-from ...widgets.channel import PyDMChannel, Registry
+from ...widgets.channel import PyDMChannel
 from pydm.data_plugins import plugin_for_address
-
-
 class A():
     pass
 
@@ -67,15 +65,14 @@ def test_construct(qtbot):
     assert equal_result is False and not_equal_result is True
 
 
-def test_pydm_connection(test_plugin, monkeypatch):
+def test_pydm_connection(test_plugin):
     # Plugin, Channel and Registry
     chan = PyDMChannel('tst://Tst:this')
-    cr = Registry()
     plugin = plugin_for_address(chan.address)
     plugin_no = len(plugin.connections)
     # Make a connection
-    cr.add_connection(chan)
+    chan.connect()
     assert len(plugin.connections) == plugin_no + 1
-    # Remove a connection
-    cr.remove_connection(chan)
+    # Remove connections
+    chan.disconnect()
     assert len(plugin.connections) == plugin_no

--- a/pydm/tests/widgets/test_channel.py
+++ b/pydm/tests/widgets/test_channel.py
@@ -35,7 +35,7 @@ def test_construct(qtbot):
         pydm_channel.write_access_slot is None and \
         pydm_channel.value_signal is None
 
-    pydm_label = PyDMLabel()
+    pydm_label = PyDMLabel(init_channel='tst://this')
     qtbot.addWidget(pydm_label)
 
     pydm_label_channels = pydm_label.channels()[0]
@@ -52,7 +52,7 @@ def test_construct(qtbot):
                                               write_access_slot=None)
     assert pydm_label_channels == default_pydm_label_channels
 
-    pydm_lineedit = PyDMLineEdit()
+    pydm_lineedit = PyDMLineEdit(init_channel='tst://this2')
     qtbot.addWidget(pydm_lineedit)
 
     # Test equal and not equal comparisons

--- a/pydm/tests/widgets/test_channel.py
+++ b/pydm/tests/widgets/test_channel.py
@@ -1,10 +1,8 @@
 # Unit Tests for the Channel widget class
-
-import pytest
-
 from ...widgets.label import PyDMLabel
 from ...widgets.line_edit import PyDMLineEdit
-from ...widgets.channel import PyDMChannel
+from ...widgets.channel import PyDMChannel, Registry
+from pydm.data_plugins import plugin_for_address
 
 
 class A():
@@ -67,3 +65,17 @@ def test_construct(qtbot):
     equal_result = not_same_type == default_pydm_label_channels
     not_equal_result = not_same_type != default_pydm_label_channels
     assert equal_result is False and not_equal_result is True
+
+
+def test_pydm_connection(test_plugin, monkeypatch):
+    # Plugin, Channel and Registry
+    chan = PyDMChannel('tst://Tst:this')
+    cr = Registry()
+    plugin = plugin_for_address(chan.address)
+    plugin_no = len(plugin.connections)
+    # Make a connection
+    cr.add_connection(chan)
+    assert len(plugin.connections) == plugin_no + 1
+    # Remove a connection
+    cr.remove_connection(chan)
+    assert len(plugin.connections) == plugin_no

--- a/pydm/tests/widgets/test_drawing.py
+++ b/pydm/tests/widgets/test_drawing.py
@@ -149,6 +149,7 @@ def test_pydmdrawing_paintEvent(qtbot, signals, alarm_sensitive_content):
 
     with qtbot.waitExposed(pydm_drawing):
         pydm_drawing.show()
+    qtbot.waitUntil(lambda: pydm_drawing.isEnabled(), timeout=5000)
     pydm_drawing.setFocus()
 
     def wait_focus():
@@ -494,6 +495,7 @@ def test_pydmdrawingline_draw_item(qtbot, signals, alarm_sensitive_content):
 
     with qtbot.waitExposed(pydm_drawingline):
         pydm_drawingline.show()
+    qtbot.waitUntil(lambda: pydm_drawingline.isEnabled(), timeout=5000)
     pydm_drawingline.setFocus()
 
     def wait_focus():

--- a/pydm/tests/widgets/test_drawing.py
+++ b/pydm/tests/widgets/test_drawing.py
@@ -140,7 +140,7 @@ def test_pydmdrawing_paintEvent(qtbot, signals, alarm_sensitive_content):
     alarm_sensitive_content : bool
         True if the widget will be redraw with a different color if an alarm is triggered; False otherwise.
     """
-    pydm_drawing = PyDMDrawing()
+    pydm_drawing = PyDMDrawing(init_channel='fake://tst')
     qtbot.addWidget(pydm_drawing)
 
     pydm_drawing.alarmSensitiveContent = alarm_sensitive_content
@@ -485,7 +485,7 @@ def test_pydmdrawingline_draw_item(qtbot, signals, alarm_sensitive_content):
     alarm_sensitive_content : bool
         True if the widget will be redraw with a different color if an alarm is triggered; False otherwise
     """
-    pydm_drawingline = PyDMDrawingLine()
+    pydm_drawingline = PyDMDrawingLine(init_channel='fake://tst')
     qtbot.addWidget(pydm_drawingline)
 
     pydm_drawingline.alarmSensitiveContent = alarm_sensitive_content

--- a/pydm/tests/widgets/test_enum_combo_box.py
+++ b/pydm/tests/widgets/test_enum_combo_box.py
@@ -6,8 +6,7 @@ from logging import ERROR
 from qtpy.QtCore import Slot, Qt
 
 from ...widgets.enum_combo_box import PyDMEnumComboBox
-from ...application import PyDMApplication
-from ...utilities import is_pydm_app
+from ... import data_plugins
 
 
 # --------------------
@@ -90,7 +89,7 @@ def test_set_items(qtbot, enums):
     (False, False, False, True),
     (False, False, False, False),
 ])
-def test_check_enable_state(qtbot, signals, monkeypatch, connected, write_access, has_enum, is_app_read_only):
+def test_check_enable_state(qtbot, signals, connected, write_access, has_enum, is_app_read_only):
     """
     Test the tooltip generated depending on the channel connection, write access, whether the widget has enum strings,
     and whether the app is read-only.
@@ -108,8 +107,6 @@ def test_check_enable_state(qtbot, signals, monkeypatch, connected, write_access
         Window for widget testing
     signals : fixture
         The signals fixture, which provides access signals to be bound to the appropriate slots
-    monkeypatch : fixture
-        To override the default behavior of PyDMApplication.is_read_only()
     connected : bool
         True if the channel is connected; False otherwise
     write_access : bool
@@ -133,7 +130,7 @@ def test_check_enable_state(qtbot, signals, monkeypatch, connected, write_access
         signals.enum_strings_signal[tuple].emit(("START", "STOP", "PAUSE"))
         assert pydm_enumcombobox._has_enums
 
-    monkeypatch.setattr(PyDMApplication, 'is_read_only', lambda *args: is_app_read_only)
+    data_plugins.set_read_only(is_app_read_only)
 
     original_tooltip = "Original Tooltip"
     pydm_enumcombobox.setToolTip(original_tooltip)
@@ -143,7 +140,7 @@ def test_check_enable_state(qtbot, signals, monkeypatch, connected, write_access
     if not pydm_enumcombobox._connected:
         assert "PV is disconnected." in actual_tooltip
     elif not write_access:
-        if is_pydm_app() and pydm_enumcombobox.app.is_read_only():
+        if data_plugins.is_read_only():
             assert "Running PyDM on Read-Only mode." in actual_tooltip
         else:
             assert "Access denied by Channel Access Security." in actual_tooltip

--- a/pydm/tests/widgets/test_frame.py
+++ b/pydm/tests/widgets/test_frame.py
@@ -3,9 +3,8 @@
 
 import pytest
 
-from ...utilities import is_pydm_app
 from ...widgets.base import is_channel_valid
-from ...application import PyDMApplication
+from ... import data_plugins
 from ...widgets.base import PyDMWidget
 from ...widgets.frame import PyDMFrame
 
@@ -140,7 +139,7 @@ def test_alarm_severity_change(qtbot, signals, channel, alarm_sensitive_content,
     ("", False, False, False),
     (None, False, False, False),
 ])
-def test_check_enable_state(qtbot, signals, monkeypatch, channel_address, connected, write_access, is_app_read_only):
+def test_check_enable_state(qtbot, signals, channel_address, connected, write_access, is_app_read_only):
     """
     Test the tooltip generated depending on the channel address validation, connection, write access, and whether the
     app is read-only.
@@ -158,8 +157,6 @@ def test_check_enable_state(qtbot, signals, monkeypatch, channel_address, connec
         Window for widget testing
     signals : fixture
         The signals fixture, which provides access signals to be bound to the appropriate slots
-    monkeypatch : fixture
-        To override the default behavior of PyDMApplication.is_read_only()
     channel_address : str
         The channel address
     connected : bool
@@ -183,7 +180,7 @@ def test_check_enable_state(qtbot, signals, monkeypatch, channel_address, connec
         signals.connection_state_signal[bool].connect(pydm_frame.connectionStateChanged)
         signals.connection_state_signal[bool].emit(connected)
 
-        monkeypatch.setattr(PyDMApplication, 'is_read_only', lambda *args: is_app_read_only)
+        data_plugins.set_read_only(is_app_read_only)
 
         original_tooltip = "Original Tooltip"
         pydm_frame.setToolTip(original_tooltip)
@@ -194,7 +191,7 @@ def test_check_enable_state(qtbot, signals, monkeypatch, channel_address, connec
             if not pydm_frame._connected:
                 assert "PV is disconnected." in actual_tooltip
             elif not write_access:
-                if is_pydm_app() and pydm_frame.app.is_read_only():
+                if data_plugins.is_read_only():
                     assert "Running PyDM on Read-Only mode." in actual_tooltip
                 else:
                     assert "Access denied by Channel Access Security." in actual_tooltip

--- a/pydm/tests/widgets/test_timeplot.py
+++ b/pydm/tests/widgets/test_timeplot.py
@@ -20,6 +20,7 @@ from ...utilities import remove_protocol
 ])
 def test_timeplotcurveitem_construct(qtbot, channel_address, name):
     pydm_timeplot_curve_item = TimePlotCurveItem(channel_address=channel_address, name=name)
+    qtbot.addWidget(pydm_timeplot_curve_item)
 
     if not name:
         assert pydm_timeplot_curve_item.to_dict()["name"] == remove_protocol(channel_address) if channel_address else \
@@ -43,8 +44,10 @@ def test_timeplotcurveitem_construct(qtbot, channel_address, name):
     ("", None),
     (None, None)
 ])
-def test_timeplotcurveitem_to_dict(channel_address, name):
+def test_timeplotcurveitem_to_dict(qtbot, channel_address, name):
     pydm_timeplot_curve_item = TimePlotCurveItem(channel_address=channel_address, name=name)
+    qtbot.addWidget(pydm_timeplot_curve_item)
+
     dictionary = pydm_timeplot_curve_item.to_dict()
     assert isinstance(dictionary, OrderedDict)
 
@@ -60,8 +63,9 @@ def test_timeplotcurveitem_to_dict(channel_address, name):
     "",
     None
 ])
-def test_timeplotcurveitem_properties_and_setters(new_address):
+def test_timeplotcurveitem_properties_and_setters(qtbot, new_address):
     pydm_timeplot_curve_item = TimePlotCurveItem()
+    qtbot.addWidget(pydm_timeplot_curve_item)
 
     assert pydm_timeplot_curve_item.address is None
 
@@ -73,8 +77,9 @@ def test_timeplotcurveitem_properties_and_setters(new_address):
         assert pydm_timeplot_curve_item.channel is None
 
 
-def test_timeplotcurveitem_connection_state_changed(signals):
+def test_timeplotcurveitem_connection_state_changed(qtbot, signals):
     pydm_timeplot_curve_item = TimePlotCurveItem()
+    qtbot.addWidget(pydm_timeplot_curve_item)
     assert pydm_timeplot_curve_item.connected is False
 
     signals.connection_state_signal.connect(pydm_timeplot_curve_item.connectionStateChanged)
@@ -134,8 +139,9 @@ def test_timeplotcurveitem_receive_value(qtbot, signals, async_update, new_data)
     (True, 100),
     (True, -123.456)
 ])
-def test_timeplotcurveitem_async_update(signals, async_update, new_data):
+def test_timeplotcurveitem_async_update(qtbot, signals, async_update, new_data):
     pydm_timeplot_curve_item = TimePlotCurveItem()
+    qtbot.addWidget(pydm_timeplot_curve_item)
 
     assert pydm_timeplot_curve_item._update_mode == PyDMTimePlot.SynchronousMode
 

--- a/pydm/utilities/__init__.py
+++ b/pydm/utilities/__init__.py
@@ -1,7 +1,7 @@
 from .units import find_unittype, convert, find_unit_options
 from . import macro
 from . import colors
-from .remove_protocol import remove_protocol
+from .remove_protocol import remove_protocol, protocol_and_address
 from .iconfont import IconFont
 
 import os

--- a/pydm/utilities/__init__.py
+++ b/pydm/utilities/__init__.py
@@ -2,6 +2,7 @@ from .units import find_unittype, convert, find_unit_options
 from . import macro
 from . import colors
 from .remove_protocol import remove_protocol, protocol_and_address
+from .connection import establish_widget_connections, close_widget_connections
 from .iconfont import IconFont
 
 import os

--- a/pydm/utilities/__init__.py
+++ b/pydm/utilities/__init__.py
@@ -4,6 +4,7 @@ from . import colors
 from .remove_protocol import remove_protocol, protocol_and_address
 from .connection import establish_widget_connections, close_widget_connections
 from .iconfont import IconFont
+from ..qtdesigner import DesignerHooks
 
 import os
 import sys
@@ -34,6 +35,18 @@ def is_pydm_app(app=None):
         return True
     else:
         return False
+
+
+def is_qt_designer():
+    """
+    Check whether or not running inside Qt Designer.
+
+    Returns
+    -------
+    bool
+        True if inside Designer, False otherwise.
+    """
+    return DesignerHooks().form_editor is not None
 
 
 def path_info(path_str):

--- a/pydm/utilities/connection.py
+++ b/pydm/utilities/connection.py
@@ -18,14 +18,17 @@ def __change_connection_status(widget, status):
     widgets = [widget]
     widgets.extend(widget.findChildren(QWidget))
     for child_widget in widgets:
-        if hasattr(child_widget, 'channels'):
-            for channel in child_widget.channels():
-                if channel is None:
-                    continue
-                if status:
-                    channel.connect()
-                else:
-                    channel.disconnect()
+        try:
+            if hasattr(child_widget, 'channels'):
+                for channel in child_widget.channels():
+                    if channel is None:
+                        continue
+                    if status:
+                        channel.connect()
+                    else:
+                        channel.disconnect()
+        except NameError:
+            continue
 
 
 def establish_widget_connections(widget):

--- a/pydm/utilities/connection.py
+++ b/pydm/utilities/connection.py
@@ -1,0 +1,52 @@
+from qtpy.QtWidgets import QWidget
+
+
+def __change_connection_status(widget, status):
+    """
+    Connect or disconnect the inner channels of widgets on the
+    given widget based on the status parameter.
+
+    Parameters
+    ----------
+    widget : QWidget
+        The widget which will be iterated over for channel connection.
+
+    status : bool
+        If True, will call connect on the channels otherwise it will call
+        disconnect.
+    """
+    widgets = [widget]
+    widgets.extend(widget.findChildren(QWidget))
+    for child_widget in widgets:
+        if hasattr(child_widget, 'channels'):
+            for channel in child_widget.channels():
+                if channel is None:
+                    continue
+                if status:
+                    channel.connect()
+                else:
+                    channel.disconnect()
+
+
+def establish_widget_connections(widget):
+    """
+    Connect the inner channels of widgets on the given widget.
+
+    Parameters
+    ----------
+    widget : QWidget
+        The widget which will be iterated over for channel connection.
+    """
+    __change_connection_status(widget, True)
+
+
+def close_widget_connections(widget):
+    """
+    Disconnect the inner channels of widgets on the given widget.
+
+    Parameters
+    ----------
+    widget : QWidget
+        The widget which will be iterated over for channel disconnection.
+    """
+    __change_connection_status(widget, False)

--- a/pydm/utilities/connection.py
+++ b/pydm/utilities/connection.py
@@ -1,7 +1,7 @@
 from qtpy.QtWidgets import QWidget
 
 
-def __change_connection_status(widget, status):
+def _change_connection_status(widget, status):
     """
     Connect or disconnect the inner channels of widgets on the
     given widget based on the status parameter.
@@ -40,7 +40,7 @@ def establish_widget_connections(widget):
     widget : QWidget
         The widget which will be iterated over for channel connection.
     """
-    __change_connection_status(widget, True)
+    _change_connection_status(widget, True)
 
 
 def close_widget_connections(widget):
@@ -52,4 +52,4 @@ def close_widget_connections(widget):
     widget : QWidget
         The widget which will be iterated over for channel disconnection.
     """
-    __change_connection_status(widget, False)
+    _change_connection_status(widget, False)

--- a/pydm/utilities/remove_protocol.py
+++ b/pydm/utilities/remove_protocol.py
@@ -1,3 +1,5 @@
+import re
+
 def remove_protocol(addr):
     """
     Removes the first occurrence of the protocol string ('://') from the string `addr`
@@ -11,11 +13,31 @@ def remove_protocol(addr):
     -------
     str
     """
+    _, addr = protocol_and_address(addr)
+    return addr
 
-    name = addr
-    name = ''.join(name[1:]) if len(name) > 1 else addr
-    if name:
-        name = addr.split("://", 1)  # maxsplit = 1... removes only the first occurrence
-        name = ''.join(name[1:]) if len(name) > 1 else addr
 
-    return name
+def protocol_and_address(address):
+    """
+    Returns the Protocol and Address pieces of a Channel Address
+
+    Parameters
+    ----------
+    address : str
+        The address from which to remove the address prefix.
+
+    Returns
+    -------
+    protocol : str
+        The protocol used. None in case the protocol is not specified.
+    addr : str
+        The piece of the address without the protocol.
+    """
+    match = re.match('.*?://', address)
+    protocol = None
+    addr = address
+    if match:
+        protocol = match.group(0)[:-3]
+        addr = address.replace(match.group(0), '')
+
+    return protocol, addr

--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -9,7 +9,6 @@ from .channel import PyDMChannel
 from .. import data_plugins
 from ..utilities import is_pydm_app, remove_protocol
 from .rules import RulesDispatcher
-from .. import config
 
 try:
     from json.decoder import JSONDecodeError

--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -191,7 +191,6 @@ class PyDMWidget(PyDMPrimitiveWidget):
 
         self.app = QApplication.instance()
         self._connected = True
-        self._color = self.local_connection_status_color_map[False]
         self._channel = None
         self._channels = list()
         self._show_units = False

--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -818,10 +818,10 @@ class PyDMWidget(PyDMPrimitiveWidget):
         """
         if self._channel != value:
             # Remove old connections
-            for channel in self._channels:
-                if channel.address == self._channel:
-                    channel.disconnect()
-                    self._channels.remove(channel)
+            for channel in [c for c in self._channels if
+                            c.address == self._channel]:
+                channel.disconnect()
+                self._channels.remove(channel)
             # Load new channel
             self._channel = str(value)
             channel = PyDMChannel(address=self._channel,

--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -392,9 +392,14 @@ class PyDMWidget(PyDMPrimitiveWidget):
         # it out before putting it on the clipboard.
         m = re.match('(.+?):/{2,3}(.+?)$', addr)
         if m is not None and DEFAULT_PROTOCOL is not None and m.group(1) == DEFAULT_PROTOCOL:
-            QApplication.clipboard().setText(m.group(2), mode=QClipboard.Selection)
+            copy_text = m.group(2)
         else:
-            QApplication.clipboard().setText(addr, mode=QClipboard.Selection)
+            copy_text = addr
+
+        clipboard = QApplication.clipboard()
+        clipboard.setText(copy_text)
+        event = QEvent(QEvent.Clipboard)
+        self.sendEvent(clipboard, event)
 
     def unit_changed(self, new_unit):
         """

--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -976,7 +976,7 @@ class PyDMWritableWidget(PyDMWidget):
             if event.type() == QEvent.Enter and not status:
                 QApplication.setOverrideCursor(QCursor(Qt.ForbiddenCursor))
 
-        return super().eventFilter(obj, event)
+        return PyDMWidget.eventFilter(self, obj, event)
 
 
     def write_access_changed(self, new_write_access):

--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -906,10 +906,6 @@ class PyDMWidget(PyDMPrimitiveWidget):
         return self.channels()
 
 
-    def qcolor_for_alarm(self, alarm, alarm_type=ALARM_CONTENT):
-        return QColor(self.alarm_style_sheet_map[alarm_type][alarm]["color"])
-
-
 class PyDMWritableWidget(PyDMWidget):
     """
     PyDM base class for Writable widgets.

--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -6,6 +6,7 @@ from qtpy.QtWidgets import QApplication, QMenu, QGraphicsOpacityEffect
 from qtpy.QtGui import QColor, QClipboard, QCursor
 from qtpy.QtCore import Qt, QEvent, Signal, Slot, Property
 from .channel import PyDMChannel
+from .. import data_plugins
 from ..utilities import is_pydm_app, remove_protocol
 from .rules import RulesDispatcher
 
@@ -1035,7 +1036,7 @@ class PyDMWritableWidget(PyDMWidget):
         elif not self._write_access:
             if tooltip != '':
                 tooltip += '\n'
-            if is_pydm_app() and self.app.is_read_only():
+            if data_plugins.is_read_only():
                 tooltip += "Running PyDM on Read-Only mode."
             else:
                 tooltip += "Access denied by Channel Access Security."

--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -9,6 +9,7 @@ from .channel import PyDMChannel
 from .. import data_plugins
 from ..utilities import is_pydm_app, remove_protocol
 from .rules import RulesDispatcher
+from .. import config
 
 try:
     from json.decoder import JSONDecodeError
@@ -235,7 +236,7 @@ class PyDMWidget(PyDMPrimitiveWidget):
         self.channeltype = None
         self.subtype = None
 
-        # If this label is inside a PyDMApplication (not Designer) start it in '
+        # If this label is inside a PyDMApplication (not Designer) start it in
         # the disconnected state.
         self.setContextMenuPolicy(Qt.DefaultContextMenu)
         self.contextMenuEvent = self.open_context_menu

--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -216,14 +216,13 @@ class PyDMWidget(PyDMPrimitiveWidget):
 
         # If this label is inside a PyDMApplication (not Designer) start it in '
         # the disconnected state.
+        self.setContextMenuPolicy(Qt.DefaultContextMenu)
+        self.contextMenuEvent = self.open_context_menu
+        self.channel = init_channel
         if is_pydm_app():
             self._connected = False
             self.alarmSeverityChanged(self.ALARM_DISCONNECTED)
             self.check_enable_state()
-
-        self.setContextMenuPolicy(Qt.DefaultContextMenu)
-        self.contextMenuEvent = self.open_context_menu
-        self.channel = init_channel
 
     def widget_ctx_menu(self):
         """

--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -62,12 +62,10 @@ def widget_destroyed(channels, widget):
     widget : QWidget
         The widget. Which is pretty useless at this point.
     """
-    print("Called destroyed for: ", widget)
     chs = channels()
     if not chs:
         return
 
-    print("Channels: ", chs)
     for ch in chs:
         if ch:
             ch.disconnect()

--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -159,6 +159,23 @@ class PyDMPrimitiveWidget(object):
             except JSONDecodeError as ex:
                 logger.exception('Invalid format for Rules')
 
+
+def widget_destroyed(channels, widget):
+    """
+    Callback invoked when the Widget is destroyed.
+    This method is used to ensure that the channels are disconnected.
+
+    Parameters
+    ----------
+    channels : list
+        A list of PyDMChannel objects that this widget uses.
+    widget : QWidget
+        The widget. Which is pretty useless at this point.
+    """
+    for ch in channels:
+        ch.disconnect()
+
+
 class PyDMWidget(PyDMPrimitiveWidget):
     """
     PyDM base class for Read-Only widgets.
@@ -221,6 +238,8 @@ class PyDMWidget(PyDMPrimitiveWidget):
             self._connected = False
             self.alarmSeverityChanged(self.ALARM_DISCONNECTED)
             self.check_enable_state()
+
+        self.destroyed.connect(functools.partial(widget_destroyed, self._channels))
 
     def widget_ctx_menu(self):
         """

--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -6,9 +6,8 @@ from qtpy.QtWidgets import QApplication, QMenu, QGraphicsOpacityEffect
 from qtpy.QtGui import QColor, QClipboard, QCursor
 from qtpy.QtCore import Qt, QEvent, Signal, Slot, Property
 from .channel import PyDMChannel
-from ..utilities import is_pydm_app
+from ..utilities import is_pydm_app, remove_protocol
 from .rules import RulesDispatcher
-from ..data_plugins import DEFAULT_PROTOCOL
 
 try:
     from json.decoder import JSONDecodeError
@@ -387,13 +386,9 @@ class PyDMWidget(PyDMPrimitiveWidget):
             return
         addr = self.channels()[0].address
         QToolTip.showText(event.globalPos(), addr)
-        # If the address has a protocol, and it is the default protocol, strip
-        # it out before putting it on the clipboard.
-        m = re.match('(.+?):/{2,3}(.+?)$', addr)
-        if m is not None and DEFAULT_PROTOCOL is not None and m.group(1) == DEFAULT_PROTOCOL:
-            copy_text = m.group(2)
-        else:
-            copy_text = addr
+        # If the address has a protocol, strip it out before putting it on the
+        # clipboard.
+        copy_text = remove_protocol(addr)
 
         clipboard = QApplication.clipboard()
         clipboard.setText(copy_text)

--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -38,7 +38,7 @@ def is_channel_valid(channel):
 
 
 def only_if_channel_set(fcn):
-    '''Decorator to avoid executing a method if a channel is not valid or configured.'''
+    """Decorator to avoid executing a method if a channel is not valid or configured."""
 
     @functools.wraps(fcn)
     def wrapper(self, *args, **kwargs):
@@ -48,6 +48,29 @@ def only_if_channel_set(fcn):
             return
 
     return wrapper
+
+
+def widget_destroyed(channels, widget):
+    """
+    Callback invoked when the Widget is destroyed.
+    This method is used to ensure that the channels are disconnected.
+
+    Parameters
+    ----------
+    channels : list
+        A list of PyDMChannel objects that this widget uses.
+    widget : QWidget
+        The widget. Which is pretty useless at this point.
+    """
+    print("Called destroyed for: ", widget)
+    chs = channels()
+    if not chs:
+        return
+
+    print("Channels: ", chs)
+    for ch in chs:
+        if ch:
+            ch.disconnect()
 
 
 class PyDMPrimitiveWidget(object):
@@ -160,22 +183,6 @@ class PyDMPrimitiveWidget(object):
                 logger.exception('Invalid format for Rules')
 
 
-def widget_destroyed(channels, widget):
-    """
-    Callback invoked when the Widget is destroyed.
-    This method is used to ensure that the channels are disconnected.
-
-    Parameters
-    ----------
-    channels : list
-        A list of PyDMChannel objects that this widget uses.
-    widget : QWidget
-        The widget. Which is pretty useless at this point.
-    """
-    for ch in channels:
-        ch.disconnect()
-
-
 class PyDMWidget(PyDMPrimitiveWidget):
     """
     PyDM base class for Read-Only widgets.
@@ -239,7 +246,7 @@ class PyDMWidget(PyDMPrimitiveWidget):
             self.alarmSeverityChanged(self.ALARM_DISCONNECTED)
             self.check_enable_state()
 
-        self.destroyed.connect(functools.partial(widget_destroyed, self._channels))
+        self.destroyed.connect(functools.partial(widget_destroyed, self.channels))
 
     def widget_ctx_menu(self):
         """

--- a/pydm/widgets/baseplot.py
+++ b/pydm/widgets/baseplot.py
@@ -304,7 +304,8 @@ class BasePlot(PlotWidget, PyDMPrimitiveWidget):
         self.redraw_timer.start()
         # Connect channels
         for chan in plot_item.channels():
-            chan.connect()
+            if chan:
+                chan.connect()
         # self._legend.addItem(plot_item, plot_item.curve_name)
 
     def removeCurve(self, plot_item):
@@ -314,7 +315,8 @@ class BasePlot(PlotWidget, PyDMPrimitiveWidget):
             self.redraw_timer.stop()
         # Disconnect channels
         for chan in plot_item.channels():
-            chan.disconnect()
+            if chan:
+                chan.disconnect()
 
     def removeCurveWithName(self, name):
         for curve in self._curves:

--- a/pydm/widgets/baseplot.py
+++ b/pydm/widgets/baseplot.py
@@ -70,7 +70,9 @@ class BasePlotCurveItem(PlotDataItem):
         if color is not None:
             self.color = color
 
-        self.destroyed.connect(functools.partial(widget_destroyed, self.channels))
+        if hasattr(self, "channels"):
+            self.destroyed.connect(functools.partial(widget_destroyed,
+                                                     self.channels))
 
     @property
     def color_string(self):
@@ -247,10 +249,8 @@ class BasePlotCurveItem(PlotDataItem):
                             ("symbol", self.symbol),
                             ("symbolSize", self.symbolSize)])
 
-    def channels(self):
-        """All channels for PlotCurve"""
-        return [getattr(self, chan) for chan in self._channels
-                if chan is not None]
+    def close(self):
+        pass
 
 
 class BasePlot(PlotWidget, PyDMPrimitiveWidget):

--- a/pydm/widgets/baseplot.py
+++ b/pydm/widgets/baseplot.py
@@ -1,9 +1,10 @@
+import functools
 from qtpy.QtGui import QColor, QBrush
 from qtpy.QtCore import Signal, Slot, Property, QTimer, Qt
 from .. import utilities
 from pyqtgraph import PlotWidget, PlotDataItem, mkPen, ViewBox, InfiniteLine, SignalProxy, CurvePoint, TextItem
 from collections import OrderedDict
-from .base import PyDMPrimitiveWidget
+from .base import PyDMPrimitiveWidget, widget_destroyed
 
 
 class NoDataError(Exception):
@@ -68,6 +69,8 @@ class BasePlotCurveItem(PlotDataItem):
         self.setSymbolBrush(None)
         if color is not None:
             self.color = color
+
+        self.destroyed.connect(functools.partial(widget_destroyed, self.channels))
 
     @property
     def color_string(self):

--- a/pydm/widgets/byte.py
+++ b/pydm/widgets/byte.py
@@ -1,7 +1,6 @@
 from qtpy.QtWidgets import QWidget, QTabWidget, QGridLayout, QLabel, QStyle, QStyleOption
 from qtpy.QtGui import QColor, QPen, QFontMetrics, QPainter, QBrush
 from qtpy.QtCore import Property, Qt, QSize, QPoint
-import numpy as np
 from .base import PyDMWidget
 
 

--- a/pydm/widgets/channel.py
+++ b/pydm/widgets/channel.py
@@ -155,3 +155,6 @@ class PyDMChannel(object):
 
     def __hash__(self):
         return id(self)
+
+    def __repr__(self):
+        return '<PyDMChannel ({:})>'.format(self.address)

--- a/pydm/widgets/channel.py
+++ b/pydm/widgets/channel.py
@@ -1,6 +1,8 @@
 import logging
 
 from pydm.data_plugins import plugin_for_address
+from pydm.utilities import is_qt_designer
+from pydm import config
 
 logger = logging.getLogger(__name__)
 
@@ -93,6 +95,8 @@ class PyDMChannel(object):
         """
         Connect a PyDMChannel to the proper PyDMPlugin
         """
+        if is_qt_designer() and not config.DESIGNER_ONLINE:
+            return
         logger.debug("Connecting %r", self.address)
         # Connect to proper PyDMPlugin
         try:
@@ -106,6 +110,8 @@ class PyDMChannel(object):
         """
         Disconnect a PyDMChannel
         """
+        if is_qt_designer() and not config.DESIGNER_ONLINE:
+            return
         try:
             plugin = plugin_for_address(self.address)
             if not plugin:

--- a/pydm/widgets/channel.py
+++ b/pydm/widgets/channel.py
@@ -6,45 +6,6 @@ from pydm.data_plugins import plugin_for_address
 logger = logging.getLogger(__name__)
 
 
-class ChannelRegistry(object):
-    """
-    Register of Channel objects
-    """
-    def __init__(self):
-        self.connections = list()
-
-    @property
-    def size(self):
-        """Number of connections in registry"""
-        return len(self.connections)
-
-    def add_connection(self, channel):
-        """
-        Connect a PyDMChannel to the proper PyDMPlugin
-        """
-        # Connect channel
-        channel.connect()
-        # Add to internal store
-        self.connections.append(channel)
-
-    def remove_connection(self, channel):
-        """
-        Disconnect a PyDMChannel
-        """
-        # Disconnect channel
-        channel.disconnect()
-        # Be loud if the channel was not in this registry
-        try:
-            self.connections.remove(channel)
-        except ValueError:
-            logger.error("%r was never added to the Channel Registry")
-
-    def clear(self):
-        """Disconnect all PyDMChannels in Registry"""
-        for channel in self.connections:
-            self.remove_connection(channel)
-
-
 class PyDMChannel(object):
     """
     Object to hold signals and slots for a PyDM Widget interface to an

--- a/pydm/widgets/channel.py
+++ b/pydm/widgets/channel.py
@@ -108,6 +108,8 @@ class PyDMChannel(object):
         """
         try:
             plugin = plugin_for_address(self.address)
+            if not plugin:
+                return
             plugin.remove_connection(self)
         except Exception as exc:
             logger.exception("Unable to remove connection "

--- a/pydm/widgets/channel.py
+++ b/pydm/widgets/channel.py
@@ -1,5 +1,4 @@
 import logging
-from weakref import finalize
 
 from pydm.data_plugins import plugin_for_address
 
@@ -102,8 +101,6 @@ class PyDMChannel(object):
         except Exception:
             logger.exception("Unable to make proper connection "
                              "for %r", self)
-        else:
-            finalize(self, self.disconnect)
 
     def disconnect(self):
         """

--- a/pydm/widgets/embedded_display.py
+++ b/pydm/widgets/embedded_display.py
@@ -1,10 +1,11 @@
-from qtpy.QtWidgets import QFrame, QApplication, QLabel, QVBoxLayout
+from qtpy.QtWidgets import QFrame, QApplication, QLabel, QVBoxLayout, QWidget
 from qtpy.QtCore import Qt, QSize
 from qtpy.QtCore import Property
 import json
 import os.path
 from .base import PyDMPrimitiveWidget
-from ..utilities import is_pydm_app
+from ..utilities import (is_pydm_app, establish_widget_connections,
+                         close_widget_connections)
 
 
 class PyDMEmbeddedDisplay(QFrame, PyDMPrimitiveWidget):
@@ -17,6 +18,7 @@ class PyDMEmbeddedDisplay(QFrame, PyDMPrimitiveWidget):
         The parent widget for the Label
 
     """
+
     def __init__(self, parent=None):
         QFrame.__init__(self, parent)
         PyDMPrimitiveWidget.__init__(self)
@@ -45,7 +47,8 @@ class PyDMEmbeddedDisplay(QFrame, PyDMPrimitiveWidget):
         -------
         QSize
         """
-        return QSize(100, 100)  # This is totally arbitrary, I just want *some* visible nonzero size
+        return QSize(100,
+                     100)  # This is totally arbitrary, I just want *some* visible nonzero size
 
     @Property(str)
     def macros(self):
@@ -110,10 +113,13 @@ class PyDMEmbeddedDisplay(QFrame, PyDMPrimitiveWidget):
             try:
                 self.embedded_widget = self.open_file()
             except ValueError as e:
-                self.err_label.setText("Could not parse macro string.\nError: {}".format(e))
+                self.err_label.setText(
+                    "Could not parse macro string.\nError: {}".format(e))
                 self.err_label.show()
             except IOError as e:
-                self.err_label.setText("Could not open {filename}.\nError: {err}".format(filename=self._filename, err=e))
+                self.err_label.setText(
+                    "Could not open {filename}.\nError: {err}".format(
+                        filename=self._filename, err=e))
                 self.err_label.show()
 
     def parsed_macros(self):
@@ -140,11 +146,10 @@ class PyDMEmbeddedDisplay(QFrame, PyDMPrimitiveWidget):
         # Expand user (~ or ~user) and environment variables.
         fname = os.path.expanduser(os.path.expandvars(self.filename))
         if os.path.isabs(fname):
-            return self.app.open_file(fname, macros=self.parsed_macros(),
-                                      establish_connection=False)
+            return self.app.open_file(fname, macros=self.parsed_macros())
         else:
-            return self.app.open_relative(fname, self, macros=self.parsed_macros(),
-                                          establish_connection=False)
+            return self.app.open_relative(fname, self,
+                                          macros=self.parsed_macros())
 
     @property
     def embedded_widget(self):
@@ -171,17 +176,13 @@ class PyDMEmbeddedDisplay(QFrame, PyDMPrimitiveWidget):
             return
         if self._embedded_widget is not None:
             self.layout.removeWidget(self._embedded_widget)
-            self.app.close_widget_connections(self._embedded_widget)
             self._embedded_widget.deleteLater()
             self._embedded_widget = None
-            should_reconnect = True
         self._embedded_widget = new_widget
         self._embedded_widget.setParent(self)
         self.layout.addWidget(self._embedded_widget)
         self.err_label.hide()
         self._embedded_widget.show()
-        if should_reconnect:
-            self.app.establish_widget_connections(self._embedded_widget)
         self._is_connected = True
 
     def connect(self):
@@ -191,7 +192,7 @@ class PyDMEmbeddedDisplay(QFrame, PyDMPrimitiveWidget):
         """
         if self._is_connected or self.embedded_widget is None:
             return
-        self.app.establish_widget_connections(self.embedded_widget)
+        establish_widget_connection(self.embedded_widget)
 
     def disconnect(self):
         """
@@ -200,7 +201,7 @@ class PyDMEmbeddedDisplay(QFrame, PyDMPrimitiveWidget):
         """
         if not self._is_connected or self.embedded_widget is None:
             return
-        self.app.close_widget_connections(self.embedded_widget)
+        close_widget_connections(self.embedded_widget)
 
     @Property(bool)
     def disconnectWhenHidden(self):

--- a/pydm/widgets/embedded_display.py
+++ b/pydm/widgets/embedded_display.py
@@ -47,8 +47,8 @@ class PyDMEmbeddedDisplay(QFrame, PyDMPrimitiveWidget):
         -------
         QSize
         """
-        return QSize(100,
-                     100)  # This is totally arbitrary, I just want *some* visible nonzero size
+        # This is totally arbitrary, I just want *some* visible nonzero size
+        return QSize(100, 100)
 
     @Property(str)
     def macros(self):
@@ -192,7 +192,7 @@ class PyDMEmbeddedDisplay(QFrame, PyDMPrimitiveWidget):
         """
         if self._is_connected or self.embedded_widget is None:
             return
-        establish_widget_connection(self.embedded_widget)
+        establish_widget_connections(self.embedded_widget)
 
     def disconnect(self):
         """

--- a/pydm/widgets/enum_combo_box.py
+++ b/pydm/widgets/enum_combo_box.py
@@ -5,7 +5,7 @@ import six
 from qtpy.QtWidgets import QComboBox
 from qtpy.QtCore import Slot, Qt
 from .base import PyDMWritableWidget
-from pydm.utilities import is_pydm_app
+from .. import data_plugins
 
 
 class PyDMEnumComboBox(QComboBox, PyDMWritableWidget):
@@ -81,7 +81,7 @@ class PyDMEnumComboBox(QComboBox, PyDMWritableWidget):
         if not self._connected:
             tooltip += "PV is disconnected."
         elif not self._write_access:
-            if is_pydm_app() and self.app.is_read_only():
+            if data_plugins.is_read_only():
                 tooltip += "Running PyDM on Read-Only mode."
             else:
                 tooltip += "Access denied by Channel Access Security."

--- a/pydm/widgets/image.py
+++ b/pydm/widgets/image.py
@@ -17,7 +17,6 @@ logger = logging.getLogger(__name__)
 
 class ReadingOrder(object):
     """Class to build ReadingOrder ENUM property."""
-
     Fortranlike = 0
     Clike = 1
 
@@ -586,7 +585,10 @@ class PyDMImageView(ImageView, PyDMWidget, PyDMColorMap, ReadingOrder):
         channels : list
             List of PyDMChannel objects
         """
-        return (self._imagechannel, self._widthchannel)
+        self._channels.clear()
+        self._channels.append(self._imagechannel)
+        self._channels.append(self._widthchannel)
+        return self._imagechannel, self._widthchannel
 
     def channels_for_tools(self):
         """Return channels for tools."""

--- a/pydm/widgets/image.py
+++ b/pydm/widgets/image.py
@@ -107,6 +107,7 @@ class PyDMImageView(ImageView, PyDMWidget, PyDMColorMap, ReadingOrder):
         """Initialize widget."""
         ImageView.__init__(self, parent)
         PyDMWidget.__init__(self)
+        self._channels = [None, None]
         self.thread = None
         self.axes = dict({'t': None, "x": 0, "y": 1, "c": None})
         self._imagechannel = None
@@ -537,6 +538,7 @@ class PyDMImageView(ImageView, PyDMWidget, PyDMColorMap, ReadingOrder):
                             connection_slot=self.image_connection_state_changed,
                             value_slot=self.image_value_changed,
                             severity_slot=self.alarmSeverityChanged)
+            self._channels[0] = self._imagechannel
             self._imagechannel.connect()
 
     @Property(str)
@@ -574,7 +576,9 @@ class PyDMImageView(ImageView, PyDMWidget, PyDMColorMap, ReadingOrder):
                             connection_slot=self.connectionStateChanged,
                             value_slot=self.image_width_changed,
                             severity_slot=self.alarmSeverityChanged)
+            self._channels[1] = self._widthchannel
             self._widthchannel.connect()
+
 
     def channels(self):
         """
@@ -585,10 +589,7 @@ class PyDMImageView(ImageView, PyDMWidget, PyDMColorMap, ReadingOrder):
         channels : list
             List of PyDMChannel objects
         """
-        self._channels.clear()
-        self._channels.append(self._imagechannel)
-        self._channels.append(self._widthchannel)
-        return self._imagechannel, self._widthchannel
+        return self._channels
 
     def channels_for_tools(self):
         """Return channels for tools."""

--- a/pydm/widgets/image.py
+++ b/pydm/widgets/image.py
@@ -513,7 +513,10 @@ class PyDMImageView(ImageView, PyDMWidget, PyDMColorMap, ReadingOrder):
         str
             Channel address
         """
-        return str(self._imagechannel.address)
+        if self._imagechannel:
+            return str(self._imagechannel.address)
+        else:
+            return ''
 
     @imageChannel.setter
     def imageChannel(self, value):
@@ -547,7 +550,10 @@ class PyDMImageView(ImageView, PyDMWidget, PyDMColorMap, ReadingOrder):
         str
             Channel address
         """
-        return str(self._widthchannel.address)
+        if self._widthchannel:
+            return str(self._widthchannel.address)
+        else:
+            return ''
 
     @widthChannel.setter
     def widthChannel(self, value):

--- a/pydm/widgets/rules.py
+++ b/pydm/widgets/rules.py
@@ -97,8 +97,6 @@ class RulesEngine(QThread):
 
     def __init__(self):
         QThread.__init__(self)
-        # Reference to App so we can establish the connection with the channel
-        self.app = QApplication.instance()
         self.map_lock = QMutex()
         self.widget_map = dict()
 
@@ -125,9 +123,8 @@ class RulesEngine(QThread):
                                                  ch_idx, ch['trigger'])
                     c = PyDMChannel(ch['channel'], connection_slot=conn_cb,
                                     value_slot=value_cb)
-                    if is_pydm_app():
-                        self.app.add_connection(c)
                     item['channels'].append(c)
+                    c.connect()
 
                 self.widget_map[widget].append(item)
 
@@ -137,8 +134,7 @@ class RulesEngine(QThread):
 
         for rule in w_data:
             for ch in rule['channels']:
-                if is_pydm_app():
-                    self.app.remove_connection(ch)
+                ch.disconnect()
 
         del w_data
 

--- a/pydm/widgets/scatterplot.py
+++ b/pydm/widgets/scatterplot.py
@@ -9,6 +9,7 @@ from .channel import PyDMChannel
 from ..utilities import remove_protocol
 
 class ScatterPlotCurveItem(BasePlotCurveItem):
+    _channels = ('x_channel', 'y_channel')
 
     def __init__(self, y_addr, x_addr, redraw_mode=None, **kws):
         self.x_channel = None

--- a/pydm/widgets/scatterplot.py
+++ b/pydm/widgets/scatterplot.py
@@ -231,6 +231,9 @@ class ScatterPlotCurveItem(BasePlotCurveItem):
         return ((float(np.amin(x_data)), float(np.amax(x_data))),
                 (float(np.amin(y_data)), float(np.amax(y_data))))
 
+    def channels(self):
+        return [self.y_channel, self.x_channel]
+
 
 class PyDMScatterPlot(BasePlot):
     """

--- a/pydm/widgets/tab_bar.py
+++ b/pydm/widgets/tab_bar.py
@@ -42,6 +42,13 @@ class PyDMTabBar(QTabBar, PyDMWidget):
         self.tab_channels[index] = str(channel)
         if index < self.count():
             self.set_initial_icon_for_tab(index)
+            if channel != "":
+                # Create PyDMChannel and connecdt
+                chan = PyDMChannel(address=str(channel),
+                                   connection_slot=partial(self.connection_changed_for_tab, index),
+                                   severity_slot=partial(self.alarm_changed_for_tab, index))
+                chan.connect()
+                self._channels.append(chan)
 
     def channels(self):
         # Note that because we cache the list of channels, tabs added or removed after this method
@@ -300,7 +307,7 @@ class PyDMTabWidget(QTabWidget):
     def disconnectedAlarmIconColor(self, new_color):
         self.tabBar().disconnectedAlarmIconColor = new_color
 
-    alarmChannels = Property("QStringList", getAlarmChannels,
+    alarmChannels = pyqtProperty("QStringList", getAlarmChannels,
                                  setAlarmChannels, designable=False)
 
     # We make a bunch of dummy properties to block out properties available on QTabWidget,

--- a/pydm/widgets/tab_bar.py
+++ b/pydm/widgets/tab_bar.py
@@ -307,8 +307,8 @@ class PyDMTabWidget(QTabWidget):
     def disconnectedAlarmIconColor(self, new_color):
         self.tabBar().disconnectedAlarmIconColor = new_color
 
-    alarmChannels = pyqtProperty("QStringList", getAlarmChannels,
-                                 setAlarmChannels, designable=False)
+    alarmChannels = Property("QStringList", getAlarmChannels,
+                             setAlarmChannels, designable=False)
 
     # We make a bunch of dummy properties to block out properties available on QTabWidget,
     # but that we don't want to support on PyDMTabWidget.

--- a/pydm/widgets/tab_bar.py
+++ b/pydm/widgets/tab_bar.py
@@ -67,6 +67,7 @@ class PyDMTabBar(QTabBar, PyDMWidget):
                                                   severity_slot=partial(
                                                       self.alarm_changed_for_tab,
                                                       index)))
+                self._channels[-1].connect()
         return self._channels
 
     def connection_changed_for_tab(self, index, conn):

--- a/pydm/widgets/tab_bar.py
+++ b/pydm/widgets/tab_bar.py
@@ -63,10 +63,8 @@ class PyDMTabBar(QTabBar, PyDMWidget):
             self._channels.append(chan)
 
     def channels(self):
-        # Note that because we cache the list of channels, tabs added or removed after this method
-        # is called will not ever get channel objects created, and will never connect to data sources.
         if self._channels is not None:
-            return self._channels
+            return list(self._channels)
         return None
 
     def connection_changed_for_tab(self, index, conn):

--- a/pydm/widgets/tab_bar.py
+++ b/pydm/widgets/tab_bar.py
@@ -1,9 +1,8 @@
-from qtpy.QtWidgets import (QTabBar, QTabWidget,
-                            QVBoxLayout, QWidget, QLabel)
-from qtpy.QtGui import QIcon, QBrush, QColor
+from qtpy.QtWidgets import (QTabBar, QTabWidget, QWidget)
+from qtpy.QtGui import QIcon, QColor
 from .base import PyDMWidget
 from .channel import PyDMChannel
-from qtpy.QtCore import Property, Q_ENUMS, Qt, QVariant
+from qtpy.QtCore import Property
 from functools import partial
 from ..utilities.iconfont import IconFont
 
@@ -16,7 +15,7 @@ class PyDMTabBar(QTabBar, PyDMWidget):
         self.tab_channels = {}
         self.tab_connection_status = {}
         self.tab_alarm_severity = {}
-        self._channels = None
+        self._channels = []
         self._no_alarm_icon_color = QColor(0, 220, 0)
         self._minor_alarm_icon_color = QColor(220, 220, 0)
         self._major_alarm_icon_color = QColor(255, 0, 0)
@@ -30,7 +29,7 @@ class PyDMTabBar(QTabBar, PyDMWidget):
         """A channel to use for this tab's alarm indicator."""
         if self.currentIndex() < 0:
             return
-        return str(self.tab_channels.get(self.currentIndex(), ""))
+        return str(self.tab_channels.get(self.currentIndex(), "")["address"])
 
     @currentTabAlarmChannel.setter
     def currentTabAlarmChannel(self, new_alarm_channel):
@@ -39,36 +38,36 @@ class PyDMTabBar(QTabBar, PyDMWidget):
         self.set_channel_for_tab(self.currentIndex(), new_alarm_channel)
 
     def set_channel_for_tab(self, index, channel):
-        self.tab_channels[index] = str(channel)
-        if index < self.count():
-            self.set_initial_icon_for_tab(index)
-            if channel != "":
-                # Create PyDMChannel and connecdt
-                chan = PyDMChannel(address=str(channel),
-                                   connection_slot=partial(self.connection_changed_for_tab, index),
-                                   severity_slot=partial(self.alarm_changed_for_tab, index))
-                chan.connect()
-                self._channels.append(chan)
+        idx = self.tab_channels.get(index)
+        if idx:
+            # Disconnect the channel if we already had one in
+            chan = idx.get("channel", None)
+            if chan:
+                self._channels.remove(chan)
+                self.tab_channels[index]["channel"] = None
+                chan.disconnect()
+                del chan
+        else:
+            chan = None
+            self.tab_channels[index] = dict()
+
+        self.tab_channels[index]["address"] = str(channel)
+        self.set_initial_icon_for_tab(index)
+        if channel:
+            # Create PyDMChannel and connecdt
+            chan = PyDMChannel(address=str(channel),
+                               connection_slot=partial(self.connection_changed_for_tab, index),
+                               severity_slot=partial(self.alarm_changed_for_tab, index))
+            self.tab_channels[index]["channel"] = chan
+            chan.connect()
+            self._channels.append(chan)
 
     def channels(self):
         # Note that because we cache the list of channels, tabs added or removed after this method
         # is called will not ever get channel objects created, and will never connect to data sources.
         if self._channels is not None:
             return self._channels
-
-        self._channels = []
-        for index in range(0, self.count()):
-            channel = str(self.tab_channels[index])
-            if channel != "":
-                self._channels.append(PyDMChannel(address=str(channel),
-                                                  connection_slot=partial(
-                                                      self.connection_changed_for_tab,
-                                                      index),
-                                                  severity_slot=partial(
-                                                      self.alarm_changed_for_tab,
-                                                      index)))
-                self._channels[-1].connect()
-        return self._channels
+        return None
 
     def connection_changed_for_tab(self, index, conn):
         if not conn:
@@ -84,15 +83,15 @@ class PyDMTabBar(QTabBar, PyDMWidget):
         when it has been created in Qt Designer.  This property isn't directly editable
         by users, they will go through the currentTabAlarmChannel property to edit this
         information."""
-        return [str(self.tab_channels[i]) for i in range(0, self.count())]
+        return [str(self.tab_channels[i]["address"]) for i in range(0, self.count())]
 
     def setAlarmChannels(self, new_alarm_channels):
         for tab_number, channel_address in enumerate(new_alarm_channels):
             self.set_channel_for_tab(tab_number, channel_address)
 
     def set_initial_icon_for_tab(self, index):
-        channel = self.tab_channels.get(index, "")
-        if channel in ("", "None", None):
+        idx = self.tab_channels.get(index)
+        if idx and idx.get("address") in ("", "None", None):
             self.setTabIcon(index, QIcon())
         else:
             icon_index = self.ALARM_DISCONNECTED
@@ -102,8 +101,9 @@ class PyDMTabBar(QTabBar, PyDMWidget):
             self.setTabIcon(index, self.alarm_icons[icon_index])
 
     def tabInserted(self, index):
+        super(PyDMTabBar, self).tabInserted(index)
         if index not in self.tab_channels:
-            self.tab_channels[index] = ""
+            self.tab_channels[index]["address"] = ""
         self.set_initial_icon_for_tab(index)
 
     @Property(QColor)
@@ -185,7 +185,8 @@ class PyDMTabWidget(QTabWidget):
 
     def __init__(self, parent=None):
         super(PyDMTabWidget, self).__init__(parent=parent)
-        self.setTabBar(PyDMTabBar(parent=self))
+        self.tb = PyDMTabBar(parent=self)
+        self.setTabBar(self.tb)
 
     @Property(str)
     def currentTabAlarmChannel(self):

--- a/pydm/widgets/timeplot.py
+++ b/pydm/widgets/timeplot.py
@@ -34,6 +34,7 @@ class TimePlotCurveItem(BasePlotCurveItem):
     TimePlotCurveItem and TimePlotCurve.
     """
     _channels = ('channel',)
+
     def __init__(self, channel_address=None, plot_by_timestamps=True, **kws):
         """
         Parameters
@@ -67,7 +68,6 @@ class TimePlotCurveItem(BasePlotCurveItem):
         self.latest_value = None
         self.channel = None
         self.address = channel_address
-
         super(TimePlotCurveItem, self).__init__(**kws)
 
     def to_dict(self):
@@ -262,6 +262,9 @@ class TimePlotCurveItem(BasePlotCurveItem):
 
         """
         return self.data_buffer[0, -1]
+
+    def channels(self):
+        return [self.channel]
 
 
 class PyDMTimePlot(BasePlot):

--- a/pydm/widgets/timeplot.py
+++ b/pydm/widgets/timeplot.py
@@ -33,6 +33,7 @@ class TimePlotCurveItem(BasePlotCurveItem):
     To maintain backward compatibility, the default drawing mode is in the classic, "plot_by_timestamps" mode, for both
     TimePlotCurveItem and TimePlotCurve.
     """
+    _channels = ('channel',)
     def __init__(self, channel_address=None, plot_by_timestamps=True, **kws):
         """
         Parameters

--- a/pydm/widgets/waveformplot.py
+++ b/pydm/widgets/waveformplot.py
@@ -47,6 +47,7 @@ class WaveformCurveItem(BasePlotCurveItem):
     **kargs: optional
         PlotDataItem keyword arguments, such as symbol and symbolSize.
     """
+    _channels = ('x_channel', 'y_channel')
 
     def __init__(self, y_addr=None, x_addr=None, redraw_mode=None, **kws):
         y_addr = "" if y_addr is None else y_addr

--- a/pydm/widgets/waveformplot.py
+++ b/pydm/widgets/waveformplot.py
@@ -252,6 +252,9 @@ class WaveformCurveItem(BasePlotCurveItem):
             return ((float(np.amin(self.x_waveform)), float(np.amax(self.x_waveform))),
                     (float(np.amin(self.y_waveform)), float(np.amax(self.y_waveform))))
 
+    def channels(self):
+        return [self.y_channel, self.x_channel]
+
 
 class PyDMWaveformPlot(BasePlot):
     """

--- a/pydm/widgets/waveformtable.py
+++ b/pydm/widgets/waveformtable.py
@@ -74,10 +74,11 @@ class PyDMWaveformTable(QTableWidget, PyDMWritableWidget):
         if self._valueBeingSet:
             return
         item = self.item(row, column)
-        new_val = self.subtype(item.text())
-        ind = row*self.columnCount() + column
-        self.waveform[ind] = new_val
-        self.send_value_signal[np.ndarray].emit(self.waveform)
+        if item and self.subtype:
+            new_val = self.subtype(item.text())
+            ind = row*self.columnCount() + column
+            self.waveform[ind] = new_val
+            self.send_value_signal[np.ndarray].emit(self.waveform)
 
     def check_enable_state(self):
         """

--- a/pydm_launcher/main.py
+++ b/pydm_launcher/main.py
@@ -1,11 +1,20 @@
 import sys
 import argparse
-import pydm
 import json
 import logging
 
 
 def main():
+    logger = logging.getLogger('')
+    handler = logging.StreamHandler()
+    formatter = logging.Formatter('[%(asctime)s] [%(levelname)-8s] - %(message)s')
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+    logger.setLevel("INFO")
+    handler.setLevel("INFO")
+
+    import pydm
+
     parser = argparse.ArgumentParser(description="Python Display Manager")
     parser.add_argument(
         'displayfile',
@@ -93,11 +102,6 @@ def main():
                 key, value = pair.strip().split("=")
                 macros[key.strip()] = value.strip()
 
-    logger = logging.getLogger('')
-    handler = logging.StreamHandler()
-    formatter = logging.Formatter('[%(asctime)s] [%(levelname)-8s] - %(message)s')
-    handler.setFormatter(formatter)
-    logger.addHandler(handler)
     if pydm_args.log_level:
         logger.setLevel(pydm_args.log_level)
         handler.setLevel(pydm_args.log_level)


### PR DESCRIPTION
## Description
We used to depend on `PyDMApplication` creating connections for all of our PyDM widgets. With this PR, each individual widgets handles making its own connections. This has two major benefits:

1) PyDM can be used as a widget library for any PyQt application.
2) QtDesigner will display live widgets

## Major Changes
The first level of changes involve removing all the connection semantics away from `PyDMApplication` onto the `PyDMConnection` object. There are now `connect` and `disconnect` methods that handle the plugin lookup e.t.c.

The next step was to make sure that widgets new when to connect and disconnect their channels. Here are when connections are made now:

**PyDMWidget** -> when the `address` is set
**PyDMBasePlot** -> during `addCurve` and `removeCurve`

 I had to change some of the tests because in the past we would make `PyDMChannel` objects that didn't have an address. Now that is not possible, so tests that required connections needed to have address provided so their respective widgets would make connections.

## Screenshots
![designer](https://user-images.githubusercontent.com/25753048/41736798-58e9c6be-7542-11e8-9e0e-6b103b96c80c.gif)
