### PR TITLE
FIX: Suppress error message when value is None for display Format.

### DIFF
--- a/pydm/widgets/display_format.py
+++ b/pydm/widgets/display_format.py
@@ -17,6 +17,8 @@ class DisplayFormat(object):
 
 
 def parse_value_for_display(value, precision, display_format_type=DisplayFormat.Default, string_encoding="utf_8", widget=None):
+    if value is None:
+        return ""
     try:
         widget_name = widget.objectName()
     except(AttributeError, TypeError):


### PR DESCRIPTION
Recently PyDM started dumping the following messages:
```
~$ pydm examples/display_format/display_format.ui
[2019-12-20 15:25:42,670] [INFO    ] - Opening the default stylesheet '/Users/slepicka/sandbox/git-slaclab/pydm-git/pydm/default_stylesheet.qss'...
[2019-12-20 15:25:42,698] [ERROR   ] - Could not display value 'None' using displayFormat 'Exponential' at widget named ''.
[2019-12-20 15:25:42,699] [ERROR   ] - Could not display value 'None' using displayFormat 'Hex' at widget named ''.
[2019-12-20 15:25:42,699] [ERROR   ] - Could not display value 'None' using displayFormat 'Binary' at widget named ''.
[2019-12-20 15:25:42,703] [ERROR   ] - Could not display value 'None' using displayFormat 'Exponential' at widget named ''.
[2019-12-20 15:25:42,703] [ERROR   ] - Could not display value 'None' using displayFormat 'Hex' at widget named ''.
[2019-12-20 15:25:42,704] [ERROR   ] - Could not display value 'None' using displayFormat 'Binary' at widget named ''.
```

This PR avoids this issue by returning an empty string in case the value is `None`.