### PR TITLE
ENH: Add version command to launcher.

### DIFF
--- a/pydm_launcher/main.py
+++ b/pydm_launcher/main.py
@@ -1,6 +1,6 @@
 import sys
 import argparse
-from pydm import PyDMApplication
+import pydm
 import json
 import logging
 
@@ -46,6 +46,8 @@ def main():
         choices=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'],
         default='INFO'
         )
+    parser.add_argument('--version', action='version',
+                    version='PyDM {version}'.format(version=pydm.__version__))
     parser.add_argument(
         '-m', '--macro',
         help='Specify macro replacements to use, in JSON object format.' +
@@ -87,7 +89,7 @@ def main():
         logger.setLevel(pydm_args.log_level)
         handler.setLevel(pydm_args.log_level)
 
-    app = PyDMApplication(
+    app = pydm.PyDMApplication(
         ui_file=pydm_args.displayfile,
         command_line_args=pydm_args.display_args,
         perfmon=pydm_args.perfmon,


### PR DESCRIPTION
Added new `--version` argument that will print the version of PyDM in the command line.

Attn. @shengb

```
(py36) slepicka@TID-PC94483:~/pydm-git [version_cmd !?] $ pydm --version
PyDM v1.3.0+9.g7208b289.dirty
```

```
(py36) slepicka@TID-PC94483:~/pydm-git [version_cmd !?] $ pydm -h
usage: pydm [-h] [--perfmon] [--hide-nav-bar] [--hide-menu-bar]
            [--hide-status-bar] [--read-only]
            [--log_level {DEBUG,INFO,WARNING,ERROR,CRITICAL}] [--version]
            [-m MACRO]
            [displayfile] ...

Python Display Manager

positional arguments:
  displayfile           A PyDM file to display. Can be either a Qt .ui file,
                        or a Python file.
  display_args          Arguments to be passed to the PyDM client application
                        (which is a QApplication subclass).

optional arguments:
  -h, --help            show this help message and exit
  --perfmon             Enable performance monitoring, and print CPU usage to
                        the terminal.
  --hide-nav-bar        Start PyDM with the navigation bar hidden.
  --hide-menu-bar       Start PyDM with the menu bar hidden.
  --hide-status-bar     Start PyDM with the status bar hidden.
  --read-only           Start PyDM in a Read-Only mode.
  --log_level {DEBUG,INFO,WARNING,ERROR,CRITICAL}
                        Configure level of log display
  --version             show program's version number and exit
  -m MACRO, --macro MACRO
                        Specify macro replacements to use, in JSON object
                        format. Reminder: JSON requires double quotes for
                        strings, so you should wrap this whole argument in
                        single quotes. Example: -m '{"sector": "LI25",
                        "facility": "LCLS"}'--or-- specify macro replacements
                        as KEY=value pairs using a comma as delimiter If you
                        want to uses spaces after the delimiters or around the
                        = signs, wrap the entire set with quotes Example: -m
                        "sector = LI25, facility=LCLS"
```