### PR TITLE
FIX: Template Repeater was not protecting against invalid JSON

### DIFF
--- a/pydm/widgets/embedded_display.py
+++ b/pydm/widgets/embedded_display.py
@@ -166,6 +166,10 @@ class PyDMEmbeddedDisplay(QFrame, PyDMPrimitiveWidget):
             full_fname = os.path.join(self.base_path, fname)
         else:
             full_fname = fname
+
+        if not full_fname:
+            return
+
         if not is_pydm_app():
             (filename, extension) = os.path.splitext(full_fname)
             if extension == ".ui":

--- a/pydm/widgets/template_repeater.py
+++ b/pydm/widgets/template_repeater.py
@@ -13,6 +13,7 @@ import pydm.data_plugins
 from ..utilities import macro
 logger = logging.getLogger(__name__)
 
+
 class FlowLayout(QLayout):
     def __init__(self, parent=None, margin=-1, h_spacing=-1, v_spacing=-1):
         QLayout.__init__(self, parent)
@@ -291,7 +292,11 @@ class PyDMTemplateRepeater(QFrame, PyDMPrimitiveWidget, LayoutType):
                         # display (.ui or .py file).
                         fname = self.app.get_path(fname)
                     with open(fname) as f:
-                        self.data = json.load(f)
+                        try:
+                            self.data = json.load(f)
+                        except ValueError:
+                            logger.error('Failed to parse data source file for PyDMTemplateRepeater.')
+                            self.data = []
                 except IOError as e:
                     self.data = []
             else:


### PR DESCRIPTION
Close #563 
This PR also address the issue with the EmbeddedDisplay when full_fname is None.