### PR TITLE
MNT: Cleanups and README Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,22 @@ as the abstraction layer for the Qt Python wrappers (PyQt5/PyQt4/PySide2/PySide)
 Python package requirements are listed in the requirements.txt file, which can
 be used to install all requirements from pip: 'pip install -r requirements.txt'
 
+# Running the Tests
+In order to run the tests you will need to install some dependencies that are
+not part of the runtime dependencies of PyDM.
+
+Assuming that you have cloned this repository do:
+
+```bash
+pip install -r dev-requirements.txt
+
+python run_tests.py
+```
+
+If you want to see the coverage report do:
+```bash
+python run_tests.py --show-cov
+```
 
 # Running the Examples
 There are various examples of some of the features of the display manager.
@@ -54,6 +70,24 @@ the examples:
 ```python
 python scripts/pydm examples/home.ui
 ```
+
+# Building the Documentation Locally
+In order to build the documentation you will need to instll some dependencies
+that are not part of the runtime dependencies of PyDM.
+
+Assuming that you have cloned this repository do:
+
+```bash
+pip install -r docs-requirements.txt
+
+cd docs
+make html
+```
+
+This will generate the HTML documentation for PyDM at the `<>/docs/build/html`
+folder. Look for the `index.html` file and open it with your browser.
+
+# Online Documentation
 
 Documentation is available at http://slaclab.github.io/pydm/.  Documentation is
 somewhat sparse right now, unfortunately.

--- a/azure-test-template.yml
+++ b/azure-test-template.yml
@@ -94,6 +94,7 @@ jobs:
       source activate base
       conda install -q pydm conda=4.6.8 -c conda-forge
       pip install -r dev-requirements.txt
+      pip install pytest-azurepipelines
     displayName: 'Anaconda - Install Dependencies'
 
   # Windows Only

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,4 @@
 codecov
-pytest
+pytest>=3.6
 pytest-qt
 pytest-cov<2.6.0
-pytest-azurepipelines

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,11 @@ cur_dir = path.abspath(path.dirname(__file__))
 with open(path.join(cur_dir, 'requirements.txt'), 'r') as f:
     requirements = f.read().split()
 
+dev_requirements = []
+
+with open(path.join(cur_dir, 'dev-requirements.txt'), 'r') as f:
+    dev_requirements = f.read().split()
+
 with open(path.join(cur_dir, 'README.md'), 'r', encoding='utf-8') as f:
     long_description = f.read()
 
@@ -23,7 +28,7 @@ extras_require = {
     'PySide': ['PySide'],
     'pyepics': ['pyepics'],
     'perf': ['psutil'],
-    'test': ['codecov', 'pytest', 'pytest-cov', 'coverage', 'coveralls']
+    'dev': dev_requirements
 }
 
 if "CONDA_PREFIX" not in environ:


### PR DESCRIPTION
- Explicitly set `pytest` to be `>=3.6`.
- Removes `pytest-azurepipelines` from dev-requirements and add it specifically into `azure-test-template.yml`.
- Remove 'test' entry for `extras_require` at setup.py and add `dev` entry pulling info from `dev-requirements.txt`
- Add instructions on README.md for running tests and building docs.
