### PR TITLE
BUG: Widgets must always use its rect when painting.

### DIFF
--- a/pydm/widgets/byte.py
+++ b/pydm/widgets/byte.py
@@ -40,13 +40,13 @@ class PyDMBitIndicator(QWidget):
         self._painter.setBrush(self._brush)
         self._painter.setPen(self._pen)
         if self.circle:
-            rect = event.rect()
+            rect = self.rect()
             w = rect.width()
             h = rect.height()
             r = min(w, h) / 2.0 - 2.0 * max(self._pen.widthF(), 1.0)
             self._painter.drawEllipse(QPoint(w / 2.0, h / 2.0), r, r)
         else:
-            self._painter.drawRect(event.rect())
+            self._painter.drawRect(self.rect())
         self._painter.end()
 
     def setColor(self, color):


### PR DESCRIPTION
The usage of `event.rect()` causes weird redraw issues when the screen is resized or even someone uses a scrollarea.
This PR fixes it by using the widget rect at the paint event which will preserve the size.
Here is a screenshot of the issue:
![Screen Shot 2019-05-07 at 10 44 34 AM](https://user-images.githubusercontent.com/8185425/57321032-327daf80-70b5-11e9-9f78-3fa5bb990605.png)
