### PR TITLE
BUG: Fix bug in PyDMWaveformPlot.

### DIFF
--- a/pydm/widgets/waveformplot.py
+++ b/pydm/widgets/waveformplot.py
@@ -204,7 +204,7 @@ class WaveformCurveItem(BasePlotCurveItem):
             return
         self.latest_y = new_waveform
         self.needs_new_y = False
-        if self.x_channel is None or self.x_waveform is not None:
+        if self.x_channel is None or self.latest_x is not None:
             self.update_waveforms_if_ready()
             self.data_changed.emit()
 


### PR DESCRIPTION
The bug was being triggered when the following conditions were met:
  - the `x_channel` is a constant PV, (updates only on connection);
 - the `x_channel` connects before the `y_channel`;

It is possible to see the effect of this bug applying the following patch:

```
diff --git a/pydm/widgets/waveformplot.py b/pydm/widgets/waveformplot.py
index ba4d932..664621e 100644
--- a/pydm/widgets/waveformplot.py
+++ b/pydm/widgets/waveformplot.py
@@ -462,9 +462,9 @@ class PyDMWaveformPlot(BasePlot):
         list
         """
         chans = []
-        chans.extend([curve.y_channel for curve in self._curves])
         chans.extend([curve.x_channel for curve in self._curves
                      if curve.x_channel is not None])
+        chans.extend([curve.y_channel for curve in self._curves])
         return chans

     # The methods for autoRangeX, minXRange, maxXRange, autoRangeY, minYRange,
```

and running the `testing_ioc` and the `waveformplot` example.