### PR TITLE
FIX: Precision could be ignored if it was parsed before precisionFromPV

### DIFF
--- a/pydm/tests/widgets/test_base.py
+++ b/pydm/tests/widgets/test_base.py
@@ -90,8 +90,8 @@ def test_pydmwidget_construct(qtbot, init_channel):
     else:
         assert pydm_label._tooltip is None
 
-    assert pydm_label._precision_from_pv is True
-    assert pydm_label._prec == 0
+    assert pydm_label.precisionFromPV is True
+    assert pydm_label.precision == 0
     assert pydm_label._unit == ""
 
     assert pydm_label._upper_ctrl_limit is None

--- a/pydm/tests/widgets/test_lineedit.py
+++ b/pydm/tests/widgets/test_lineedit.py
@@ -325,9 +325,9 @@ def test_precision_change(qtbot, signals, is_precision_from_pv, pv_precision, no
         signals.prec_signal[type(pv_precision)].connect(pydm_lineedit.precisionChanged)
         signals.prec_signal.emit(pv_precision)
 
-        assert pydm_lineedit._prec == pv_precision
+        assert pydm_lineedit.precision == pv_precision
     else:
-        assert pydm_lineedit._prec == non_pv_precision if non_pv_precision else pydm_lineedit._prec == 0
+        assert pydm_lineedit.precision == (non_pv_precision if non_pv_precision is not None else 0)
 
 
 @pytest.mark.parametrize("new_unit", [

--- a/pydm/tests/widgets/test_spinbox.py
+++ b/pydm/tests/widgets/test_spinbox.py
@@ -73,7 +73,7 @@ def test_key_press_event(qtbot, signals, monkeypatch, first_key_pressed, second_
         pydm_spinbox.show()
 
     pydm_spinbox.step_exponent = 0
-    pydm_spinbox._precision_from_pv = True
+    pydm_spinbox.precisionFromPV = True
     signals.prec_signal[int].connect(pydm_spinbox.precisionChanged)
     signals.prec_signal[int].emit(3)
 
@@ -270,7 +270,7 @@ def test_send_value(qtbot, signals, init_value, user_typed_value, precision):
 
     pydm_spinbox.setValue(init_value)
 
-    pydm_spinbox._precision_from_pv = True
+    pydm_spinbox.precisionFromPV = True
     signals.prec_signal[type(precision)].connect(pydm_spinbox.precisionChanged)
     signals.prec_signal[type(precision)].emit(precision)
 

--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -202,10 +202,13 @@ class PyDMPrimitiveWidget(object):
                 logger.exception('Invalid format for Rules')
 
 class TextFormatter(object):
+
+    default_precision_from_pv = True
+
     def __init__(self):
         self._show_units = False
         self.format_string = "{}"
-        self._precision_from_pv = True
+        self._precision_from_pv = None
         self._prec = 0
         self._unit = ""
     
@@ -238,7 +241,7 @@ class TextFormatter(object):
         new_precison : int or float
             The new precision value
         """
-        if self._precision_from_pv and new_precision != self._prec:
+        if self.precisionFromPV and new_precision != self._prec:
             self._prec = new_precision
             if self.value is not None:
                 self.value_changed(self.value)
@@ -282,7 +285,7 @@ class TextFormatter(object):
         """
         # Only allow one to change the property if not getting the precision
         # from the PV
-        if self._precision_from_pv:
+        if self._precision_from_pv is not None and self._precision_from_pv:
             return
         if new_prec and self._prec != int(new_prec) and new_prec >= 0:
             self._prec = int(new_prec)
@@ -376,7 +379,9 @@ class TextFormatter(object):
             True means that the widget will use the precision information
             from the Channel if available.
         """
-        return self._precision_from_pv
+        return (self._precision_from_pv
+                if self._precision_from_pv is not None
+                else self.default_precision_from_pv)
 
     @precisionFromPV.setter
     def precisionFromPV(self, value):
@@ -400,7 +405,7 @@ class TextFormatter(object):
             True means that the widget will use the precision information
             from the PV if available.
         """
-        if self._precision_from_pv != bool(value):
+        if self._precision_from_pv is None or self._precision_from_pv != bool(value):
             self._precision_from_pv = value
     
     def value_changed(self, new_val):


### PR DESCRIPTION
When user in Qt Designer sets precisionFromPV to False, and some non-zero precision, it will be disregarded in some cases, if precisionFromPV is parsed after, because during object creation it defaults to True and precision setter gets ignored.