### PR TITLE
Stop using the deprecated displayFilename property in initializer.

### DIFF
--- a/pydm/widgets/related_display_button.py
+++ b/pydm/widgets/related_display_button.py
@@ -42,14 +42,14 @@ class PyDMRelatedDisplayButton(QPushButton, PyDMPrimitiveWidget):
         self.setIconSize(QSize(16, 16))
         self.setIcon(self._icon)
 
-        self._filenames = []
+        self._filenames = [filename] if filename is not None else []
         self._titles = []
         self._macros = []
         self.num_additional_items = 0
         self._shift_key_was_down = False
         self.setCursor(QCursor(self._icon.pixmap(16, 16)))
         self._display_menu_items = None
-        self._display_filename = filename if filename is not None else ""
+        self._display_filename = ""
         self._macro_string = None
         self._open_in_new_window = False
         self.open_in_new_window_action = QAction("Open in New Window", self)


### PR DESCRIPTION
When the user instantiates a related display button with a filename, like this: `b = PyDMRelatedDisplayButton(filename='myfile.ui')`, put the filename argument into the `filenames` property, not the old deprecated `displayFilename` property.