### PR TITLE
FIX: Missed fix for precision

### DIFF
--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -287,7 +287,7 @@ class TextFormatter(object):
         """
         # Only allow one to change the property if not getting the precision
         # from the PV
-        if self.precisionFromPV:
+        if self._precision_from_pv is not None and self._precision_from_pv:
             return
         if new_prec and self._prec != int(new_prec) and new_prec >= 0:
             self._user_prec = int(new_prec)


### PR DESCRIPTION
It seems that https://github.com/slaclab/pydm/pull/524 has been merged with slight modification, which prevents it from fixing the problem.

Reproduction steps:
1. Create a display with PyDMLabel in Qt Designer.
2. Set precision to 2, precisionFromPV to False
3. Run the application, precision of the label will be 0, not 2  (considering using PV that does not broadcast any precision)

This PR brings that missing bit back.
