### PR TITLE
ENH: Add exception hook when running with Qt Designer.

### DIFF
--- a/azure-test-template-win.yml
+++ b/azure-test-template-win.yml
@@ -66,3 +66,9 @@ jobs:
       python run_tests.py --timeout 30 --show-cov --test-run-title="Tests for $(Agent.OS) - Python $(python.version)" --napoleon-docstrings
     displayName: 'Tests - Run'
     continueOnError: false
+
+  - script: |
+      call activate test-environment-$(python.name)
+      codecov
+    displayName: 'Codecov - Upload'
+    continueOnError: true

--- a/azure-test-template.yml
+++ b/azure-test-template.yml
@@ -109,3 +109,9 @@ jobs:
     continueOnError: false
     env:
       DISPLAY: :99.0
+
+  - bash: |
+      source activate test-environmnet-$(python.version)
+      bash <(curl -s https://codecov.io/bash)
+    displayName: 'Codecov - Upload'
+    continueOnError: true

--- a/pydm/qtdesigner.py
+++ b/pydm/qtdesigner.py
@@ -1,3 +1,5 @@
+import sys
+import traceback
 from qtpy.QtCore import QTimer
 from .utilities import stylesheet
 from . import data_plugins
@@ -39,6 +41,7 @@ class DesignerHooks(object):
         self.setup_hooks()
 
     def setup_hooks(self):
+        sys.excepthook = self.__handle_exceptions
         # Set PyDM to be read-only
         data_plugins.set_read_only(True)
 
@@ -62,6 +65,11 @@ class DesignerHooks(object):
             widget = fwman.activeFormWindow()
             if widget:
                 widget.update()
+
+    def __handle_exceptions(self, exc_type, value, trace):
+        print("Exception occurred while running Qt Designer.")
+        msg = ''.join(traceback.format_exception(exc_type, value, trace))
+        print(msg)
 
     def __start_kicker(self):
         self.__timer = QTimer()

--- a/pydm/widgets/embedded_display.py
+++ b/pydm/widgets/embedded_display.py
@@ -176,6 +176,10 @@ class PyDMEmbeddedDisplay(QFrame, PyDMPrimitiveWidget):
                 loadfunc = load_ui_file
             elif extension == ".py":
                 loadfunc = load_py_file
+            else:
+                self.display_error_text('Invalid filename extension.')
+                return
+
             try:
                 w = loadfunc(full_fname, macros=self.parsed_macros())
                 self._needs_load = False
@@ -344,6 +348,6 @@ class PyDMEmbeddedDisplay(QFrame, PyDMPrimitiveWidget):
 
     def _display_designer_load_error(self):
         self._load_error_timer = None
-        logger.exception("Exception while opening embedded display file.")
+        logger.exception("Exception while opening embedded display file.", exc_info=self._load_error)
         if self._load_error:
             self.display_error_text(self._load_error)


### PR DESCRIPTION
ENH: Add exception information to Embedded Display widget error message.
ENH: Properly present error at Embedded Display when extension is invalid.

Related to #565 

After this PR is in, the Qt Designer should no longer crash. For now we will print a message at the terminal but in the future the goal is to do a better handling of that. Since I am still unsure what is best this will get it done for now.