### PR TITLE
ENH: Some new functionalities for ExternalTools

### DIFF
--- a/examples/external_tool/lookup_path/new_tool.py
+++ b/examples/external_tool/lookup_path/new_tool.py
@@ -9,7 +9,10 @@ class DummyTool2(ExternalTool):
         name = "Dummy Tool 2"
         group = "Example"
         use_with_widgets = True
-        ExternalTool.__init__(self, icon=icon, name=name, group=group, use_with_widgets=use_with_widgets)
+        use_without_widget = False
+        ExternalTool.__init__(self, icon=icon, name=name, group=group,
+                              use_with_widgets=use_with_widgets,
+                              use_without_widget=use_without_widget)
 
     def call(self, channels, sender):
         print("Called Dummy Tool 2 from: {} with:".format(sender))

--- a/pydm/tools/__init__.py
+++ b/pydm/tools/__init__.py
@@ -70,7 +70,7 @@ def install_external_tool(tool):
 
 
 def assemble_tools_menu(parent_menu, clear_menu=False, widget_only=False,
-                        **kwargs):
+                        widget=None, **kwargs):
     """
     Assemble the Tools menu for a given parent menu.
 
@@ -84,6 +84,11 @@ def assemble_tools_menu(parent_menu, clear_menu=False, widget_only=False,
         Whether or not generate only the menu for widgets compatible
         tools. This should be True when creating the menu for the
         PyDMWidgets and False for most of the other cases.
+    widget: QWidget
+        The widget for which the menu is being assembled. This allow for the
+        tools to filter if they are compatible or not with the widget based
+        on properties, types and etc. Default is None which means all tools
+        will be assembled.
     kwargs : dict
         Parameters sent directly to the `call` method of the ExternalTool
         instance. In general this dict is composed by `channels` which
@@ -110,8 +115,15 @@ def assemble_tools_menu(parent_menu, clear_menu=False, widget_only=False,
             m = QMenu(k, parent=parent_menu)
             should_create_menu = False
             for _, t in v.items():
-                if widget_only and not t.use_with_widgets:
-                    continue
+                if widget_only:
+                    if not t.use_with_widgets:
+                        continue
+                    if widget is not None and not t.is_compatible_with(widget):
+                        logger.debug('Skipping tool {} as it is incompatible with widget {}.'.format(t.name, widget))
+                        continue
+                else:
+                    if not t.use_without_widget:
+                        continue
                 assemble_action(m, t)
                 should_create_menu = True
             if should_create_menu:

--- a/pydm/tools/tools.py
+++ b/pydm/tools/tools.py
@@ -24,15 +24,18 @@ class ExternalTool():
         for the PyDMWidgets. If `False` the tool will be available at the Main Window
         menu only and will receive as a parameter `channels` as `None` and `sender` as
         the `main_window` object.
-
+    use_without_widgets : bool
+        Whether or not this action should be rendered at locations other than a
+        widget Custom Context Menu.
     """
-
-    def __init__(self, icon, name, group, author="", use_with_widgets=True):
+    def __init__(self, icon, name, group, author="", use_with_widgets=True,
+                 use_without_widget=True):
         self.icon = icon
         self.name = name
         self.group = group
         self.author = author
         self.use_with_widgets = use_with_widgets
+        self.use_without_widget = use_without_widget
 
     def call(self, channels, sender):
         """
@@ -87,3 +90,20 @@ class ExternalTool():
             'group': self.group,
             'name': self.name
             }
+
+    def is_compatible_with(self, widget):
+        """
+        Verify if the ExternalTool is compatible with the given widget.
+
+        Parameters
+        ----------
+        widget : QWidget
+            The widget for which the ExternalTool is being assembled.
+
+        Returns
+        -------
+        bool
+            True if this ExternalTool is compatible with the widget, False
+            otherwise.
+        """
+        return True

--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -516,7 +516,7 @@ class PyDMWidget(PyDMPrimitiveWidget):
             menu = QMenu(parent=self)
 
         kwargs = {'channels': self.channels_for_tools(), 'sender': self}
-        tools.assemble_tools_menu(menu, widget_only=True, **kwargs)
+        tools.assemble_tools_menu(menu, widget_only=True, widget=self, **kwargs)
         return menu
 
     def open_context_menu(self, ev):


### PR DESCRIPTION
- Allow one to specify that an ExternalTool is not to be used at the whole application menu. (`use_without_widget`)
- Allow ExternalTools to determine based on the widget if they are compatible or not with the widget before adding it to the menu.  E.g.: One can now filter out the EPICS ExternalTools for a widget using Archiver as the data plugin.

Attn. @slacrherbst 