### PR TITLE
FIX: PyDMComboBox only accepts integers

### DIFF
--- a/pydm/tests/widgets/test_enum_combo_box.py
+++ b/pydm/tests/widgets/test_enum_combo_box.py
@@ -154,6 +154,8 @@ def test_check_enable_state(qtbot, signals, monkeypatch, connected, write_access
 @pytest.mark.parametrize("values, selected_index, expected", [
     (("RUN", "STOP"), 0, "RUN"),
     (("RUN", "STOP"), 1, "STOP"),
+    (("RUN", "STOP"), "RUN", "RUN"),
+    (("RUN", "STOP"), "STOP", "STOP"),
 ])
 def test_enum_strings_changed(qtbot, signals, values, selected_index, expected):
     """

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ scipy>=0.12.0
 pyepics>=3.2.7
 requests>=1.1.0
 pyqtgraph>=0.10.0
+six


### PR DESCRIPTION
## Description
I have a case where I have a plugin that emits `str` values and also has `enum_strs`. The `PyDMEnumComboBox` has a slot that accepts all types of input but piped this directly to `setCurrentIndex`. This PR checks the type and tries to do the correct thing. 

I also noticed that `six` isn't in the `requirements.txt` file so I added it there.

**Question**:  Is there a way to have the widget only accept certain types. It looks like one side affect of the `base.PyDMWidget`  is that we automatically subscribe `valueChanged` to all the types.