### PR TITLE
Make EDM-style macros usable in widget properties

### DIFF
--- a/pydm/utilities/macro.py
+++ b/pydm/utilities/macro.py
@@ -52,7 +52,7 @@ def parse_macro_string(macro_string):
         macros = json.loads(macro_string)
         return macros
     except ValueError:
-        if macro_string.find("=") < 0:
+        if "=" not in macro_string:
             raise ValueError("Could not parse macro argument as JSON.")
         macros = {}
         state = PRE_NAME

--- a/pydm/utilities/macro.py
+++ b/pydm/utilities/macro.py
@@ -1,7 +1,7 @@
 import io
 import six
 from string import Template
-
+import json
 
 def substitute_in_file(file_path, macros):
     """
@@ -34,3 +34,18 @@ def find_base_macros(widget):
             return widget.base_macros
         widget = widget.parent()
     return {}
+
+def parse_macro_string(macro_string):
+    macro_string = str(macro_string)
+    try:
+        macros = json.loads(macro_string)
+        return macros
+    except ValueError:
+        if macro_string.find("=") < 0:
+            raise ValueError("Could not parse macro argument as JSON.")
+        macros = {}
+        for pair in macro_string.split(","):
+            key, value = pair.strip().split("=")
+            macros[key.strip()] = value.strip()
+        return macros
+    

--- a/pydm/widgets/embedded_display.py
+++ b/pydm/widgets/embedded_display.py
@@ -6,6 +6,7 @@ import os.path
 from .base import PyDMPrimitiveWidget
 from ..utilities import (is_pydm_app, establish_widget_connections,
                          close_widget_connections)
+from ..utilities.macro import parse_macro_string
 
 
 class PyDMEmbeddedDisplay(QFrame, PyDMPrimitiveWidget):
@@ -130,10 +131,7 @@ class PyDMEmbeddedDisplay(QFrame, PyDMPrimitiveWidget):
         --------
         dict
         """
-        if self.macros is not None and len(self.macros) > 0:
-            return json.loads(self.macros)
-        else:
-            return {}
+        return parse_macro_string(self.macros)
 
     def open_file(self):
         """

--- a/pydm/widgets/related_display_button.py
+++ b/pydm/widgets/related_display_button.py
@@ -7,7 +7,7 @@ import logging
 from functools import partial
 from .base import PyDMPrimitiveWidget
 from ..utilities import IconFont
-from ..utilities.macro import find_base_macros
+from ..utilities.macro import find_base_macros, parse_macro_string
 
 
 class PyDMRelatedDisplayButton(QPushButton, PyDMPrimitiveWidget):
@@ -201,10 +201,7 @@ class PyDMRelatedDisplayButton(QPushButton, PyDMPrimitiveWidget):
         # Check for None and ""
         if not self.displayFilename:
             return
-        macros = {}
-        if self._macro_string is not None:
-            macros = json.loads(str(self._macro_string))
-
+        macros = parse_macro_string(self._macro_string)
         base_macros = find_base_macros(self)
         merged_macros = base_macros.copy()
         merged_macros.update(macros)

--- a/pydm_launcher/main.py
+++ b/pydm_launcher/main.py
@@ -14,6 +14,7 @@ def main():
     handler.setLevel("INFO")
 
     import pydm
+    from pydm.utilities.macro import parse_macro_string
 
     parser = argparse.ArgumentParser(description="Python Display Manager")
     parser.add_argument(
@@ -93,15 +94,7 @@ def main():
     pydm_args = parser.parse_args()
     macros = None
     if pydm_args.macro is not None:
-        try:
-            macros = json.loads(pydm_args.macro)
-        except ValueError:
-            if pydm_args.macro.find("=") < 0:
-                raise ValueError("Could not parse macro argument as JSON.")
-            macros = {}
-            for pair in pydm_args.macro.split(","):
-                key, value = pair.strip().split("=")
-                macros[key.strip()] = value.strip()
+        macros = parse_macro_string(pydm_args.macro)
 
     if pydm_args.log_level:
         logger.setLevel(pydm_args.log_level)


### PR DESCRIPTION
This PR lets you use the 'variable=value' style macro syntax inside the 'macro' properties of PyDMEmbeddedDisplay and PyDMRelatedDisplayButton widgets.