### PR TITLE
CI: Reduce the Test Matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,6 @@ matrix:
       language: python
       env: CONDA_FOLDER="linux-64" MC_URL="https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh"
     - os: linux
-      python: 3.5
-      language: python
-      env: CONDA_FOLDER="linux-64" MC_URL="https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh"
-    - os: linux
       python: 3.6
       language: python
       env: BUILD_DOCS=1 CONDA_FOLDER="linux-64" MC_URL="https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,10 +14,6 @@ environment:
     secure: qROm2iOANaz9zZRZzyde8b7SMNpEC3rDP78SLAGaoRZBrLiE1MzP62VLjqfXMYBN
 
   matrix:
-    - PYTHON_VERSION: 2.7
-      MINICONDA: C:\Miniconda
-    - PYTHON_VERSION: 3.5
-      MINICONDA: C:\Miniconda35
     - PYTHON_VERSION: 3.6
       MINICONDA: C:\Miniconda36
 

--- a/setup.py
+++ b/setup.py
@@ -70,8 +70,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
     ]
 )


### PR DESCRIPTION
This PR is targeted at removing Python 3.5 at Travis, which means no Conda Package for Python 3.5 under Linux and Mac as well as Python 2.7 and Python 3.5 at AppVeyor, resulting in no Conda Package for PyDM on Windows with those versions of Python.

This is part of a initiative to move folks towards Python 3.6 or higher. In the near future we will add Python 3.7 to the matrix. That will come after we do some in-house tests.

The reduced matrix will allow us to run tests faster, which is always good.