### PR TITLE
Remove unused base class properties from widgets.

### DIFF
--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -675,7 +675,6 @@ class PyDMWidget(PyDMPrimitiveWidget):
         self._alarm_sensitive_border = checked
         self.alarm_severity_changed(self._alarm_state)
 
-    @Property(bool)
     def precisionFromPV(self):
         """
         A choice whether or not to use the precision given by channel.
@@ -699,8 +698,7 @@ class PyDMWidget(PyDMPrimitiveWidget):
         """
         return self._precision_from_pv
 
-    @precisionFromPV.setter
-    def precisionFromPV(self, value):
+    def setPrecisionFromPV(self, value):
         """
         A choice whether or not to use the precision given by channel.
 
@@ -724,7 +722,6 @@ class PyDMWidget(PyDMPrimitiveWidget):
         if self._precision_from_pv != bool(value):
             self._precision_from_pv = value
 
-    @Property(int)
     def precision(self):
         """
         The precision to be used when formatting the output of the PV
@@ -736,8 +733,7 @@ class PyDMWidget(PyDMPrimitiveWidget):
         """
         return self._prec
 
-    @precision.setter
-    def precision(self, new_prec):
+    def setPrecision(self, new_prec):
         """
         The precision to be used when formatting the output of the PV.
         This has no effect when ```precisionFromPV``` is True.
@@ -755,7 +751,6 @@ class PyDMWidget(PyDMPrimitiveWidget):
             self._prec = int(new_prec)
             self.update_format_string()
 
-    @Property(bool)
     def showUnits(self):
         """
         A choice whether or not to show the units given by the channel
@@ -772,8 +767,7 @@ class PyDMWidget(PyDMPrimitiveWidget):
         """
         return self._show_units
 
-    @showUnits.setter
-    def showUnits(self, show_units):
+    def setShowUnits(self, show_units):
         """
         A choice whether or not to show the units given by the channel
 

--- a/pydm/widgets/label.py
+++ b/pydm/widgets/label.py
@@ -78,3 +78,28 @@ class PyDMLabel(QLabel, PyDMWidget, DisplayFormat):
         # If you made it this far, just turn whatever the heck the value
         # is into a string and display it.
         self.setText(str(new_value))
+    
+    # The methods for precisionFromPV, precision, and showUnits are
+    # all defined in PyDMWidget, but we don't expose them as properties there,
+    # because not all widgets necessarily need them.
+    # A future version of PyDM may move the methods out of PyDMWidget entirely.
+    precisionFromPV = Property(bool, PyDMWidget.precisionFromPV,
+                          PyDMWidget.setPrecisionFromPV,
+                          doc="""
+    If True, the widget will use the precision information
+    from the Channel, if available.
+    """)
+
+    precision = Property(int, PyDMWidget.precision,
+                          PyDMWidget.setPrecision,
+                          doc="""
+    The precision to be used when formatting the output of the PV.
+    """)
+    
+    showUnits = Property(bool, PyDMWidget.showUnits,
+                          PyDMWidget.setShowUnits,
+                          doc="""
+    If set to True, the units given in the channel will be displayed
+    with the value. If using an EPICS channel, this will automatically
+    be linked to the EGU field of the PV.
+    """)

--- a/pydm/widgets/line_edit.py
+++ b/pydm/widgets/line_edit.py
@@ -270,3 +270,28 @@ class PyDMLineEdit(QLineEdit, PyDMWritableWidget, DisplayFormat):
         if self._display is not None:
             self.setText(self._display)
         super(PyDMLineEdit, self).focusOutEvent(event)
+    
+    # The methods for precisionFromPV, precision, and showUnits are
+    # all defined in PyDMWidget, but we don't expose them as properties there,
+    # because not all widgets necessarily need them.
+    # A future version of PyDM may move the methods out of PyDMWidget entirely.
+    precisionFromPV = Property(bool, PyDMWritableWidget.precisionFromPV,
+                          PyDMWritableWidget.setPrecisionFromPV,
+                          doc="""
+    If True, the widget will use the precision information
+    from the Channel, if available.
+    """)
+
+    precision = Property(int, PyDMWritableWidget.precision,
+                          PyDMWritableWidget.setPrecision,
+                          doc="""
+    The precision to be used when formatting the output of the PV.
+    """)
+    
+    showUnits = Property(bool, PyDMWritableWidget.showUnits,
+                          PyDMWritableWidget.setShowUnits,
+                          doc="""
+    If set to True, the units given in the channel will be displayed
+    with the value. If using an EPICS channel, this will automatically
+    be linked to the EGU field of the PV.
+    """)

--- a/pydm/widgets/slider.py
+++ b/pydm/widgets/slider.py
@@ -528,3 +528,28 @@ class PyDMSlider(QFrame, PyDMWritableWidget):
         """
         self._num_steps = int(new_steps)
         self.reset_slider_limits()
+    
+    # The methods for precisionFromPV, precision, and showUnits are
+    # all defined in PyDMWidget, but we don't expose them as properties there,
+    # because not all widgets necessarily need them.
+    # A future version of PyDM may move the methods out of PyDMWidget entirely.
+    precisionFromPV = Property(bool, PyDMWritableWidget.precisionFromPV,
+                          PyDMWritableWidget.setPrecisionFromPV,
+                          doc="""
+    If True, the widget will use the precision information
+    from the Channel, if available.
+    """)
+
+    precision = Property(int, PyDMWritableWidget.precision,
+                          PyDMWritableWidget.setPrecision,
+                          doc="""
+    The precision to be used when formatting the output of the PV.
+    """)
+    
+    showUnits = Property(bool, PyDMWritableWidget.showUnits,
+                          PyDMWritableWidget.setShowUnits,
+                          doc="""
+    If set to True, the units given in the channel will be displayed
+    with the value. If using an EPICS channel, this will automatically
+    be linked to the EGU field of the PV.
+    """)

--- a/pydm/widgets/spinbox.py
+++ b/pydm/widgets/spinbox.py
@@ -175,3 +175,28 @@ class PyDMSpinbox(QDoubleSpinBox, PyDMWritableWidget):
         """
         self._show_step_exponent = val
         self.update_format_string()
+    
+    # The methods for precisionFromPV, precision, and showUnits are
+    # all defined in PyDMWidget, but we don't expose them as properties there,
+    # because not all widgets necessarily need them.
+    # A future version of PyDM may move the methods out of PyDMWidget entirely.
+    precisionFromPV = Property(bool, PyDMWritableWidget.precisionFromPV,
+                          PyDMWritableWidget.setPrecisionFromPV,
+                          doc="""
+    If True, the widget will use the precision information
+    from the Channel, if available.
+    """)
+
+    precision = Property(int, PyDMWritableWidget.precision,
+                          PyDMWritableWidget.setPrecision,
+                          doc="""
+    The precision to be used when formatting the output of the PV.
+    """)
+    
+    showUnits = Property(bool, PyDMWritableWidget.showUnits,
+                          PyDMWritableWidget.setShowUnits,
+                          doc="""
+    If set to True, the units given in the channel will be displayed
+    with the value. If using an EPICS channel, this will automatically
+    be linked to the EGU field of the PV.
+    """)


### PR DESCRIPTION
This PR removes the Qt Properties "precisionFromPV", "precision", and "showUnits" from the PyDMWidget base class, then selectively adds them back to the widgets that actually use them.  This way, the properties won't show up in Designer for widgets where they don't do anything.

In order to do this with minimal structural changes, I left the methods for those properties on the base class, and just added properties to the classes that use the methods.  In the future, we may want to completely remove the methods from PyDMWidget, and put them somewhere else.