### PR TITLE
FIX: Update Text when Unit/Precision Changes & more...

### DIFF
--- a/pydm/data_plugins/epics_plugins/caproto_plugin_component.py
+++ b/pydm/data_plugins/epics_plugins/caproto_plugin_component.py
@@ -5,7 +5,7 @@ import numpy as np
 from pydm.data_plugins.plugin import PyDMPlugin, PyDMConnection
 from qtpy.QtCore import Slot, Qt
 from qtpy.QtWidgets import QApplication
-from pydm.utilities import is_pydm_app
+from pydm.data_plugins import is_read_only
 
 logger = logging.getLogger(__name__)
 
@@ -23,6 +23,7 @@ class Connection(PyDMConnection):
     def __init__(self, channel, pv, protocol=None, parent=None):
         super(Connection, self).__init__(channel, pv, protocol, parent)
         self.app = QApplication.instance()
+        self._value = None
         self._severity = None
         self._precision = None
         self._enum_strs = None
@@ -30,11 +31,12 @@ class Connection(PyDMConnection):
         self._upper_ctrl_limit = None
         self._lower_ctrl_limit = None
 
-        self.pv = epics.get_pv(pv, connection_callback=self.send_connection_state, form='ctrl', auto_monitor=SubscriptionType.DBE_VALUE|SubscriptionType.DBE_ALARM, access_callback=self.send_access_state)
+        self.pv = epics.get_pv(pv, connection_callback=self.send_connection_state, form='ctrl', auto_monitor=SubscriptionType.DBE_VALUE|SubscriptionType.DBE_ALARM|SubscriptionType.DBE_PROPERTY, access_callback=self.send_access_state)
         self.pv.add_callback(self.send_new_value, with_ctrlvars=True)
         self.add_listener(channel)
 
     def clear_cache(self):
+        self._value = None
         self._severity = None
         self._precision = None
         self._enum_strs = None
@@ -44,7 +46,8 @@ class Connection(PyDMConnection):
 
     def send_new_value(self, value=None, char_value=None, count=None, typefull=None, type=None, *args, **kws):
         self.update_ctrl_vars(**kws)
-        if value is not None:
+        if value is not None and value != self._value:
+            self._value = value
             if isinstance(value, np.ndarray):
                 self.new_value_signal[np.ndarray].emit(value)
             else:
@@ -88,7 +91,7 @@ class Connection(PyDMConnection):
             self.lower_ctrl_limit_signal.emit(lower_ctrl_limit)
 
     def send_access_state(self, read_access, write_access, *args, **kws):
-        if is_pydm_app() and self.app.is_read_only():
+        if is_read_only():
             self.write_access_signal.emit(False)
             return
 
@@ -96,8 +99,8 @@ class Connection(PyDMConnection):
             self.write_access_signal.emit(write_access)
 
     def reload_access_state(self):
-        read_access = epics.ca.read_access(self.pv.chid)
-        write_access = epics.ca.write_access(self.pv.chid)
+        read_access = self.pv.read_access
+        write_access = self.pv.write_access
         self.send_access_state(read_access, write_access)
 
     def send_connection_state(self, conn=None, *args, **kws):
@@ -114,7 +117,7 @@ class Connection(PyDMConnection):
     @Slot(str)
     @Slot(np.ndarray)
     def put_value(self, new_val):
-        if is_pydm_app() and self.app.is_read_only():
+        if is_read_only():
             return
 
         if self.pv.write_access:
@@ -151,27 +154,6 @@ class Connection(PyDMConnection):
                 channel.value_signal[np.ndarray].connect(self.put_value, Qt.QueuedConnection)
             except KeyError:
                 pass
-
-    def remove_listener(self, channel):
-        if channel.value_signal is not None:
-            try:
-                channel.value_signal[str].disconnect(self.put_value)
-            except (KeyError, TypeError):
-                pass
-            try:
-                channel.value_signal[int].disconnect(self.put_value)
-            except (KeyError, TypeError):
-                pass
-            try:
-                channel.value_signal[float].disconnect(self.put_value)
-            except (KeyError, TypeError):
-                pass
-            try:
-                channel.value_signal[np.ndarray].disconnect(self.put_value)
-            except (KeyError, TypeError):
-                pass
-
-        super(Connection, self).remove_listener(channel)
 
     def close(self):
         self.pv.disconnect()

--- a/pydm/data_plugins/epics_plugins/pyepics_plugin_component.py
+++ b/pydm/data_plugins/epics_plugins/pyepics_plugin_component.py
@@ -23,10 +23,13 @@ class Connection(PyDMConnection):
     def __init__(self, channel, pv, protocol=None, parent=None):
         super(Connection, self).__init__(channel, pv, protocol, parent)
         self.app = QApplication.instance()
-        self.pv = epics.PV(pv, connection_callback=self.send_connection_state, form='ctrl', auto_monitor=epics.dbr.DBE_VALUE|epics.dbr.DBE_ALARM, access_callback=self.send_access_state)
+        self.pv = epics.PV(pv, connection_callback=self.send_connection_state,
+                           form='ctrl', auto_monitor=epics.dbr.DBE_VALUE|epics.dbr.DBE_ALARM|epics.dbr.DBE_PROPERTY,
+                           access_callback=self.send_access_state)
         self.pv.add_callback(self.send_new_value, with_ctrlvars=True)
         self.add_listener(channel)
 
+        self._value = None
         self._severity = None
         self._precision = None
         self._enum_strs = None
@@ -35,6 +38,7 @@ class Connection(PyDMConnection):
         self._lower_ctrl_limit = None
 
     def clear_cache(self):
+        self._value = None
         self._severity = None
         self._precision = None
         self._enum_strs = None
@@ -44,7 +48,8 @@ class Connection(PyDMConnection):
 
     def send_new_value(self, value=None, char_value=None, count=None, ftype=None, type=None, *args, **kws):
         self.update_ctrl_vars(**kws)
-        if value is not None:
+        if value is not None and value != self.value:
+            self.value = value
             if isinstance(value, np.ndarray):
                 self.new_value_signal[np.ndarray].emit(value)
             else:

--- a/pydm/tests/widgets/test_spinbox.py
+++ b/pydm/tests/widgets/test_spinbox.py
@@ -82,6 +82,7 @@ def test_key_press_event(qtbot, signals, monkeypatch, first_key_pressed, second_
     signals.new_value_signal[float].emit(INIT_SPINBOX_VALUE)
 
     pydm_spinbox.setFocus()
+
     def wait_focus():
         return pydm_spinbox.hasFocus()
     qtbot.waitUntil(wait_focus, timeout=5000)
@@ -208,6 +209,10 @@ def test_update_format_string(qtbot, signals, show_unit, new_unit, step_exp, sho
     pydm_spinbox.step_exponent = step_exp
     pydm_spinbox.showStepExponent = show_step_exp
     assert pydm_spinbox.showStepExponent == show_step_exp
+
+    INIT_SPINBOX_VALUE = 1.2
+    signals.new_value_signal[float].connect(pydm_spinbox.channelValueChanged)
+    signals.new_value_signal[float].emit(INIT_SPINBOX_VALUE)
 
     units = ""
     pydm_spinbox.showUnits = show_unit

--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -8,7 +8,7 @@ from qtpy.QtCore import Qt, QEvent, Signal, Slot, Property
 from .channel import PyDMChannel
 from .. import data_plugins
 from .. import tools
-from ..utilities import is_pydm_app, remove_protocol
+from ..utilities import is_qt_designer, remove_protocol
 from .rules import RulesDispatcher
 
 try:
@@ -241,7 +241,7 @@ class PyDMWidget(PyDMPrimitiveWidget):
         self.setContextMenuPolicy(Qt.DefaultContextMenu)
         self.contextMenuEvent = self.open_context_menu
         self.channel = init_channel
-        if is_pydm_app():
+        if not is_qt_designer():
             self._connected = False
             self.alarmSeverityChanged(self.ALARM_DISCONNECTED)
             self.check_enable_state()
@@ -433,7 +433,8 @@ class PyDMWidget(PyDMPrimitiveWidget):
         """
         if self._unit != new_unit:
             self._unit = new_unit
-            self.update_format_string()
+            if self.value is not None:
+                self.value_changed(self.value)
 
     def precision_changed(self, new_precision):
         """
@@ -446,9 +447,10 @@ class PyDMWidget(PyDMPrimitiveWidget):
         new_precison : int or float
             The new precision value
         """
-        if self._precision_from_pv:
+        if self._precision_from_pv and new_precision != self._prec:
             self._prec = new_precision
-            self.update_format_string()
+            if self.value is not None:
+                self.value_changed(self.value)
 
     def ctrl_limit_changed(self, which, new_limit):
         """
@@ -753,7 +755,7 @@ class PyDMWidget(PyDMPrimitiveWidget):
             return
         if new_prec and self._prec != int(new_prec) and new_prec >= 0:
             self._prec = int(new_prec)
-            self.update_format_string()
+            self.value_changed(self.value)
 
     @Property(bool)
     def showUnits(self):
@@ -824,16 +826,16 @@ class PyDMWidget(PyDMPrimitiveWidget):
             # Load new channel
             self._channel = str(value)
             channel = PyDMChannel(address=self._channel,
-                          connection_slot=self.connectionStateChanged,
-                          value_slot=self.channelValueChanged,
-                          severity_slot=self.alarmSeverityChanged,
-                          enum_strings_slot=self.enumStringsChanged,
-                          unit_slot=self.unitChanged,
-                          prec_slot=self.precisionChanged,
-                          upper_ctrl_limit_slot=self.upperCtrlLimitChanged,
-                          lower_ctrl_limit_slot=self.lowerCtrlLimitChanged,
-                          value_signal=None,
-                          write_access_slot=None)
+                                  connection_slot=self.connectionStateChanged,
+                                  value_slot=self.channelValueChanged,
+                                  severity_slot=self.alarmSeverityChanged,
+                                  enum_strings_slot=self.enumStringsChanged,
+                                  unit_slot=self.unitChanged,
+                                  prec_slot=self.precisionChanged,
+                                  upper_ctrl_limit_slot=self.upperCtrlLimitChanged,
+                                  lower_ctrl_limit_slot=self.lowerCtrlLimitChanged,
+                                  value_signal=None,
+                                  write_access_slot=None)
             # Load writeable channels if our widget requires them. These should
             # not exist on the base PyDMWidget but prevents us from duplicating
             # the method below to only make two more connections
@@ -894,7 +896,7 @@ class PyDMWidget(PyDMPrimitiveWidget):
         (lower, upper) : tuple
             Lower and Upper control limits
         """
-        return (self._lower_ctrl_limit, self._upper_ctrl_limit)
+        return self._lower_ctrl_limit, self._upper_ctrl_limit
 
     def channels(self):
         """
@@ -952,7 +954,7 @@ class PyDMWritableWidget(PyDMWidget):
         self.app = QApplication.instance()
         # We should  install the Event Filter only if we are running
         # and not at the Designer
-        if is_pydm_app():
+        if not is_qt_designer():
             self.installEventFilter(self)
 
     def init_for_designer(self):
@@ -985,14 +987,12 @@ class PyDMWritableWidget(PyDMWidget):
             status = self._write_access and self._connected
 
             if event.type() == QEvent.Leave:
-                # QApplication.setOverrideCursor(QCursor(Qt.ArrowCursor))
                 QApplication.restoreOverrideCursor()
 
             if event.type() == QEvent.Enter and not status:
                 QApplication.setOverrideCursor(QCursor(Qt.ForbiddenCursor))
 
         return PyDMWidget.eventFilter(self, obj, event)
-
 
     def write_access_changed(self, new_write_access):
         """

--- a/pydm/widgets/line_edit.py
+++ b/pydm/widgets/line_edit.py
@@ -132,10 +132,6 @@ class PyDMLineEdit(QLineEdit, PyDMWritableWidget, DisplayFormat):
         self.setEnabled(True)
         self.setReadOnly(not new_write_access)
 
-    def precision_changed(self, new_precision):
-        super(PyDMLineEdit, self).precision_changed(new_precision)
-        self.set_display()
-
     def unit_changed(self, new_unit):
         """
         Accept a unit to display with a channel's value
@@ -146,7 +142,6 @@ class PyDMLineEdit(QLineEdit, PyDMWritableWidget, DisplayFormat):
         """
         super(PyDMLineEdit, self).unit_changed(new_unit)
         self._scale = 1
-        self.set_display()
         self.create_unit_options()
 
     def create_unit_options(self):


### PR DESCRIPTION
- Fixes a couple of issues with caproto plugin.
- Address the long standing issue #281 in which text was not being updated when units and precision were changed.
- Avoid sending new value when it has not changed for pyepics and caproto.
- Adjust tests for spinbox in which value was not being considered.
- Install the event filter when not in qt designer. Since we are allowing the widgets to be used outside of pydm_app, it makes sense to install the filter when not in designer.

Closes #281 .