### PR TITLE
Initialize data plugins only on demand to avoid circular imports

### DIFF
--- a/pydm/about_pydm/about.py
+++ b/pydm/about_pydm/about.py
@@ -57,6 +57,7 @@ class AboutWindow(QWidget):
         self.ui.dataPluginsTableWidget.setHorizontalHeaderLabels(col_labels)
         self.ui.dataPluginsTableWidget.horizontalHeader().setStretchLastSection(True)
         self.ui.dataPluginsTableWidget.verticalHeader().setVisible(False)
+        pydm.data_plugins.initialize_plugins_if_needed()
         for (protocol, plugin) in pydm.data_plugins.plugin_modules.items():
             protocol_item = QTableWidgetItem(protocol)
             file_item = QTableWidgetItem(inspect.getfile(plugin.__class__))

--- a/pydm/data_plugins/__init__.py
+++ b/pydm/data_plugins/__init__.py
@@ -23,6 +23,7 @@ global __CONNECTION_QUEUE__
 __CONNECTION_QUEUE__ = None
 global __DEFER_CONNECTIONS__
 __DEFER_CONNECTIONS__ = False
+__plugins_initialized = False
 
 @contextmanager
 def connection_queue(defer_connections=False):
@@ -77,6 +78,7 @@ def plugin_for_address(address):
         protocol = config.DEFAULT_PROTOCOL
     # Load proper plugin module
     if protocol:
+        initialize_plugins_if_needed()
         try:
             return plugin_modules[str(protocol)]
         except KeyError as exc:
@@ -188,20 +190,28 @@ def set_read_only(read_only):
         logger.info("Running PyDM in Read Only mode.")
 
 
-# Load the data plugins from PYDM_DATA_PLUGINS_PATH
-logger.debug("*"*80)
-logger.debug("* Loading PyDM Data Plugins")
-logger.debug("*"*80)
+def initialize_plugins_if_needed():
+    global __plugins_initialized
 
-DATA_PLUGIN_TOKEN = "_plugin.py"
-path = os.getenv("PYDM_DATA_PLUGINS_PATH", None)
-if path is None:
-    locations = []
-else:
-    locations = path.split(os.pathsep)
+    if __plugins_initialized:
+        return
 
-# Ensure that we first visit the local data_plugins location
-plugin_dir = os.path.dirname(os.path.realpath(__file__))
-locations.insert(0, plugin_dir)
+    __plugins_initialized = True
 
-load_plugins_from_path(locations, DATA_PLUGIN_TOKEN)
+    # Load the data plugins from PYDM_DATA_PLUGINS_PATH
+    logger.debug("*"*80)
+    logger.debug("* Loading PyDM Data Plugins")
+    logger.debug("*"*80)
+
+    DATA_PLUGIN_TOKEN = "_plugin.py"
+    path = os.getenv("PYDM_DATA_PLUGINS_PATH", None)
+    if path is None:
+        locations = []
+    else:
+        locations = path.split(os.pathsep)
+
+    # Ensure that we first visit the local data_plugins location
+    plugin_dir = os.path.dirname(os.path.realpath(__file__))
+    locations.insert(0, plugin_dir)
+
+    load_plugins_from_path(locations, DATA_PLUGIN_TOKEN)

--- a/pydm/tests/test_data_plugins_import.py
+++ b/pydm/tests/test_data_plugins_import.py
@@ -1,12 +1,13 @@
 import os
 
-import pydm.data_plugins
-from pydm.data_plugins import (plugin_modules, load_plugins_from_path,
-                               plugin_for_address)
+from pydm.data_plugins import (initialize_plugins_if_needed, plugin_modules,
+                               load_plugins_from_path, plugin_for_address)
 from pydm import config
+
 
 def test_data_plugin_add(qapp, test_plugin):
     # Check that adding this after import will be reflected in PyDMApp
+    initialize_plugins_if_needed()
     assert isinstance(plugin_modules['tst'], test_plugin)
     assert isinstance(qapp.plugins['tst'], test_plugin)
 

--- a/pydm/widgets/template_repeater.py
+++ b/pydm/widgets/template_repeater.py
@@ -11,7 +11,6 @@ from pydm.utilities import is_qt_designer, is_pydm_app
 import pydm.data_plugins
 from ..utilities import macro
 logger = logging.getLogger(__name__)
-pydm.data_plugins.initialize_plugins_if_needed()
 
 class FlowLayout(QLayout):
     def __init__(self, parent=None, margin=-1, h_spacing=-1, v_spacing=-1):
@@ -139,6 +138,7 @@ class PyDMTemplateRepeater(QFrame, PyDMPrimitiveWidget, LayoutType):
     Q_ENUMS(LayoutType)
     LayoutType = LayoutType
     def __init__(self, parent=None):
+        pydm.data_plugins.initialize_plugins_if_needed()
         QFrame.__init__(self, parent)
         PyDMPrimitiveWidget.__init__(self)
         self._template_filename = ""

--- a/pydm/widgets/template_repeater.py
+++ b/pydm/widgets/template_repeater.py
@@ -3,15 +3,15 @@ import json
 import logging
 from qtpy.QtWidgets import (QFrame, QApplication, QLabel, QVBoxLayout,
                            QHBoxLayout, QWidget, QStyle, QSizePolicy,
-                           QLayout, QListWidget, QListWidgetItem)
-from qtpy.QtCore import Qt, QSize, QRect, Slot, Property, QPoint, QUrl, Q_ENUMS
+                           QLayout)
+from qtpy.QtCore import Qt, QSize, QRect, Property, QPoint, Q_ENUMS
 from qtpy import uic
-from .base import PyDMPrimitiveWidget, PyDMWidget
-from .embedded_display import PyDMEmbeddedDisplay
+from .base import PyDMPrimitiveWidget
 from pydm.utilities import is_qt_designer, is_pydm_app
 import pydm.data_plugins
 from ..utilities import macro
 logger = logging.getLogger(__name__)
+pydm.data_plugins.initialize_plugins_if_needed()
 
 class FlowLayout(QLayout):
     def __init__(self, parent=None, margin=-1, h_spacing=-1, v_spacing=-1):


### PR DESCRIPTION
This patch wraps code executed in `pydm.data_plugins.__init__.py` into a function that is executed on demand.
The problem it was causing me is the circular import, when in my data plugin, I would do
```python
import pydm.widgets.channel
```
and receive exception:
```
undefined symbol: is_qt_designer
```

The problem was that `channel.py` imports `pydm.data_plugins` first, which in turn loads the plugins right away, including my plugin. That file will try to import `channel.py`, which did not yet have time to finish imports, such as `pydm.utilities.is_qt_designer`. By initializing data plugins on demand, it is deferred until the connection gets established.