### PR TITLE
FIX: propagate macros with related display buttons

### DIFF
--- a/pydm/application.py
+++ b/pydm/application.py
@@ -435,6 +435,9 @@ class PyDMApplication(QApplication):
             self.directory_stack.pop()
             self.macro_stack.pop()
             raise ValueError("Invalid file type: {}".format(extension))
+        # Add on the macros to the widget after initialization. This is
+        # done for both ui files and python files.
+        widget.base_macros = merged_macros
         if establish_connection:
             self.establish_widget_connections(widget)
         self.directory_stack.pop()

--- a/pydm/utilities/macro.py
+++ b/pydm/utilities/macro.py
@@ -22,3 +22,15 @@ def substitute_in_file(file_path, macros):
         text = Template(orig_file.read())
     expanded_text = text.safe_substitute(macros)
     return io.StringIO(six.text_type(expanded_text))
+
+
+def find_base_macros(widget):
+    '''
+    Find and return the first set of defined base_macros from this widget or
+    its ancestors.
+    '''
+    while widget is not None:
+        if hasattr(widget, 'base_macros'):
+            return widget.base_macros
+        widget = widget.parent()
+    return {}

--- a/pydm/widgets/related_display_button.py
+++ b/pydm/widgets/related_display_button.py
@@ -6,6 +6,7 @@ import logging
 from functools import partial
 from .base import PyDMPrimitiveWidget
 from ..utilities import IconFont
+from ..utilities.macro import find_base_macros
 
 
 class PyDMRelatedDisplayButton(QPushButton, PyDMPrimitiveWidget):
@@ -22,8 +23,8 @@ class PyDMRelatedDisplayButton(QPushButton, PyDMPrimitiveWidget):
         The file to be opened
     """
     # Constants for determining where to open the display.
-    EXISTING_WINDOW = 0;
-    NEW_WINDOW = 1;
+    EXISTING_WINDOW = 0
+    NEW_WINDOW = 1
 
     def __init__(self, parent=None, filename=None):
         QPushButton.__init__(self, parent)
@@ -203,10 +204,15 @@ class PyDMRelatedDisplayButton(QPushButton, PyDMPrimitiveWidget):
         if self._macro_string is not None:
             macros = json.loads(str(self._macro_string))
 
+        base_macros = find_base_macros(self)
+        merged_macros = base_macros.copy()
+        merged_macros.update(macros)
+
         if target == self.EXISTING_WINDOW:
-            self.window().go(self.displayFilename, macros=macros)
+            self.window().go(self.displayFilename, macros=merged_macros)
         if target == self.NEW_WINDOW:
-            self.window().new_window(self.displayFilename, macros=macros)
+            self.window().new_window(self.displayFilename,
+                                     macros=merged_macros)
 
     def context_menu(self):
         try:


### PR DESCRIPTION
(Disclaimer: I'm fairly new to the codebase and may be doing something dumb here. I also don't mind if this isn't merged, this just points to where the issue is.)

It did not seem obvious if any widget (derived from either ui-files or Python classes) had access to the correct set of macros, necessary to fix #342, so I have added them here in a not-so-ideal fashion. I can say that this fixes the issue I've observed locally, at least.