### PR TITLE
MNT: Base PyDMWidget should have no write_acesss

### DIFF
--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -460,6 +460,7 @@ class PyDMWidget(PyDMPrimitiveWidget):
 
         self._upper_ctrl_limit = None
         self._lower_ctrl_limit = None
+        self._write_access = False
 
         self.enum_strings = None
 


### PR DESCRIPTION
If we keep track of `_write_access` on `PyDMWritableWidget` it would be nice to do the same on the base `PyDMWidget` that we can check if a generic widget can be written to without much concern about its' type.