### PR TITLE
ENH: Protect against invalid chars on Channel address.

### DIFF
--- a/pydm/tests/widgets/test_channel.py
+++ b/pydm/tests/widgets/test_channel.py
@@ -1,8 +1,12 @@
 # Unit Tests for the Channel widget class
+import pytest
+
 from ...widgets.label import PyDMLabel
 from ...widgets.line_edit import PyDMLineEdit
 from ...widgets.channel import PyDMChannel
 from pydm.data_plugins import plugin_for_address
+
+
 class A():
     pass
 
@@ -76,3 +80,21 @@ def test_pydm_connection(test_plugin):
     # Remove connections
     chan.disconnect()
     assert len(plugin.connections) == plugin_no
+
+
+
+@pytest.mark.parametrize(
+    "ch, ch_expected", [
+        ("ca://MTEST:Float", "ca://MTEST:Float"),
+        (" foo://bar", "foo://bar"),
+        (" foo://bar ", "foo://bar"),
+        ("foo://bar ", "foo://bar"),
+        ("\nfoo://bar", "foo://bar"),
+        ("\tfoo://bar", "foo://bar"),
+        ("", ""),
+        (None, None),
+    ])
+def test_channel_address(ch, ch_expected):
+    channel = PyDMChannel()
+    channel.address = ch
+    assert channel.address == ch_expected

--- a/pydm/utilities/remove_protocol.py
+++ b/pydm/utilities/remove_protocol.py
@@ -1,5 +1,6 @@
 import re
 
+
 def remove_protocol(addr):
     """
     Removes the first occurrence of the protocol string ('://') from the string `addr`

--- a/pydm/widgets/channel.py
+++ b/pydm/widgets/channel.py
@@ -7,6 +7,14 @@ from pydm import config
 logger = logging.getLogger(__name__)
 
 
+def clear_channel_address(channel):
+    # We must remove spaces, \n, \t and other crap from
+    # channel address
+    if channel is None:
+        return None
+    return str(channel).strip()
+
+
 class PyDMChannel(object):
     """
     Object to hold signals and slots for a PyDM Widget interface to an
@@ -75,6 +83,7 @@ class PyDMChannel(object):
                  enum_strings_slot=None, unit_slot=None, prec_slot=None,
                  upper_ctrl_limit_slot=None, lower_ctrl_limit_slot=None,
                  value_signal=None):
+        self._address = None
         self.address = address
 
         self.connection_slot = connection_slot
@@ -89,6 +98,14 @@ class PyDMChannel(object):
         self.lower_ctrl_limit_slot = lower_ctrl_limit_slot
 
         self.value_signal = value_signal
+
+    @property
+    def address(self):
+        return self._address
+
+    @address.setter
+    def address(self, address):
+        self._address = clear_channel_address(address)
 
     def connect(self):
         """


### PR DESCRIPTION
Came across this issue with an user copying and pasting stuff from an editor into the Designer and line edits for PyDM...

This prevents the channel address to be messed up.

Test added to ensure that this will be around for a long time.