### PR TITLE
Add alarmSensitiveContent tests for drawings and labels.

### DIFF
--- a/pydm/application.py
+++ b/pydm/application.py
@@ -237,8 +237,7 @@ class PyDMApplication(QApplication):
                                      hide_status_bar=self.hide_status_bar)
 
         self.main_window = main_window
-        if stylesheet_path:
-            apply_stylesheet(stylesheet_path, widget=self.main_window)
+        apply_stylesheet(stylesheet_path, widget=self.main_window)
         self.main_window.update_tools_menu()
 
         if self.fullscreen:

--- a/pydm/tests/widgets/test_drawing.py
+++ b/pydm/tests/widgets/test_drawing.py
@@ -145,23 +145,14 @@ def test_pydmdrawing_paintEvent(qtbot, signals, alarm_sensitive_content):
     """
     QApplication.instance().make_main_window()
     main_window = QApplication.instance().main_window
-    print(main_window.styleSheet())
+    qtbot.addWidget(main_window)
     pydm_drawing = PyDMDrawing(parent=main_window, init_channel='fake://tst')
     qtbot.addWidget(pydm_drawing)
     pydm_drawing.alarmSensitiveContent = alarm_sensitive_content
     brush_before = pydm_drawing.brush.color().name()
     signals.new_severity_signal.connect(pydm_drawing.alarmSeverityChanged)
     signals.new_severity_signal.emit(PyDMWidget.ALARM_MAJOR)
-    
-    with qtbot.waitExposed(pydm_drawing):
-        pydm_drawing.show()
-    qtbot.waitUntil(lambda: pydm_drawing.isEnabled(), timeout=5000)
-    pydm_drawing.setFocus()
 
-    def wait_focus():
-        return pydm_drawing.hasFocus()
-
-    qtbot.waitUntil(wait_focus, timeout=5000)
     brush_after = pydm_drawing.brush.color().name()
     if alarm_sensitive_content:
         assert brush_before != brush_after

--- a/pydm/tests/widgets/test_drawing.py
+++ b/pydm/tests/widgets/test_drawing.py
@@ -5,6 +5,7 @@ from logging import ERROR
 import pytest
 
 from qtpy.QtGui import QColor, QBrush, QPixmap
+from qtpy.QtWidgets import QApplication
 from qtpy.QtCore import Property, Qt, QPoint, QSize
 from qtpy.QtDesigner import QDesignerFormWindowInterface
 
@@ -16,6 +17,8 @@ from ...widgets.drawing import (deg_to_qt, qt_to_deg, PyDMDrawing,
                                 PyDMDrawingCircle, PyDMDrawingArc,
                                 PyDMDrawingPie, PyDMDrawingChord,
                                 PyDMDrawingPolygon)
+
+from ...utilities.stylesheet import apply_stylesheet
 
 
 # --------------------
@@ -128,6 +131,8 @@ def test_pydmdrawing_paintEvent(qtbot, signals, alarm_sensitive_content):
 
     Expectations:
     The paintEvent will be triggered, and the widget's brush color is correctly set.
+    
+    NOTE: This test depends on the default stylesheet having different values for 'qproperty-brush' for different alarm states of PyDMDrawing.
 
     Parameters
     ----------
@@ -138,13 +143,16 @@ def test_pydmdrawing_paintEvent(qtbot, signals, alarm_sensitive_content):
     alarm_sensitive_content : bool
         True if the widget will be redraw with a different color if an alarm is triggered; False otherwise.
     """
-    pydm_drawing = PyDMDrawing(init_channel='fake://tst')
+    QApplication.instance().make_main_window()
+    main_window = QApplication.instance().main_window
+    print(main_window.styleSheet())
+    pydm_drawing = PyDMDrawing(parent=main_window, init_channel='fake://tst')
     qtbot.addWidget(pydm_drawing)
-
     pydm_drawing.alarmSensitiveContent = alarm_sensitive_content
+    brush_before = pydm_drawing.brush.color().name()
     signals.new_severity_signal.connect(pydm_drawing.alarmSeverityChanged)
     signals.new_severity_signal.emit(PyDMWidget.ALARM_MAJOR)
-
+    
     with qtbot.waitExposed(pydm_drawing):
         pydm_drawing.show()
     qtbot.waitUntil(lambda: pydm_drawing.isEnabled(), timeout=5000)
@@ -154,6 +162,11 @@ def test_pydmdrawing_paintEvent(qtbot, signals, alarm_sensitive_content):
         return pydm_drawing.hasFocus()
 
     qtbot.waitUntil(wait_focus, timeout=5000)
+    brush_after = pydm_drawing.brush.color().name()
+    if alarm_sensitive_content:
+        assert brush_before != brush_after
+    else:
+        assert brush_before == brush_after
 
 
 @pytest.mark.parametrize("widget_width, widget_height, expected_results", [

--- a/pydm/tests/widgets/test_label.py
+++ b/pydm/tests/widgets/test_label.py
@@ -285,7 +285,8 @@ def test_label_alarms(qtbot, signals, alarm_severity, alarm_sensitive_content, a
     """
     QApplication.instance().make_main_window()
     main_window = QApplication.instance().main_window
-    pydm_label = PyDMLabel(parent=main_window, init_channel="CA://FOOO")
+    qtbot.addWidget(main_window)
+    pydm_label = PyDMLabel(parent=main_window, init_channel="ca://FOOO")
     qtbot.addWidget(pydm_label)
 
     pydm_label.alarmSensitiveContent = alarm_sensitive_content

--- a/pydm/tests/widgets/test_label.py
+++ b/pydm/tests/widgets/test_label.py
@@ -10,6 +10,7 @@ from ...widgets.label import PyDMLabel
 from ...widgets.base import PyDMWidget
 from ...widgets.display_format import parse_value_for_display, DisplayFormat
 
+from qtpy.QtWidgets import QApplication, QStyleOption
 
 # --------------------
 # POSITIVE TEST CASES
@@ -267,6 +268,8 @@ def test_label_alarms(qtbot, signals, alarm_severity, alarm_sensitive_content, a
        solid, transparent, etc.
     3. The alarm color and border appearance will change only if each corresponding Boolean flag is set to True
 
+    NOTE: This test depends on the default stylesheet having different values for 'color' for different alarm states of PyDMLabel.
+
     Parameters
     ----------
     qtbot : fixture
@@ -280,16 +283,29 @@ def test_label_alarms(qtbot, signals, alarm_severity, alarm_sensitive_content, a
     alarm_sensitive_border : bool
         True if the widget's border will change color and thickness accordingly to the alarm's severity; False if not
     """
-    pydm_label = PyDMLabel(init_channel="CA://FOOO")
+    QApplication.instance().make_main_window()
+    main_window = QApplication.instance().main_window
+    pydm_label = PyDMLabel(parent=main_window, init_channel="CA://FOOO")
     qtbot.addWidget(pydm_label)
 
     pydm_label.alarmSensitiveContent = alarm_sensitive_content
     pydm_label.alarmSensitiveBorder = alarm_sensitive_border
 
     signals.new_severity_signal.connect(pydm_label.alarmSeverityChanged)
+    initial_severity = pydm_label._alarm_state
+    option = QStyleOption()
+    option.initFrom(pydm_label)
+    before_color = option.palette.text().color().name()
     signals.new_severity_signal.emit(alarm_severity)
 
     assert pydm_label._alarm_state == alarm_severity
+    option = QStyleOption()
+    option.initFrom(pydm_label)
+    after_color = option.palette.text().color().name()
+    if alarm_sensitive_content and (alarm_severity != initial_severity):
+        assert after_color != before_color
+    else:
+        assert after_color == before_color
 
 
 TOOLTIP_TEXT = "Testing with Alarm State Changes, Channel Provided."


### PR DESCRIPTION
This PR fixes unit tests for PyDMDrawing and PyDMLabel to *actually* test whether alarms change text/brush color when alarmSensitiveContent is True.

NOTE: This will probably cause the tests to fail until we implement a fix for #446.