### PR TITLE
Temporarily restore pydm.PyQt module.

### DIFF
--- a/pydm/PyQt/Qt.py
+++ b/pydm/PyQt/Qt.py
@@ -1,0 +1,1 @@
+from qtpy.Qt import *

--- a/pydm/PyQt/QtCore.py
+++ b/pydm/PyQt/QtCore.py
@@ -1,0 +1,1 @@
+from qtpy.QtCore import *

--- a/pydm/PyQt/QtDesigner.py
+++ b/pydm/PyQt/QtDesigner.py
@@ -1,0 +1,1 @@
+from qtpy.QtDesigner import *

--- a/pydm/PyQt/QtGui.py
+++ b/pydm/PyQt/QtGui.py
@@ -1,0 +1,3 @@
+from qtpy.QtGui import *
+from qtpy.QtWidgets import *
+from qtpy.QtCore import QItemSelection

--- a/pydm/PyQt/QtSvg.py
+++ b/pydm/PyQt/QtSvg.py
@@ -1,0 +1,1 @@
+from qtpy.QtSvg import *

--- a/pydm/PyQt/QtWidgets.py
+++ b/pydm/PyQt/QtWidgets.py
@@ -1,0 +1,1 @@
+from qtpy.QtWidgets import *

--- a/pydm/PyQt/__init__.py
+++ b/pydm/PyQt/__init__.py
@@ -1,0 +1,5 @@
+import warnings
+warnings.warn(
+    "'pydm.PyQt' is deprecated, "
+    "please directly import from the 'qtpy' module.  "
+    "pydm.PyQt will be removed in PyDM v1.8")

--- a/pydm/PyQt/uic.py
+++ b/pydm/PyQt/uic.py
@@ -1,0 +1,1 @@
+from qtpy.uic import *


### PR DESCRIPTION
This PR puts the pydm.PyQt module back in place, but routes everything to qtpy.  The only interesting thing is that it supports the old, PyQt4-ish module paths too: You can import QWidget from pydm.PyQt.QtGui, OR from pydm.PyQt.QtWidgets.

This will fix import errors for people who wrote Display classes, and imported things from pydm.PyQt in those classes.  Note, we're only doing this temporarily, and PyDM will emit a deprecation warning if you import from pydm.PyQt.