### PR TITLE
Fix docs to show the various Plot Curve Items 

### DIFF
--- a/docs/source/widgets/scatterplot.rst
+++ b/docs/source/widgets/scatterplot.rst
@@ -4,3 +4,5 @@ PyDMScatterPlot
 
 .. autoclass:: pydm.widgets.scatterplot.PyDMScatterPlot
    :members:
+.. autoclass:: pydm.widgets.scatterplot.ScatterPlotCurveItem
+   :members:

--- a/docs/source/widgets/timeplot.rst
+++ b/docs/source/widgets/timeplot.rst
@@ -4,3 +4,6 @@ PyDMTimePlot
 
 .. autoclass:: pydm.widgets.timeplot.PyDMTimePlot
    :members:
+.. autoclass:: pydm.widgets.timeplot.TimePlotCurveItem
+   :members:
+

--- a/docs/source/widgets/waveformplot.rst
+++ b/docs/source/widgets/waveformplot.rst
@@ -4,3 +4,6 @@ PyDMWaveformPlot
 
 .. autoclass:: pydm.widgets.waveformplot.PyDMWaveformPlot
    :members:
+
+.. autoclass:: pydm.widgets.waveformplot.WaveformCurveItem
+   :members:

--- a/pydm/widgets/scatterplot.py
+++ b/pydm/widgets/scatterplot.py
@@ -44,12 +44,13 @@ class ScatterPlotCurveItem(BasePlotCurveItem):
 
     def to_dict(self):
         """
-        Returns an OrderedDict representation with values for all properties
-        needed to recreate this curve.
+        Serialize this curve into a dictionary.
 
         Returns
         -------
         OrderedDict
+            Representation with values for all properties
+            needed to recreate this curve.
         """
         dic_ = OrderedDict([("y_channel", self.y_address),
                             ("x_channel", self.x_address)])
@@ -66,6 +67,7 @@ class ScatterPlotCurveItem(BasePlotCurveItem):
         Returns
         -------
         str
+            The address of the channel used to get the x axis data.
         """
         if self.x_channel is None:
             return None
@@ -96,6 +98,7 @@ class ScatterPlotCurveItem(BasePlotCurveItem):
         Returns
         -------
         str
+            The address of the channel used to get the y axis data.
         """
         if self.y_channel is None:
             return None
@@ -130,7 +133,13 @@ class ScatterPlotCurveItem(BasePlotCurveItem):
     @Slot(float)
     def receiveXValue(self, new_x):
         """
-        Handler for new x data.
+        Handler for new x data.  This method is usually called by a PyDMChannel
+        when it updates.  You can call this yourself to inject data into the curve.
+        
+        Parameters
+        ----------
+        new_x: numpy.ndarray
+            A new array values for the X axis.
         """
         if new_x is None:
             return
@@ -142,7 +151,13 @@ class ScatterPlotCurveItem(BasePlotCurveItem):
     @Slot(float)
     def receiveYValue(self, new_y):
         """
-        Handler for new y data.
+        Handler for new y data.  This method is usually called by a PyDMChannel
+        when it updates.  You can call this yourself to inject data into the curve.
+        
+        Parameters
+        ----------
+        new_y: numpy.ndarray
+            A new array values for the Y axis.
         """
         if new_y is None:
             return
@@ -217,12 +232,12 @@ class ScatterPlotCurveItem(BasePlotCurveItem):
 
     def limits(self):
         """
-        Limits of the data for this curve.
-        Returns a nested tuple of limits: ((xmin, xmax), (ymin, ymax))
+        Get the limits of the data for this curve.
 
         Returns
         -------
         tuple
+            A nested tuple of limits: ((xmin, xmax), (ymin, ymax))
         """
         if self.points_accumulated == 0:
             raise NoDataError("Curve has no data, cannot determine limits.")

--- a/pydm/widgets/timeplot.py
+++ b/pydm/widgets/timeplot.py
@@ -124,9 +124,10 @@ class TimePlotCurveItem(BasePlotCurveItem):
         Get the minimum y-value so far in the same plot. This is useful to
         scale the y-axis for a selected curve.
 
-        Returns : float
+        Returns
         -------
-        The minimum y-value collected so far for this current curve.
+        float
+            The minimum y-value collected so far for this current curve.
         """
         return self._min_y_value
 

--- a/pydm/widgets/timeplot.py
+++ b/pydm/widgets/timeplot.py
@@ -162,11 +162,14 @@ class TimePlotCurveItem(BasePlotCurveItem):
         For Asynchronous, write the new value into a temporary (buffered)
         variable, which will be written to the data buffer when asyncUpdate
         is called.
+        
+        This method is usually called by a PyDMChannel when it updates.  You
+        can call it yourself to inject data into the curve.
 
         Parameters
         ----------
         new_value : float
-            The new y-value just available.
+            The new y-value.
         """
         self.update_min_max_y_values(new_value)
 

--- a/pydm/widgets/waveformplot.py
+++ b/pydm/widgets/waveformplot.py
@@ -20,13 +20,13 @@ class WaveformCurveItem(BasePlotCurveItem):
 
     Parameters
     ----------
-    y_addr : str, optional
+    y_addr: str, optional
         The address to waveform data for the Y axis.
         Curves must have Y data to plot.
-    x_addr : str, optional
+    x_addr: str, optional
         The address to waveform data for the X axis.
         If None, the curve will plot Y data vs. the Y index.
-    color : QColor, optional
+    color: QColor, optional
         The color used to draw the curve line and the symbols.
     lineStyle: int, optional
         Style of the line connecting the data points.
@@ -36,14 +36,11 @@ class WaveformCurveItem(BasePlotCurveItem):
         Width of the line connecting the data points.
     redraw_mode: int, optional
         Must be one four values:
-        WaveformCurveItem.REDRAW_ON_EITHER: (Default)
-            Redraw after either X or Y receives new data.
-        WaveformCurveItem.REDRAW_ON_X:
-            Redraw after X receives new data.
-        WaveformCurveItem.REDRAW_ON_Y:
-            Redraw after Y receives new data.
-        WaveformCurveItem.REDRAW_ON_BOTH:
-            Redraw after both X and Y receive new data.
+        
+        - WaveformCurveItem.REDRAW_ON_EITHER: (Default) Redraw after either X or Y receives new data.
+        - WaveformCurveItem.REDRAW_ON_X: Redraw after X receives new data.
+        - WaveformCurveItem.REDRAW_ON_Y: Redraw after Y receives new data.
+        - WaveformCurveItem.REDRAW_ON_BOTH: Redraw after both X and Y receive new data.
     **kargs: optional
         PlotDataItem keyword arguments, such as symbol and symbolSize.
     """

--- a/pydm/widgets/waveformplot.py
+++ b/pydm/widgets/waveformplot.py
@@ -187,7 +187,14 @@ class WaveformCurveItem(BasePlotCurveItem):
     @Slot(np.ndarray)
     def receiveXWaveform(self, new_waveform):
         """
-        Handler for new x waveform data.
+        Handler for new x waveform data.  This method is usually called by a
+        PyDMChannel when it updates.  You can call this yourself to inject data
+        into the curve.
+        
+        Parameters
+        ----------
+        new_waveform: numpy.ndarray
+            A new array values for the X axis.
         """
         if new_waveform is None:
             return
@@ -203,7 +210,14 @@ class WaveformCurveItem(BasePlotCurveItem):
     @Slot(np.ndarray)
     def receiveYWaveform(self, new_waveform):
         """
-        Handler for new y waveform data.
+        Handler for new y waveform data.  This method is usually called by a
+        PyDMChannel when it updates.  You can call this yourself to inject data
+        into the curve.
+        
+        Parameters
+        ----------
+        new_waveform: numpy.ndarray
+            A new array values for the Y axis.
         """
         if new_waveform is None:
             return


### PR DESCRIPTION
Due to an oversight in the doc index, the docstrings for the WaveformPlotCurveItem, TimePlotCurveItem, and ScatterPlotCurveItem weren't making it into the sphinx docs.  This was a real shame, since they were actually pretty well documented.  This PR fixes that.