### PR TITLE
Add support for establishing channel connections in batches.

### DIFF
--- a/pydm/application.py
+++ b/pydm/application.py
@@ -401,14 +401,15 @@ class PyDMApplication(QApplication):
         merged_macros = self.macro_stack[-1].copy()
         merged_macros.update(macros)
         self.macro_stack.append(merged_macros)
-        if extension == '.ui':
-            widget = self.load_ui_file(filepath, merged_macros)
-        elif extension == '.py':
-            widget = self.load_py_file(filepath, args, merged_macros)
-        else:
-            self.directory_stack.pop()
-            self.macro_stack.pop()
-            raise ValueError("Invalid file type: {}".format(extension))
+        with data_plugins.connection_queue():
+            if extension == '.ui':
+                widget = self.load_ui_file(filepath, merged_macros)
+            elif extension == '.py':
+                widget = self.load_py_file(filepath, args, merged_macros)
+            else:
+                self.directory_stack.pop()
+                self.macro_stack.pop()
+                raise ValueError("Invalid file type: {}".format(extension))
         # Add on the macros to the widget after initialization. This is
         # done for both ui files and python files.
         widget.base_macros = merged_macros

--- a/pydm/data_plugins/__init__.py
+++ b/pydm/data_plugins/__init__.py
@@ -9,10 +9,7 @@ import inspect
 import logging
 import imp
 import uuid
-try:
-    from Queue import Queue
-except ImportError:
-    from queue import Queue
+from collections import deque
 from contextlib import contextmanager
 
 from .plugin import PyDMPlugin
@@ -29,11 +26,11 @@ __CONNECTION_QUEUE__ = None
 def connection_queue():
     global __CONNECTION_QUEUE__
     if __CONNECTION_QUEUE__ is None:
-        __CONNECTION_QUEUE__ = Queue()
+        __CONNECTION_QUEUE__ = deque()
     try:
         yield
-        while not __CONNECTION_QUEUE__.empty():
-            channel = __CONNECTION_QUEUE__.get()
+        while not len(__CONNECTION_QUEUE__) == 0:
+            channel = __CONNECTION_QUEUE__.pop()
             establish_connection_immediately(channel)
     finally:
         __CONNECTION_QUEUE__ = None
@@ -41,7 +38,7 @@ def connection_queue():
 def establish_connection(channel):
     global __CONNECTION_QUEUE__
     if __CONNECTION_QUEUE__:
-        __CONNECTION_QUEUE__.put(channel)
+        __CONNECTION_QUEUE__.append(channel)
     else:
         establish_connection_immediately(channel)
 

--- a/pydm/widgets/channel.py
+++ b/pydm/widgets/channel.py
@@ -1,6 +1,6 @@
 import logging
 
-from pydm.data_plugins import plugin_for_address
+import pydm.data_plugins
 from pydm.utilities import is_qt_designer
 from pydm import config
 
@@ -116,8 +116,7 @@ class PyDMChannel(object):
         logger.debug("Connecting %r", self.address)
         # Connect to proper PyDMPlugin
         try:
-            plugin = plugin_for_address(self.address)
-            plugin.add_connection(self)
+            pydm.data_plugins.establish_connection(self)
         except Exception:
             logger.exception("Unable to make proper connection "
                              "for %r", self)
@@ -129,7 +128,7 @@ class PyDMChannel(object):
         if is_qt_designer() and not config.DESIGNER_ONLINE:
             return
         try:
-            plugin = plugin_for_address(self.address)
+            plugin = pydm.data_plugins.plugin_for_address(self.address)
             if not plugin:
                 return
             plugin.remove_connection(self, destroying=destroying)


### PR DESCRIPTION
In the current version of PyDM, connections to channels are established when widgets are instantiated.  For displays with hundreds of channels, this is kind of a slow way to do it.  Some tests I ran indicate that waiting until all widgets are instantiated, then establishing all connections in a second pass can shave ~15% off of display load times.

This PR provides a way to do that, without breaking the existing API for establishing connections.  It introduces a connection queue context manager, that lets you request that all connections made within a block are deferred until exiting the block:

```
with pydm.data_plugins.connection_queue():
            for item in some_huge_list:
                widget = create_widget_for_item(item)
```

All calls to pydm.data_plugins.establish_connection (which pretty much exclusively happens inside pydm.channel) will be queued up if called within the connection queue block.

PyDMApplication now uses this queue whenever it opens any display file (.py or .ui).