### PR TITLE
Only launch a display on a left mouse button click.

### DIFF
--- a/pydm/widgets/related_display_button.py
+++ b/pydm/widgets/related_display_button.py
@@ -172,8 +172,8 @@ class PyDMRelatedDisplayButton(QPushButton, PyDMPrimitiveWidget):
         mouse_event : QMouseEvent
 
         """
-	if mouse_event.button() != Qt.LeftButton:
-		return super(PyDMRelatedDisplayButton, self).mouseReleaseEvent(mouse_event)
+        if mouse_event.button() != Qt.LeftButton:
+            return super(PyDMRelatedDisplayButton, self).mouseReleaseEvent(mouse_event)
         try:
             if mouse_event.modifiers() == Qt.ShiftModifier or self._open_in_new_window:
                 self.open_display(target=self.NEW_WINDOW)

--- a/pydm/widgets/related_display_button.py
+++ b/pydm/widgets/related_display_button.py
@@ -172,6 +172,8 @@ class PyDMRelatedDisplayButton(QPushButton, PyDMPrimitiveWidget):
         mouse_event : QMouseEvent
 
         """
+	if mouse_event.button() != Qt.LeftButton:
+		return super(PyDMRelatedDisplayButton, self).mouseReleaseEvent(mouse_event)
         try:
             if mouse_event.modifiers() == Qt.ShiftModifier or self._open_in_new_window:
                 self.open_display(target=self.NEW_WINDOW)


### PR DESCRIPTION
In PyDMRelatedDisplayButton, only open a display if the user left-clicks on a button.  Ignore middle- and right-clicks.