### PR TITLE
FIX: penWidth is a floating point property.

### DIFF
--- a/pydm/default_stylesheet.qss
+++ b/pydm/default_stylesheet.qss
@@ -43,7 +43,7 @@ ALARM_DISCONNECTED = 4
 /* We have to call out the custom pen on PyDMDrawingWidget */
 PyDMDrawing[alarmSensitiveBorder="true"] {
     border: none;
-    qproperty-penWidth: 2px;
+    qproperty-penWidth: 2;
 
 }
 


### PR DESCRIPTION
Removing the wrong 'px' after the value.

Closes #396