### PR TITLE
DOC: Fix copy/paste errors in widget doc strings and make consistent with code

### DIFF
--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -158,8 +158,6 @@ class PyDMPrimitiveWidget(object):
                 RulesDispatcher().register(self, rules_list)
             except JSONDecodeError as ex:
                 logger.exception('Invalid format for Rules')
-                return
-
 
 class PyDMWidget(PyDMPrimitiveWidget):
     """

--- a/pydm/widgets/byte.py
+++ b/pydm/widgets/byte.py
@@ -55,7 +55,7 @@ class PyDMBitIndicator(QWidget):
         Property for the color to be used when drawing
 
         Parameters
-        -------
+        ----------
         QColor
         """
         self._brush.setColor(color)
@@ -366,7 +366,7 @@ class PyDMByteIndicator(QWidget, PyDMWidget):
         Draw indicators as circles, rather than rectangles.
 
         Parameters
-        -------
+        ----------
         draw_circles : bool
             If True, bits will be represented as circles
         """

--- a/pydm/widgets/byte.py
+++ b/pydm/widgets/byte.py
@@ -54,7 +54,7 @@ class PyDMBitIndicator(QWidget):
         """
         Property for the color to be used when drawing
 
-        Returns
+        Parameters
         -------
         QColor
         """
@@ -312,7 +312,7 @@ class PyDMByteIndicator(QWidget, PyDMWidget):
         """
         Whether or not to show labels next to each bit indicator.
 
-        Returns
+        Parameters
         -------
         show : bool
             If True the widget will show a label next to the bit indicator
@@ -337,7 +337,7 @@ class PyDMByteIndicator(QWidget, PyDMWidget):
         """
         Whether the most significant bit is at the start or end of the widget.
 
-        Returns
+        Parameters
         -------
         is_big_endian : bool
             If True, the Big Endian will be used, Little Endian otherwise
@@ -365,7 +365,7 @@ class PyDMByteIndicator(QWidget, PyDMWidget):
         """
         Draw indicators as circles, rather than rectangles.
 
-        Returns
+        Parameters
         -------
         draw_circles : bool
             If True, bits will be represented as circles

--- a/pydm/widgets/drawing.py
+++ b/pydm/widgets/drawing.py
@@ -564,7 +564,7 @@ class PyDMDrawingImage(PyDMDrawing):
         PyQT Property for aspect ratio mode to be used when rendering
         the image
 
-        Returns
+        Parameters
         -------
         new_mode : int
             Index at Qt.AspectRatioMode enum

--- a/pydm/widgets/drawing.py
+++ b/pydm/widgets/drawing.py
@@ -565,7 +565,7 @@ class PyDMDrawingImage(PyDMDrawing):
         the image
 
         Parameters
-        -------
+        ----------
         new_mode : int
             Index at Qt.AspectRatioMode enum
         """

--- a/pydm/widgets/embedded_display.py
+++ b/pydm/widgets/embedded_display.py
@@ -216,7 +216,7 @@ class PyDMEmbeddedDisplay(QFrame, PyDMPrimitiveWidget):
         """
         Disconnect from PVs when this widget is not visible.
 
-        Returns
+        Parameters
         -------
         disconnect_when_hidden : bool
         """

--- a/pydm/widgets/embedded_display.py
+++ b/pydm/widgets/embedded_display.py
@@ -217,7 +217,7 @@ class PyDMEmbeddedDisplay(QFrame, PyDMPrimitiveWidget):
         Disconnect from PVs when this widget is not visible.
 
         Parameters
-        -------
+        ----------
         disconnect_when_hidden : bool
         """
         self._disconnect_when_hidden = disconnect_when_hidden

--- a/pydm/widgets/rules.py
+++ b/pydm/widgets/rules.py
@@ -49,8 +49,7 @@ class RulesDispatcher(object):
 
         Returns
         -------
-        bool
-            True if all the rules were successfully registered, False otherwise.
+        None
         """
         self.rules_engine.register(widget, rules)
 

--- a/pydm/widgets/spinbox.py
+++ b/pydm/widgets/spinbox.py
@@ -84,9 +84,7 @@ class PyDMSpinbox(QDoubleSpinBox, PyDMWritableWidget):
 
         Returns
         -------
-        format_string : str
-            The format string to be used including or not the precision
-            and unit
+        None
         """
         if self._show_units:
             units = " {}".format(self._unit)


### PR DESCRIPTION
Fix some minor copy/paste errors in widget doc strings and make return values consistent with what the code actually returns.