### PR TITLE
BUG: Prevent PyDMScaleIndicator from crashing when receiving None

### DIFF
--- a/pydm/widgets/scale.py
+++ b/pydm/widgets/scale.py
@@ -202,7 +202,7 @@ class QScale(QFrame):
         """
         Calculate the position (pixel) in which the pointer should be drawn for a given value.
         """
-        if value < self._lower_limit or value > self._upper_limit or \
+        if value is None or value < self._lower_limit or value > self._upper_limit or \
            self._upper_limit - self._lower_limit == 0:
             proportion = -1 # Invalid
         else:


### PR DESCRIPTION
When creating a PyDMScaleIndicator in Qt Designer:

    Set precisionFromPV to False
    Set precision to 2
    Set channel

When launching this application, it crashes because PyDMScaleIndicator receives initial None value, which it cannot handle.