### PR TITLE
FIX: Found a bug with pyqtgraph related to the display of data…

### DIFF
--- a/pydm/widgets/scatterplot.py
+++ b/pydm/widgets/scatterplot.py
@@ -207,8 +207,8 @@ class ScatterPlotCurveItem(BasePlotCurveItem):
         Called by the curve's parent plot whenever the curve needs to be
         re-drawn with new data.
         """
-        self.setData(x=self.data_buffer[1, -self.points_accumulated:],
-                     y=self.data_buffer[0, -self.points_accumulated:])
+        self.setData(x=self.data_buffer[1, -self.points_accumulated:].astype(np.float),
+                     y=self.data_buffer[0, -self.points_accumulated:].astype(np.float))
         self.needs_new_x = True
         self.needs_new_y = True
 
@@ -225,8 +225,8 @@ class ScatterPlotCurveItem(BasePlotCurveItem):
             raise NoDataError("Curve has no data, cannot determine limits.")
         x_data = self.data_buffer[0, -self.points_accumulated:]
         y_data = self.data_buffer[1, -self.points_accumulated:]
-        return ((np.amin(x_data), np.amax(x_data)),
-                (np.amin(y_data), np.amax(y_data)))
+        return ((float(np.amin(x_data)), float(np.amax(x_data))),
+                (float(np.amin(y_data)), float(np.amax(y_data))))
 
 
 class PyDMScatterPlot(BasePlot):

--- a/pydm/widgets/timeplot.py
+++ b/pydm/widgets/timeplot.py
@@ -99,8 +99,8 @@ class TimePlotCurveItem(BasePlotCurveItem):
     @pyqtSlot()
     def redrawCurve(self):
         if self.connected:
-            self.setData(y=self.data_buffer[1, -self.points_accumulated:],
-                         x=self.data_buffer[0, -self.points_accumulated:])
+            self.setData(y=self.data_buffer[1, -self.points_accumulated:].astype(np.float),
+                         x=self.data_buffer[0, -self.points_accumulated:].astype(np.float))
 
     def setUpdatesAsynchronously(self, value):
         if value is True:

--- a/pydm/widgets/waveformplot.py
+++ b/pydm/widgets/waveformplot.py
@@ -219,13 +219,14 @@ class WaveformCurveItem(BasePlotCurveItem):
         if self.y_waveform is None:
             return
         if self.x_waveform is None:
-            self.setData(y=self.y_waveform)
+            self.setData(y=self.y_waveform.astype(np.float))
             return
         if self.x_waveform.shape[0] > self.y_waveform.shape[0]:
             self.x_waveform = self.x_waveform[:self.y_waveform.shape[0]]
         elif self.x_waveform.shape[0] < self.y_waveform.shape[0]:
             self.y_waveform = self.y_waveform[:self.x_waveform.shape[0]]
-        self.setData(x=self.x_waveform, y=self.y_waveform)
+        self.setData(x=self.x_waveform.astype(np.float),
+                     y=self.y_waveform.astype(np.float))
         self.needs_new_x = True
         self.needs_new_y = True
 
@@ -247,8 +248,8 @@ class WaveformCurveItem(BasePlotCurveItem):
                     (float(np.amin(self.y_waveform) - yspan),
                      float(np.amax(self.y_waveform) + yspan)))
         else:
-            return ((np.amin(self.x_waveform), np.amax(self.x_waveform)),
-                    (np.amin(self.y_waveform), np.amax(self.y_waveform)))
+            return ((float(np.amin(self.x_waveform)), float(np.amax(self.x_waveform))),
+                    (float(np.amin(self.y_waveform)), float(np.amax(self.y_waveform))))
 
 
 class PyDMWaveformPlot(BasePlot):


### PR DESCRIPTION
…and limits. This commit fixes it by converting the data to float before sending into pyqtgraph. That is a temporary fix while pyqtgraph fix is not merged.

Here is the offending line: https://github.com/pyqtgraph/pyqtgraph/blob/e99eb67677ed09e995c9cd6c42a18e9f5420d324/pyqtgraph/graphicsItems/ViewBox/ViewBox.py#L1302

And the related issue: https://github.com/pyqtgraph/pyqtgraph/issues/456

I tested with @marciodo data as well as the examples that we have and all is behaving well now.
<img width="974" alt="screen shot 2018-07-20 at 6 51 14 pm" src="https://user-images.githubusercontent.com/8185425/43092067-c7686f00-8e60-11e8-85a7-cb2d38a384b4.png">
![screen shot 2018-07-23 at 10 04 21 am](https://user-images.githubusercontent.com/8185425/43092069-ca23206e-8e60-11e8-9664-0dfd667097d2.png)
