### PR TITLE
Fix 'About' Screen Crash

### DIFF
--- a/pydm/about_pydm/about.py
+++ b/pydm/about_pydm/about.py
@@ -13,7 +13,6 @@ import inspect
 class AboutWindow(QWidget):
     def __init__(self, parent=None):
         super(AboutWindow, self).__init__(parent, Qt.Window)
-        self.app = QApplication.instance()
         self.ui = Ui_Form()
         self.ui.setupUi(self)
         self.ui.pydmVersionLabel.setText(str(self.ui.pydmVersionLabel.text()).format(version=pydm.__version__))
@@ -58,7 +57,7 @@ class AboutWindow(QWidget):
         self.ui.dataPluginsTableWidget.setHorizontalHeaderLabels(col_labels)
         self.ui.dataPluginsTableWidget.horizontalHeader().setStretchLastSection(True)
         self.ui.dataPluginsTableWidget.verticalHeader().setVisible(False)
-        for (protocol, plugin) in self.app.plugins.items():
+        for (protocol, plugin) in pydm.data_plugins.plugin_modules.items():
             protocol_item = QTableWidgetItem(protocol)
             file_item = QTableWidgetItem(inspect.getfile(plugin.__class__))
             new_row = self.ui.dataPluginsTableWidget.rowCount()

--- a/pydm/about_pydm/about.py
+++ b/pydm/about_pydm/about.py
@@ -33,7 +33,7 @@ class AboutWindow(QWidget):
         self.ui.externalToolsTableWidget.setHorizontalHeaderLabels(col_labels)
         self.ui.externalToolsTableWidget.horizontalHeader().setStretchLastSection(True)
         self.ui.externalToolsTableWidget.verticalHeader().setVisible(False)
-        self.add_tools_to_list(self.app.tools)
+        self.add_tools_to_list(pydm.tools.ext_tools)
 
     def add_tools_to_list(self, tools):
         for (name, tool) in tools.items():

--- a/pydm/tests/test_about_screen.py
+++ b/pydm/tests/test_about_screen.py
@@ -1,0 +1,6 @@
+from pydm.about_pydm import AboutWindow
+def test_about_window_launches(qtbot):
+    """Make sure the About window doesn't crash."""
+    a = AboutWindow(parent=None)
+    qtbot.addWidget(a)
+    a.show()


### PR DESCRIPTION
This PR removes the 'About' screen's dependency on using the PyDMApplication to get lists of plugins and external tools.  It also adds an incredibly dumb test to just make sure that the AboutScreen can be created and shown.  Closes #431.