### PR TITLE
CI: Fix Travis missing tags with long number of commits.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,8 @@ before_install:
     fi
   # Make sure we have the tags no matter how far from them we are.
   - git pull --unshallow
+  # Gotta do the pull again to ensure that the Tag is present.
+  - git pull
   - wget $MC_URL -O miniconda.sh;
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"


### PR DESCRIPTION
@jesusvasquez333 alerted me today about this issue in which Travis after the `git pull --unshallow` still misses the new tag...
This PR fixes this issue, which I noticed in the past but never when after it or the causes.

Thank you, @jesusvasquez333