### PR TITLE
Add an implementation of ui_filepath to Display class

### DIFF
--- a/examples/camviewer/camviewer.py
+++ b/examples/camviewer/camviewer.py
@@ -503,9 +503,6 @@ class CamViewer(Display):
     def ui_filename(self):
         return 'camviewer.ui'
 
-    def ui_filepath(self):
-        return path.join(path.dirname(path.realpath(__file__)), self.ui_filename())
-
     def channels(self):
         return self._channels
 

--- a/examples/image_processing/image_view.py
+++ b/examples/image_processing/image_view.py
@@ -19,9 +19,6 @@ class ImageViewer(Display):
     def ui_filename(self):
         return 'image_view.ui'
 
-    def ui_filepath(self):
-        return path.join(path.dirname(path.realpath(__file__)), self.ui_filename())
-
     def draw_markers(self, *args, **kwargs):
         with self.markers_lock:
             for m in self.markers:

--- a/examples/macros/macros_and_python/macro_addition.py
+++ b/examples/macros/macros_and_python/macro_addition.py
@@ -8,6 +8,3 @@ class MacroAddition(Display):
     
     def ui_filename(self):
         return 'macro_addition.ui'
-        
-    def ui_filepath(self):
-        return path.join(path.dirname(path.realpath(__file__)), self.ui_filename())

--- a/examples/macros/nested_embedded_windows/macro_addition.py
+++ b/examples/macros/nested_embedded_windows/macro_addition.py
@@ -8,6 +8,3 @@ class MacroAddition(Display):
     
     def ui_filename(self):
         return 'macro_addition.ui'
-        
-    def ui_filepath(self):
-        return path.join(path.dirname(path.realpath(__file__)), self.ui_filename())

--- a/pydm/display_module.py
+++ b/pydm/display_module.py
@@ -5,19 +5,30 @@ from qtpy.QtWidgets import QWidget
 from .utilities import macro
 
 class Display(QWidget):
-    def __init__(self, parent=None, args=None, macros=None):
+    def __init__(self, parent=None, args=None, macros=None, ui_filename=None):
         super(Display, self).__init__(parent=parent)
         self.ui = None
+        self._ui_filename = ui_filename
         self.load_ui(parent=parent, macros=macros)
 
     def ui_filepath(self):
+        """ Returns the path to the ui file relative to the file of the class
+        calling this function."""
         path_to_class = sys.modules[self.__module__].__file__
         return path.join(path.dirname(path.realpath(path_to_class)), self.ui_filename())
 
     def ui_filename(self):
-        raise NotImplementedError
+        """ Returns the name of the ui file.  In modern PyDM, it is preferable
+        specify this via the ui_filename argument in Display's constructor,
+        rather than reimplementing this in Display subclasses."""
+        if self._ui_filename is None:
+            raise NotImplementedError
+        else:
+            return self._ui_filename
 
     def load_ui(self, parent=None, macros=None):
+        """ Load and parse the ui file, and make the file's widgets available
+        in self.ui.  Called by the initializer."""
         if self.ui:
             return self.ui
         if self.ui_filepath() is not None and self.ui_filepath() != "":

--- a/pydm/display_module.py
+++ b/pydm/display_module.py
@@ -1,8 +1,8 @@
+import sys
 from os import path
 from qtpy import uic
 from qtpy.QtWidgets import QWidget
 from .utilities import macro
-
 
 class Display(QWidget):
     def __init__(self, parent=None, args=None, macros=None):
@@ -11,7 +11,8 @@ class Display(QWidget):
         self.load_ui(parent=parent, macros=macros)
 
     def ui_filepath(self):
-        raise NotImplementedError
+        path_to_class = sys.modules[self.__module__].__file__
+        return path.join(path.dirname(path.realpath(path_to_class)), self.ui_filename())
 
     def ui_filename(self):
         raise NotImplementedError

--- a/pydm/tests/test_data/test.ui
+++ b/pydm/tests/test_data/test.ui
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>594</width>
+    <height>412</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="PyDMImageView" name="imageView">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="whatsThis">
+      <string/>
+     </property>
+     <property name="readingOrder" stdset="0">
+      <enum>PyDMImageView::Clike</enum>
+     </property>
+     <property name="imageChannel" stdset="0">
+      <string>ca://MTEST:TwoSpotImage</string>
+     </property>
+     <property name="widthChannel" stdset="0">
+      <string>ca://MTEST:ImageWidth</string>
+     </property>
+     <property name="maxRedrawRate" stdset="0">
+      <number>4</number>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QFormLayout" name="formLayout">
+     <item row="0" column="0">
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>Number of Blobs:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QLabel" name="numBlobsLabel">
+       <property name="text">
+        <string>TextLabel</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>PyDMImageView</class>
+   <extends>QWidget</extends>
+   <header>pydm.widgets.image</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/pydm/tests/test_display.py
+++ b/pydm/tests/test_display.py
@@ -1,0 +1,35 @@
+import os
+import pytest
+from pydm import Display
+
+# The path to the .ui file used in these tests
+test_ui_path = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)),
+    "test_data", "test.ui")
+
+def test_display_raises_without_filename():
+    """If you don't specify a ui_filename argument, or don't reimplement
+    ui_filename(), make sure you get a NotImplementedError."""
+    with pytest.raises(NotImplementedError):
+        my_display = Display(parent=None)
+
+def test_ui_filename_arg():
+    """If you supply a valid filename argument, you shouldn't get any exceptions."""
+    my_display = Display(parent=None, ui_filename=test_ui_path)
+
+def test_reimplemented_ui_filename():
+    """If you reimplement ui_filename and return a valid filename, you
+    shouldn't get any exceptions."""
+    class TestDisplay(Display):
+        def ui_filename(self):
+            return test_ui_path
+    my_display = TestDisplay(parent=None)
+
+def test_nonexistant_ui_file_raises():
+    with pytest.raises(IOError):
+        my_display = Display(parent=None, ui_filename="this_doesnt_exist.ui")
+    class TestDisplay(Display):
+        def ui_filename(self):
+            return "this_doesnt_exist.ui"
+    with pytest.raises(IOError):
+        my_display = TestDisplay(parent=None)


### PR DESCRIPTION
This PR implements the `ui_filepath` method of the Display class on the class itself, in a way that will work with subclasses.  Effectively, this means that Display subclasses should not need to implement `ui_filepath` anymore.

The PR also removes `ui_filepath` implementations from all of the Python-based examples.