### PR TITLE
CI: Ensure that we use a valid Access Token when pushing docs.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -100,13 +100,12 @@ jobs:
 
     - bash: |
         git config --global user.name "Azure Pipelines"
-        git config --global user.email "azurebot@nonvalidemail.com"
         git checkout gh-pages
         cp -r $(Build.Repository.LocalPath)/artifacts/docs_html/* .
         rm -rf $(Build.Repository.LocalPath)/artifacts
         git add *
         git commit -m "Updating Docs with latest build"
-        git push origin gh-pages
+        git push https://$(GITHUB_DOCS_PAT)@github.com/$(Build.Repository.Name).git gh-pages
       displayName: Documentation - Upload
 
   - job: 'Publish_PyPI'


### PR DESCRIPTION
GitHub Pages was failing to build as the changes were being submitted by an invalid authentication from Azure Pipelines.
This PR adds the tweak to use an Access Token to upload the docs (as doctr was doing on the days of TravisCI).