### PR TITLE
BUG: Crashfix for PyDMByteIndicator with negative shift

### DIFF
--- a/pydm/tests/widgets/test_byte.py
+++ b/pydm/tests/widgets/test_byte.py
@@ -1,0 +1,52 @@
+import pytest
+
+from ...widgets.byte import PyDMByteIndicator
+
+
+@pytest.mark.parametrize("shift, value, expected", [
+    (0, 0, (False, False, False)),
+    (0, 5, (True, False, True)),
+    (0, -5, (False, False, False)),
+
+    (1, 0, (False, False, False)),
+    (1, 4, (False, True, False)),
+    (1, -5, (False, False, False)),
+
+    (-1, 0, (False, False, False)),
+    (-1, 1, (False, True, False)),
+    (-1, -5, (False, False, False)),
+])
+def test_value_shift(qtbot, signals, shift, value, expected):
+    """
+    Test the widget's handling of the value changed event affected by predefined shift.
+
+    Expectations:
+    1. Value coming from the control system is correctly shifted by the predefined value
+    2. Resulting value should be non-negative
+
+    Parameters
+    ----------
+    qtbot : fixture
+        pytest-qt window for widget testing
+    signals : fixture
+        The signals fixture, which provides access signals to be bound to the appropriate slots
+    value : int
+        The value to be displayed by the widget
+    shift : int
+        The value's bit shift
+    expected : int
+        Expected resulting value
+    """
+    num_bits = len(expected)
+    pydm_byte = PyDMByteIndicator()
+    qtbot.addWidget(pydm_byte)
+    pydm_byte.numBits = num_bits
+    pydm_byte.shift = shift
+    pydm_byte._connected = True
+
+    signals.new_value_signal[type(value)].connect(pydm_byte.channelValueChanged)
+    signals.new_value_signal[type(value)].emit(value)
+
+    for i, bit, indicator in zip(range(num_bits), expected, pydm_byte._indicators):
+        expected_color = pydm_byte.onColor if bit else pydm_byte.offColor
+        assert indicator._brush.color().name() == expected_color.name(), "Failed to match bit#{}".format(i)

--- a/pydm/widgets/byte.py
+++ b/pydm/widgets/byte.py
@@ -194,7 +194,10 @@ class PyDMByteIndicator(QWidget, PyDMWidget):
         """
         Update the inner bit indicators accordingly with the new value.
         """
-        value = int(self.value) >> self._shift
+        if self._shift < 0:
+            value = int(self.value) << abs(self._shift)
+        else:
+            value = int(self.value) >> self._shift
         if value < 0:
             value = 0
 


### PR DESCRIPTION
Crash was caused by bit shift operation which affected both PyDM runtime and Qt Designer.

I also added test_byte.py because I could not find a test class for PyDMByteIndicator.