### PR TITLE
FIX: Watch for widgets with no channels

### DIFF
--- a/pydm/utilities/connection.py
+++ b/pydm/utilities/connection.py
@@ -1,4 +1,8 @@
+import logging
+
 from qtpy.QtWidgets import QWidget
+
+logger = logging.getLogger(__name__)
 
 
 def _change_connection_status(widget, status):
@@ -20,13 +24,17 @@ def _change_connection_status(widget, status):
     for child_widget in widgets:
         try:
             if hasattr(child_widget, 'channels'):
-                for channel in child_widget.channels():
-                    if channel is None:
-                        continue
-                    if status:
-                        channel.connect()
-                    else:
-                        channel.disconnect()
+                if not channels:
+                    logger.error("Widget has not channels configured")
+                    return
+                else:
+                    for channel in child_widget.channels():
+                        if channel is None:
+                            continue
+                        if status:
+                            channel.connect()
+                        else:
+                            channel.disconnect()
         except NameError:
             continue
 

--- a/pydm/utilities/connection.py
+++ b/pydm/utilities/connection.py
@@ -25,7 +25,9 @@ def _change_connection_status(widget, status):
         try:
             if hasattr(child_widget, 'channels'):
                 if not channels:
-                    logger.error("Widget has not channels configured")
+                    logger.error("Widget %r has no channels configured. "
+                                 "Can not change connection status.",
+                                 child_widget)
                     return
                 else:
                     for channel in child_widget.channels():


### PR DESCRIPTION
If we do not set `Widget.channel`, `Widget.channels()` will return `None` instead of an empty list. If this happens we should not raise an `Exception` but instead log and move on. 