### PR TITLE
Value should not be reset in Qt Desinger when changing DisplayFormat or precision

### DIFF
--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -8,8 +8,7 @@ from qtpy.QtWidgets import (QApplication, QMenu, QGraphicsOpacityEffect,
 from qtpy.QtGui import QCursor
 from qtpy.QtCore import Qt, QEvent, Signal, Slot, Property
 from .channel import PyDMChannel
-from .. import data_plugins
-from .. import tools
+from .. import data_plugins, tools, config
 from ..utilities import is_qt_designer, remove_protocol
 from .rules import RulesDispatcher
 
@@ -289,7 +288,8 @@ class TextFormatter(object):
             return
         if new_prec and self._prec != int(new_prec) and new_prec >= 0:
             self._prec = int(new_prec)
-            self.value_changed(self.value)
+            if not is_qt_designer() or config.DESIGNER_ONLINE:
+                self.value_changed(self.value)
     
     @Slot(str)
     def unitChanged(self, new_unit):

--- a/pydm/widgets/label.py
+++ b/pydm/widgets/label.py
@@ -2,7 +2,8 @@ from .base import PyDMWidget, TextFormatter
 from qtpy.QtWidgets import QLabel, QApplication
 from qtpy.QtCore import Qt, Property, Q_ENUMS
 from .display_format import DisplayFormat, parse_value_for_display
-from pydm.utilities import is_pydm_app
+from pydm.utilities import is_pydm_app, is_qt_designer
+from pydm import config
 
 
 class PyDMLabel(QLabel, TextFormatter, PyDMWidget, DisplayFormat):
@@ -46,8 +47,10 @@ class PyDMLabel(QLabel, TextFormatter, PyDMWidget, DisplayFormat):
 
     @displayFormat.setter
     def displayFormat(self, new_type):
-        if self._display_format_type != new_type:
-            self._display_format_type = new_type
+        if self._display_format_type == new_type:
+            return
+        self._display_format_type = new_type
+        if not is_qt_designer() or config.DESIGNER_ONLINE:
             # Trigger the update of display format
             self.value_changed(self.value)
 


### PR DESCRIPTION
In Qt Designer:
1. Set a custom "text" on a PyDMLabel
2. Select any DisplayFormat -> text is reset to None
3. OR Uncheck precisionFromPV and change "precision" -> text is reset to None

Changing the precision on PyDMSpinBox would actually crash the Designer, as PyDMSpinBox cannot accept None as value.