### PR TITLE
Defer connections until after PyDMMainWindow loads the display.

### DIFF
--- a/pydm/application.py
+++ b/pydm/application.py
@@ -360,7 +360,7 @@ class PyDMApplication(QApplication):
             kwargs['macros'] = macros
         return cls(**kwargs)
 
-    def open_file(self, ui_file, macros=None, command_line_args=None, **kwargs):
+    def open_file(self, ui_file, macros=None, command_line_args=None, defer_connections=False, **kwargs):
         """
         Open a .ui or .py file, and return a widget from the loaded file.
         This method is the entry point for all opening of new displays,
@@ -401,7 +401,7 @@ class PyDMApplication(QApplication):
         merged_macros = self.macro_stack[-1].copy()
         merged_macros.update(macros)
         self.macro_stack.append(merged_macros)
-        with data_plugins.connection_queue():
+        with data_plugins.connection_queue(defer_connections=defer_connections):
             if extension == '.ui':
                 widget = self.load_ui_file(filepath, merged_macros)
             elif extension == '.py':

--- a/pydm/data_plugins/__init__.py
+++ b/pydm/data_plugins/__init__.py
@@ -41,10 +41,9 @@ def establish_queued_connections():
     global __CONNECTION_QUEUE__
     if __CONNECTION_QUEUE__ is None:
         return
-    
     try:
         while not len(__CONNECTION_QUEUE__) == 0:
-            channel = __CONNECTION_QUEUE__.pop()
+            channel = __CONNECTION_QUEUE__.popleft()
             establish_connection_immediately(channel)
             QApplication.instance().processEvents()
     finally:

--- a/pydm/data_plugins/__init__.py
+++ b/pydm/data_plugins/__init__.py
@@ -39,7 +39,7 @@ def connection_queue():
         
 def establish_connection(channel):
     global __CONNECTION_QUEUE__
-    if __CONNECTION_QUEUE__:
+    if __CONNECTION_QUEUE__ is not None:
         __CONNECTION_QUEUE__.append(channel)
     else:
         establish_connection_immediately(channel)

--- a/pydm/data_plugins/__init__.py
+++ b/pydm/data_plugins/__init__.py
@@ -11,7 +11,7 @@ import imp
 import uuid
 from collections import deque
 from contextlib import contextmanager
-
+from qtpy.QtWidgets import QApplication
 from .plugin import PyDMPlugin
 from ..utilities import protocol_and_address
 from .. import config
@@ -21,21 +21,36 @@ plugin_modules = {}
 __read_only = False
 global __CONNECTION_QUEUE__
 __CONNECTION_QUEUE__ = None
+global __DEFER_CONNECTIONS__
+__DEFER_CONNECTIONS__ = False
 
 @contextmanager
-def connection_queue():
+def connection_queue(defer_connections=False):
     global __CONNECTION_QUEUE__
+    global __DEFER_CONNECTIONS__
     if __CONNECTION_QUEUE__ is None:
         __CONNECTION_QUEUE__ = deque()
+        __DEFER_CONNECTIONS__ = defer_connections
+    yield
+    if __DEFER_CONNECTIONS__:
+        return
+    establish_queued_connections()
+
+def establish_queued_connections():
+    global __DEFER_CONNECTIONS__
+    global __CONNECTION_QUEUE__
+    if __CONNECTION_QUEUE__ is None:
+        return
+    
     try:
-        yield
-        if __CONNECTION_QUEUE__ is None:
-            return
         while not len(__CONNECTION_QUEUE__) == 0:
             channel = __CONNECTION_QUEUE__.pop()
             establish_connection_immediately(channel)
+            QApplication.instance().processEvents()
     finally:
         __CONNECTION_QUEUE__ = None
+        __DEFER_CONNECTIONS__ = False
+    
         
 def establish_connection(channel):
     global __CONNECTION_QUEUE__

--- a/pydm/main_window.py
+++ b/pydm/main_window.py
@@ -140,7 +140,7 @@ class PyDMMainWindow(QMainWindow):
         if command_line_args is None:
             command_line_args = []
         merged_macros = self.merge_with_current_macros(macros)
-        widget = self.app.open_file(filename, merged_macros, command_line_args)
+        widget = self.app.open_file(filename, merged_macros, command_line_args, defer_connections=True)
         if (len(self.back_stack) == 0) or (self.current_file() != filename):
             self.back_stack.append((filename, merged_macros, command_line_args))
         self.set_display_widget(widget)
@@ -160,6 +160,7 @@ class PyDMMainWindow(QMainWindow):
         self.ui.actionEdit_in_Designer.setText(edit_in_text)
         if self.designer_path:
             self.ui.actionEdit_in_Designer.setEnabled(True)
+        data_plugins.establish_queued_connections()
 
     def new_window(self, ui_file, macros=None, command_line_args=None):
         filename = self.join_to_current_file_path(ui_file)

--- a/pydm/widgets/template_repeater.py
+++ b/pydm/widgets/template_repeater.py
@@ -328,7 +328,7 @@ class PyDMTemplateRepeater(QFrame, PyDMPrimitiveWidget, LayoutType):
                 QWidget().setLayout(self.layout())
             l = layout_class(self)
             self.setLayout(l)
-        with pydm.data_plugins.connection_queue():
+        with pydm.data_plugins.connection_queue(defer_connections=True):
             for i, variables in enumerate(self.data):
                 if is_qt_designer() and i > self.countShownInDesigner - 1:
                     break
@@ -339,6 +339,7 @@ class PyDMTemplateRepeater(QFrame, PyDMPrimitiveWidget, LayoutType):
                 w.setParent(self)
                 self.layout().addWidget(w)
         self.setUpdatesEnabled(True)
+        pydm.data_plugins.establish_queued_connections()
     
     def clear(self):
         """ Clear out any existing instances of the template inside


### PR DESCRIPTION
This PR adds a new feature to the recently-added `pydm.data_plugins.connection_queue`.  By setting a flag when you create the queue, you can prevent PyDM from establishing connections after exiting the `with connection_queue` block, then establish those connections at some later time via `pydm.data_plugins.establish_queued_connections()`.

PyDMMainWindow now uses this.  The motivation here is to prioritize loading a display and showing it to the user above establishing connections to widgets.  While this doesn't really make things much faster, they certainly *feel* faster, and the user doesn't sit at a blank screen while PyDM frantically establishes connections to the thousands of channels that the display author foolishly decided the user needed to know about.

Additionally, the queue now calls `QApplication.processEvents()` while establishing connections, which keeps the application responsive - widgets become usable as soon as _their_ connections are made, instead of after _every_ connection is made.

Finally, a bug was fixed that was effectively bypassing the connection_queue in all cases.  Whoops!