### PR TITLE
Configure button layout spacings and margins in PyDMEnumButton

### DIFF
--- a/pydm/widgets/enum_button.py
+++ b/pydm/widgets/enum_button.py
@@ -251,7 +251,6 @@ class PyDMEnumButton(QWidget, PyDMWritableWidget, WidgetType):
         if new_spacing != self._layout_spacing_horizontal:
             self._layout_spacing_horizontal = new_spacing
             self.layout().setHorizontalSpacing(new_spacing)
-            self.rebuild_layout()
 
     @Property(int)
     def verticalSpacing(self):
@@ -277,7 +276,7 @@ class PyDMEnumButton(QWidget, PyDMWritableWidget, WidgetType):
         if new_spacing != self._layout_spacing_vertical:
             self._layout_spacing_vertical = new_spacing
             self.layout().setVerticalSpacing(new_spacing)
-            self.rebuild_layout()
+
     @Property(bool)
     def checkable(self):
         """

--- a/pydm/widgets/enum_button.py
+++ b/pydm/widgets/enum_button.py
@@ -131,7 +131,7 @@ class PyDMEnumButton(QWidget, PyDMWritableWidget, WidgetType):
             self.rebuild_layout()
 
     @Property(int)
-    def margin_top(self):
+    def marginTop(self):
         """
         The top margin of the QGridLayout of buttons.
 
@@ -141,8 +141,8 @@ class PyDMEnumButton(QWidget, PyDMWritableWidget, WidgetType):
         """
         return self._layout_margins.top()
 
-    @margin_top.setter
-    def margin_top(self, new_margin):
+    @marginTop.setter
+    def marginTop(self, new_margin):
         """
         Set the top margin of the QGridLayout of buttons.
 

--- a/pydm/widgets/enum_button.py
+++ b/pydm/widgets/enum_button.py
@@ -1,4 +1,4 @@
-from qtpy.QtCore import (Qt, QSize, Property, Slot, Q_ENUMS)
+from qtpy.QtCore import (Qt, QSize, Property, Slot, Q_ENUMS, QMargins)
 from qtpy.QtWidgets import (QWidget, QButtonGroup, QGridLayout, QPushButton,
                             QRadioButton, QStyleOption, QStyle)
 from qtpy.QtGui import QPainter
@@ -42,6 +42,9 @@ class PyDMEnumButton(QWidget, PyDMWritableWidget, WidgetType):
         PyDMWritableWidget.__init__(self, init_channel=init_channel)
         self._has_enums = False
         self.setLayout(QGridLayout(self))
+        self._layout_spacing_horizontal = 6
+        self._layout_spacing_vertical = 6
+        self._layout_margins = QMargins(9, 9, 9, 9)
         self._btn_group = QButtonGroup()
         self._btn_group.setExclusive(True)
         self._btn_group.buttonClicked[int].connect(self.handle_button_clicked)
@@ -125,6 +128,158 @@ class PyDMEnumButton(QWidget, PyDMWritableWidget, WidgetType):
         """
         if new_orientation != self._orientation:
             self._orientation = new_orientation
+            self.rebuild_layout()
+
+    @Property(int)
+    def margin_top(self):
+        """
+        The top margin of the QGridLayout of buttons.
+
+        Returns
+        -------
+        int
+        """
+        return self._layout_margins.top()
+
+    @margin_top.setter
+    def margin_top(self, new_margin):
+        """
+        Set the top margin of the QGridLayout of buttons.
+
+        Parameters
+        -------
+        int
+        """
+        new_margin = max(0, int(new_margin))
+        self._layout_margins.setTop(new_margin)
+        self.layout().setContentsMargins(self._layout_margins)
+        self.rebuild_layout()
+
+    @Property(int)
+    def margin_bottom(self):
+        """
+        The bottom margin of the QGridLayout of buttons.
+
+        Returns
+        -------
+        int
+        """
+        return self._layout_margins.bottom()
+
+    @margin_bottom.setter
+    def margin_bottom(self, new_margin):
+        """
+        Set the bottom margin of the QGridLayout of buttons.
+
+        Parameters
+        -------
+        int
+        """
+        new_margin = max(0, int(new_margin))
+        self._layout_margins.setBottom(new_margin)
+        self.layout().setContentsMargins(self._layout_margins)
+        self.rebuild_layout()
+
+    @Property(int)
+    def margin_left(self):
+        """
+        The left margin of the QGridLayout of buttons.
+
+        Returns
+        -------
+        int
+        """
+        return self._layout_margins.left()
+
+    @margin_left.setter
+    def margin_left(self, new_margin):
+        """
+        Set the left margin of the QGridLayout of buttons.
+
+        Parameters
+        -------
+        int
+        """
+        new_margin = max(0, int(new_margin))
+        self._layout_margins.setLeft(new_margin)
+        self.layout().setContentsMargins(self._layout_margins)
+        self.rebuild_layout()
+
+    @Property(int)
+    def margin_right(self):
+        """
+        The right margin of the QGridLayout of buttons.
+
+        Returns
+        -------
+        int
+        """
+        return self._layout_margins.right()
+
+    @margin_right.setter
+    def margin_right(self, new_margin):
+        """
+        Set the right margin of the QGridLayout of buttons.
+
+        Parameters
+        -------
+        int
+        """
+        new_margin = max(0, int(new_margin))
+        self._layout_margins.setRight(new_margin)
+        self.layout().setContentsMargins(self._layout_margins)
+        self.rebuild_layout()
+
+    @Property(int)
+    def horizontalSpacing(self):
+        """
+        The horizontal gap of the QGridLayout containing the QButtonGroup.
+
+        Returns
+        -------
+        int
+        """
+        return self._layout_spacing_horizontal
+
+    @horizontalSpacing.setter
+    def horizontalSpacing(self, new_spacing):
+        """
+        Set the layout horizontal gap between buttons.
+
+        Parameters
+        -------
+        new_spacing : int
+        """
+        new_spacing = max(0, int(new_spacing))
+        if new_spacing != self._layout_spacing_horizontal:
+            self._layout_spacing_horizontal = new_spacing
+            self.layout().setHorizontalSpacing(new_spacing)
+            self.rebuild_layout()
+
+    @Property(int)
+    def verticalSpacing(self):
+        """
+        The vertical gap of the QGridLayout containing the QButtonGroup.
+
+        Returns
+        -------
+        int
+        """
+        return self._layout_spacing_vertical
+
+    @verticalSpacing.setter
+    def verticalSpacing(self, new_spacing):
+        """
+        Set the layout vertical gap between buttons.
+
+        Parameters
+        -------
+        new_spacing : int
+        """
+        new_spacing = max(0, int(new_spacing))
+        if new_spacing != self._layout_spacing_vertical:
+            self._layout_spacing_vertical = new_spacing
+            self.layout().setVerticalSpacing(new_spacing)
             self.rebuild_layout()
 
     @Slot(int)

--- a/pydm/widgets/enum_button.py
+++ b/pydm/widgets/enum_button.py
@@ -153,10 +153,9 @@ class PyDMEnumButton(QWidget, PyDMWritableWidget, WidgetType):
         new_margin = max(0, int(new_margin))
         self._layout_margins.setTop(new_margin)
         self.layout().setContentsMargins(self._layout_margins)
-        self.rebuild_layout()
 
     @Property(int)
-    def margin_bottom(self):
+    def marginBottom(self):
         """
         The bottom margin of the QGridLayout of buttons.
 
@@ -166,8 +165,8 @@ class PyDMEnumButton(QWidget, PyDMWritableWidget, WidgetType):
         """
         return self._layout_margins.bottom()
 
-    @margin_bottom.setter
-    def margin_bottom(self, new_margin):
+    @marginBottom.setter
+    def marginBottom(self, new_margin):
         """
         Set the bottom margin of the QGridLayout of buttons.
 
@@ -178,10 +177,9 @@ class PyDMEnumButton(QWidget, PyDMWritableWidget, WidgetType):
         new_margin = max(0, int(new_margin))
         self._layout_margins.setBottom(new_margin)
         self.layout().setContentsMargins(self._layout_margins)
-        self.rebuild_layout()
 
     @Property(int)
-    def margin_left(self):
+    def marginLeft(self):
         """
         The left margin of the QGridLayout of buttons.
 
@@ -191,8 +189,8 @@ class PyDMEnumButton(QWidget, PyDMWritableWidget, WidgetType):
         """
         return self._layout_margins.left()
 
-    @margin_left.setter
-    def margin_left(self, new_margin):
+    @marginLeft.setter
+    def marginLeft(self, new_margin):
         """
         Set the left margin of the QGridLayout of buttons.
 
@@ -203,10 +201,9 @@ class PyDMEnumButton(QWidget, PyDMWritableWidget, WidgetType):
         new_margin = max(0, int(new_margin))
         self._layout_margins.setLeft(new_margin)
         self.layout().setContentsMargins(self._layout_margins)
-        self.rebuild_layout()
 
     @Property(int)
-    def margin_right(self):
+    def marginRight(self):
         """
         The right margin of the QGridLayout of buttons.
 
@@ -216,8 +213,8 @@ class PyDMEnumButton(QWidget, PyDMWritableWidget, WidgetType):
         """
         return self._layout_margins.right()
 
-    @margin_right.setter
-    def margin_right(self, new_margin):
+    @marginRight.setter
+    def marginRight(self, new_margin):
         """
         Set the right margin of the QGridLayout of buttons.
 
@@ -228,7 +225,6 @@ class PyDMEnumButton(QWidget, PyDMWritableWidget, WidgetType):
         new_margin = max(0, int(new_margin))
         self._layout_margins.setRight(new_margin)
         self.layout().setContentsMargins(self._layout_margins)
-        self.rebuild_layout()
 
     @Property(int)
     def horizontalSpacing(self):

--- a/pydm/widgets/enum_button.py
+++ b/pydm/widgets/enum_button.py
@@ -41,6 +41,7 @@ class PyDMEnumButton(QWidget, PyDMWritableWidget, WidgetType):
         QWidget.__init__(self, parent)
         PyDMWritableWidget.__init__(self, init_channel=init_channel)
         self._has_enums = False
+        self._checkable = True
         self.setLayout(QGridLayout(self))
         self._layout_spacing_horizontal = 6
         self._layout_spacing_vertical = 6
@@ -277,6 +278,23 @@ class PyDMEnumButton(QWidget, PyDMWritableWidget, WidgetType):
             self._layout_spacing_vertical = new_spacing
             self.layout().setVerticalSpacing(new_spacing)
             self.rebuild_layout()
+    @Property(bool)
+    def checkable(self):
+        """
+        Whether or not the button should be checkable.
+
+        Returns
+        -------
+        bool
+        """
+        return self._checkable
+
+    @checkable.setter
+    def checkable(self, value):
+        if value != self._checkable:
+            self._checkable = value
+            for widget in self._widgets:
+                widget.setCheckable(value)
 
     @Slot(int)
     def handle_button_clicked(self, id):
@@ -316,7 +334,7 @@ class PyDMEnumButton(QWidget, PyDMWritableWidget, WidgetType):
 
             for idx, entry in enumerate(items):
                 w = class_for_type[self._widget_type](parent=self)
-                w.setCheckable(True)
+                w.setCheckable(self.checkable)
                 w.setText(entry)
                 self._widgets.append(w)
                 self._btn_group.addButton(w, idx)

--- a/pydm/widgets/enum_button.py
+++ b/pydm/widgets/enum_button.py
@@ -18,7 +18,7 @@ class_for_type = [QPushButton, QRadioButton]
 class PyDMEnumButton(QWidget, PyDMWritableWidget, WidgetType):
     """
     A QWidget that renders buttons for every option of Enum Items.
-    For now three types of buttons can be rendered:
+    For now, two types of buttons can be rendered:
     - Push Button
     - Radio Button
 


### PR DESCRIPTION
Expose properties of the PyDMEnumButton widget to customize the layout spacings and margins, which fixes #605.  Here are settings for the .ui file that MEDM screens will use:

```
   <property name="horizontalSpacing" stdset="0">
    <number>0</number>
   </property>
   <property name="verticalSpacing" stdset="0">
    <number>0</number>
   </property>
   <property name="margin_top" stdset="0">
    <number>0</number>
   </property>
   <property name="margin_bottom" stdset="0">
    <number>0</number>
   </property>
   <property name="margin_left" stdset="0">
    <number>0</number>
   </property>
   <property name="margin_right" stdset="0">
    <number>0</number>
   </property>
```