### PR TITLE
Support for multiple files in Related Display Buttons

### DIFF
--- a/examples/related_displays/multiple_files.ui
+++ b/examples/related_displays/multiple_files.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Form</string>
+   <string>Related Display Button with Multiple Files</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
@@ -20,22 +20,21 @@
       <string/>
      </property>
      <property name="text">
-      <string>More Displays</string>
+      <string>Multiple Displays...</string>
      </property>
-     <property name="additionalFilenames" stdset="0">
+     <property name="filenames" stdset="0">
       <stringlist>
        <string>display1.ui</string>
        <string>display2.ui</string>
       </stringlist>
      </property>
-     <property name="additionalTitles" stdset="0">
+     <property name="titles" stdset="0">
       <stringlist>
        <string>Display 1</string>
-       <string>Display 2</string>
       </stringlist>
      </property>
-     <property name="displayFilename" stdset="0">
-      <string/>
+     <property name="openInNewWindow" stdset="0">
+      <bool>true</bool>
      </property>
     </widget>
    </item>

--- a/examples/related_displays/multiple_files.ui
+++ b/examples/related_displays/multiple_files.ui
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="PyDMRelatedDisplayButton" name="PyDMRelatedDisplayButton">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="text">
+      <string>More Displays</string>
+     </property>
+     <property name="additionalFilenames" stdset="0">
+      <stringlist>
+       <string>display1.ui</string>
+       <string>display2.ui</string>
+      </stringlist>
+     </property>
+     <property name="additionalTitles" stdset="0">
+      <stringlist>
+       <string>Display 1</string>
+       <string>Display 2</string>
+      </stringlist>
+     </property>
+     <property name="displayFilename" stdset="0">
+      <string/>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>PyDMRelatedDisplayButton</class>
+   <extends>QPushButton</extends>
+   <header>pydm.widgets.related_display_button</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/pydm/tests/widgets/test_related_display_button.py
+++ b/pydm/tests/widgets/test_related_display_button.py
@@ -1,0 +1,91 @@
+import os
+import pytest
+from qtpy.QtCore import Qt
+from qtpy.QtWidgets import QApplication, QVBoxLayout
+from ...widgets.related_display_button import PyDMRelatedDisplayButton
+
+test_ui_path = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)),
+    "../test_data", "test.ui")
+
+def test_press_with_filename(qtbot):
+    QApplication.instance().make_main_window()
+    main_window = QApplication.instance().main_window
+    main_window.setWindowTitle("Related Display Button Test")
+    qtbot.addWidget(main_window)
+    button = PyDMRelatedDisplayButton(parent=main_window)
+    button.displayFilename = test_ui_path
+    qtbot.addWidget(button)
+    qtbot.mouseRelease(button, Qt.LeftButton)
+    def check_title():
+        assert "Form" in QApplication.instance().main_window.windowTitle()
+    qtbot.waitUntil(check_title)
+
+def test_press_without_filename(qtbot):
+    QApplication.instance().make_main_window()
+    main_window = QApplication.instance().main_window
+    main_window.setWindowTitle("Related Display Button Test")
+    qtbot.addWidget(main_window)
+    button = PyDMRelatedDisplayButton(parent=main_window)
+    qtbot.addWidget(button)
+    qtbot.mouseRelease(button, Qt.LeftButton)
+    qtbot.wait(250)
+    assert "Form" not in QApplication.instance().main_window.windowTitle()
+
+def test_no_menu_without_additional_files(qtbot):
+    QApplication.instance().make_main_window()
+    main_window = QApplication.instance().main_window
+    main_window.setWindowTitle("Related Display Button Test")
+    qtbot.addWidget(main_window)
+    button = PyDMRelatedDisplayButton(parent=main_window)
+    button.displayFilename = test_ui_path
+    qtbot.addWidget(button)
+    assert button.menu() is None
+
+def test_menu_with_additional_files(qtbot):
+    QApplication.instance().make_main_window()
+    main_window = QApplication.instance().main_window
+    main_window.setWindowTitle("Related Display Button Test")
+    qtbot.addWidget(main_window)
+    button = PyDMRelatedDisplayButton(parent=main_window)
+    main_window.set_display_widget(button)
+    button.displayFilename = test_ui_path
+    button.additionalFiles = [test_ui_path, test_ui_path]
+    button.additionalTitles = ["One", "Two"]
+    qtbot.addWidget(button)
+    assert button.menu() is not None
+    qtbot.mouseRelease(button, Qt.LeftButton)
+    qtbot.waitExposed(button.menu())
+    qtbot.mouseRelease(button.menu(), Qt.LeftButton)
+    button.menu().actions()[0].trigger()
+    def check_title():
+        assert "Form" in QApplication.instance().main_window.windowTitle()
+    qtbot.waitUntil(check_title)
+
+def test_menu_goes_away_when_files_removed(qtbot):
+    QApplication.instance().make_main_window()
+    main_window = QApplication.instance().main_window
+    main_window.setWindowTitle("Related Display Button Test")
+    qtbot.addWidget(main_window)
+    button = PyDMRelatedDisplayButton(parent=main_window)
+    main_window.set_display_widget(button)
+    button.displayFilename = test_ui_path
+    button.additionalFiles = ["one.ui", "two.ui"]
+    button.additionalTitles = ["One", "Two"]
+    qtbot.addWidget(button)
+    assert button.menu() is not None
+    button.additionalFiles = []
+    button.additionalTitles = []
+    assert button.menu() is None
+
+def test_menu_goes_away_when_files_all_blank(qtbot):
+    QApplication.instance().make_main_window()
+    main_window = QApplication.instance().main_window
+    main_window.setWindowTitle("Related Display Button Test")
+    qtbot.addWidget(main_window)
+    button = PyDMRelatedDisplayButton(parent=main_window)
+    button.displayFilename = test_ui_path
+    button.additionalFiles = ["", ""]
+    button.additionalTitles = ["", ""]
+    qtbot.addWidget(button)
+    assert button.menu() is None

--- a/pydm/widgets/related_display_button.py
+++ b/pydm/widgets/related_display_button.py
@@ -4,6 +4,7 @@ from qtpy.QtCore import Slot, Property, Qt, QSize, QPoint
 import os
 import json
 import logging
+import warnings
 from functools import partial
 from .base import PyDMPrimitiveWidget
 from ..utilities import IconFont
@@ -41,8 +42,9 @@ class PyDMRelatedDisplayButton(QPushButton, PyDMPrimitiveWidget):
         self.setIconSize(QSize(16, 16))
         self.setIcon(self._icon)
 
-        self._additional_filenames = []
-        self._additional_titles = []
+        self._filenames = []
+        self._titles = []
+        self._macros = []
         self.num_additional_items = 0
         self._shift_key_was_down = False
         self.setCursor(QCursor(self._icon.pixmap(16, 16)))
@@ -126,7 +128,7 @@ class PyDMRelatedDisplayButton(QPushButton, PyDMPrimitiveWidget):
                 self._icon = self.icon()
                 self.setIcon(QIcon())
 
-    @Property(str)
+    @Property(str, designable=False)
     def displayFilename(self):
         """
         The filename to open
@@ -146,22 +148,22 @@ class PyDMRelatedDisplayButton(QPushButton, PyDMPrimitiveWidget):
         ----------
         value : str
         """
+        warnings.warn("'PyDMRelatedDisplayButton.displayFilename' is deprecated, "
+                      "use 'PyDMRelatedDisplayButton.filenames' instead.")
         if self._display_filename != value:
             self._display_filename = str(value)
             self._rebuild_menu()
             
-    @Property(str)
+    @Property('QStringList')
     def macros(self):
         """
         The macro substitutions to use when launching the display, in JSON object format.
 
         Returns
         -------
-        str
+        list of str
         """
-        if self._macro_string is None:
-            return ""
-        return self._macro_string
+        return self._macros
 
     @macros.setter
     def macros(self, new_macros):
@@ -170,12 +172,12 @@ class PyDMRelatedDisplayButton(QPushButton, PyDMPrimitiveWidget):
 
         Parameters
         ----------
-        new_macros : str
+        new_macros : list of str
         """
-        if len(new_macros) < 1:
-            self._macro_string = None
-        else:
-            self._macro_string = new_macros
+        #Handle the deprecated form of macros where it was a single string.
+        if isinstance(new_macros, str):
+            new_macros = [new_macros]
+        self._macros = new_macros
 
     @Property(bool)
     def openInNewWindow(self):

--- a/pydm/widgets/related_display_button.py
+++ b/pydm/widgets/related_display_button.py
@@ -79,13 +79,6 @@ class PyDMRelatedDisplayButton(QPushButton, PyDMPrimitiveWidget):
                 self._icon = self.icon()
                 self.setIcon(QIcon())
 
-    def check_enable_state(self):
-        """
-        Because the related display button's channel is only used for alarm
-        status, the widget is never disabled by connection state.
-        """
-        self.setEnabled(True)
-
     @Property(str)
     def displayFilename(self):
         """


### PR DESCRIPTION
This PR adds two new properties to PyDMRelatedDisplayButton: additionalFilenames and additionalTitles.  They are both string lists.  If these are specified, and not empty, the related display button will turn into a menu button, where a left-click displays a menu of files to open.  If additionalFilenames and displayFilename are both specified, the displayFilename will be the first item in the menu.

A new example illustrates the new behavior.

Also, I've added a few unit tests for PyDMRelatedDisplayButton, capturing the basic functionality, plus the new stuff.

This will close #464 and #99.  Paging @prjemian and @klauer for comments!