### PR TITLE
Fix some slider problems

### DIFF
--- a/pydm/tests/widgets/test_slider.py
+++ b/pydm/tests/widgets/test_slider.py
@@ -256,19 +256,18 @@ def test_setup_widgets_for_orientation(qtbot, new_orientation):
         assert pydm_slider._slider.orientation() == new_orientation
 
 
-@pytest.mark.parametrize("minimum, maximum, current_value", [
-    (10, 20.5, 11),
-    (10, 1, 5),
-    (10, 20, 30),
-    (-10, 20.5, -5),
+@pytest.mark.parametrize("minimum, maximum", [
+    (10, 20.5),
+    (10, 1),
+    (10, 20),
+    (-10, 20.5),
 ])
-def test_update_labels(qtbot, signals, minimum, maximum, current_value):
+def test_update_labels(qtbot, signals, minimum, maximum):
     """
-    Test the changes in the user minimum, user maximum, and the current value labels as the widget's slider component
-    moves.
+    Test that changes in the user minimum and user maximum update the limit labels.
 
     Expectations:
-    The widget's min, max, and current values are reflected correctly on the correponsiding labels.
+    The widget's min and max are reflected correctly on the correponsiding labels.
 
     Parameters
     ----------
@@ -280,8 +279,6 @@ def test_update_labels(qtbot, signals, minimum, maximum, current_value):
         The slider's minimum value as set by the user
     maximum : int
         The slider's maximum value as set by the user
-    current_value : int
-        The current slider's value as set by the user
     """
     def validate(value, widget):
         if value is None:
@@ -296,14 +293,10 @@ def test_update_labels(qtbot, signals, minimum, maximum, current_value):
     pydm_slider.userMinimum = minimum
     pydm_slider.userMaximum = maximum
 
-    signals.internal_slider_moved[int].connect(pydm_slider.internal_slider_moved)
-    signals.internal_slider_moved[int].emit(current_value)
-
     pydm_slider.update_labels()
 
     validate(minimum, pydm_slider.low_lim_label)
     validate(maximum, pydm_slider.high_lim_label)
-    validate(pydm_slider._slider_position_to_value_map[current_value], pydm_slider.value_label)
 
 
 @pytest.mark.parametrize("minimum, maximum, write_access, connected", [

--- a/pydm/widgets/slider.py
+++ b/pydm/widgets/slider.py
@@ -333,15 +333,6 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget):
         ----------
         val : float
         """
-        # Avoid potential crash if limits are undefined
-        if self._slider_position_to_value_map is None:
-            return
-        # The user has moved the slider, we need to update our value.
-        # Only update the underlying value, not the self.value property,
-        # because we don't need to reset the slider position.    If we change
-        # self.value, we can get into a loop where the position changes, which
-        # updates the value, which changes the position again, etc etc.
-        self.value = self._slider_position_to_value_map[val]
         self.sliderMoved.emit(self.value)
 
     @Slot()
@@ -368,12 +359,12 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget):
         Parameters
         ----------
         val : int
-        """
-        # At this point, our local copy of the value reflects the position of the
-        # slider, now all we need to do is emit a signal to PyDM so that the data
-        # plugin will send a put to the channel.  Don't update self.value or self._value
-        # in here, it is pointless at best, and could cause an infinite loop at worst.
+        """        
+        # Avoid potential crash if limits are undefined
+        if self._slider_position_to_value_map is None:
+            return
         if not self._mute_internal_slider_changes:
+            self.value = self._slider_position_to_value_map[val]
             self.send_value_signal[float].emit(self.value)
 
     @Property(bool)

--- a/pydm/widgets/slider.py
+++ b/pydm/widgets/slider.py
@@ -31,6 +31,7 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget):
         self.alarmSensitiveContent = True
         self.alarmSensitiveBorder = False
         # Internal values for properties
+        self._ignore_mouse_wheel = False
         self._show_limit_labels = True
         self._show_value_label = True
         self._user_defined_limits = False
@@ -57,6 +58,7 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget):
         self.high_lim_label.setAlignment(Qt.AlignRight | Qt.AlignTrailing | Qt.AlignVCenter)
         self._slider = QSlider(parent=self)
         self._slider.setOrientation(Qt.Horizontal)
+        self._orig_wheel_event = self._slider.wheelEvent
         self._slider.sliderMoved.connect(self.internal_slider_moved)
         self._slider.sliderPressed.connect(self.internal_slider_pressed)
         self._slider.sliderReleased.connect(self.internal_slider_released)
@@ -67,6 +69,14 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget):
         self._mute_internal_slider_changes = False
         self.setup_widgets_for_orientation(self._orientation)
         self.reset_slider_limits()
+
+    def wheelEvent(self, e):
+        #We specifically want to ignore mouse wheel events.
+        if self._ignore_mouse_wheel:
+            e.ignore()
+        else:
+            super(PyDMSlider, self).wheelEvent(e)
+        return
 
     def init_for_designer(self):
         """
@@ -162,10 +172,13 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget):
         """
         Reset the limits and adjust the labels properly for the slider.
         """
+        print("{}: Running reset_slider_limits".format(self.channel))
         if self.minimum is None or self.maximum is None:
             self._needs_limit_info = True
+            print("{}: Needs both limits before reset_slider_limits can work.".format(self.channel))
             self.set_enable_state()
             return
+        print("{}: Has both limits, proceeding.".format(self.channel))
         self._needs_limit_info = False
         self._slider.setMinimum(0)
         self._slider.setMaximum(self._num_steps - 1)
@@ -191,6 +204,7 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget):
         int
         """
         diff = abs(self._slider_position_to_value_map - float(val))
+        print("{}: The closest value to {} is: {}".format(self.channel, val, self._slider_position_to_value_map[np.argmin(diff)]))
         return np.argmin(diff)
 
     def set_slider_to_closest_value(self, val):
@@ -202,6 +216,7 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget):
         val : float
         """
         if val is None or self._needs_limit_info:
+            print("{}: Not setting slider to closest value because we need limits.".format(self.channel))
             return
         # When we set the slider to the closest value, it may end up at a slightly
         # different position than val (if val is not in self._slider_position_to_value_map)
@@ -211,6 +226,7 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget):
         # it to where the slider gets set.  Therefore, we mute the internal slider changes
         # so that its valueChanged signal doesn't cause us to emit a signal to PyDM to change
         # the value of the channel.
+        print("{}: Setting slider to closest value.".format(self.channel))
         self._mute_internal_slider_changes = True
         self._slider.setValue(self.find_closest_slider_position_to_value(val))
         self._mute_internal_slider_changes = False
@@ -252,8 +268,10 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget):
         new_val : int or float
             The new value from the channel.
         """
+        print("{}: Slider got a new value = {}".format(self.channel, new_val))
         PyDMWritableWidget.value_changed(self, new_val)
         if hasattr(self, "value_label"):
+            print("{}: Setting text for value label.".format(self.channel))
             self.value_label.setText(self.format_string.format(self.value))
         if not self._slider.isSliderDown():
             self.set_slider_to_closest_value(self.value)
@@ -270,6 +288,7 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget):
         new_limit : float
             New value for the control limit
         """
+        print("{}: {} limit changed to {}".format(self.channel, which, new_limit))
         PyDMWritableWidget.ctrl_limit_changed(self, which, new_limit)
         if not self.userDefinedLimits:
             self.reset_slider_limits()
@@ -356,6 +375,23 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget):
         # in here, it is pointless at best, and could cause an infinite loop at worst.
         if not self._mute_internal_slider_changes:
             self.send_value_signal[float].emit(self.value)
+
+    @Property(bool)
+    def ignoreMouseWheel(self):
+        """
+        If true, the mouse wheel will not change the value of the slider.
+        This is useful if you want to put sliders inside a scroll view, and
+        don't want to accidentally change the slider as you are scrolling.
+        """
+        return self._ignore_mouse_wheel
+        
+    @ignoreMouseWheel.setter
+    def ignoreMouseWheel(self, checked):
+        self._ignore_mouse_wheel = checked
+        if checked:
+            self._slider.wheelEvent = self.wheelEvent
+        else:
+            self._slider.wheelEvent = self._orig_wheel_event
 
     @Property(bool)
     def showLimitLabels(self):

--- a/pydm/widgets/slider.py
+++ b/pydm/widgets/slider.py
@@ -368,6 +368,37 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget):
             self.send_value_signal[float].emit(self.value)
 
     @Property(bool)
+    def tracking(self):
+        """
+        If tracking is enabled (the default), the slider emits new values
+        while the slider is being dragged.  If tracking is disabled, it will
+        only emit new values when the user releases the slider.  Tracking can
+        cause PyDM to rapidly send new values to the channel.  If you are using
+        the slider to control physical hardware, consider whether the device
+        you want to control can handle large amounts of changes in a short
+        timespan.
+        """
+        return self._slider.hasTracking()
+        
+    @tracking.setter
+    def tracking(self, checked):
+        self._slider.setTracking(checked)
+    
+    def hasTracking(self):
+        """
+        An alternative function to get the tracking property, to match what
+        Qt provides for QSlider.
+        """
+        return self.tracking
+    
+    def setTracking(self, checked):
+        """
+        An alternative function to set the tracking property, to match what
+        Qt provides for QSlider.
+        """
+        self.tracking = checked
+
+    @Property(bool)
     def ignoreMouseWheel(self):
         """
         If true, the mouse wheel will not change the value of the slider.

--- a/pydm/widgets/slider.py
+++ b/pydm/widgets/slider.py
@@ -172,13 +172,13 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget):
         """
         Reset the limits and adjust the labels properly for the slider.
         """
-        print("{}: Running reset_slider_limits".format(self.channel))
+        logger.debug("Running reset_slider_limits.")
         if self.minimum is None or self.maximum is None:
             self._needs_limit_info = True
-            print("{}: Needs both limits before reset_slider_limits can work.".format(self.channel))
+            logger.debug("Need both limits before reset_slider_limits can work.")
             self.set_enable_state()
             return
-        print("{}: Has both limits, proceeding.".format(self.channel))
+        logger.debug("Has both limits, proceeding.")
         self._needs_limit_info = False
         self._slider.setMinimum(0)
         self._slider.setMaximum(self._num_steps - 1)
@@ -204,7 +204,7 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget):
         int
         """
         diff = abs(self._slider_position_to_value_map - float(val))
-        print("{}: The closest value to {} is: {}".format(self.channel, val, self._slider_position_to_value_map[np.argmin(diff)]))
+        logger.debug("The closest value to %f is: %f", val, self._slider_position_to_value_map[np.argmin(diff)])
         return np.argmin(diff)
 
     def set_slider_to_closest_value(self, val):
@@ -216,7 +216,7 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget):
         val : float
         """
         if val is None or self._needs_limit_info:
-            print("{}: Not setting slider to closest value because we need limits.".format(self.channel))
+            logger.debug("Not setting slider to closest value because we need limits.")
             return
         # When we set the slider to the closest value, it may end up at a slightly
         # different position than val (if val is not in self._slider_position_to_value_map)
@@ -226,7 +226,7 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget):
         # it to where the slider gets set.  Therefore, we mute the internal slider changes
         # so that its valueChanged signal doesn't cause us to emit a signal to PyDM to change
         # the value of the channel.
-        print("{}: Setting slider to closest value.".format(self.channel))
+        logger.debug("Setting slider to closest value.")
         self._mute_internal_slider_changes = True
         self._slider.setValue(self.find_closest_slider_position_to_value(val))
         self._mute_internal_slider_changes = False
@@ -268,10 +268,10 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget):
         new_val : int or float
             The new value from the channel.
         """
-        print("{}: Slider got a new value = {}".format(self.channel, new_val))
+        logger.debug("Slider got a new value = %f", float(new_val))
         PyDMWritableWidget.value_changed(self, new_val)
         if hasattr(self, "value_label"):
-            print("{}: Setting text for value label.".format(self.channel))
+            logger.debug("Setting text for value label.")
             self.value_label.setText(self.format_string.format(self.value))
         if not self._slider.isSliderDown():
             self.set_slider_to_closest_value(self.value)
@@ -288,7 +288,7 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget):
         new_limit : float
             New value for the control limit
         """
-        print("{}: {} limit changed to {}".format(self.channel, which, new_limit))
+        logger.debug("%s limit changed to %f", which, new_limit)
         PyDMWritableWidget.ctrl_limit_changed(self, which, new_limit)
         if not self.userDefinedLimits:
             self.reset_slider_limits()


### PR DESCRIPTION
The slider had two issues:

1. Clicking on the slider bar to jump to a new value (rather than dragging the handle around) would move the handle, but would not update the slider's value.  This PR fixes that by moving the slider's value calculation from the 'internal_slider_moved' slot (which is only called during a drag, not a click) to the 'internal_slider_value_changed' slot (which is called after a drag OR click).

2. If a slider was embedded in a scroll view, you could accidentally change the slider value while trying to scroll using the mouse wheel.  This PR fixes that by adding a new property, "ignoreMouseWheel", that lets you disable slider value changes via the mouse wheel.