### PR TITLE
Fix and improve font size adjustments

### DIFF
--- a/pydm/application.py
+++ b/pydm/application.py
@@ -106,11 +106,10 @@ class PyDMApplication(QApplication):
 
         # Open a window if required.
         if ui_file is not None:
-            apply_stylesheet(stylesheet_path)
-            self.make_main_window()
+            self.make_main_window(stylesheet_path=stylesheet_path)
             self.make_window(ui_file, macros, command_line_args)
         elif use_main_window:
-            self.make_main_window()
+            self.make_main_window(stylesheet_path=stylesheet_path)
 
         self.had_file = ui_file is not None
         # Re-enable sigint (usually blocked by pyqt)
@@ -226,7 +225,7 @@ class PyDMApplication(QApplication):
         # All new windows are spawned as new processes.
         self.new_pydm_process(ui_file, macros, command_line_args)
 
-    def make_main_window(self):
+    def make_main_window(self, stylesheet_path=None):
         """
         Instantiate a new PyDMMainWindow, add it to the application's
         list of windows. Typically, this function is only called as part
@@ -238,6 +237,8 @@ class PyDMApplication(QApplication):
                                      hide_status_bar=self.hide_status_bar)
 
         self.main_window = main_window
+        if stylesheet_path:
+            apply_stylesheet(stylesheet_path, widget=self.main_window)
         self.main_window.update_tools_menu()
 
         if self.fullscreen:

--- a/pydm/main_window.py
+++ b/pydm/main_window.py
@@ -27,6 +27,7 @@ class PyDMMainWindow(QMainWindow):
         self.ui.setupUi(self)
         self._display_widget = None
         self._showing_file_path_in_title_bar = False
+        self.default_font_size = QApplication.instance().font().pointSizeF()
         self.ui.navbar.setIconSize(QSize(24, 24))
         self.ui.navbar.setToolButtonStyle(Qt.ToolButtonTextUnderIcon)
         # No search bar for now, since there isn't really any capability to search yet.
@@ -49,6 +50,7 @@ class PyDMMainWindow(QMainWindow):
         self.ui.actionReload_Display.triggered.connect(self.reload_display)
         self.ui.actionIncrease_Font_Size.triggered.connect(self.increase_font_size)
         self.ui.actionDecrease_Font_Size.triggered.connect(self.decrease_font_size)
+        self.ui.actionDefault_Font_Size.triggered.connect(self.reset_font_size)
         self.ui.actionEnter_Fullscreen.triggered.connect(self.enter_fullscreen)
         self.ui.actionShow_File_Path_in_Title_Bar.triggered.connect(self.toggle_file_path_in_title_bar)
         self.ui.actionShow_Navigation_Bar.triggered.connect(self.toggle_nav_bar)
@@ -413,6 +415,13 @@ class PyDMMainWindow(QMainWindow):
     def decrease_font_size(self, checked):
         current_font = QApplication.instance().font()
         current_font.setPointSizeF(current_font.pointSizeF() / 1.1)
+        QApplication.instance().setFont(current_font)
+        QTimer.singleShot(0, self.resizeForNewDisplayWidget)
+    
+    @Slot(bool)
+    def reset_font_size(self, checked):
+        current_font = QApplication.instance().font()
+        current_font.setPointSizeF(self.default_font_size)
         QApplication.instance().setFont(current_font)
         QTimer.singleShot(0, self.resizeForNewDisplayWidget)
 

--- a/pydm/main_window.py
+++ b/pydm/main_window.py
@@ -443,7 +443,8 @@ class PyDMMainWindow(QMainWindow):
         a.show()
 
     def resizeForNewDisplayWidget(self):
-        self.resize(self._new_widget_size)
+        if not self.isFullScreen():
+            self.resize(self._new_widget_size)
 
     def closeEvent(self, event):
         self.clear_display_widget()

--- a/pydm/pydm.ui
+++ b/pydm/pydm.ui
@@ -50,6 +50,7 @@
     <addaction name="actionEnter_Fullscreen"/>
     <addaction name="actionIncrease_Font_Size"/>
     <addaction name="actionDecrease_Font_Size"/>
+    <addaction name="actionDefault_Font_Size"/>
     <addaction name="separator"/>
     <addaction name="actionShow_File_Path_in_Title_Bar"/>
     <addaction name="actionShow_Navigation_Bar"/>
@@ -270,6 +271,14 @@
    </property>
    <property name="shortcut">
     <string>F11</string>
+   </property>
+  </action>
+  <action name="actionDefault_Font_Size">
+   <property name="text">
+    <string>Default Font Size</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+0</string>
    </property>
   </action>
  </widget>

--- a/pydm/pydm_ui.py
+++ b/pydm/pydm_ui.py
@@ -2,7 +2,7 @@
 
 # Form implementation generated from reading ui file 'pydm.ui'
 #
-# Created by: PyQt5 UI code generator 5.6
+# Created by: PyQt5 UI code generator 5.11.3
 #
 # WARNING! All changes made in this file will be lost!
 
@@ -93,6 +93,8 @@ class Ui_MainWindow(object):
         self.actionLoadTool.setObjectName("actionLoadTool")
         self.actionEnter_Fullscreen = QtWidgets.QAction(MainWindow)
         self.actionEnter_Fullscreen.setObjectName("actionEnter_Fullscreen")
+        self.actionDefault_Font_Size = QtWidgets.QAction(MainWindow)
+        self.actionDefault_Font_Size.setObjectName("actionDefault_Font_Size")
         self.menuFile.addAction(self.actionOpen_File)
         self.menuFile.addSeparator()
         self.menuFile.addAction(self.actionEdit_in_Designer)
@@ -102,6 +104,7 @@ class Ui_MainWindow(object):
         self.menuView.addAction(self.actionEnter_Fullscreen)
         self.menuView.addAction(self.actionIncrease_Font_Size)
         self.menuView.addAction(self.actionDecrease_Font_Size)
+        self.menuView.addAction(self.actionDefault_Font_Size)
         self.menuView.addSeparator()
         self.menuView.addAction(self.actionShow_File_Path_in_Title_Bar)
         self.menuView.addAction(self.actionShow_Navigation_Bar)
@@ -158,4 +161,6 @@ class Ui_MainWindow(object):
         self.actionLoadTool.setText(_translate("MainWindow", "Load..."))
         self.actionEnter_Fullscreen.setText(_translate("MainWindow", "Enter Fullscreen"))
         self.actionEnter_Fullscreen.setShortcut(_translate("MainWindow", "F11"))
+        self.actionDefault_Font_Size.setText(_translate("MainWindow", "Default Font Size"))
+        self.actionDefault_Font_Size.setShortcut(_translate("MainWindow", "Ctrl+0"))
 


### PR DESCRIPTION
Since the stylesheet system was added (#372), the controls to increase and decrease the application font size hasn't worked, because changing the application font doesn't do anything if you've also set a stylesheet on the application.  This PR changes things so that the stylesheet is applied to the main window, *not* the application, which fixes this problem.

In addition, it also adds a new menu item to reset the font size to the default value.