### PR TITLE
Fix waveform plot bug that prevented constant waveforms from ever getting plotted.

### DIFF
--- a/pydm/widgets/waveformplot.py
+++ b/pydm/widgets/waveformplot.py
@@ -162,18 +162,22 @@ class WaveformCurveItem(BasePlotCurveItem):
         if self.redraw_mode == WaveformCurveItem.REDRAW_ON_EITHER:
             self.x_waveform = self.latest_x
             self.y_waveform = self.latest_y
+            self.data_changed.emit()
         elif self.redraw_mode == WaveformCurveItem.REDRAW_ON_X:
             if not self.needs_new_x:
                 self.x_waveform = self.latest_x
                 self.y_waveform = self.latest_y
+                self.data_changed.emit()
         elif self.redraw_mode == WaveformCurveItem.REDRAW_ON_Y:
             if not self.needs_new_y:
                 self.x_waveform = self.latest_x
                 self.y_waveform = self.latest_y
+                self.data_changed.emit()
         elif self.redraw_mode == WaveformCurveItem.REDRAW_ON_BOTH:
             if not (self.needs_new_y or self.needs_new_x):
                 self.x_waveform = self.latest_x
                 self.y_waveform = self.latest_y
+                self.data_changed.emit()
 
     @Slot(bool)
     def xConnectionStateChanged(self, connected):
@@ -197,7 +201,7 @@ class WaveformCurveItem(BasePlotCurveItem):
         # Don't redraw unless we already have Y data.
         if self.latest_y is not None:
             self.update_waveforms_if_ready()
-            self.data_changed.emit()
+            
 
     @Slot(np.ndarray)
     def receiveYWaveform(self, new_waveform):
@@ -212,7 +216,6 @@ class WaveformCurveItem(BasePlotCurveItem):
         self.needs_new_y = False
         if self.x_channel is None or self.latest_x is not None:
             self.update_waveforms_if_ready()
-            self.data_changed.emit()
 
     def redrawCurve(self):
         """

--- a/pydm/widgets/waveformplot.py
+++ b/pydm/widgets/waveformplot.py
@@ -197,6 +197,7 @@ class WaveformCurveItem(BasePlotCurveItem):
         # Don't redraw unless we already have Y data.
         if self.latest_y is not None:
             self.update_waveforms_if_ready()
+            self.data_changed.emit()
 
     @Slot(np.ndarray)
     def receiveYWaveform(self, new_waveform):


### PR DESCRIPTION
This PR fixes the problem reported by @anacso17 in #556, which prevented a waveform plot from drawing anything in the case where both X and Y waveforms have non-updating values.