### PR TITLE
Explicitly monitor DBE_VALUE and DBE_ALARM.

### DIFF
--- a/pydm/data_plugins/epics_plugins/pyepics_plugin_component.py
+++ b/pydm/data_plugins/epics_plugins/pyepics_plugin_component.py
@@ -23,7 +23,7 @@ class Connection(PyDMConnection):
     def __init__(self, channel, pv, protocol=None, parent=None):
         super(Connection, self).__init__(channel, pv, protocol, parent)
         self.app = QApplication.instance()
-        self.pv = epics.PV(pv, connection_callback=self.send_connection_state, form='ctrl', auto_monitor=True, access_callback=self.send_access_state)
+        self.pv = epics.PV(pv, connection_callback=self.send_connection_state, form='ctrl', auto_monitor=epics.dbr.DBE_VALUE|epics.dbr.DBE_ALARM, access_callback=self.send_access_state)
         self.pv.add_callback(self.send_new_value, with_ctrlvars=True)
         self.add_listener(channel)
 


### PR DESCRIPTION
Fixes a bug where PyDM wouldn't send out alarm status changes unless the value also changed at the same time.