### PR TITLE
Several channel connection fixes

### DIFF
--- a/pydm/data_plugins/plugin.py
+++ b/pydm/data_plugins/plugin.py
@@ -182,4 +182,5 @@ class PyDMPlugin(object):
                                                           destroying=destroying)
                 self.channels.remove(channel)
                 if self.connections[address].listener_count < 1:
+                    self.connections[address].deleteLater()
                     del self.connections[address]

--- a/pydm/widgets/embedded_display.py
+++ b/pydm/widgets/embedded_display.py
@@ -325,7 +325,6 @@ class PyDMEmbeddedDisplay(QFrame, PyDMPrimitiveWidget):
             if w:
                 self.embedded_widget = w
         if self.disconnectWhenHidden:
-            print("Embedded widget {} was shown".format(self))
             self.connect()
 
     def hideEvent(self, e):
@@ -337,7 +336,6 @@ class PyDMEmbeddedDisplay(QFrame, PyDMPrimitiveWidget):
         event : QHideEvent
         """
         if self.disconnectWhenHidden:
-            print("Embedded widget {} was hidden".format(self))
             self.disconnect()
 
     def _display_designer_load_error(self):

--- a/pydm/widgets/embedded_display.py
+++ b/pydm/widgets/embedded_display.py
@@ -255,6 +255,7 @@ class PyDMEmbeddedDisplay(QFrame, PyDMPrimitiveWidget):
         if self._is_connected or self.embedded_widget is None:
             return
         establish_widget_connections(self.embedded_widget)
+        self._is_connected = True
 
     def disconnect(self):
         """
@@ -264,6 +265,7 @@ class PyDMEmbeddedDisplay(QFrame, PyDMPrimitiveWidget):
         if not self._is_connected or self.embedded_widget is None:
             return
         close_widget_connections(self.embedded_widget)
+        self._is_connected = False
 
     @Property(bool)
     def loadWhenShown(self):
@@ -323,6 +325,7 @@ class PyDMEmbeddedDisplay(QFrame, PyDMPrimitiveWidget):
             if w:
                 self.embedded_widget = w
         if self.disconnectWhenHidden:
+            print("Embedded widget {} was shown".format(self))
             self.connect()
 
     def hideEvent(self, e):
@@ -334,6 +337,7 @@ class PyDMEmbeddedDisplay(QFrame, PyDMPrimitiveWidget):
         event : QHideEvent
         """
         if self.disconnectWhenHidden:
+            print("Embedded widget {} was hidden".format(self))
             self.disconnect()
 
     def _display_designer_load_error(self):


### PR DESCRIPTION
This PR fixes three separate bugs related to connections:

1) A bug in the embedded display widget.  When `disconnectWhenHidden` is true, the widget is supposed to disconnect from its channels on a hideEvent, then on a showEvent, it is supposed to reconnect.  Due to a missing update to the `_is_connected` variable, the reconnect was never happening on a showEvent.

2) A bug that would cause completely disconnected PyDMConnection objects to stick around, and sometimes cause havoc, since they were in a disconnected state, but could potentially maintain things like write callbacks.

3) A bug in the PSP data plugin.  There were cases where widgets wouldn't receive enum string values, or the read/write access state from a PSP connection.