### PR TITLE
Add support for multiple commands to shell command button

### DIFF
--- a/examples/shell_command/shell_command.ui
+++ b/examples/shell_command/shell_command.ui
@@ -44,9 +44,6 @@
      <property name="allowMultipleExecutions" stdset="0">
       <bool>false</bool>
      </property>
-     <property name="command" stdset="0">
-      <string>echo &quot;Hello World!&quot;</string>
-     </property>
     </widget>
    </item>
    <item>

--- a/examples/shell_command/shell_command.ui
+++ b/examples/shell_command/shell_command.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>375</width>
-    <height>206</height>
+    <width>379</width>
+    <height>358</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -31,19 +31,6 @@
     </widget>
    </item>
    <item>
-    <spacer name="verticalSpacer_2">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item>
     <widget class="PyDMShellCommand" name="PyDMShellCommand">
      <property name="toolTip">
       <string/>
@@ -53,6 +40,9 @@
      </property>
      <property name="text">
       <string>Run Shell Command</string>
+     </property>
+     <property name="allowMultipleExecutions" stdset="0">
+      <bool>false</bool>
      </property>
      <property name="command" stdset="0">
       <string>echo &quot;Hello World!&quot;</string>
@@ -71,6 +61,38 @@
       </size>
      </property>
     </spacer>
+   </item>
+   <item>
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>You can also specify multiple commands for a single button.  If you do, you'll get a menu to pick one of them when you click the button.</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="PyDMShellCommand" name="PyDMShellCommand_2">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="text">
+      <string>Multiple Shell Command Menu</string>
+     </property>
+     <property name="titles" stdset="0">
+      <stringlist>
+       <string>Print &quot;Hello, World!&quot; to terminal</string>
+       <string>Print current working directory to terminal</string>
+      </stringlist>
+     </property>
+     <property name="commands" stdset="0">
+      <stringlist>
+       <string>echo &quot;Hello, World!&quot;</string>
+       <string>echo `pwd`</string>
+      </stringlist>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/pydm/tests/widgets/test_shell_command.py
+++ b/pydm/tests/widgets/test_shell_command.py
@@ -135,7 +135,7 @@ def test_mouse_release_event(qtbot, caplog, cmd, retcode, stdout):
         if "invalid" not in command:
             stdout, stderr = pydm_shell_command.process.communicate()
             assert pydm_shell_command.process.returncode == expected_retcode
-            assert str(stdout, 'utf-8').strip() == expected_stdout
+            assert expected_stdout in str(stdout)
         else:
             for record in caplog.records:
                 assert record.levelno == ERROR

--- a/pydm/tests/widgets/test_shell_command.py
+++ b/pydm/tests/widgets/test_shell_command.py
@@ -7,6 +7,7 @@ from logging import ERROR
 
 from qtpy import QtCore
 from qtpy.QtCore import QSize
+from qtpy.QtWidgets import QMenu, QAction
 
 from ...widgets.shell_command import PyDMShellCommand
 from ...utilities import IconFont
@@ -16,35 +17,46 @@ from ...utilities import IconFont
 # POSITIVE TEST CASES
 # --------------------
 
-@pytest.mark.parametrize("command", [
-    "ping",
-    "",
-    None,
+@pytest.mark.parametrize("command, title", [
+    ("foo", None),
+    ("", None),
+    (None, None),
+    (["foo", "bar"], ["A", "B"]),
 ])
-def test_construct(qtbot, command):
+def test_construct(qtbot, command, title):
     """
     Test the construct of the widget.
 
     Expectations:
-    The widget is initialized with all the expected default values for its properties, including its icon and mouse
-    cursor.
+    The widget is initialized, and the commands and titles match the
+    constructor arguments provided.  Also tests the icon and cursor pixmaps.
 
     Parameters
     ----------
     qtbot : fixture
         Window for widget testing
     command : str
-        The shell command to be executed when the widget is pressed
+        The shell command(s) to be executed when the widget is pressed
+    title : str
+        The titles for the shell commands.  Really only relevant if
+        len(commands) > 1
 
     """
-    pydm_shell_command = PyDMShellCommand(command=command)
+    pydm_shell_command = PyDMShellCommand(command=command, title=title)
     qtbot.addWidget(pydm_shell_command)
-
-    assert pydm_shell_command._command == command
-    assert pydm_shell_command._allow_multiple is False
-    assert pydm_shell_command.process is None
-    assert pydm_shell_command._show_icon is True
-
+    if command and isinstance(command, str):
+        assert pydm_shell_command._commands == [command]
+    elif command:
+        assert pydm_shell_command._commands == command
+    else:
+        assert pydm_shell_command._commands == []
+    if title and isinstance(title, str):
+        assert pydm_shell_command._titles == [title]
+    elif title:
+        assert pydm_shell_command._titles == title
+    else:
+        assert pydm_shell_command._titles == []
+    
     DEFAULT_ICON_NAME = "cog"
     DEFAULT_ICON_SIZE = QSize(16, 16)
 
@@ -56,135 +68,52 @@ def test_construct(qtbot, command):
     assert shell_cmd_icon_pixmap.toImage() == default_icon_pixmap.toImage()
     assert pydm_shell_command.cursor().pixmap().toImage() == default_icon_pixmap.toImage()
 
-
-@pytest.mark.parametrize("currently_show_icon, to_show_icon", [
-    (True, False),
-    (False, True),
-    (True, True),
-    (False, False),
-    (None, True),
-    (None, False),
-    (True, None),
-    (False, None),
-    (None, None),
-])
-def test_show_icon(qtbot, currently_show_icon, to_show_icon):
-    """
-    Test the widget's show icon setting.
-
-    Expectations:
-    The widget will retain the show icon setting as it is set.
-
-    Parameters
-    ----------
-    qtbot : fixture
-        Window for widget testing
-    currently_show_icon : bool
-        The current show icon setting (True is to show the icon; None otherwise)
-    to_show_icon : bool
-        The next show icon setting (True is to show the icon; None otherwise)
-    """
+def test_deprecated_command_property_with_no_commands(qtbot):
     pydm_shell_command = PyDMShellCommand()
     qtbot.addWidget(pydm_shell_command)
+    pydm_shell_command.command = "test"
+    assert pydm_shell_command.commands == ["test"]
 
-    pydm_shell_command.showIcon = currently_show_icon
-    assert pydm_shell_command.showIcon == currently_show_icon
-
-    pydm_shell_command.showIcon = to_show_icon
-    assert pydm_shell_command.showIcon == to_show_icon
-
-
-@pytest.mark.parametrize("currently_allowed, to_allow", [
-    (True, False),
-    (False, True),
-    (True, True),
-    (False, False),
-    (None, True),
-    (None, False),
-    (True, None),
-    (False, None),
-    (None, None),
-])
-def test_allow_multiple_execs(qtbot, currently_allowed, to_allow):
-    """
-    Test the widget's multiple command execution setting.
-
-    Expectations:
-    The widget will retain the multiple command execution setting as it is set.
-
-    Parameters
-    ----------
-    qtbot : fixture
-       Window for widget testing
-    currently_allowed : bool
-       The current  multiple command execution setting (True is to allow the multiple executions; None otherwise)
-    to_show_icon : bool
-       The next multiple command execution setting (True is to allow the multiple executions; None otherwise)
-    """
+def test_deprecated_command_property_with_commands(qtbot):
     pydm_shell_command = PyDMShellCommand()
     qtbot.addWidget(pydm_shell_command)
+    existing_commands = ["existing", "commands"]
+    pydm_shell_command.commands = existing_commands
+    pydm_shell_command.command = "This shouldn't work"
+    assert pydm_shell_command.commands == existing_commands
 
-    pydm_shell_command.allowMultipleExecutions = currently_allowed
-    assert pydm_shell_command.allowMultipleExecutions == currently_allowed
+def test_no_crash_without_any_commands(qtbot):
+     pydm_shell_command = PyDMShellCommand()
+     qtbot.addWidget(pydm_shell_command)
+     pydm_shell_command.commands = None
+     qtbot.mouseClick(pydm_shell_command, QtCore.Qt.LeftButton)
 
-    pydm_shell_command.allowMultipleExecutions = to_allow
-    assert pydm_shell_command.allowMultipleExecutions == to_allow
+def test_no_crash_with_none_command(qtbot):
+     pydm_shell_command = PyDMShellCommand()
+     qtbot.addWidget(pydm_shell_command)
+     pydm_shell_command.command = None
+     qtbot.mouseClick(pydm_shell_command, QtCore.Qt.LeftButton)
 
-
-@pytest.mark.parametrize("current_cmd, next_cmd", [
-    ("ping", "pong"),
-    ("ping", "ping"),
-    ("ping", "ping"),
-    ("ping", None),
-    ("", "ping"),
-    ("", ""),
-    (None, "ping"),
-    (None, ""),
-    (None, None)
+@pytest.mark.parametrize("cmd, retcode, stdout", [
+    (["choice /c yn /d n /t 0"] if platform.system() == "Windows" else ["sleep 0"],
+        [2] if platform.system() == "Windows" else [0], ["[Y,N]?N"] if platform.system() == "Windows" else [""]),
+    (["pydm_shell_invalid_command_test invalid command"], [None], [""]),
+    (["echo hello", "echo world"], [0, 0], ["hello", "world"])
 ])
-def test_get_set_command(qtbot, current_cmd, next_cmd):
+def test_mouse_release_event(qtbot, caplog, cmd, retcode, stdout):
     """
-    Test the widget's capability to set the shell command to execute.
-
-    Expectations:
-    The widget will retain the shell command as set.
-
-    Parameters
-    ----------
-    qtbot : fixture
-       Window for widget testing
-    current_cmd : str
-        The current shell command being set for the widget to execute
-    next_cmd : str
-        The next shell command to set for the widget to execute
-    """
-    pydm_shell_command = PyDMShellCommand()
-    qtbot.addWidget(pydm_shell_command)
-
-    pydm_shell_command.command = current_cmd
-    assert pydm_shell_command.command == current_cmd
-
-    pydm_shell_command.command = next_cmd
-    assert pydm_shell_command.command == next_cmd
-
-
-@pytest.mark.parametrize("cmd, val", [
-    ("choice /c yn /d n /t 0" if platform.system() == "Windows" else "sleep 0",
-        2 if platform.system() == "Windows" else 0),
-    ("pydm_shell_invalid_command_test invalid command", None),
-    ("", None),
-    (None, None),
-])
-def test_mouse_release_event(qtbot, caplog, cmd, val):
-    """
-    Test to ensure the widget's triggering of the Mouse Release event, which will also execute the shell command.
-
-    Expectations:
+    Test to ensure the widget's triggering of the Mouse Release event.
+    
+    Expectations if len(cmd) == 1:
     1. The mouse release will trigger the current shell command being assigned to the widget to execute
     2. If the command is not valid, there will be an error message in the log
     3. If the command is valid, there will be output in stdout (the result could be a success or failure, but at least
         the command will send out text to stdout)
     4. If the command is None or empty, there will be no output to stdout.
+    
+    Expectations if len(cmd) > 1:
+    1. The mouse press will cause the widget to set its 'menu' attribute to an instance of QMenu.
+    2. Triggering each menu item runs the right command.
 
     Parameters
     ----------
@@ -194,73 +123,42 @@ def test_mouse_release_event(qtbot, caplog, cmd, val):
         To capture the log messages
     cmd : str
         The shell command for the widget to execute
-    val : int
+    retcode : int
         The expected exit code.
+    stdout : str
+        The expected stdout for the command.
     """
     pydm_shell_command = PyDMShellCommand()
     qtbot.addWidget(pydm_shell_command)
 
-    pydm_shell_command.command = cmd
-    qtbot.mouseClick(pydm_shell_command, QtCore.Qt.LeftButton)
-
-    if cmd:
-        if "invalid" not in cmd:
-            ret = pydm_shell_command.process.wait()
-            assert ret == val
+    def check_command_output(command, expected_retcode, expected_stdout):
+        if "invalid" not in command:
+            stdout, stderr = pydm_shell_command.process.communicate()
+            assert pydm_shell_command.process.returncode == expected_retcode
+            assert str(stdout, 'utf-8').strip() == expected_stdout
         else:
             for record in caplog.records:
                 assert record.levelno == ERROR
-            assert "Error in command" in caplog.text
+            assert "Error in shell command" in caplog.text
+
+    pydm_shell_command.commands = cmd
+    
+    if len(cmd) > 1:
+        for current_command, expected_retcode, expected_stdout in zip(cmd, retcode, stdout):
+            # We can't actually do the click and show the menu - it halts the test and waits
+            # for user input.  So instead, we'll force trigger _rebuild_menu().
+            pydm_shell_command._rebuild_menu()
+            assert isinstance(pydm_shell_command.menu(), QMenu)
+            actions = pydm_shell_command.menu().findChildren(QAction)
+            assert current_command in [a.text() for a in actions]
+            action_for_current_command = [a for a in actions if a.text() == current_command][0]
+            action_for_current_command.trigger()
+            check_command_output(current_command, expected_retcode, expected_stdout)
+    elif len(cmd) == 1:
+        qtbot.mouseClick(pydm_shell_command, QtCore.Qt.LeftButton)
+        check_command_output(cmd[0], retcode[0], stdout[0])
     else:
-        assert pydm_shell_command.process is None
-
-
-@pytest.mark.parametrize("cmd, val", [
-    ("choice /c yn /d n /t 0" if platform.system() == "Windows" else "sleep 0",
-        2 if platform.system() == "Windows" else 0),
-    ("pydm_shell_invalid_command_test invalid command", None),
-    ("", None),
-    (None, None),
-])
-def test_execute_command(qtbot, signals, caplog, cmd, val):
-    """
-    Test to ensure the widget's ability to execute a shell command.
-
-    Expectations:
-    1. If the command is not valid, there will be an error message in the log
-    2. If the command is valid, there will be output in stdout (the result could be a success or failure, but at least
-        the command will send out text to stdout)
-    3. If the command is None or empty, there will be no output to stdout.
-
-    Parameters
-    ----------
-    qtbot : fixture
-        Window for widget testing
-    signals : fixture
-        The signals fixture, which provides access signals to be bound to the appropriate slots
-    caplog : fixture
-        To capture the log messages
-    cmd : str
-        The shell command for the widget to execute
-    val : int
-        The expected exit code.
-    """
-    pydm_shell_command = PyDMShellCommand()
-    qtbot.addWidget(pydm_shell_command)
-
-    pydm_shell_command.command = cmd
-    signals.send_value_signal[str].connect(pydm_shell_command.execute_command)
-    signals.send_value_signal[str].emit(cmd)
-
-    if cmd:
-        if "invalid" not in cmd:
-            ret = pydm_shell_command.process.wait()
-            assert ret == val
-        else:
-            for record in caplog.records:
-                assert record.levelno == ERROR
-            assert "Error in command" in caplog.text
-    else:
+        qtbot.mouseClick(pydm_shell_command, QtCore.Qt.LeftButton)
         assert pydm_shell_command.process is None
 
 
@@ -294,14 +192,12 @@ def test_execute_multiple_commands(qtbot, signals, caplog, allow_multiple):
     pydm_shell_command._allow_multiple = allow_multiple
 
     cmd = "choice /c yn /d y /t 1" if platform.system() == "Windows" else "sleep 0.1"
-    pydm_shell_command.command = cmd
-    signals.send_value_signal[str].connect(pydm_shell_command.execute_command)
-    signals.send_value_signal[str].emit(cmd)
-    signals.send_value_signal[str].emit(cmd)
+    pydm_shell_command.execute_command(cmd)
+    pydm_shell_command.execute_command(cmd)
 
     if not allow_multiple:
         for record in caplog.records:
             assert record.levelno == ERROR
-        assert "Command already active." in caplog.text
+        assert "already active" in caplog.text
     else:
         assert not caplog.text

--- a/pydm/widgets/shell_command.py
+++ b/pydm/widgets/shell_command.py
@@ -1,22 +1,24 @@
-from qtpy.QtWidgets import QPushButton
-from qtpy.QtGui import QCursor, QIcon
-from qtpy.QtCore import Slot, Property, QSize, Qt
 import shlex
 import subprocess
+from functools import partial
+import sys
+import logging
+import warnings
+
+from qtpy.QtWidgets import QPushButton, QMenu
+from qtpy.QtGui import QCursor, QIcon
+from qtpy.QtCore import Property, QSize, Qt
 from .base import PyDMPrimitiveWidget
 from ..utilities import IconFont
 
-import sys
-import logging
 logger = logging.getLogger(__name__)
-
 
 class PyDMShellCommand(QPushButton, PyDMPrimitiveWidget):
     """
     A QPushButton capable of execute shell commands.
     """
 
-    def __init__(self, parent=None, command=None):
+    def __init__(self, parent=None, command=None, title=None):
         QPushButton.__init__(self, parent)
         PyDMPrimitiveWidget.__init__(self)
         self.iconFont = IconFont()
@@ -24,8 +26,19 @@ class PyDMShellCommand(QPushButton, PyDMPrimitiveWidget):
         self.setIconSize(QSize(16, 16))
         self.setIcon(self._icon)
         self.setCursor(QCursor(self._icon.pixmap(16, 16)))
-
-        self._command = command
+        if not title:
+            title = []
+        if not command:
+            command = []
+        if isinstance(title, str):
+            title = [title]
+        if isinstance(command, str):
+            command = [command]
+        if len(title) > 0 and (len(title) != len(command)):
+            raise ValueError("Number of items in 'command' must match number of items in 'title'.")
+        self._commands = command
+        self._titles = title
+        self._menu_needs_rebuild = True
         self._allow_multiple = False
         self.process = None
         self._show_icon = True
@@ -84,28 +97,89 @@ class PyDMShellCommand(QPushButton, PyDMPrimitiveWidget):
         if self._allow_multiple != value:
             self._allow_multiple = value
 
-    @Property(str)
+    @Property('QStringList')
+    def titles(self):
+        return self._titles
+        
+    @titles.setter
+    def titles(self, val):
+        self._titles = val
+        self._menu_needs_rebuild = True
+        
+    @Property('QStringList')
+    def commands(self):
+        return self._commands
+        
+    @commands.setter
+    def commands(self, val):
+        if not val:
+            self._commands = []
+        else:
+            self._commands = val
+        self._menu_needs_rebuild = True
+
+    @Property(str, designable=False)
     def command(self):
         """
-        The Shell Command to be executed
+        DEPRECATED: use the 'commands' property.
+        This property simply returns the first command from the 'commands'
+        property.
+        The shell command to run.
 
         Returns
         -------
         str
         """
-        return self._command
+        if len(self.commands) == 0:
+            return ""
+        return self.commands[0]
 
     @command.setter
     def command(self, value):
         """
-        The Shell Command to be executed
+        DEPRECATED: Use the 'commands' property instead.
+        This property only has an effect if the 'commands' property is empty.
+        If 'commands' is empty, it will be set to a single item list containing
+        the value of 'command'.
 
         Parameters
         ----------
         value : str
         """
-        if self._command != value:
-            self._command = value
+        warnings.warn("'PyDMShellCommand.command' is deprecated, "
+                      "use 'PyDMShellCommand.commands' instead.")
+        if not self._commands:
+            if value:
+                self.commands = [value]
+            else:
+                self.commands = []
+        
+    def _rebuild_menu(self):
+        if not any(self._commands):
+            self._commands = []
+        if not any(self._titles):
+            self._titles = []
+        if len(self._commands) == 0:
+            self.setEnabled(False)
+        if len(self._commands) <= 1:
+            self.setMenu(None)
+            self._menu_needs_rebuild = False
+            return
+        menu = QMenu(self)
+        for i, command in enumerate(self._commands):
+            if i >= len(self._titles):
+                title = command
+            else:
+                title = self._titles[i]
+            action = menu.addAction(title)
+            action.triggered.connect(partial(self.execute_command, command))
+        self.setMenu(menu)
+        self._menu_needs_rebuild = False
+
+    def mousePressEvent(self, event):
+        if self._menu_needs_rebuild:
+            self._rebuild_menu()
+        super(PyDMShellCommand, self).mousePressEvent(event)
 
     def mouseReleaseEvent(self, mouse_event):
         """
@@ -118,26 +192,29 @@ class PyDMShellCommand(QPushButton, PyDMPrimitiveWidget):
         ----------
         mouse_event :
         """
-        if mouse_event.button() == Qt.LeftButton:
-            self.execute_command()
+        if mouse_event.button() != Qt.LeftButton:
+            return super(PyDMShellCommand, self).mouseReleaseEvent(mouse_event)
+        if self.menu() is not None:
+            return super(PyDMShellCommand, self).mouseReleaseEvent(mouse_event)
+        assert len(self.commands) == 1, "More than one command present, but no menu created."
+        self.execute_command(self.commands[0])
         super(PyDMShellCommand, self).mouseReleaseEvent(mouse_event)
 
-    @Slot()
-    def execute_command(self):
+    def execute_command(self, command):
         """
         Execute the shell command given by ```command```.
         The process is available through the ```process``` member.
         """
-
-        if self._command is None or self._command == "":
+        if not command:
             logger.info("The command is not set, so no command was executed.")
             return
 
         if (self.process is None or self.process.poll() is not None) or self._allow_multiple:
-            args = shlex.split(self._command, posix='win' not in sys.platform)
+            args = shlex.split(command, posix='win' not in sys.platform)
             try:
+                logger.debug("Launching process: %s", repr(args))
                 self.process = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             except Exception as exc:
-                logger.error("Error in command: {0}".format(exc))
+                logger.error("Error in shell command: %s", exc)
         else:
-            logging.error("Command already active.")
+            logger.error("Command '%s' already active.", command)


### PR DESCRIPTION
This PR replaces the PyDMShellCommand button's QString `command` property with a new QStringList property called `commands`.  This lets you specify more than one shell command to associate with the button.  If more than one command is specified, clicking the button will present a menu where the user can choose which command to run.  Another new QStringList property, `titles`, lets you specify what to call each command in the menu.

The old `command` property is deprecated - it still exists, but is no longer exposed in designer.  If you load an old .ui file that had `command` set, it will now populate `commands` with a single item instead.  If `commands` is not empty, setting `command` has no effect.  In any case, setting `command` will trigger a deprecation warning message.

The tests for PyDMShellCommand have been updated for the new property, as well as the deprecation behavior for the old property.  The example file has been updated to include examples for both 'one command' and 'multiple commands' behaviors.

This should fix #581.