### PR TITLE
CI: Fix PyPI upload using twine.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -166,7 +166,7 @@ jobs:
       displayName: Artifact Download - PyPI Package
 
     - bash: |
-        twine upload --config-file $(PYPIRC_PATH) $(Build.Repository.LocalPath)/artifacts/dist/
+        twine upload --config-file $(PYPIRC_PATH) $(Build.Repository.LocalPath)/artifacts/dist/*
       condition: contains(variables['Build.SourceBranch'], 'tags')
       displayName: PyPI - Upload
 


### PR DESCRIPTION
The miserable `*` that was missing failed the upload to PyPI.
I did a manual upload... next tag it will be okay! 👍 
All the other uploads worked fine for the tag. I call it a success. 🏆 