### PR TITLE
FIX: Designer crashes due to extensions

### DIFF
--- a/pydm/widgets/qtplugin_extensions.py
+++ b/pydm/widgets/qtplugin_extensions.py
@@ -35,11 +35,12 @@ class PyDMTaskMenuExtension(QPyDesignerTaskMenuExtension):
         self.widget = widget
         self.__actions = None
         self.__extensions = []
-        extensions = getattr(widget, 'extensions', [])
+        extensions = getattr(widget, 'extensions', None)
 
-        for ex in extensions:
-            extension = ex(self.widget)
-            self.__extensions.append(extension)
+        if extensions is not None:
+            for ex in extensions:
+                extension = ex(self.widget)
+                self.__extensions.append(extension)
 
     def taskActions(self):
         if self.__actions is None:
@@ -52,7 +53,8 @@ class PyDMTaskMenuExtension(QPyDesignerTaskMenuExtension):
     def preferredEditAction(self):
         if self.__actions is None:
             self.taskActions()
-        return self.__actions[0]
+        if self.__actions:
+            return self.__actions[0]
 
 
 class PyDMExtension(object):

--- a/pydm/widgets/qtplugins.py
+++ b/pydm/widgets/qtplugins.py
@@ -61,10 +61,12 @@ PyDMScatterPlotPlugin = qtplugin_factory(PyDMScatterPlot,
 
 # Byte plugin
 PyDMByteIndicatorPlugin = qtplugin_factory(PyDMByteIndicator,
-                                           group=WidgetCategory.DISPLAY)
+                                           group=WidgetCategory.DISPLAY,
+                                           extensions=BASE_EXTENSIONS)
 
 # Checkbox plugin
-PyDMCheckboxPlugin = qtplugin_factory(PyDMCheckbox, group=WidgetCategory.INPUT)
+PyDMCheckboxPlugin = qtplugin_factory(PyDMCheckbox, group=WidgetCategory.INPUT,
+                                      extensions=BASE_EXTENSIONS)
 
 # Drawing plugins
 PyDMDrawingArcPlugin = qtplugin_factory(PyDMDrawingArc,
@@ -96,8 +98,8 @@ PyDMDrawingTrianglePlugin = qtplugin_factory(PyDMDrawingTriangle,
                                              extensions=BASE_EXTENSIONS)
 
 PyDMDrawingPolygonPlugin = qtplugin_factory(PyDMDrawingPolygon,
-                                             group=WidgetCategory.DRAWING,
-                                             extensions=BASE_EXTENSIONS)
+                                            group=WidgetCategory.DRAWING,
+                                            extensions=BASE_EXTENSIONS)
 
 # Embedded Display plugin
 PyDMEmbeddedDisplayPlugin = qtplugin_factory(PyDMEmbeddedDisplay,


### PR DESCRIPTION
The lines patched in this PR caused designer to crash either after startup or adding a PyDM widget and clicking on it.

There may be a misconfiguration that I'm not seeing, but these minor fixes should be benign regardless.