### PR TITLE
Add option to defer loading embedded displays until they become visible.

### DIFF
--- a/pydm/application.py
+++ b/pydm/application.py
@@ -5,24 +5,21 @@ Contains our PyDMApplication class with core connection and loading logic and
 our PyDMMainWindow class with navigation logic.
 """
 import os
-import imp
 import sys
-import uuid
 import signal
 import subprocess
 import json
-import inspect
 import logging
 import warnings
-from .display_module import Display
+
 from qtpy.QtCore import Qt, QTimer, Slot
 from qtpy.QtWidgets import QApplication, QWidget
 from qtpy.QtGui import QColor
-from qtpy import uic
 from .main_window import PyDMMainWindow
 
 from .utilities import macro, which, path_info, find_display_in_path
 from .utilities.stylesheet import apply_stylesheet
+from .utilities.display_loading import load_ui_file, load_py_file
 from .utilities import connection
 from . import data_plugins
 from .widgets.rules import RulesDispatcher
@@ -278,87 +275,7 @@ class PyDMApplication(QApplication):
             # it means that we already closed it.
             pass
 
-    def load_ui_file(self, uifile, macros=None):
-        """
-        Load a .ui file, perform macro substitution, then return the resulting QWidget.
-
-        This is an internal method, users will usually want to use `open_file` instead.
-
-        Parameters
-        ----------
-        uifile : str
-            The path to a .ui file to load.
-        macros : dict, optional
-            A dictionary of macro variables to supply to the file
-            to be opened.
-
-        Returns
-        -------
-        QWidget
-        """
-        if macros is not None and len(macros) > 0:
-            f = macro.substitute_in_file(uifile, macros)
-        else:
-            f = uifile
-        return uic.loadUi(f)
-
-    def load_py_file(self, pyfile, args=None, macros=None):
-        """
-        Load a .py file, performs some sanity checks to try and determine
-        if the file actually contains a valid PyDM Display subclass, and if
-        the checks pass, create and return an instance.
-
-        This is an internal method, users will usually want to use `open_file` instead.
-
-        Parameters
-        ----------
-        pyfile : str
-            The path to a .ui file to load.
-        args : list, optional
-            A list of command-line arguments to pass to the
-            loaded display subclass.
-        macros : dict, optional
-            A dictionary of macro variables to supply to the
-            loaded display subclass.
-
-        Returns
-        -------
-        pydm.Display
-        """
-        # Add the intelligence module directory to the python path, so that submodules can be loaded.    Eventually, this should go away, and intelligence modules should behave as real python modules.
-        module_dir = os.path.dirname(os.path.abspath(pyfile))
-        sys.path.append(module_dir)
-        temp_name = str(uuid.uuid4())
-
-        # Now load the intelligence module.
-        module = imp.load_source(temp_name, pyfile)
-        if hasattr(module, 'intelclass'):
-            cls = module.intelclass
-            if not issubclass(cls, Display):
-                raise ValueError("Invalid class definition at file {}. {} does not inherit from Display. Nothing to open at this time.".format(pyfile, cls.__name__))
-        else:
-            classes = [obj for name, obj in inspect.getmembers(module) if inspect.isclass(obj) and issubclass(obj, Display) and obj != Display]
-            if len(classes) == 0:
-                raise ValueError("Invalid File Format. {} has no class inheriting from Display. Nothing to open at this time.".format(pyfile))
-            if len(classes) > 1:
-                warnings.warn("More than one Display class in file {}. The first occurence (in alphabetical order) will be opened: {}".format(pyfile, classes[0].__name__), RuntimeWarning, stacklevel=2)
-            cls = classes[0]
-
-        try:
-            # This only works in python 3 and up.
-            module_params = inspect.signature(cls).parameters
-        except AttributeError:
-            # Works in python 2, deprecated in 3.0 and up.
-            module_params = inspect.getargspec(cls.__init__).args
-
-        # Because older versions of Display may not have the args parameter or the macros parameter, we check
-        # to see if it does before trying to use them.
-        kwargs = {}
-        if 'args' in module_params:
-            kwargs['args'] = args
-        if 'macros' in module_params:
-            kwargs['macros'] = macros
-        return cls(**kwargs)
+    
 
     def open_file(self, ui_file, macros=None, command_line_args=None, **kwargs):
         """
@@ -403,9 +320,9 @@ class PyDMApplication(QApplication):
         self.macro_stack.append(merged_macros)
         with data_plugins.connection_queue():
             if extension == '.ui':
-                widget = self.load_ui_file(filepath, merged_macros)
+                widget = load_ui_file(filepath, merged_macros)
             elif extension == '.py':
-                widget = self.load_py_file(filepath, args, merged_macros)
+                widget = load_py_file(filepath, args, merged_macros)
             else:
                 self.directory_stack.pop()
                 self.macro_stack.pop()
@@ -565,6 +482,6 @@ class PyDMApplication(QApplication):
         merged_macros = self.macro_stack[-1].copy()
         merged_macros.update(macros)
         f = macro.replace_macros_in_template(template, merged_macros)
-        w = self.load_ui_file(f)
+        w = load_ui_file(f)
         w.base_macros = merged_macros
         return w

--- a/pydm/utilities/display_loading.py
+++ b/pydm/utilities/display_loading.py
@@ -1,0 +1,91 @@
+import os
+import sys
+import imp
+import uuid
+import inspect
+import warnings
+from ..display_module import Display
+from qtpy import uic
+from . import macro
+
+def load_ui_file(uifile, macros=None):
+    """
+    Load a .ui file, perform macro substitution, then return the resulting QWidget.
+
+    This is an internal method, users will usually want to use `open_file` instead.
+
+    Parameters
+    ----------
+    uifile : str
+        The path to a .ui file to load.
+    macros : dict, optional
+        A dictionary of macro variables to supply to the file
+        to be opened.
+
+    Returns
+    -------
+    QWidget
+    """
+    if macros is not None and len(macros) > 0:
+        f = macro.substitute_in_file(uifile, macros)
+    else:
+        f = uifile
+    return uic.loadUi(f)
+
+def load_py_file(pyfile, args=None, macros=None):
+    """
+    Load a .py file, performs some sanity checks to try and determine
+    if the file actually contains a valid PyDM Display subclass, and if
+    the checks pass, create and return an instance.
+
+    This is an internal method, users will usually want to use `open_file` instead.
+
+    Parameters
+    ----------
+    pyfile : str
+        The path to a .ui file to load.
+    args : list, optional
+        A list of command-line arguments to pass to the
+        loaded display subclass.
+    macros : dict, optional
+        A dictionary of macro variables to supply to the
+        loaded display subclass.
+
+    Returns
+    -------
+    pydm.Display
+    """
+    # Add the intelligence module directory to the python path, so that submodules can be loaded.    Eventually, this should go away, and intelligence modules should behave as real python modules.
+    module_dir = os.path.dirname(os.path.abspath(pyfile))
+    sys.path.append(module_dir)
+    temp_name = str(uuid.uuid4())
+
+    # Now load the intelligence module.
+    module = imp.load_source(temp_name, pyfile)
+    if hasattr(module, 'intelclass'):
+        cls = module.intelclass
+        if not issubclass(cls, Display):
+            raise ValueError("Invalid class definition at file {}. {} does not inherit from Display. Nothing to open at this time.".format(pyfile, cls.__name__))
+    else:
+        classes = [obj for name, obj in inspect.getmembers(module) if inspect.isclass(obj) and issubclass(obj, Display) and obj != Display]
+        if len(classes) == 0:
+            raise ValueError("Invalid File Format. {} has no class inheriting from Display. Nothing to open at this time.".format(pyfile))
+        if len(classes) > 1:
+            warnings.warn("More than one Display class in file {}. The first occurence (in alphabetical order) will be opened: {}".format(pyfile, classes[0].__name__), RuntimeWarning, stacklevel=2)
+        cls = classes[0]
+
+    try:
+        # This only works in python 3 and up.
+        module_params = inspect.signature(cls).parameters
+    except AttributeError:
+        # Works in python 2, deprecated in 3.0 and up.
+        module_params = inspect.getargspec(cls.__init__).args
+
+    # Because older versions of Display may not have the args parameter or the macros parameter, we check
+    # to see if it does before trying to use them.
+    kwargs = {}
+    if 'args' in module_params:
+        kwargs['args'] = args
+    if 'macros' in module_params:
+        kwargs['macros'] = macros
+    return cls(**kwargs)

--- a/pydm/widgets/embedded_display.py
+++ b/pydm/widgets/embedded_display.py
@@ -29,7 +29,7 @@ class PyDMEmbeddedDisplay(QFrame, PyDMPrimitiveWidget):
         self._embedded_widget = None
         self._disconnect_when_hidden = True
         self._is_connected = False
-        self._only_load_when_shown = False
+        self._only_load_when_shown = True
         self._needs_load = True
         self.layout = QVBoxLayout(self)
         self.err_label = QLabel(self)

--- a/pydm/widgets/embedded_display.py
+++ b/pydm/widgets/embedded_display.py
@@ -31,6 +31,9 @@ class PyDMEmbeddedDisplay(QFrame, PyDMPrimitiveWidget):
         self._is_connected = False
         self._only_load_when_shown = True
         self._needs_load = True
+        self.base_path = ""
+        if is_pydm_app():
+          self.base_path = self.app.directory_stack[-1]
         self.layout = QVBoxLayout(self)
         self.err_label = QLabel(self)
         self.err_label.setAlignment(Qt.AlignHCenter)
@@ -41,6 +44,7 @@ class PyDMEmbeddedDisplay(QFrame, PyDMPrimitiveWidget):
             self.setFrameShape(QFrame.Box)
         else:
             self.setFrameShape(QFrame.NoFrame)
+        
 
     def minimumSizeHint(self):
         """
@@ -143,6 +147,8 @@ class PyDMEmbeddedDisplay(QFrame, PyDMPrimitiveWidget):
             return
         try:
             fname = os.path.expanduser(os.path.expandvars(self.filename))
+            if self.base_path:
+                fname = os.path.join(self.base_path, fname)
             if os.path.isabs(fname):
                 w = self.app.open_file(fname, macros=self.parsed_macros())
             else:

--- a/pydm/widgets/embedded_display.py
+++ b/pydm/widgets/embedded_display.py
@@ -214,7 +214,7 @@ class PyDMEmbeddedDisplay(QFrame, PyDMPrimitiveWidget):
         close_widget_connections(self.embedded_widget)
 
     @Property(bool)
-    def onlyLoadWhenShown(self):
+    def loadWhenShown(self):
         """
         If True, only load and display the file once the
         PyDMEmbeddedDisplayWidget is visible on screen.  This is very useful
@@ -231,8 +231,8 @@ class PyDMEmbeddedDisplay(QFrame, PyDMPrimitiveWidget):
         """
         return self._only_load_when_shown
         
-    @onlyLoadWhenShown.setter
-    def onlyLoadWhenShown(self, val):
+    @loadWhenShown.setter
+    def loadWhenShown(self, val):
         self._only_load_when_shown = val
         if val is False and self._needs_load:
             self.embedded_widget = self.open_file()

--- a/pydm/widgets/embedded_display.py
+++ b/pydm/widgets/embedded_display.py
@@ -29,7 +29,7 @@ class PyDMEmbeddedDisplay(QFrame, PyDMPrimitiveWidget):
         self._embedded_widget = None
         self._disconnect_when_hidden = True
         self._is_connected = False
-        self._only_load_when_shown = True
+        self._only_load_when_shown = False
         self._needs_load = True
         self.layout = QVBoxLayout(self)
         self.err_label = QLabel(self)

--- a/pydm/widgets/embedded_display.py
+++ b/pydm/widgets/embedded_display.py
@@ -115,12 +115,6 @@ class PyDMEmbeddedDisplay(QFrame, PyDMPrimitiveWidget):
         filename = str(filename)
         if filename != self._filename:
             self._filename = filename
-            # If we aren't in a PyDMApplication (usually that means we are in Qt Designer),
-            # don't try to load the file, just show text with the filename.
-            #if not is_pydm_app():
-            #    self.err_label.setText(self._filename)
-            #    self.err_label.show()
-            #    return
             if self._only_load_when_shown and (not is_qt_designer()):
                 self._needs_load = True
             else:

--- a/pydm/widgets/embedded_display.py
+++ b/pydm/widgets/embedded_display.py
@@ -147,7 +147,6 @@ class PyDMEmbeddedDisplay(QFrame, PyDMPrimitiveWidget):
         display : QWidget
         """
         if (not force) and (not self._needs_load):
-            print("Not loading.")
             return
             
         if not self.filename:
@@ -163,13 +162,11 @@ class PyDMEmbeddedDisplay(QFrame, PyDMPrimitiveWidget):
             elif extension == ".py":
                 loadfunc = load_py_file
             try:
-                print("Loading {} with macros {}".format(fname, self.parsed_macros()))
                 w = loadfunc(fname, macros=self.parsed_macros())
                 self._needs_load = False
                 self.clear_error_text()
                 return w
             except Exception as e:
-                print(e)
                 logger.exception("Exception while opening embedded display file.")
                 self.display_error_text(e)
             return None


### PR DESCRIPTION
This PR adds a new property ("loadWhenShown") to PyDMEmbeddedDisplay that lets you control when the embedded .ui or .py file gets loaded.  The default, loadWhenShown=False, is the old behavior, where the embedded file gets loaded as soon as the 'filename' property is set (usually shortly after instantiation).  If you set loadWhenShown=True, the widget will wait until it gets a showEvent before loading the embedded file.

I added this because I built a huge display with 15 tabs, each tab containing an embedded display that contained a very large number of widgets (hundreds).  This display was unbearably slow to load (five seconds to just instantiate widgets, then five more to establish channel access connections).  With loadWhenShown=True, loading is nearly instantaneous, and connections only get made for the widgets the user is looking at.