### PR TITLE
FIX: OSX build with Python 3.6 & CI: Enable Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,26 @@ matrix:
       python: 3.6
       language: python
       env: BUILD_DOCS=1 CONDA_FOLDER="linux-64" MC_URL="https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh"
+    - os: linux
+      python: 3.7
+      dist: xenial
+      language: python
+      env: CONDA_FOLDER="linux-64" MC_URL="https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh"
     - os: osx
       python: 3.6
       env: TRAVIS_PYTHON_VERSION=3.6 CONDA_FOLDER="osx-64" MC_URL="https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh"
+    - os: osx
+      python: 3.7
+      env: TRAVIS_PYTHON_VERSION=3.7 CONDA_FOLDER="osx-64" MC_URL="https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh"
+  allow_failures:
+    - os: linux
+      python: 3.7
+      dist: xenial
+      language: python
+      env: CONDA_FOLDER="linux-64" MC_URL="https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh"
+    - os: osx
+      python: 3.7
+      env: TRAVIS_PYTHON_VERSION=3.7 CONDA_FOLDER="osx-64" MC_URL="https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh"
 
 before_install:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,15 +27,6 @@ matrix:
     - os: osx
       python: 3.7
       env: TRAVIS_PYTHON_VERSION=3.7 CONDA_FOLDER="osx-64" MC_URL="https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh"
-  allow_failures:
-    - os: linux
-      python: 3.7
-      dist: xenial
-      language: python
-      env: CONDA_FOLDER="linux-64" MC_URL="https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh"
-    - os: osx
-      python: 3.7
-      env: TRAVIS_PYTHON_VERSION=3.7 CONDA_FOLDER="osx-64" MC_URL="https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh"
 
 before_install:
   - |

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,4 @@
 codecov
 pytest
 pytest-qt
-pytest-cov
+pytest-cov<2.6.0


### PR DESCRIPTION
Following the 🚂 ...
Let's enable Python 3.7 for PyDM as well...
This PR also fix the build issue with OSX and Python 3.6 at Travis...
Somehow I can't reproduce the issue locally and it is related to the newer version of pytest-cov.
For now pinning it to `< 2.6.0`.