### PR TITLE
MNT: Eliminate coupling between rules and PyDMApplication and PyDMMainWindow

### DIFF
--- a/examples/actions/actions2.ui
+++ b/examples/actions/actions2.ui
@@ -29,7 +29,10 @@
     <string/>
    </property>
    <property name="rules" stdset="0">
-    <string>[{&quot;name&quot;: &quot;New Rule&quot;, &quot;property&quot;: &quot;Visible&quot;, &quot;expression&quot;: &quot;np.abs(ch[0]) &gt; 1&quot;, &quot;channels&quot;: [{&quot;channel&quot;: &quot;ca://MTEST:Float&quot;, &quot;trigger&quot;: true}]}]</string>
+    <string>[{&quot;name&quot;: &quot;Plot Visible Rule&quot;, &quot;property&quot;: &quot;Visible&quot;, &quot;expression&quot;: &quot;np.abs(ch[0]) &gt; 1&quot;, &quot;channels&quot;: [{&quot;channel&quot;: &quot;ca://MTEST:Float&quot;, &quot;trigger&quot;: true}]}]</string>
+   </property>
+   <property name="curves">
+    <stringlist/>
    </property>
   </widget>
   <widget class="PyDMLineEdit" name="PyDMLineEdit">
@@ -48,7 +51,7 @@
     <string/>
    </property>
    <property name="rules" stdset="0">
-    <string>[{&quot;name&quot;: &quot;New Rule&quot;, &quot;property&quot;: &quot;Enable&quot;, &quot;expression&quot;: &quot;np.abs(ch[0]) &gt; 1&quot;, &quot;channels&quot;: [{&quot;channel&quot;: &quot;ca://MTEST:Float&quot;, &quot;trigger&quot;: true}]}]</string>
+    <string>[{&quot;name&quot;: &quot;Line Edit Enable&quot;, &quot;property&quot;: &quot;Enable&quot;, &quot;expression&quot;: &quot;np.abs(ch[0]) &gt; 1&quot;, &quot;channels&quot;: [{&quot;channel&quot;: &quot;ca://MTEST:Float&quot;, &quot;trigger&quot;: true}]}]</string>
    </property>
    <property name="channel" stdset="0">
     <string>ca://MTEST:Float</string>

--- a/pydm/application.py
+++ b/pydm/application.py
@@ -543,22 +543,3 @@ class PyDMApplication(QApplication):
             "'PyDMApplication.close_widget_connections' is deprecated, "
             "this function is now found on `utilities.close_widget_connections`.")
         connection.close_widget_connections(widget)
-
-    def unregister_widget_rules(self, widget):
-        """
-        Given a widget to start from, traverse the tree of child widgets,
-        and try to unregister rules to any widgets.
-
-        Parameters
-        ----------
-        widget : QWidget
-        """
-        widgets = [widget]
-        widgets.extend(widget.findChildren(QWidget))
-        for child_widget in widgets:
-            try:
-                if hasattr(child_widget, 'rules'):
-                    if child_widget.rules:
-                        RulesDispatcher().unregister(child_widget)
-            except Exception:
-                pass

--- a/pydm/data_plugins/epics_plugins/caproto_plugin_component.py
+++ b/pydm/data_plugins/epics_plugins/caproto_plugin_component.py
@@ -152,25 +152,6 @@ class Connection(PyDMConnection):
             except KeyError:
                 pass
 
-    def remove_listener(self, channel):
-        if channel.value_signal is not None:
-            try:
-                channel.value_signal[str].disconnect(self.put_value)
-            except (KeyError, TypeError):
-                pass
-            try:
-                channel.value_signal[int].disconnect(self.put_value)
-            except (KeyError, TypeError):
-                pass
-            try:
-                channel.value_signal[float].disconnect(self.put_value)
-            except (KeyError, TypeError):
-                pass
-            try:
-                channel.value_signal[np.ndarray].disconnect(self.put_value)
-            except (KeyError, TypeError):
-                pass
-
         super(Connection, self).remove_listener(channel)
 
     def close(self):

--- a/pydm/main_window.py
+++ b/pydm/main_window.py
@@ -7,6 +7,7 @@ from .pydm_ui import Ui_MainWindow
 from .display_module import Display
 from .connection_inspector import ConnectionInspector
 from .about_pydm import AboutWindow
+from .widgets import rules
 from . import data_plugins
 from . import tools
 import subprocess
@@ -104,7 +105,7 @@ class PyDMMainWindow(QMainWindow):
     def clear_display_widget(self):
         if self._display_widget is not None:
             self.setCentralWidget(QWidget())
-            self.app.unregister_widget_rules(self._display_widget)
+            rules.unregister_widget_rules(self._display_widget)
             self._display_widget.deleteLater()
             self._display_widget = None
             self.ui.actionEdit_in_Designer.setEnabled(False)

--- a/pydm/tests/widgets/test_base.py
+++ b/pydm/tests/widgets/test_base.py
@@ -586,7 +586,7 @@ def test_pydmwidget_rules(qtbot, caplog):
 
     rules = [{'name': 'Rule #1', 'property': 'Enable',
               'expression': 'ch[0] > 1',
-              'channels': [{'channel': 'foo://MTEST:Float', 'trigger': True}]}]
+              'channels': [{'channel': 'ca://MTEST:Float', 'trigger': True}]}]
 
     rules_json = json.dumps(rules)
     pydm_label.rules = rules_json

--- a/pydm/tests/widgets/test_rules_editor.py
+++ b/pydm/tests/widgets/test_rules_editor.py
@@ -43,7 +43,7 @@ def test_rules_editor(qtbot, monkeypatch):
     rules_list = [{'name': 'Rule #1', 'property': 'Enable',
                    'expression': 'ch[0] > 1',
                    'channels': [
-                       {'channel': 'foo://MTEST:Float', 'trigger': True}]}]
+                       {'channel': 'ca://MTEST:Float', 'trigger': True}]}]
 
     # Add the rules to the widget
     widget.rules = json.dumps(rules_list)
@@ -61,7 +61,7 @@ def test_rules_editor(qtbot, monkeypatch):
     assert re.txt_name.text() == 'Rule #1'
     assert re.cmb_property.currentText() == 'Enable'
     assert re.tbl_channels.rowCount() == 1
-    assert re.tbl_channels.item(0, 0).text() == 'foo://MTEST:Float'
+    assert re.tbl_channels.item(0, 0).text() == 'ca://MTEST:Float'
     assert re.tbl_channels.item(0, 1).checkState() == QtCore.Qt.Checked
     assert re.lbl_expected_type.text() == 'bool'
     assert re.txt_expression.text() == 'ch[0] > 1'
@@ -72,8 +72,8 @@ def test_rules_editor(qtbot, monkeypatch):
     assert re.rules[0]['name'] == 'Rule #1-Test'
 
     qtbot.mouseClick(re.btn_add_channel, QtCore.Qt.LeftButton)
-    re.tbl_channels.item(1, 0).setText("foo://TEST")
-    assert re.rules[0]['channels'][1]['channel'] == 'foo://TEST'
+    re.tbl_channels.item(1, 0).setText("ca://TEST")
+    assert re.rules[0]['channels'][1]['channel'] == 'ca://TEST'
     assert re.rules[0]['channels'][1]['trigger'] is False
 
     re.txt_expression.clear()
@@ -168,7 +168,7 @@ def test_rules_editor_data_valid(qtbot):
     rules_list = [{'name': 'Rule #1', 'property': 'Enable',
                    'expression': 'ch[0] > 1',
                    'channels': [
-                       {'channel': 'foo://MTEST:Float', 'trigger': True}]}]
+                       {'channel': 'ca://MTEST:Float', 'trigger': True}]}]
 
     # Add the rules to the widget
     widget.rules = json.dumps(rules_list)

--- a/pydm/widgets/channel.py
+++ b/pydm/widgets/channel.py
@@ -75,7 +75,6 @@ class PyDMChannel(object):
                  enum_strings_slot=None, unit_slot=None, prec_slot=None,
                  upper_ctrl_limit_slot=None, lower_ctrl_limit_slot=None,
                  value_signal=None):
-
         self.address = address
 
         self.connection_slot = connection_slot
@@ -106,7 +105,7 @@ class PyDMChannel(object):
             logger.exception("Unable to make proper connection "
                              "for %r", self)
 
-    def disconnect(self):
+    def disconnect(self, destroying=False):
         """
         Disconnect a PyDMChannel
         """
@@ -116,7 +115,7 @@ class PyDMChannel(object):
             plugin = plugin_for_address(self.address)
             if not plugin:
                 return
-            plugin.remove_connection(self)
+            plugin.remove_connection(self, destroying=destroying)
         except Exception as exc:
             logger.exception("Unable to remove connection "
                              "for %r", self)

--- a/pydm/widgets/rules.py
+++ b/pydm/widgets/rules.py
@@ -1,18 +1,36 @@
 import logging
 import functools
+import weakref
 
-import collections
-
-from qtpy.QtCore import QObject, QThread, QMutex, Signal, QMutexLocker
-from qtpy.QtWidgets import QApplication
+from qtpy.QtCore import QThread, QMutex, Signal, QMutexLocker
+from qtpy.QtWidgets import QWidget
 
 from .channel import PyDMChannel
-from ..utilities import is_pydm_app
 
 import numpy as np
 import math
 
 logger = logging.getLogger(__name__)
+
+
+def unregister_widget_rules(widget):
+    """
+    Given a widget to start from, traverse the tree of child widgets,
+    and try to unregister rules to any widgets.
+
+    Parameters
+    ----------
+    widget : QWidget
+    """
+    widgets = [widget]
+    widgets.extend(widget.findChildren(QWidget))
+    for child_widget in widgets:
+        try:
+            if hasattr(child_widget, 'rules'):
+                if child_widget.rules:
+                    RulesDispatcher().unregister(weakref.ref(child_widget))
+        except Exception:
+            pass
 
 
 class RulesDispatcher(object):
@@ -59,11 +77,14 @@ class RulesDispatcher(object):
 
         Parameters
         ----------
-        widget : QWidget
-            The widget that is associated with the rules.
+        widget : QWidget or weakref
+            The weakref to widget or widget that is associated with the rules.
 
         """
-        self.rules_engine.unregister(widget)
+        if isinstance(widget, weakref.ref):
+            self.rules_engine.unregister(widget)
+        else:
+            self.rules_engine.unregister(weakref.ref(widget))
 
     def dispatch(self, payload):
         """
@@ -78,7 +99,13 @@ class RulesDispatcher(object):
         """
         try:
             widget = payload.pop('widget')
-            widget.rule_evaluated(payload)
+            if isinstance(widget, weakref.ref):
+                widget_ref = widget
+                widget = widget()
+            if widget is None: # Widget is dead... lets unregister the ref
+                self.rules_engine.unregister(widget_ref)
+            else:
+                widget.rule_evaluated(payload)
         except Exception as ex:
             logger.exception("Error at RulesDispatcher.")
 
@@ -100,12 +127,16 @@ class RulesEngine(QThread):
         self.map_lock = QMutex()
         self.widget_map = dict()
 
+    def widget_destroyed(self, ref):
+        self.unregister(ref)
+
     def register(self, widget, rules):
-        if widget in self.widget_map:
-            self.unregister(widget)
+        widget_ref = weakref.ref(widget, self.widget_destroyed)
+        if widget_ref in self.widget_map:
+            self.unregister(widget_ref)
 
         with QMutexLocker(self.map_lock):
-            self.widget_map[widget] = []
+            self.widget_map[widget_ref] = []
             for idx, rule in enumerate(rules):
                 channels_list = rule.get('channels', [])
 
@@ -117,20 +148,23 @@ class RulesEngine(QThread):
                 item['channels'] = []
 
                 for ch_idx, ch in enumerate(channels_list):
-                    conn_cb = functools.partial(self.callback_conn, widget, idx,
-                                                ch_idx)
-                    value_cb = functools.partial(self.callback_value, widget, idx,
-                                                 ch_idx, ch['trigger'])
+                    conn_cb = functools.partial(self.callback_conn, widget_ref,
+                                                idx, ch_idx)
+                    value_cb = functools.partial(self.callback_value, widget_ref,
+                                                 idx, ch_idx, ch['trigger'])
                     c = PyDMChannel(ch['channel'], connection_slot=conn_cb,
                                     value_slot=value_cb)
                     item['channels'].append(c)
                     c.connect()
 
-                self.widget_map[widget].append(item)
+                self.widget_map[widget_ref].append(item)
 
-    def unregister(self, widget):
+    def unregister(self, widget_ref):
         with QMutexLocker(self.map_lock):
-            w_data = self.widget_map.pop(widget)
+            w_data = self.widget_map.pop(widget_ref, None)
+
+        if not w_data:
+            return
 
         for rule in w_data:
             for ch in rule['channels']:
@@ -141,20 +175,20 @@ class RulesEngine(QThread):
     def run(self):
         while not self.isInterruptionRequested():
             with QMutexLocker(self.map_lock):
-                for widget in self.widget_map:
-                    for rule in self.widget_map[widget]:
+                for widget_ref in self.widget_map:
+                    for rule in self.widget_map[widget_ref]:
                         if rule['calculate']:
-                            self.calculate_expression(widget, rule)
+                            self.calculate_expression(widget_ref, rule)
             self.msleep(33)  # 30Hz
 
-    def callback_value(self, widget, index, ch_index, trigger, value):
+    def callback_value(self, widget_ref, index, ch_index, trigger, value):
         """
         Callback executed when a channel receives a new value.
 
         Parameters
         ----------
-        widget : QWidget
-            The widget owner of the rule.
+        widget_ref : weakref
+            A weakref to the widget owner of the rule.
         index : int
             The index of the rule being processed.
         ch_index : int
@@ -170,21 +204,21 @@ class RulesEngine(QThread):
         None
         """
         with QMutexLocker(self.map_lock):
-            self.widget_map[widget][index]['values'][ch_index] = value
+            self.widget_map[widget_ref][index]['values'][ch_index] = value
             if trigger:
-                if not all(self.widget_map[widget][index]['conn']):
-                    self.warn_unconnected_channels(widget, index)
+                if not all(self.widget_map[widget_ref][index]['conn']):
+                    self.warn_unconnected_channels(widget_ref, index)
                     return
-                self.widget_map[widget][index]['calculate'] = True
+                self.widget_map[widget_ref][index]['calculate'] = True
 
-    def callback_conn(self, widget, index, ch_index, value):
+    def callback_conn(self, widget_ref, index, ch_index, value):
         """
         Callback executed when a channel connection status is changed.
 
         Parameters
         ----------
-        widget : QWidget
-            The widget owner of the rule.
+        widget_ref : weakref
+            A weakref to the widget owner of the rule.
         index : int
             The index of the rule being processed.
         ch_index : int
@@ -196,14 +230,14 @@ class RulesEngine(QThread):
         -------
         None
         """
-        self.widget_map[widget][index]['conn'][ch_index] = value
+        self.widget_map[widget_ref][index]['conn'][ch_index] = value
 
-    def warn_unconnected_channels(self, widget, index):
+    def warn_unconnected_channels(self, widget_ref, index):
         logger.error(
             "Rule '%s': Not all channels are connected, skipping execution.",
-            self.widget_map[widget][index]['rule']['name'])
+            self.widget_map[widget_ref][index]['rule']['name'])
 
-    def calculate_expression(self, widget, rule):
+    def calculate_expression(self, widget_ref, rule):
         """
         Evaluate the expression defined by the rule and emit the `rule_signal`
         with the new value.
@@ -229,7 +263,7 @@ class RulesEngine(QThread):
             prop = rule['rule']['property']
 
             val = eval(expression, eval_env)
-            payload = {'widget': widget, 'name': name, 'property': prop,
+            payload = {'widget': widget_ref, 'name': name, 'property': prop,
                        'value': val}
             self.rule_signal.emit(payload)
         except Exception as e:


### PR DESCRIPTION
This PR also addresses an issue when closing PyDM that disconnect received a null parameter.
The main problem was that when destroying the widget, it was already gone when we reach the code in python to disconnect the slots and signals... Now I pass a `destroying` parameter when the disconnect is invoked by the `destroyed` signal at the widget.

For the Rules, a little refactor went in to use `weakref.ref` instead of keep a reference to the widget itself. IMHO, it is much better and cleaner now.
