### PR TITLE
BUG: loadWhenShown in Qt Designer loses embedded widget

### DIFF
--- a/pydm/widgets/embedded_display.py
+++ b/pydm/widgets/embedded_display.py
@@ -136,7 +136,8 @@ class PyDMEmbeddedDisplay(QFrame, PyDMPrimitiveWidget):
         return m
 
     def load_if_needed(self):
-        if (not self._only_load_when_shown) or self.isVisible() or is_qt_designer():
+        if self._needs_load and (
+                not self._only_load_when_shown or self.isVisible() or is_qt_designer()):
             self.embedded_widget = self.open_file()
 
     def open_file(self, force=False):


### PR DESCRIPTION
Scenario:
1. Have a PyDMEmbeddedDisplay with some inner UI, which normally gets rendered by the Qt Designer
2. Toggle loadWhenShown property
3. Embedded display is not rendered until next restart of Qt Designer

Cause:
Because of the invalid condition, existing widget was set to None