### PR TITLE
CI: Attempt to fix Windows build

### DIFF
--- a/azure-test-template-win.yml
+++ b/azure-test-template-win.yml
@@ -31,6 +31,7 @@ jobs:
   - bash: |
       conda config --set always_yes yes
       conda config --set channel_priority strict
+      conda config --set show_channel_urls yes
       conda config --add channels conda-forge
       conda config --add channels 'file:///$(Build.Repository.LocalPath)/bld-dir'
     displayName: 'Anaconda - Configure - Add local bld-dir'
@@ -43,7 +44,7 @@ jobs:
 
   - script: |
       call activate test-environment-$(python.name)
-      conda build conda-recipe -c conda-forge --python=$(python.version) --output-folder bld-dir
+      conda build conda-recipe --python=$(python.version) --output-folder bld-dir
     displayName: 'Anaconda - Build PyDM Package'
 
   - task: PublishBuildArtifacts@1
@@ -54,7 +55,7 @@ jobs:
 
   - script: |
       call activate test-environment-$(python.name)
-      conda install -q pytest-azurepipelines pydm --file dev-requirements.txt -c conda-forge --update-deps
+      conda install -q pytest-azurepipelines pydm --file dev-requirements.txt --update-deps
     displayName: 'Anaconda - Install Dependencies'
 
   - script: |

--- a/azure-test-template-win.yml
+++ b/azure-test-template-win.yml
@@ -30,8 +30,8 @@ jobs:
 
   - bash: |
       conda config --set always_yes yes
-      conda config --add channels conda-forge
       conda config --add channels 'file:///$(Build.Repository.LocalPath)/bld-dir'
+      conda config --add channels conda-forge
     displayName: 'Anaconda - Configure - Add local bld-dir'
 
   - script: |
@@ -53,7 +53,7 @@ jobs:
 
   - script: |
       call activate test-environment-$(python.name)
-      conda install -q -c conda-forge pytest-azurepipelines pydm --file dev-requirements.txt
+      conda install -q pytest-azurepipelines pydm --file dev-requirements.txt -c conda-forge
     displayName: 'Anaconda - Install Dependencies'
 
   - script: |

--- a/azure-test-template-win.yml
+++ b/azure-test-template-win.yml
@@ -30,6 +30,7 @@ jobs:
 
   - bash: |
       conda config --set always_yes yes
+      conda config --set channel_priority strict
       conda config --add channels conda-forge
       conda config --add channels 'file:///$(Build.Repository.LocalPath)/bld-dir'
     displayName: 'Anaconda - Configure - Add local bld-dir'

--- a/azure-test-template-win.yml
+++ b/azure-test-template-win.yml
@@ -30,8 +30,8 @@ jobs:
 
   - bash: |
       conda config --set always_yes yes
-      conda config --add channels 'file:///$(Build.Repository.LocalPath)/bld-dir'
       conda config --add channels conda-forge
+      conda config --add channels 'file:///$(Build.Repository.LocalPath)/bld-dir'
     displayName: 'Anaconda - Configure - Add local bld-dir'
 
   - script: |
@@ -53,7 +53,7 @@ jobs:
 
   - script: |
       call activate test-environment-$(python.name)
-      conda install -q pytest-azurepipelines pydm --file dev-requirements.txt -c conda-forge
+      conda install -q pytest-azurepipelines pydm --file dev-requirements.txt -c conda-forge --update-deps
     displayName: 'Anaconda - Install Dependencies'
 
   - script: |

--- a/azure-test-template-win.yml
+++ b/azure-test-template-win.yml
@@ -53,16 +53,8 @@ jobs:
 
   - script: |
       call activate test-environment-$(python.name)
-      conda install -q -c conda-forge epics-base pytest-azurepipelines pydm --file dev-requirements.txt
+      conda install -q -c conda-forge pytest-azurepipelines pydm --file dev-requirements.txt
     displayName: 'Anaconda - Install Dependencies'
-
-  # Windows Only
-  - powershell: |
-      $MyProcess = Start-Process $Env:REPEATER -PassThru
-    env:
-      REPEATER: C:\Miniconda\envs\test-environment-$(python.name)\epics\bin\windows-x64\caRepeater.exe
-    displayName: 'Windows - Start CaRepeater'
-    condition: eq(variables['agent.os'], 'Windows_NT' )
 
   - script: |
       call activate test-environment-$(python.name)
@@ -76,9 +68,6 @@ jobs:
   - script: |
       call activate test-environment-$(python.name)
       python run_tests.py --show-cov --test-run-title="Tests for $(Agent.OS) - Python $(python.version)" --napoleon-docstrings
-    env:
-      PYEPICS_LIBCA: C:\Miniconda\envs\test-environment-$(python.name)\epics\lib\ca.lib
-      PATH: C:\Miniconda\envs\test-environment-$(python.name)\epics\lib:C:\Miniconda\envs\test-environment-$(python.name)\epics\bin:$(PATH)
     displayName: 'Tests - Run'
     continueOnError: false
 

--- a/azure-test-template.yml
+++ b/azure-test-template.yml
@@ -66,9 +66,10 @@ jobs:
 
   - bash: |
       source activate base
+      conda update --all
       conda config --set always_yes yes
-      conda config --add channels conda-forge
       conda config --add channels 'file:///$(Build.Repository.LocalPath)/bld-dir'
+      conda config --add channels conda-forge
     displayName: 'Anaconda - Configure - Add local bld-dir'
 
   - bash: |
@@ -90,7 +91,7 @@ jobs:
 
   - bash: |
       source activate base
-      conda install -q -c conda-forge pydm --file dev-requirements.txt
+      conda install -q pydm --file dev-requirements.txt -c conda-forge
       pip install pytest-azurepipelines
     displayName: 'Anaconda - Install Dependencies'
 

--- a/azure-test-template.yml
+++ b/azure-test-template.yml
@@ -68,8 +68,8 @@ jobs:
       source activate base
       conda update --all
       conda config --set always_yes yes
-      conda config --add channels 'file:///$(Build.Repository.LocalPath)/bld-dir'
       conda config --add channels conda-forge
+      conda config --add channels 'file:///$(Build.Repository.LocalPath)/bld-dir'
     displayName: 'Anaconda - Configure - Add local bld-dir'
 
   - bash: |
@@ -91,7 +91,7 @@ jobs:
 
   - bash: |
       source activate base
-      conda install -q pydm --file dev-requirements.txt -c conda-forge
+      conda install -q pydm --file dev-requirements.txt -c conda-forge --update-deps
       pip install pytest-azurepipelines
     displayName: 'Anaconda - Install Dependencies'
 

--- a/azure-test-template.yml
+++ b/azure-test-template.yml
@@ -69,6 +69,7 @@ jobs:
       conda update --all
       conda config --set always_yes yes
       conda config --set channel_priority strict
+      conda config --set show_channel_urls yes
       conda config --add channels conda-forge
       conda config --add channels 'file:///$(Build.Repository.LocalPath)/bld-dir'
     displayName: 'Anaconda - Configure - Add local bld-dir'
@@ -81,7 +82,7 @@ jobs:
 
   - bash: |
       source activate base
-      conda build conda-recipe -c conda-forge --python=$(python.version) --output-folder bld-dir
+      conda build conda-recipe --python=$(python.version) --output-folder bld-dir
     displayName: 'Anaconda - Build PyDM Package'
 
   - task: PublishBuildArtifacts@1
@@ -92,7 +93,7 @@ jobs:
 
   - bash: |
       source activate base
-      conda install -q pydm --file dev-requirements.txt -c conda-forge --update-deps
+      conda install -q pydm --file dev-requirements.txt --update-deps
       pip install pytest-azurepipelines
     displayName: 'Anaconda - Install Dependencies'
 

--- a/azure-test-template.yml
+++ b/azure-test-template.yml
@@ -66,7 +66,6 @@ jobs:
 
   - bash: |
       source activate base
-      conda update --all
       conda config --set always_yes yes
       conda config --set channel_priority strict
       conda config --set show_channel_urls yes

--- a/azure-test-template.yml
+++ b/azure-test-template.yml
@@ -68,6 +68,7 @@ jobs:
       source activate base
       conda update --all
       conda config --set always_yes yes
+      conda config --set channel_priority strict
       conda config --add channels conda-forge
       conda config --add channels 'file:///$(Build.Repository.LocalPath)/bld-dir'
     displayName: 'Anaconda - Configure - Add local bld-dir'

--- a/azure-test-template.yml
+++ b/azure-test-template.yml
@@ -90,7 +90,7 @@ jobs:
 
   - bash: |
       source activate base
-      conda install -q -c conda-forge epics-base pydm --file dev-requirements.txt
+      conda install -q -c conda-forge pydm --file dev-requirements.txt
       pip install pytest-azurepipelines
     displayName: 'Anaconda - Install Dependencies'
 


### PR DESCRIPTION
CI: Windows no longer needs caRepeater.
CI: epics-base is no longer required as pyepics now uses epicscorelibs.