### PR TITLE
Fix crash in case where base_path property isn't set.

### DIFF
--- a/pydm/widgets/embedded_display.py
+++ b/pydm/widgets/embedded_display.py
@@ -154,6 +154,7 @@ class PyDMEmbeddedDisplay(QFrame, PyDMPrimitiveWidget):
             return
         # Expand user (~ or ~user) and environment variables.
         fname = os.path.expanduser(os.path.expandvars(self.filename))
+        full_fname = None
         if self.base_path:
             full_fname = os.path.join(self.base_path, fname)
         if not is_pydm_app():
@@ -175,7 +176,7 @@ class PyDMEmbeddedDisplay(QFrame, PyDMPrimitiveWidget):
         # If you get this far, you are running inside a PyDMApplication, load
         # using that system.
         try:
-            if os.path.isabs(full_fname) and os.path.exists(full_fname):
+            if full_fname and os.path.isabs(full_fname) and os.path.exists(full_fname):
                 w = self.app.open_file(full_fname, macros=self.parsed_macros())
             else:
                 w = self.app.open_relative(fname, self,


### PR DESCRIPTION
I forgot to handle one of the strange corner cases of Embedded Display, where it doesn't get a base_path set.  That caused a crash.  This fixes it.