### PR TITLE
FIX: Waveform and Scatter plots were not respecting user defined limits.

### DIFF
--- a/pydm/widgets/baseplot.py
+++ b/pydm/widgets/baseplot.py
@@ -253,6 +253,10 @@ class BasePlot(PlotWidget, PyDMPrimitiveWidget):
         self.setAutoRangeX(True)
         self._auto_range_y = None
         self.setAutoRangeY(True)
+        self._min_x = 0.0
+        self._max_x = 1.0
+        self._min_y = 0.0
+        self._max_y = 1.0
         self._show_x_grid = None
         self.setShowXGrid(False)
         self._show_y_grid = None
@@ -402,7 +406,8 @@ class BasePlot(PlotWidget, PyDMPrimitiveWidget):
 
     def setAutoRangeX(self, value):
         self._auto_range_x = value
-        self.plotItem.enableAutoRange(ViewBox.XAxis, enable=self._auto_range_x)
+        if self._auto_range_x:
+            self.plotItem.enableAutoRange(ViewBox.XAxis, enable=self._auto_range_x)
 
     def resetAutoRangeX(self):
         self.setAutoRangeX(True)
@@ -412,7 +417,8 @@ class BasePlot(PlotWidget, PyDMPrimitiveWidget):
 
     def setAutoRangeY(self, value):
         self._auto_range_y = value
-        self.plotItem.enableAutoRange(ViewBox.YAxis, enable=self._auto_range_y)
+        if self._auto_range_y:
+            self.plotItem.enableAutoRange(ViewBox.YAxis, enable=self._auto_range_y)
 
     def resetAutoRangeY(self):
         self.setAutoRangeY(True)
@@ -435,9 +441,10 @@ class BasePlot(PlotWidget, PyDMPrimitiveWidget):
         -------
         new_min_x_range : float
         """
-        viewRange = self.plotItem.viewRange()
-        viewRange[0][0] = new_min_x_range
-        self.plotItem.setXRange(viewRange[0][0], viewRange[0][1], padding=0)
+        if self._auto_range_x:
+            return
+        self._min_x = new_min_x_range
+        self.plotItem.setXRange(self._min_x, self._max_x, padding=0)
 
     def getMaxXRange(self):
         """
@@ -457,9 +464,11 @@ class BasePlot(PlotWidget, PyDMPrimitiveWidget):
         -------
         new_max_x_range : float
         """
-        viewRange = self.plotItem.viewRange()
-        viewRange[0][1] = new_max_x_range
-        self.plotItem.setXRange(viewRange[0][0], viewRange[0][1], padding=0)
+        if self._auto_range_x:
+            return
+
+        self._max_x = new_max_x_range
+        self.plotItem.setXRange(self._min_x, self._max_x, padding=0)
 
     def getMinYRange(self):
         """
@@ -479,9 +488,12 @@ class BasePlot(PlotWidget, PyDMPrimitiveWidget):
         -------
         new_min_y_range : float
         """
-        viewRange = self.plotItem.viewRange()
-        viewRange[1][0] = new_min_y_range
-        self.plotItem.setYRange(viewRange[1][0], viewRange[1][1], padding=0)
+        if self._auto_range_y:
+            return
+
+        self._min_y = new_min_y_range
+        self.plotItem.setYRange(self._min_y, self._max_y, padding=0)
+
 
     def getMaxYRange(self):
         """
@@ -501,9 +513,11 @@ class BasePlot(PlotWidget, PyDMPrimitiveWidget):
         -------
         new_max_y_range : float
         """
-        viewRange = self.plotItem.viewRange()
-        viewRange[1][1] = new_max_y_range
-        self.plotItem.setYRange(viewRange[1][0], viewRange[1][1], padding=0)
+        if self._auto_range_y:
+            return
+
+        self._max_y = new_max_y_range
+        self.plotItem.setYRange(self._min_y, self._max_y, padding=0)
 
     @pyqtProperty(bool)
     def mouseEnabledX(self):

--- a/pydm/widgets/scatterplot.py
+++ b/pydm/widgets/scatterplot.py
@@ -372,39 +372,12 @@ class PyDMScatterPlot(BasePlot):
         curve = self._curves[index]
         self.removeChannel(curve)
 
-    def updateAxes(self):
-        """
-        Update the X and Y axes for the plot to fit all data in
-        all curves for the plot.
-        """
-        plot_xmin = None
-        plot_xmax = None
-        plot_ymin = None
-        plot_ymax = None
-        for curve in self._curves:
-            try:
-                ((curve_xmin, curve_xmax),
-                 (curve_ymin, curve_ymax)) = curve.limits()
-            except NoDataError:
-                continue
-            if plot_xmin is None or curve_xmin < plot_xmin:
-                plot_xmin = curve_xmin
-            if plot_xmax is None or curve_xmax > plot_xmax:
-                plot_xmax = curve_xmax
-            if plot_ymin is None or curve_ymin < plot_ymin:
-                plot_ymin = curve_ymin
-            if plot_ymax is None or curve_ymax > plot_ymax:
-                plot_ymax = curve_ymax
-        self.plotItem.setLimits(xMin=plot_xmin, xMax=plot_xmax,
-                                yMin=plot_ymin, yMax=plot_ymax)
-
     @pyqtSlot()
     def redrawPlot(self):
         """
         Request a redraw from each curve in the plot.
         Called by curves when they get new data.
         """
-        self.updateAxes()
         for curve in self._curves:
             curve.redrawCurve()
 

--- a/pydm/widgets/waveformplot.py
+++ b/pydm/widgets/waveformplot.py
@@ -397,32 +397,6 @@ class PyDMWaveformPlot(BasePlot):
     def set_needs_redraw(self):
         self._needs_redraw = True
 
-    def updateAxes(self):
-        """
-        Update the X and Y axes for the plot to fit all data in
-        all curves for the plot.
-        """
-        plot_xmin = None
-        plot_xmax = None
-        plot_ymin = None
-        plot_ymax = None
-        for curve in self._curves:
-            try:
-                ((curve_xmin, curve_xmax),
-                 (curve_ymin, curve_ymax)) = curve.limits()
-            except NoDataError:
-                continue
-            if plot_xmin is None or curve_xmin < plot_xmin:
-                plot_xmin = curve_xmin
-            if plot_xmax is None or curve_xmax > plot_xmax:
-                plot_xmax = curve_xmax
-            if plot_ymin is None or curve_ymin < plot_ymin:
-                plot_ymin = curve_ymin
-            if plot_ymax is None or curve_ymax > plot_ymax:
-                plot_ymax = curve_ymax
-        self.plotItem.setLimits(xMin=plot_xmin, xMax=plot_xmax,
-                                yMin=plot_ymin, yMax=plot_ymax)
-
     @pyqtSlot()
     def redrawPlot(self):
         """
@@ -431,7 +405,6 @@ class PyDMWaveformPlot(BasePlot):
         """
         if not self._needs_redraw:
             return
-        self.updateAxes()
         for curve in self._curves:
             curve.redrawCurve()
         self._needs_redraw = False


### PR DESCRIPTION
PyDM Waveform plot as well as the Scatter plot were not respecting the user defined ranges for X and Y and also the AutoRange was not behaving properly being limited by the min and max of the current data being plotted.

Attn. @mattgibbs @marciodo @ernestow