### PR TITLE
CI: Add OSX target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,16 @@ matrix:
     - os: linux
       python: 3.6
       env: BUILD_DOCS=1 MC_URL="https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh"
+    - os: osx
+      python: 3.6
+      env: BUILD_DOCS=1 MC_URL="https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh"
 
 before_install:
-  - sudo apt-get update
-  - sudo apt-get install -y xvfb herbstluftwm
+  - |
+    if [[ $TRAVIS_OS_NAME == 'linux' ]]; then
+      sudo apt-get update
+      sudo apt-get install -y xvfb herbstluftwm
+    fi
   # Make sure we have the tags no matter how far from them we are.
   - git pull --unshallow
   - wget $MC_URL -O miniconda.sh;
@@ -40,13 +46,19 @@ before_install:
   - source activate test-environment
 
 install:
-  - "export DISPLAY=:99.0"
-  - "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1920x1200x24 -ac +extension GLX +render -noreset"
-  - sleep 3
+  - |
+    if [[ $TRAVIS_OS_NAME == 'linux' ]]; then
+      "export DISPLAY=:99.0"
+      "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1920x1200x24 -ac +extension GLX +render -noreset"
+      sleep 3
+    fi
 
 before_script:
-  - "herbstluftwm &"
-  - sleep 1
+  - |
+    if [[ $TRAVIS_OS_NAME == 'linux' ]]; then
+      "herbstluftwm &"
+      sleep 1
+    fi
 
 script:
   - python run_tests.py --show-cov

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,15 +50,15 @@ before_install:
 install:
   - |
     if [[ $TRAVIS_OS_NAME == 'linux' ]]; then
-      "export DISPLAY=:99.0"
-      "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1920x1200x24 -ac +extension GLX +render -noreset"
+      export DISPLAY=:99.0
+      /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1920x1200x24 -ac +extension GLX +render -noreset
       sleep 3
     fi
 
 before_script:
   - |
     if [[ $TRAVIS_OS_NAME == 'linux' ]]; then
-      "herbstluftwm &"
+      herbstluftwm &
       sleep 1
     fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 sudo: required
-language: python
 
 env:
   global:
@@ -11,12 +10,15 @@ matrix:
   include:
     - os: linux
       python: 2.7
+      language: python
       env: MC_URL="https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh"
     - os: linux
       python: 3.5
+      language: python
       env: MC_URL="https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh"
     - os: linux
       python: 3.6
+      language: python
       env: BUILD_DOCS=1 MC_URL="https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh"
     - os: osx
       python: 3.6


### PR DESCRIPTION
Travis-CI pool of OSX builds is no longer saturated. This means that we can add osx to our matrix of tests.
This PR adds it in and also solves an issue that is: 
- Hugo needs to remember to build the package all the time. 😄 

Attn. @shengb 