### PR TITLE
Always decode README.md as utf-8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ cur_dir = path.abspath(path.dirname(__file__))
 with open(path.join(cur_dir, 'requirements.txt')) as f:
     requirements = f.read().split()
 
-with open(path.join(cur_dir, 'README.md')) as f:
+with open(path.join(cur_dir, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 # Remove the 'optional' requirements


### PR DESCRIPTION
This forces setup.py to decode README.md as utf-8, fixing a potential crash if a user has a strange default character encoding.