### PR TITLE
FIX: Separate precision from channel from precision from user defined property.

### DIFF
--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -208,6 +208,7 @@ class TextFormatter(object):
         self._show_units = False
         self.format_string = "{}"
         self._precision_from_pv = None
+        self._user_prec = 0
         self._prec = 0
         self._unit = ""
     
@@ -224,7 +225,7 @@ class TextFormatter(object):
         """
         self.format_string = "{}"
         if isinstance(self.value, (int, float)):
-            self.format_string = "{:." + str(self._prec) + "f}"
+            self.format_string = "{:." + str(self.precision) + "f}"
         if self._show_units and self._unit != "":
             self.format_string += " {}".format(self._unit)
         return self.format_string
@@ -269,7 +270,9 @@ class TextFormatter(object):
         prec : int
             The current precision value
         """
-        return self._prec
+        if self.precisionFromPV:
+            return self._prec
+        return self._user_prec
 
     @precision.setter
     def precision(self, new_prec):
@@ -284,10 +287,10 @@ class TextFormatter(object):
         """
         # Only allow one to change the property if not getting the precision
         # from the PV
-        if self._precision_from_pv is not None and self._precision_from_pv:
+        if self.precisionFromPV:
             return
         if new_prec and self._prec != int(new_prec) and new_prec >= 0:
-            self._prec = int(new_prec)
+            self._user_prec = int(new_prec)
             if not is_qt_designer() or config.DESIGNER_ONLINE:
                 self.value_changed(self.value)
     
@@ -407,6 +410,7 @@ class TextFormatter(object):
         """
         if self._precision_from_pv is None or self._precision_from_pv != bool(value):
             self._precision_from_pv = value
+            self.update_format_string()
     
     def value_changed(self, new_val):
         """

--- a/pydm/widgets/label.py
+++ b/pydm/widgets/label.py
@@ -65,7 +65,7 @@ class PyDMLabel(QLabel, TextFormatter, PyDMWidget, DisplayFormat):
             The new value from the channel. The type depends on the channel.
         """
         super(PyDMLabel, self).value_changed(new_value)
-        new_value = parse_value_for_display(value=new_value, precision=self._prec,
+        new_value = parse_value_for_display(value=new_value, precision=self.precision,
                                             display_format_type=self._display_format_type,
                                             string_encoding=self._string_encoding,
                                             widget=self)

--- a/pydm/widgets/line_edit.py
+++ b/pydm/widgets/line_edit.py
@@ -236,7 +236,7 @@ class PyDMLineEdit(QLineEdit, TextFormatter, PyDMWritableWidget, DisplayFormat):
                     logger.error("Cannot convert the value '{0}', for channel '{1}', to type '{2}'. ".format(
                         self._scale, self._channel, self.channeltype))
 
-        new_value = parse_value_for_display(value=new_value,  precision=self._prec,
+        new_value = parse_value_for_display(value=new_value,  precision=self.precision,
                                             display_format_type=self._display_format_type,
                                             string_encoding=self._string_encoding,
                                             widget=self)

--- a/pydm/widgets/spinbox.py
+++ b/pydm/widgets/spinbox.py
@@ -157,6 +157,22 @@ class PyDMSpinbox(QDoubleSpinBox, TextFormatter, PyDMWritableWidget):
         super(PyDMSpinbox, self).precision_changed(new_precision)
         self.setDecimals(new_precision)
 
+    @Property(int)
+    def precision(self):
+        if self.precisionFromPV:
+            return self._prec
+        else:
+            return self._user_prec
+
+    @precision.setter
+    def precision(self, new_prec):
+        if self.precisionFromPV:
+            return
+        if new_prec and self._user_prec != int(new_prec) and new_prec >= 0:
+            self._user_prec = int(new_prec)
+            self.value_changed(self.value)
+            self.setDecimals(new_prec)
+
     @Property(bool)
     def showStepExponent(self):
         """


### PR DESCRIPTION
This fix address the race condition of loading UI files in which sometimes the property precision is interpreted before the precisionFromPV. This fix was tested and it is working properly.
It is a backport of a fix that I was going to submit to 2.0 branch.