### PR TITLE
Fix crash in PyDMSymbol when the imageFiles attribute is invalid.

### DIFF
--- a/pydm/widgets/symbol.py
+++ b/pydm/widgets/symbol.py
@@ -1,9 +1,12 @@
 import json
+import logging
 from ..PyQt.QtGui import QApplication, QWidget, QPainter, QPixmap, QStyle, QStyleOption
 from ..PyQt.QtCore import pyqtProperty, Qt, QSize, QSizeF, QRectF, qInstallMessageHandler
 from ..PyQt.QtSvg import QSvgRenderer
 from ..utilities import is_pydm_app
 from .base import PyDMWidget
+
+logger = logging.getLogger(__name__)
 
 class PyDMSymbol(QWidget, PyDMWidget):
     """
@@ -69,7 +72,7 @@ class PyDMSymbol(QWidget, PyDMWidget):
                 try:
                     file_path = self.app.get_path(filename)
                 except Exception as e:
-                    print(e)
+                    logger.exception(e)
                     file_path = filename
             else:
                 file_path = filename
@@ -95,7 +98,7 @@ class PyDMSymbol(QWidget, PyDMWidget):
                 self._sizeHint = self._sizeHint.expandedTo(image.size())
                 continue
             # If we get this far, the file specified could not be loaded at all.
-            print("Could not load image: {}".format(filename))
+            logger.error("Could not load image: {}".format(filename))
             self._state_images[int(state)] = (filename, None)
 
     @pyqtProperty(Qt.AspectRatioMode)

--- a/pydm/widgets/symbol.py
+++ b/pydm/widgets/symbol.py
@@ -72,7 +72,7 @@ class PyDMSymbol(QWidget, PyDMWidget):
                 try:
                     file_path = self.app.get_path(filename)
                 except Exception as e:
-                    logger.exception(e)
+                    logger.exception("Couldn't get file with path %s", filename)
                     file_path = filename
             else:
                 file_path = filename


### PR DESCRIPTION
The setter for the 'imageFiles' property on PyDMSymbol would throw an exception if it wasn't valid JSON.  This made it impossible to type in a value for this property in Designer.

Now, the exception is handled, and if the property can't be parsed as JSON, the image dictionary is just left empty.