### PR TITLE
BUG: Prevent PyDMSpinBox from crashing when receiving None

### DIFF
--- a/pydm/widgets/spinbox.py
+++ b/pydm/widgets/spinbox.py
@@ -107,6 +107,10 @@ class PyDMSpinbox(QDoubleSpinBox, TextFormatter, PyDMWritableWidget):
         new_val : int or float
             The new value from the channel.
         """
+        if new_val is None:
+            # SpinBox is unable to work with None and
+            # but sometimes it can arrive as an initial value
+            return
         super(PyDMSpinbox, self).value_changed(new_val)
         self.valueBeingSet = True
         self.setValue(new_val)


### PR DESCRIPTION
When creating a PyDMSpinBox in Qt Designer:
1.  Set precisionFromPV to False
2.  Set precision to 2
3.  Set channel

When launching this application, it crashes because PyDMSpinBox receives initial `None` value, which it cannot handle.
