### PR TITLE
BLD: Synchronize conda-recipe with conda-forge and some other fixes.

### DIFF
--- a/conda-recipe/bld.bat
+++ b/conda-recipe/bld.bat
@@ -1,1 +1,0 @@
-"%PYTHON%" setup.py install --single-version-externally-managed --record=record.txt

--- a/conda-recipe/build.sh
+++ b/conda-recipe/build.sh
@@ -19,7 +19,7 @@ echo "unset PYQTDESIGNERPATH" >> $DEACTIVATE.sh
 
 echo '@echo OFF' >> $ACTIVATE.bat
 echo 'IF "%PYQTDESIGNERPATH%" == "" (' >> $ACTIVATE.bat
-echo 'set PYQTDESIGNERPATH=%CONDA_PREFIX%\etc\pydm;' >> $ACTIVATE.bat
+echo 'set PYQTDESIGNERPATH=%CONDA_PREFIX%\etc\pydm' >> $ACTIVATE.bat
 echo ')ELSE (' >> $ACTIVATE.bat
 echo 'set PYQTDESIGNERPATH=%CONDA_PREFIX%\etc\pydm;%PYQTDESIGNERPATH%' >> $ACTIVATE.bat
 echo ')' >> $ACTIVATE.bat

--- a/conda-recipe/build.sh
+++ b/conda-recipe/build.sh
@@ -9,12 +9,20 @@ mkdir -p $PREFIX/etc/pydm
 # Create auxiliary vars
 DESIGNER_PLUGIN_PATH=$PREFIX/etc/pydm
 DESIGNER_PLUGIN=$DESIGNER_PLUGIN_PATH/pydm_designer_plugin.py
-ACTIVATE=$PREFIX/etc/conda/activate.d/pydm.sh
-DEACTIVATE=$PREFIX/etc/conda/deactivate.d/pydm.sh
+ACTIVATE=$PREFIX/etc/conda/activate.d/pydm
+DEACTIVATE=$PREFIX/etc/conda/deactivate.d/pydm
 
 echo "from pydm.widgets.qtplugins import *" >> $DESIGNER_PLUGIN
-echo "export PYQTDESIGNERPATH="$DESIGNER_PLUGIN_PATH":\$PYQTDESIGNERPATH" >> $ACTIVATE
-echo "unset PYQTDESIGNERPATH" >> $DEACTIVATE
+
+echo "export PYQTDESIGNERPATH=\$CONDA_PREFIX/etc/pydm:\$PYQTDESIGNERPATH" >> $ACTIVATE.sh
+echo "unset PYQTDESIGNERPATH" >> $DEACTIVATE.sh
+
+echo '@echo OFF' >> $ACTIVATE.bat
+echo 'IF "%PYQTDESIGNERPATH%" == "" (' >> $ACTIVATE.bat
+echo 'set PYQTDESIGNERPATH=%CONDA_PREFIX%\etc\pydm;' >> $ACTIVATE.bat
+echo ')ELSE (' >> $ACTIVATE.bat
+echo 'set PYQTDESIGNERPATH=%CONDA_PREFIX%\etc\pydm;%PYQTDESIGNERPATH%' >> $ACTIVATE.bat
+echo ')' >> $ACTIVATE.bat
 
 unset DESIGNER_PLUGIN_PATH
 unset DESIGNER_PLUGIN

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -9,30 +9,30 @@ source:
 
 build:
   noarch: python
+  entry_points:
+    - pydm = pydm_launcher.main:main
 
 requirements:
-    build:
-      - python
-      - pip
-      - setuptools
-      - pyqt >=5
-      - qtpy
-
-    run:
-      - python
-      - six
-      - numpy >=1.11.0
-      - scipy >=0.12.0
-      - pyepics >=3.2.7
-      - requests >=1.1.0
-      - psutil
-      - pyqt >=5
-      - pyqtgraph
-      - qtpy
+  host:
+    - python
+    - pip
+    - setuptools
+    - pyqt >=5
+    - qtpy
+  run:
+    - python
+    - six
+    - numpy
+    - scipy
+    - pyepics
+    - requests
+    - pyqt >=5
+    - pyqtgraph
+    - qtpy
 
 test:
-    imports:
-      - pydm
+  imports:
+    - pydm
 
 about:
   home: https://github.com/slaclab/pydm
@@ -40,7 +40,6 @@ about:
   license_family: OTHER
   license_file: LICENSE.md
   summary: 'Python Display Manager'
-
   description: |
     PyDM is a PyQt-based framework for building user interfaces for control systems.
     The goal is to provide a no-code, drag-and-drop system to make simple screens,


### PR DESCRIPTION
- Delay expansion of `CONDA_PREFIX` until the script is used. This avoids the issue in which users get the wrong path for the designer plugin file.
- Address issue with Windows in which the PYQTDESIGNERPATH was not being set due to lack of pydm.bat file.

Attn. @ZLLentz this will be the same at Typhos.