### PR TITLE
ENH: PyDMEnumButton items property

### DIFF
--- a/pydm/tests/widgets/test_enum_button.py
+++ b/pydm/tests/widgets/test_enum_button.py
@@ -174,6 +174,58 @@ def test_check_enable_state(qtbot, connected, write_access, has_enum,
         assert "Enums not available" in actual_tooltip
 
 
+def test_items_is_not_none():
+    """
+    Test that items property is not None, as QStringList definition meant for Qt Designer cannot handle that.
+    """
+    widget = PyDMEnumButton()
+    assert widget.items is not None
+    assert isinstance(widget.items, list)
+
+
+def test_items_defines_button_group(qtbot):
+    """
+    Test that defining items via the property actually alters buttons.
+
+    Parameters
+    ----------
+    qtbot : fixture
+        Window for widget testing
+    """
+    widget = PyDMEnumButton()
+    qtbot.addWidget(widget)
+    widget.items = ["PLAY", "PAUSE"]
+    assert len(widget._btn_group.buttons()) == 2
+    assert widget._btn_group.button(0).text() == "PLAY"
+    assert widget._btn_group.button(1).text() == "PAUSE"
+    widget.items = ["STOP"]
+    assert len(widget._btn_group.buttons()) == 1
+    assert widget._btn_group.button(0).text() == "STOP"
+
+
+def test_enum_strings_signal_alters_items_prop(qtbot, signals):
+    """
+    Test that receiving new enum_strings from the CS overrides predefined button items.
+
+    Parameters
+    ----------
+    qtbot : fixture
+        Window for widget testing
+    signals : fixture
+        The signals fixture, which provides access signals to be bound to the appropriate slots
+    """
+    widget = PyDMEnumButton()
+    qtbot.addWidget(widget)
+    signals.enum_strings_signal[tuple].connect(widget.enumStringsChanged)
+    widget.items = ["PLAY", "PAUSE"]
+    assert len(widget._btn_group.buttons()) == 2
+    assert widget._btn_group.button(0).text() == "PLAY"
+    assert widget._btn_group.button(1).text() == "PAUSE"
+    signals.enum_strings_signal[tuple].emit(("STOP", ))
+    assert len(widget._btn_group.buttons()) == 1
+    assert widget._btn_group.button(0).text() == "STOP"
+
+
 def test_send_receive_value(qtbot, signals):
     """
     Test the widget for round-trip data transfer.

--- a/pydm/tests/widgets/test_enum_button.py
+++ b/pydm/tests/widgets/test_enum_button.py
@@ -174,11 +174,17 @@ def test_check_enable_state(qtbot, connected, write_access, has_enum,
         assert "Enums not available" in actual_tooltip
 
 
-def test_items_is_not_none():
+def test_items_is_not_none(qtbot):
     """
     Test that items property is not None, as QStringList definition meant for Qt Designer cannot handle that.
+
+    Parameters
+    ----------
+    qtbot : fixture
+        Window for widget testing
     """
     widget = PyDMEnumButton()
+    qtbot.addWidget(widget)
     assert widget.items is not None
     assert isinstance(widget.items, list)
 

--- a/pydm/widgets/enum_button.py
+++ b/pydm/widgets/enum_button.py
@@ -60,6 +60,24 @@ class PyDMEnumButton(QWidget, PyDMWritableWidget, WidgetType):
         # This is totally arbitrary, I just want *some* visible nonzero size
         return QSize(50, 100)
 
+    @Property("QStringList")
+    def items(self):
+        """
+        Items to be displayed in the button group.
+
+        This property can be overridden by the items coming from the control system.
+        Because C++ QStringList expects a list type, we need to make sure that None is never returned.
+
+        Returns
+        -------
+        List[str]
+        """
+        return self.enum_strings or []
+
+    @items.setter
+    def items(self, value):
+        self.enum_strings_changed(value)
+
     @Property(WidgetType)
     def widgetType(self):
         """


### PR DESCRIPTION
Allows defining the items manually without involving enum_strings_changed signal.

This way, user can define buttons in Qt Designer.