### PR TITLE
FIX: Cascade the unpolish-polish into child widgets.

### DIFF
--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -3,7 +3,8 @@ import logging
 import functools
 import json
 import numpy as np
-from qtpy.QtWidgets import QApplication, QMenu, QGraphicsOpacityEffect, QToolTip
+from qtpy.QtWidgets import (QApplication, QMenu, QGraphicsOpacityEffect,
+                            QToolTip, QWidget)
 from qtpy.QtGui import QCursor
 from qtpy.QtCore import Qt, QEvent, Signal, Slot, Property
 from .channel import PyDMChannel
@@ -72,6 +73,23 @@ def widget_destroyed(channels, widget):
                 ch.disconnect(destroying=True)
 
     RulesDispatcher().unregister(widget)
+
+
+def refresh_style(widget):
+    """
+    Method that traverse the widget tree starting at `widget` and refresh the
+    style for this widget and its childs.
+
+    Parameters
+    ----------
+    widget : QWidget
+    """
+    widgets = [widget]
+    widgets.extend(widget.findChildren(QWidget))
+    for child_widget in widgets:
+        child_widget.style().unpolish(child_widget)
+        child_widget.style().polish(child_widget)
+        child_widget.update()
 
 
 class PyDMPrimitiveWidget(object):
@@ -373,9 +391,7 @@ class PyDMWidget(PyDMPrimitiveWidget):
             self._alarm_state = PyDMWidget.ALARM_NONE
         else:
             self._alarm_state = new_alarm_severity
-        self.style().unpolish(self)
-        self.style().polish(self)
-        self.update()
+        refresh_style(self)
 
     def enum_strings_changed(self, new_enum_strings):
         """

--- a/pydm/widgets/slider.py
+++ b/pydm/widgets/slider.py
@@ -216,15 +216,6 @@ class PyDMSlider(QFrame, PyDMWritableWidget):
         self._slider.setValue(self.find_closest_slider_position_to_value(val))
         self._mute_internal_slider_changes = False
 
-    def alarm_severity_changed(self, new_alarm_severity):
-        PyDMWritableWidget.alarm_severity_changed(self, new_alarm_severity)
-        try:
-            self.value_label.style().unpolish(self.value_label)
-            self.value_label.style().polish(self.value_label)
-            self.value_label.update()
-        except AttributeError: # In case self.value_label was not yet created
-            pass
-
     def value_changed(self, new_val):
         """
         Callback invoked when the Channel value is changed.


### PR DESCRIPTION
I came across this issue while trying to make widgets inside of a `PyDMFrame` updated depending on the PyDMFrame conditions...

The case was:
- Drop a PyDMFrame into the form...
- Set the widget to a PV in which you can control the alarmSeverity...
- Change the severity...

Without this fix, the frame updates but the inner objects are never notified to unpolish and polish again.

E.g.:

```css
PyDMFrame[alarmSeverity="0"] {
    border: 3px solid white;
}
PyDMFrame[alarmSeverity="1"] {
    border: 3px solid yellow;
}
PyDMFrame[alarmSeverity="2"]{
    border: 3px solid red;
}

PyDMFrame[alarmSeverity="0"] QLabel {
    color: white;
    background-color: black;
}
PyDMFrame[alarmSeverity="1"] QLabel {
    color:yellow;
    background-color: blue;
}
PyDMFrame[alarmSeverity="2"] QLabel {
    color:red;
    background-color: green;
}
```