### PR TITLE
FIX: Hide channel Property at ImageView widget.

### DIFF
--- a/pydm/widgets/image.py
+++ b/pydm/widgets/image.py
@@ -157,6 +157,15 @@ class PyDMImageView(ImageView, PyDMWidget, PyDMColorMap, ReadingOrder):
         if width_channel:
             self.widthChannel = width_channel or ''
 
+    @Property(str, designable=False)
+    def channel(self):
+        return
+
+    @channel.setter
+    def channel(self, ch):
+        logger.info("Use the imageChannel property with the ImageView widget.")
+        return
+
     def widget_ctx_menu(self):
         """
         Fetch the Widget specific context menu.


### PR DESCRIPTION
This PR hides the channel property at the ImageView widget and also makes it a no-op to avoid issues with people writing Python based displays.
I was skeptical to raise an exception there so I just added a logger info message instead. I think it will be good enough.

Closes #466