### PR TITLE
FIX: Show Units with no units metadata

### DIFF
--- a/pydm/widgets/line_edit.py
+++ b/pydm/widgets/line_edit.py
@@ -118,7 +118,7 @@ class PyDMLineEdit(QLineEdit, PyDMWritableWidget, DisplayFormat):
                 # Lets just send what we have after all
                 self.send_value_signal[str].emit(send_value)
         except ValueError:
-            logger.error("Error trying to set data '{0}' with type '{1}' and format '{2}' at widget '{3}'."
+            logger.exception("Error trying to set data '{0}' with type '{1}' and format '{2}' at widget '{3}'."
                          .format(self.text(), self.channeltype, self._display_format_type, self.objectName()))
 
         self.clearFocus()

--- a/pydm/widgets/line_edit.py
+++ b/pydm/widgets/line_edit.py
@@ -82,7 +82,7 @@ class PyDMLineEdit(QLineEdit, PyDMWritableWidget, DisplayFormat):
         """
         send_value = str(self.text())
         # Clean text of unit string
-        if self._show_units and self._unit in send_value:
+        if self._show_units and self._unit and self._unit in send_value:
             send_value = send_value[:-len(self._unit)].strip()
         try:
             if self.channeltype not in [str, np.ndarray]:


### PR DESCRIPTION
## Description
A widget may be configured to `showUnits`but the channel might not have any units specified. This leads to a scenario in which we were stripping the entire entered value. 

## Existing Issues
* ``` send_value = send_value[:-len(self._unit)].strip()``` seems really aggressive. I guess it works but why blindly pop information out? Shouldn't something like:
```python
split_send = send_value.split()
if split_send[-1] == self._units:
    spilt_send.pop()
    send_value = ' '.join(split_send)
```
* The tests for `send_value` do not accurately test what happens to the widget in reality. Many of tests have the `user_typed_value` listed as `float` or `int`. The user will **only** supply us with `str` values. I think these tests need to be re-written to accurately test real-life behavior i.e
```python
pydm_lineedit.setText(user_supplied_value)
pydm_lineedit.returnPressed.emit()
```
A quick swap of this revealed a number of issues with precision and scale.