### PR TITLE
MNT: Add **kwargs to PyDMPrimitiveWidget ctor.

### DIFF
--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -105,7 +105,7 @@ class PyDMPrimitiveWidget(object):
         'Opacity': ['set_opacity', float]
     }
 
-    def __init__(self):
+    def __init__(self, **kwargs):
         self._rules = None
         self._opacity = 1.0
 


### PR DESCRIPTION
While developing the PCDS Vacuum Widgets I came across this issue when calling super() at the constructor that PyDMPrimitiveWidget was very restrictive for other params.
This fix will allow folks to inherit from PyDMPrimitiveWidget at their custom widgets and make proper usage of super().