### PR TITLE
Fix bugs and documentation issues in TimePlot.

### DIFF
--- a/pydm/widgets/baseplot.py
+++ b/pydm/widgets/baseplot.py
@@ -395,9 +395,9 @@ class BasePlot(PlotWidget, PyDMPrimitiveWidget):
         Parameters
         ----------
         show : bool
-            True for showing the right a-xis; False is for not showing.
+            True for showing the right axis; False is for not showing.
         """
-        if self._show_right_axis != show:
+        if show:
             self.showAxis("right")
         else:
             self.hideAxis("right")

--- a/pydm/widgets/timeplot.py
+++ b/pydm/widgets/timeplot.py
@@ -319,12 +319,14 @@ class PyDMTimePlot(BasePlot):
         parent : Widget
             The parent widget of the chart.
         init_y_channels : list
-            A list of PV channels to plot when the graph is ready.
-         plot_by_timestamps : bool
-            True if the x-axis shows the timestamps as ticks, and moves automatically to the left. False if the the
-            x-axis starts at 0, and shows relative time in negative values to the left.
-        background : str
-            The color descriptor for the background of the graph
+            A list of scalar channels to plot vs time.
+        plot_by_timestamps : bool
+            If True, the x-axis shows timestamps as ticks, and those timestamps
+            scroll to the left as time progresses.  If False, the x-axis tick
+            marks show time relative to the current time.
+        background : str, optional
+            The background color for the plot.  Accepts any arguments that
+            pyqtgraph.mkColor will accept.
         """
         self._plot_by_timestamps = plot_by_timestamps
 

--- a/pydm/widgets/timeplot.py
+++ b/pydm/widgets/timeplot.py
@@ -381,34 +381,6 @@ class PyDMTimePlot(BasePlot):
         # This function gets called by PyDMTimePlot's designer plugin.
         self.redraw_timer.setSingleShot(True)
 
-    def getPlotByTimestamps(self):
-        """
-        Whether the graph will show the moving timestamps as the x-axis
-        (default), or the relative time after the starting time.
-
-        Returns
-        -------
-            If True, the x-axis will show moving timestamps (default).
-            If False, the x-axis will show relative time.
-        """
-        return self._plot_by_timestamps
-
-    def setPlotByTimesStamps(self, new_value):
-        """
-        Change the x-axis appearance and behavior.
-
-        Parameters
-        ----------
-        new_value : bool
-            Set to True for the x-axis to show moving timestamps (default).
-            Set to False for the x-axis to show the relative time after the
-            starting time.
-        """
-        if new_value != self._plot_by_timestamps:
-            self._plot_by_timestamps = new_value
-
-    plotByTimeStamps = Property("bool", getPlotByTimestamps, setPlotByTimesStamps)
-
     def addYChannel(self, y_channel=None, name=None, color=None,
                     lineStyle=None, lineWidth=None, symbol=None,
                     symbolSize=None):

--- a/pydm/widgets/timeplot.py
+++ b/pydm/widgets/timeplot.py
@@ -829,6 +829,9 @@ class PyDMTimePlot(BasePlot):
 
 
 class TimeAxisItem(AxisItem):
+    """
+    TimeAxisItem formats a unix time axis into a human-readable format.
+    """
     def tickStrings(self, values, scale, spacing):
         strings = []
         for val in values:

--- a/pydm/widgets/timeplot.py
+++ b/pydm/widgets/timeplot.py
@@ -73,7 +73,6 @@ class TimePlotCurveItem(BasePlotCurveItem):
         # Keep the x-axis moving with latest timestamps as ticks
         self._plot_by_timestamps = plot_by_timestamps
 
-        self.starting_epoch_time = time.time()
         self._bufferSize = MINIMUM_BUFFER_SIZE
         self._update_mode = PyDMTimePlot.SynchronousMode
 
@@ -218,11 +217,6 @@ class TimePlotCurveItem(BasePlotCurveItem):
         """
         Initialize the data buffer used to plot the current curve.
         """
-        if not self._plot_by_timestamps:
-            # Since we're initializing a new buffer, must reset the epoch time
-            #for the relative time x-axis
-            self.starting_epoch_time = time.time()
-
         self.points_accumulated = 0
 
         # If you don't specify dtype=float, you don't have enough


### PR DESCRIPTION
Fixes a few bugs in TimePlot, and cleans up the documentation.  Completely removes the plotByTimeStamps pyqtProperty, which didn't work.  If we want to change the x-axis mode via a pyqtProperty (or equivalently, at run time), it isn't trivial.  We will need to:

1. Make sure all set-up for the x-axis mode happens inside the property setter (can't rely on it happening at initialization).
2. Remove the old bottom AxisItem from the layout, and replace it with the new one.

I don't want to do that right now, so if we do want it, we'll have to add it in later.