### PR TITLE
Fix related display buttons that don't have any macros specified.

### DIFF
--- a/pydm/widgets/related_display_button.py
+++ b/pydm/widgets/related_display_button.py
@@ -201,7 +201,7 @@ class PyDMRelatedDisplayButton(QPushButton, PyDMPrimitiveWidget):
         # Check for None and ""
         if not self.displayFilename:
             return
-        macros = None
+        macros = {}
         if self._macro_string is not None:
             macros = json.loads(str(self._macro_string))
 


### PR DESCRIPTION
Fixes a problem introduced in #392 where related display buttons would not open displays unless they had macros specified.