### PR TITLE
TST: add smoke tests for fun, profit and coverage

### DIFF
--- a/pydm/tests/test_smoke.py
+++ b/pydm/tests/test_smoke.py
@@ -1,0 +1,199 @@
+from __future__ import print_function
+import os
+import pkgutil
+import sys
+import types
+import time
+from inspect import isclass, signature, Parameter
+
+import pytest
+
+from qtpy.QtCore import Property, Qt
+from qtpy.QtGui import QColor
+from qtpy.QtWidgets import QTabWidget, QWidget
+
+from .. import widgets
+from ..widgets.base import PyDMWidget
+
+
+def get_all_widgets(base_class=QWidget, prefix='PyDM'):
+    modules = pkgutil.iter_modules([os.path.dirname(widgets.__file__)])
+    ret = []
+    for (_, name, _) in modules:
+        module_name = 'pydm.widgets.{}'.format(name)
+        __import__(module_name)
+        module = sys.modules[module_name]
+        print(module_name, module)
+        for name in dir(module):
+            if not name.startswith(prefix):
+                continue
+
+            obj = getattr(module, name)
+
+            if (isclass(obj) and issubclass(obj, base_class)
+                    and obj is not base_class):
+                print(module_name, name)
+                ret.append(obj)
+    return ret
+
+
+all_widgets = get_all_widgets()
+
+
+def find_properties(cls):
+    properties = {}
+    for attr in dir(cls):
+        obj = getattr(cls, attr)
+        if isinstance(obj, Property):
+            properties[attr] = dict(
+                type_=obj.type,
+                read_only=obj.fset is None,
+            )
+
+    return properties
+
+
+type_to_values = {
+    bool: [True, False],
+    'bool': [True, False],
+    int: [0, 1],
+    float: [0.01, 1.0],
+    str: ['{}', '{"a":1}'],
+    QColor: [QColor(0, 0, 0), QColor(100, 100, 100)],
+    Qt.Orientation: [Qt.Vertical, Qt.Horizontal],
+    QTabWidget.TabPosition: [QTabWidget.North,
+                             QTabWidget.South],
+    'QStringList': [['a', 'b'], ],
+}
+
+
+method_parameters = [0, 1]
+
+special_values = {
+    'channel': ['ca://MTEST:Float'],
+    'rules': '',
+}
+
+
+initial_values = {'PyDMWaveformTable': [0, 1, 2]}
+
+skip_methods = {'paintEvent', 'init_for_designer', 'exportClicked',
+                'validate_password', 'confirm_dialog', }
+
+special_method_args = {
+    'alarm_severity_changed': [[PyDMWidget.ALARM_NONE, ],
+                               [PyDMWidget.ALARM_MINOR, ],
+                               [PyDMWidget.ALARM_MAJOR, ],
+                               [PyDMWidget.ALARM_INVALID, ],
+                               [PyDMWidget.ALARM_DISCONNECTED, ],
+                               ],
+    'alarmSeverityChanged': [[PyDMWidget.ALARM_NONE, ],
+                             [PyDMWidget.ALARM_MINOR, ],
+                             [PyDMWidget.ALARM_MAJOR, ],
+                             [PyDMWidget.ALARM_INVALID, ],
+                             [PyDMWidget.ALARM_DISCONNECTED, ],
+                             ],
+    'value_changed': [[0]],
+}
+
+
+@pytest.mark.xfail(reason='smoke test', strict=False)
+@pytest.mark.parametrize("cls", all_widgets)
+def test_smoke_widget(qtbot, cls, call_methods=False):
+    widget = cls()
+
+    # qtbot.addWidget(widget)
+    print('Testing', cls, widget)
+
+    initial_value = initial_values.get(cls.__name__, 0)
+
+    print('Setting initial value of', widget, 'to', initial_value)
+    with qtbot.capture_exceptions():
+        try:
+            widget.value_changed(initial_value)
+        except (AttributeError, NameError):
+            pass
+
+        properties = find_properties(cls)
+        for attr, prop_info in properties.items():
+            print()
+            print('-- Attribute:', attr)
+            # Call the getter:
+            try:
+                value = getattr(widget, attr)
+            except Exception as ex:
+                print('* {}: getter failed: {} {}'.format(attr, type(ex), ex))
+                continue
+
+            print(attr, prop_info, value)
+            if not prop_info['read_only']:
+                type_ = prop_info['type_']
+                if attr in special_values:
+                    values = special_values[attr]
+                else:
+                    try:
+                        values = type_to_values[type_]
+                    except KeyError:
+                        print('* No values for type {}; skipping'.format(type_))
+                        continue
+
+                # Call the setter once per value:
+                for value in values:
+                    try:
+                        setattr(widget, attr, value)
+                    except Exception as ex:
+                        print('Setter failed!', attr, type_, value, type(ex), ex)
+
+        if call_methods:
+            other_attrs = set(dir(widget)) - set(properties) - skip_methods
+            for attr in other_attrs:
+                try:
+                    method = getattr(widget, attr)
+                except Exception as ex:
+                    print('Skipping', attr, type(ex), ex)
+                    continue
+
+                if not isinstance(method, types.MethodType):
+                    continue
+                elif attr.endswith('Event'):
+                    continue
+
+                if attr in special_method_args:
+                    arg_options = special_method_args[attr]
+                else:
+                    try:
+                        sig = signature(method)
+                    except ValueError:
+                        # built-in method; skip
+                        continue
+                    parameters = [param
+                                  for param in sig.parameters.values()
+                                  if param.name != 'self' and
+                                  param.kind != Parameter.KEYWORD_ONLY]
+
+                    if len(parameters) == 0:
+                        arg_options = [[]]
+                    elif len(parameters) == 1:
+                        # Try sending every type we know about
+                        arg_options = [[param] for param in method_parameters]
+                    else:
+                        print('Skipping complex method', attr)
+                        continue
+
+                for args in arg_options:
+                    print('Calling method', attr, 'with args', args, end=': ')
+                    sys.stdout.flush()
+                    try:
+                        print('Returned:', method(*args))
+                    except Exception as ex:
+                        print('Failed', type(ex), ex)
+
+        try:
+            print('Closing widget')
+            widget.close()
+            print('Marking for deletion')
+            widget.deleteLater()
+            time.sleep(0.1)
+            del widget
+        except Exception as ex:
+            print('Exception on closing widget', type(ex), ex)

--- a/pydm/widgets/waveformtable.py
+++ b/pydm/widgets/waveformtable.py
@@ -43,11 +43,17 @@ class PyDMWaveformTable(QTableWidget, PyDMWritableWidget):
         new_waveform : np.ndarray
             The new waveform value from the channel.
         """
+        try:
+            len_wave = len(new_waveform)
+        except TypeError:
+            new_waveform = np.array([new_waveform])
+            len_wave = 1
+
         PyDMWritableWidget.value_changed(self, new_waveform)
         self._valueBeingSet = True
         self.waveform = new_waveform
         col_count = self.columnCount()
-        len_wave = len(new_waveform)
+
         row_count = len_wave//col_count + (1 if len_wave % col_count else 0)
         self.setRowCount(row_count)
         for ind, element in enumerate(new_waveform):


### PR DESCRIPTION
**I would not recommend merging this** (*). It's a proof-of-concept that could drastically increase pydm's abysmal coverage without too much effort.

With smoke tests alone - no other unit tests - I'm seeing the following coverage locally:
```
$ coverage report pydm/widgets/*.py
Name                                        Stmts   Miss  Cover
---------------------------------------------------------------
pydm/widgets/__init__.py                       20      0   100%
pydm/widgets/base.py                          332     95    71%
pydm/widgets/baseplot.py                      287    105    63%
pydm/widgets/baseplot_curve_editor.py         121     85    30%
pydm/widgets/baseplot_table_model.py          108     87    19%
pydm/widgets/byte.py                          204     30    85%
pydm/widgets/channel.py                        72     21    71%
pydm/widgets/checkbox.py                       18      5    72%
pydm/widgets/colormaps.py                      35      0   100%
pydm/widgets/display_format.py                 57     40    30%
pydm/widgets/drawing.py                       348    157    55%
pydm/widgets/embedded_display.py               96     34    65%
pydm/widgets/enum_button.py                    95     14    85%
pydm/widgets/enum_combo_box.py                 61     22    64%
pydm/widgets/frame.py                          19      0   100%
pydm/widgets/image.py                         233     83    64%
pydm/widgets/label.py                          41     11    73%
pydm/widgets/line_edit.py                     127     62    51%
pydm/widgets/logdisplay.py                     92     15    84%
pydm/widgets/pushbutton.py                    116     51    56%
pydm/widgets/qtplugin_base.py                  61     27    56%
pydm/widgets/qtplugin_extensions.py            75     44    41%
pydm/widgets/qtplugins.py                      60      0   100%
pydm/widgets/related_display_button.py         96     35    64%
pydm/widgets/rules.py                         126     98    22%
pydm/widgets/rules_editor.py                  310    285     8%
pydm/widgets/scale.py                         489    130    73%
pydm/widgets/scatterplot.py                   200    134    33%
pydm/widgets/scatterplot_curve_editor.py       48     36    25%
pydm/widgets/shell_command.py                  56     13    77%
pydm/widgets/slider.py                        208     13    94%
pydm/widgets/spinbox.py                        66     20    70%
pydm/widgets/symbol.py                        115     53    54%
pydm/widgets/tab_bar.py                       152     23    85%
pydm/widgets/tab_bar_qtplugin.py                8      1    88%
pydm/widgets/timeplot.py                      321    184    43%
pydm/widgets/timeplot_curve_editor.py          31     19    39%
pydm/widgets/waveformplot.py                  190    131    31%
pydm/widgets/waveformplot_curve_editor.py      44     32    27%
pydm/widgets/waveformtable.py                  75      6    92%
---------------------------------------------------------------
TOTAL                                        5258   2201    58%
```

Feel free to close (or modify for your purposes, if you see fit).

(*) There appears to be some instability in Qt when calling the methods (i.e., `call_methods=True` in the test). Widget instantiation and Qt Property getting/setting seems to work reliably, though.