### PR TITLE
Add support for changing label text via the rules system.

### DIFF
--- a/examples/actions/label_text_from_rule.ui
+++ b/examples/actions/label_text_from_rule.ui
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QHBoxLayout" name="horizontalLayout">
+   <item>
+    <widget class="PyDMLabel" name="PyDMLabel">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="rules" stdset="0">
+      <string>[{&quot;channels&quot;: [{&quot;trigger&quot;: true, &quot;channel&quot;: &quot;ca://MTEST:Run&quot;}], &quot;property&quot;: &quot;Text&quot;, &quot;expression&quot;: &quot;{0: \&quot;Its off :(\&quot;, 1: \&quot;Its on!\&quot;}[ch[0]]&quot;, &quot;name&quot;: &quot;Text from value&quot;}]</string>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>PyDMLabel</class>
+   <extends>QLabel</extends>
+   <header>pydm.widgets.label</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/pydm/widgets/label.py
+++ b/pydm/widgets/label.py
@@ -22,6 +22,10 @@ class PyDMLabel(QLabel, TextFormatter, PyDMWidget, DisplayFormat):
     def __init__(self, parent=None, init_channel=None):
         QLabel.__init__(self, parent)
         PyDMWidget.__init__(self, init_channel=init_channel)
+        if 'Text' not in PyDMLabel.RULE_PROPERTIES:
+            PyDMLabel.RULE_PROPERTIES = PyDMWidget.RULE_PROPERTIES.copy()
+            PyDMLabel.RULE_PROPERTIES.update(
+                {'Text': ['value_changed', str]})
         self.app = QApplication.instance()
         self.setTextFormat(Qt.PlainText)
         self.setTextInteractionFlags(Qt.NoTextInteraction)

--- a/pydm/widgets/label.py
+++ b/pydm/widgets/label.py
@@ -9,7 +9,12 @@ class PyDMLabel(QLabel, TextFormatter, PyDMWidget, DisplayFormat):
     Q_ENUMS(DisplayFormat)
     DisplayFormat = DisplayFormat
     """
-    A QLabel with support for Channels and more from PyDM
+    A QLabel with support for setting the text via a PyDM Channel, or
+    through the PyDM Rules system.
+    
+    Note: If a PyDMLabel is configured to use a Channel, and also with a rule
+    which changes the 'Text' property, the behavior is undefined.  Use either
+    the Channel *or* a text rule, but not both.
 
     Parameters
     ----------


### PR DESCRIPTION
You can now set the text on a PyDMLabel via the rules system.  Comes with a new example showing how it works.

This can be useful for doing things like making a label that behaves like an enum, even though behind the scenes it is driven by plain-old integer or boolean channels.  Or, if you *do* have an enum, overriding the string for each value.

Thanks to @hhslepicka for making this trivial to implement.