### PR TITLE
Silence exceptions when channel address is blank.

### DIFF
--- a/pydm/data_plugins/__init__.py
+++ b/pydm/data_plugins/__init__.py
@@ -46,7 +46,8 @@ def establish_connection(channel):
 
 def establish_connection_immediately(channel):
     plugin = plugin_for_address(channel.address)
-    plugin.add_connection(channel)
+    if plugin:
+        plugin.add_connection(channel)
 
 def plugin_for_address(address):
     """
@@ -54,6 +55,8 @@ def plugin_for_address(address):
     """
     # Check for a configured protocol
     protocol, addr = protocol_and_address(address)
+    if not addr:
+        return None
     # Use default protocol
     if protocol is None and config.DEFAULT_PROTOCOL is not None:
         logger.debug("Using default protocol %s for %s",

--- a/pydm/data_plugins/__init__.py
+++ b/pydm/data_plugins/__init__.py
@@ -46,8 +46,7 @@ def establish_connection(channel):
 
 def establish_connection_immediately(channel):
     plugin = plugin_for_address(channel.address)
-    if plugin:
-        plugin.add_connection(channel)
+    plugin.add_connection(channel)
 
 def plugin_for_address(address):
     """
@@ -55,8 +54,6 @@ def plugin_for_address(address):
     """
     # Check for a configured protocol
     protocol, addr = protocol_and_address(address)
-    if not addr:
-        return None
     # Use default protocol
     if protocol is None and config.DEFAULT_PROTOCOL is not None:
         logger.debug("Using default protocol %s for %s",

--- a/pydm/widgets/channel.py
+++ b/pydm/widgets/channel.py
@@ -111,6 +111,8 @@ class PyDMChannel(object):
         """
         Connect a PyDMChannel to the proper PyDMPlugin
         """
+        if not self.address:
+            return
         if is_qt_designer() and not config.DESIGNER_ONLINE:
             return
         logger.debug("Connecting %r", self.address)


### PR DESCRIPTION
There are occasions when a user intentionally leaves the channel property for a PyDM widget empty.  Right now, this causes PyDM to emit a bunch of error messages if the underlying data plugin tries to connect to an empty string and throws an exception.  This PR changes the behavior to do nothing at all if the channel address is blank.