### PR TITLE
ENH: add quick access to channel timestamp/value history (tabular/plot)

### DIFF
--- a/examples/label/label.ui
+++ b/examples/label/label.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
  <class>Dialog</class>
- <widget class="QDialog" name="Dialog">
+ <widget class="QWidget" name="Dialog">
   <property name="geometry">
    <rect>
     <x>0</x>
@@ -13,34 +13,107 @@
   <property name="windowTitle">
    <string>Dialog</string>
   </property>
-  <widget class="PyDMLabel" name="PyDMLabel">
-   <property name="geometry">
-    <rect>
-     <x>60</x>
-     <y>80</y>
-     <width>69</width>
-     <height>16</height>
-    </rect>
-   </property>
-   <property name="focusPolicy">
-    <enum>Qt::StrongFocus</enum>
-   </property>
-   <property name="toolTip">
-    <string/>
-   </property>
-   <property name="whatsThis">
-    <string/>
-   </property>
-   <property name="alarmSensitiveContent" stdset="0">
-    <bool>true</bool>
-   </property>
-   <property name="channel" stdset="0">
-    <string>ca://MTEST:SinVal</string>
-   </property>
-   <property name="displayFormat" stdset="0">
-    <enum>PyDMLabel::String</enum>
-   </property>
-  </widget>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>MTEST:SinValue</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>MTEST:Float</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="PyDMLabel" name="PyDMLabel">
+     <property name="focusPolicy">
+      <enum>Qt::StrongFocus</enum>
+     </property>
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="whatsThis">
+      <string/>
+     </property>
+     <property name="alarmSensitiveContent" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="precisionFromPV" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="precision" stdset="0">
+      <number>3</number>
+     </property>
+     <property name="channel" stdset="0">
+      <string>ca://MTEST:SinVal</string>
+     </property>
+     <property name="displayFormat" stdset="0">
+      <enum>PyDMLabel::String</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1">
+    <widget class="PyDMLabel" name="PyDMLabel_2">
+     <property name="focusPolicy">
+      <enum>Qt::StrongFocus</enum>
+     </property>
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="whatsThis">
+      <string/>
+     </property>
+     <property name="alarmSensitiveContent" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="channel" stdset="0">
+      <string>ca://MTEST:Float</string>
+     </property>
+     <property name="displayFormat" stdset="0">
+      <enum>PyDMLabel::String</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="label_3">
+     <property name="text">
+      <string>MTEST:CosValue</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="PyDMLabel" name="PyDMLabel_3">
+     <property name="focusPolicy">
+      <enum>Qt::StrongFocus</enum>
+     </property>
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="whatsThis">
+      <string/>
+     </property>
+     <property name="alarmSensitiveContent" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="precisionFromPV" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="precision" stdset="0">
+      <number>3</number>
+     </property>
+     <property name="channel" stdset="0">
+      <string>ca://MTEST:CosVal</string>
+     </property>
+     <property name="displayFormat" stdset="0">
+      <enum>PyDMLabel::String</enum>
+     </property>
+    </widget>
+   </item>
+  </layout>
  </widget>
  <customwidgets>
   <customwidget>

--- a/examples/label/label.ui
+++ b/examples/label/label.ui
@@ -35,7 +35,7 @@
     <bool>true</bool>
    </property>
    <property name="channel" stdset="0">
-    <string>ca://MTEST:Float</string>
+    <string>ca://MTEST:SinVal</string>
    </property>
    <property name="displayFormat" stdset="0">
     <enum>PyDMLabel::String</enum>

--- a/pydm/application.py
+++ b/pydm/application.py
@@ -19,6 +19,7 @@ import warnings
 import platform
 import collections
 from functools import partial
+from . import config
 from .display_module import Display
 from qtpy.QtCore import Qt, QEvent, QTimer, Slot
 from qtpy.QtWidgets import QApplication, QWidget, QToolTip, QAction, QMenu
@@ -33,10 +34,6 @@ from . import data_plugins
 from .widgets.rules import RulesDispatcher
 
 logger = logging.getLogger(__name__)
-DEFAULT_PROTOCOL = os.getenv("PYDM_DEFAULT_PROTOCOL")
-if DEFAULT_PROTOCOL is not None:
-    # Get rid of the "://" part if it exists
-    DEFAULT_PROTOCOL = DEFAULT_PROTOCOL.split("://")[0]
 
 
 class PyDMApplication(QApplication):
@@ -497,9 +494,10 @@ class PyDMApplication(QApplication):
         match = re.match('.*://', channel.address)
         if match:
             protocol = match.group(0)[:-3]
-        elif DEFAULT_PROTOCOL is not None:
-            # If no protocol was specified, and the default protocol environment variable is specified, try to use that instead.
-            protocol = DEFAULT_PROTOCOL
+        elif config.DEFAULT_PROTOCOL is not None:
+            # If no protocol was specified, and the default protocol
+            # environment variable is specified, try to use that instead.
+            protocol = config.DEFAULT_PROTOCOL
         if protocol:
             try:
                 plugin_to_use = self.plugins[str(protocol)]

--- a/pydm/config.py
+++ b/pydm/config.py
@@ -1,0 +1,10 @@
+import os
+
+__all__ = ['DEFAULT_PROTOCOL',
+           ]
+
+
+DEFAULT_PROTOCOL = os.getenv("PYDM_DEFAULT_PROTOCOL")
+if DEFAULT_PROTOCOL is not None:
+    # Get rid of the "://" part if it exists
+    DEFAULT_PROTOCOL = DEFAULT_PROTOCOL.split("://")[0]

--- a/pydm/main_window.py
+++ b/pydm/main_window.py
@@ -85,6 +85,7 @@ class PyDMMainWindow(QMainWindow):
     def set_display_widget(self, new_widget):
         if new_widget == self._display_widget:
             return
+
         self.clear_display_widget()
         if not new_widget.layout():
             new_widget.setMinimumSize(new_widget.size())

--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -5,8 +5,8 @@ import logging
 import functools
 import json
 import numpy as np
-from qtpy.QtWidgets import QApplication, QMenu, QGraphicsOpacityEffect
-from qtpy.QtGui import QCursor, QToolTip, QDrag
+from qtpy.QtWidgets import QApplication, QMenu, QGraphicsOpacityEffect, QToolTip
+from qtpy.QtGui import QCursor, QDrag
 from qtpy.QtCore import Qt, QEvent, Signal, Slot, Property, QTimer, QMimeData
 from .channel import PyDMChannel
 from ..utilities import is_pydm_app

--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -10,6 +10,7 @@ from qtpy.QtCore import Qt, QEvent, Signal, Slot, Property
 from .channel import PyDMChannel
 from ..utilities import is_pydm_app
 from .rules import RulesDispatcher
+from .. import config
 
 try:
     from json.decoder import JSONDecodeError
@@ -219,7 +220,7 @@ class PyDMWidget(PyDMPrimitiveWidget):
         self.channeltype = None
         self.subtype = None
 
-        # If this label is inside a PyDMApplication (not Designer) start it in '
+        # If this label is inside a PyDMApplication (not Designer) start it in
         # the disconnected state.
         if is_pydm_app():
             self._connected = False

--- a/pydm/widgets/baseplot.py
+++ b/pydm/widgets/baseplot.py
@@ -248,6 +248,7 @@ class BasePlot(PlotWidget, PyDMPrimitiveWidget):
         PlotWidget.__init__(self, parent=parent, background=background,
                             axisItems=axisItems)
         PyDMPrimitiveWidget.__init__(self)
+        self.app = QApplication.instance()
         self.plotItem = self.getPlotItem()
         self.plotItem.hideButtons()
         self._auto_range_x = None

--- a/pydm/widgets/timeplot.py
+++ b/pydm/widgets/timeplot.py
@@ -1,13 +1,15 @@
 import time
 import json
 import datetime
+import logging
 import collections
 from collections import OrderedDict
 from pyqtgraph import ViewBox, AxisItem
 import numpy as np
-from qtpy.QtGui import (QColor, QFrame, QVBoxLayout, QApplication, QLabel,
-                        QPushButton, QTableWidget, QTableWidgetItem, QCursor)
+from qtpy.QtGui import QColor
 from qtpy.QtCore import (Slot, Property, QTimer, Qt)
+from qtpy.QtWidgets import (QFrame, QVBoxLayout, QPushButton, QTableWidget,
+                            QTableWidgetItem)
 from .baseplot import BasePlot, BasePlotCurveItem
 from .channel import PyDMChannel
 from ..utilities import remove_protocol
@@ -470,7 +472,7 @@ class PyDMHistoryTable(QTableWidget, PyDMWidget):
         self.setHorizontalHeaderLabels(self._columnHeaders)
         self.resizeColumnsToContents()
 
-    @pyqtProperty("QStringList")
+    @Property("QStringList")
     def columnHeaderLabels(self):
         """
         Return the list of labels for the columns of the Table.
@@ -498,7 +500,7 @@ class PyDMHistoryTable(QTableWidget, PyDMWidget):
         self.setHorizontalHeaderLabels(self._columnHeaders)
         self.setColumnCount(len(self._columnHeaders))
 
-    @pyqtProperty("QStringList")
+    @Property("QStringList")
     def rowHeaderLabels(self):
         """
         Return the list of labels for the rows of the Table.


### PR DESCRIPTION
Here's an example of what this PR does:
![historywidget gifcask 2018-09-17 14_36_06](https://user-images.githubusercontent.com/5139267/45651715-0dd1ba80-ba87-11e8-8526-e8e076fd3a1f.gif)

The main gist is that a long-right click (or a short right click to get the context menu, and 'History') leads to a pop-up window that contains both a PyDMTimePlot and a new `camonitor`-like table of previous values. The changes in this PR make it such that PyDM widgets now keep track of timestamp/value pairs, which end up being the source for the history widget.

A few additional things, all of which can be removed/changed if desirable:
* Added functionality to the plot to allow for drag/drop of signal from the main screen (shift + right-click/drag)
* Made an initial step to move configuration settings into its own submodule (`pydm.config`)
* Moved all context menu handling (eventFilter) stuff into the base widget
* Changed `label.ui` example to be more descriptive/useful (seen in the video above)

Other:
* "History" altogether is a bit of a misnomer - it does show the previous history, but then continues to update as time goes on.
* The 'long-click' thing may be controversial. I settled on this after a few other options which I liked much less.
* For the `QDrag`, I initially tried using `QUrl`, but it turns out most of our signals are not proper URLs, so I reverted back to text/plain

TODO:
If it's seen as useful enough to merge, we'll need to add some tests and likely rebase on #402.