### PR TITLE
FIX: Explicitly open as 'r' the requirements file.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,10 +7,10 @@ from os import path, environ
 
 cur_dir = path.abspath(path.dirname(__file__))
 
-with open(path.join(cur_dir, 'requirements.txt')) as f:
+with open(path.join(cur_dir, 'requirements.txt', 'r')) as f:
     requirements = f.read().split()
 
-with open(path.join(cur_dir, 'README.md'), encoding='utf-8') as f:
+with open(path.join(cur_dir, 'README.md'), 'r', encoding='utf-8') as f:
     long_description = f.read()
 
 # Remove the 'optional' requirements

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from os import path, environ
 
 cur_dir = path.abspath(path.dirname(__file__))
 
-with open(path.join(cur_dir, 'requirements.txt', 'r')) as f:
+with open(path.join(cur_dir, 'requirements.txt'), 'r') as f:
     requirements = f.read().split()
 
 with open(path.join(cur_dir, 'README.md'), 'r', encoding='utf-8') as f:


### PR DESCRIPTION
I came across the following issue with a newer version of setuptools:
`'install_requires' must be a string or list of strings containing valid project/version requirement specifiers;`
We need to explicitly use `'r'` mode when reading the requirements file.