### PR TITLE
FIX: Use console_scripts for Windows for Output

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 import versioneer
 from setuptools import setup, find_packages
+import platform
 
 # To use a consistent encoding
 from codecs import open
@@ -49,6 +50,10 @@ extras_require['all'] = sorted(set(sum(extras_require.values(), [])))
 # Preference for PyQt5 if you select ALL...
 extras_require['all'].remove('PySide')
 
+entry_style = "gui_scripts"
+if platform.system() == "Windows":
+    entry_style = "console_script"
+
 setup(
     name='pydm',
     version=versioneer.get_version(),
@@ -63,7 +68,7 @@ setup(
     long_description_content_type='text/markdown',
     url='https://github.com/slaclab/pydm',
     entry_points={
-        'gui_scripts': [
+        entry_style: [
             'pydm=pydm_launcher.main:main'
         ]
     },

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ extras_require['all'].remove('PySide')
 
 entry_style = "gui_scripts"
 if platform.system() == "Windows":
-    entry_style = "console_script"
+    entry_style = "console_scripts"
 
 setup(
     name='pydm',


### PR DESCRIPTION
With Windows and when using `gui_scripts` as an `entry_point` it uses `pythonw` which creates an asynchronous process and releases the console causing output to not be displayed.
We don't have this kind of issues with `*nix` systems so that is why we revert just Windows to `console_scripts`.

This was tested at my windows VM and it works properly.