### PR TITLE
DOC: Show inherited-members and show-inheritance.

### DIFF
--- a/docs/source/widgets/byte.rst
+++ b/docs/source/widgets/byte.rst
@@ -4,3 +4,5 @@ PyDMByteIndicator
 
 .. autoclass:: pydm.widgets.byte.PyDMByteIndicator
    :members:
+   :inherited-members:
+   :show-inheritance:

--- a/docs/source/widgets/checkbox.rst
+++ b/docs/source/widgets/checkbox.rst
@@ -4,3 +4,5 @@ PyDMCheckbox
 
 .. autoclass:: pydm.widgets.checkbox.PyDMCheckbox
    :members:
+   :inherited-members:
+   :show-inheritance:

--- a/docs/source/widgets/drawing.rst
+++ b/docs/source/widgets/drawing.rst
@@ -2,35 +2,52 @@
 PyDMDrawing Widgets
 #######################
 
-.. autoclass:: pydm.widgets.drawing.PyDMDrawing
-   :members:
-
 .. autoclass:: pydm.widgets.drawing.PyDMDrawingLine
    :members:
-   
+   :inherited-members:
+   :show-inheritance:
+
 .. autoclass:: pydm.widgets.drawing.PyDMDrawingImage
    :members:
-   
+   :inherited-members:
+   :show-inheritance:
+
 .. autoclass:: pydm.widgets.drawing.PyDMDrawingRectangle
    :members:
-   
+   :inherited-members:
+   :show-inheritance:
+
 .. autoclass:: pydm.widgets.drawing.PyDMDrawingTriangle
    :members:
-   
+   :inherited-members:
+   :show-inheritance:
+
 .. autoclass:: pydm.widgets.drawing.PyDMDrawingEllipse
    :members:
-   
+   :inherited-members:
+   :show-inheritance:
+
 .. autoclass:: pydm.widgets.drawing.PyDMDrawingCircle
    :members:
-   
+   :inherited-members:
+   :show-inheritance:
+
 .. autoclass:: pydm.widgets.drawing.PyDMDrawingArc
    :members:
-   
+   :inherited-members:
+   :show-inheritance:
+
 .. autoclass:: pydm.widgets.drawing.PyDMDrawingPie
    :members:
-   
+   :inherited-members:
+   :show-inheritance:
+
 .. autoclass:: pydm.widgets.drawing.PyDMDrawingChord
    :members:
+   :inherited-members:
+   :show-inheritance:
 
 .. autoclass:: pydm.widgets.drawing.PyDMDrawingPolygon
    :members:
+   :inherited-members:
+   :show-inheritance:

--- a/docs/source/widgets/embedded_display.rst
+++ b/docs/source/widgets/embedded_display.rst
@@ -4,3 +4,5 @@ PyDMEmbeddedDisplay
 
 .. autoclass:: pydm.widgets.embedded_display.PyDMEmbeddedDisplay
    :members:
+   :inherited-members:
+   :show-inheritance:

--- a/docs/source/widgets/enum_button.rst
+++ b/docs/source/widgets/enum_button.rst
@@ -4,3 +4,5 @@ PyDMEnumButton
 
 .. autoclass:: pydm.widgets.enum_button.PyDMEnumButton
    :members:
+   :inherited-members:
+   :show-inheritance:

--- a/docs/source/widgets/enum_combo_box.rst
+++ b/docs/source/widgets/enum_combo_box.rst
@@ -4,3 +4,5 @@ PyDMEnumComboBox
 
 .. autoclass:: pydm.widgets.enum_combo_box.PyDMEnumComboBox
    :members:
+   :inherited-members:
+   :show-inheritance:

--- a/docs/source/widgets/frame.rst
+++ b/docs/source/widgets/frame.rst
@@ -4,3 +4,5 @@ PyDMFrame
 
 .. autoclass:: pydm.widgets.frame.PyDMFrame
    :members:
+   :inherited-members:
+   :show-inheritance:

--- a/docs/source/widgets/image.rst
+++ b/docs/source/widgets/image.rst
@@ -4,3 +4,5 @@ PyDMImageView
 
 .. autoclass:: pydm.widgets.image.PyDMImageView
    :members:
+   :inherited-members:
+   :show-inheritance:

--- a/docs/source/widgets/label.rst
+++ b/docs/source/widgets/label.rst
@@ -4,3 +4,5 @@ PyDMLabel
 
 .. autoclass:: pydm.widgets.label.PyDMLabel
    :members:
+   :inherited-members:
+   :show-inheritance:

--- a/docs/source/widgets/line_edit.rst
+++ b/docs/source/widgets/line_edit.rst
@@ -4,4 +4,5 @@ PyDMLineEdit
 
 .. autoclass:: pydm.widgets.line_edit.PyDMLineEdit
    :members:
-
+   :inherited-members:
+   :show-inheritance:

--- a/docs/source/widgets/log.rst
+++ b/docs/source/widgets/log.rst
@@ -4,3 +4,5 @@ PyDMLogDisplay
 
 .. autoclass:: pydm.widgets.logdisplay.PyDMLogDisplay
    :members:
+   :inherited-members:
+   :show-inheritance:

--- a/docs/source/widgets/pushbutton.rst
+++ b/docs/source/widgets/pushbutton.rst
@@ -4,4 +4,6 @@ PyDMPushButton
 
 .. autoclass:: pydm.widgets.pushbutton.PyDMPushButton
    :members:
+   :inherited-members:
+   :show-inheritance:
 

--- a/docs/source/widgets/related_display_button.rst
+++ b/docs/source/widgets/related_display_button.rst
@@ -4,3 +4,5 @@ PyDMRelatedDisplayButton
 
 .. autoclass:: pydm.widgets.related_display_button.PyDMRelatedDisplayButton
    :members:
+   :inherited-members:
+   :show-inheritance:

--- a/docs/source/widgets/scale.rst
+++ b/docs/source/widgets/scale.rst
@@ -4,3 +4,5 @@ PyDMScaleIndicator
 
 .. autoclass:: pydm.widgets.scale.PyDMScaleIndicator
    :members:
+   :inherited-members:
+   :show-inheritance:

--- a/docs/source/widgets/scatterplot.rst
+++ b/docs/source/widgets/scatterplot.rst
@@ -4,5 +4,14 @@ PyDMScatterPlot
 
 .. autoclass:: pydm.widgets.scatterplot.PyDMScatterPlot
    :members:
+   :inherited-members:
+   :show-inheritance:
+
+#####################
+ScatterPlotCurveItem
+#####################
+
 .. autoclass:: pydm.widgets.scatterplot.ScatterPlotCurveItem
    :members:
+   :inherited-members:
+   :show-inheritance:

--- a/docs/source/widgets/shell_command.rst
+++ b/docs/source/widgets/shell_command.rst
@@ -4,3 +4,5 @@ PyDMShellCommand
 
 .. autoclass:: pydm.widgets.shell_command.PyDMShellCommand
    :members:
+   :inherited-members:
+   :show-inheritance:

--- a/docs/source/widgets/slider.rst
+++ b/docs/source/widgets/slider.rst
@@ -4,3 +4,5 @@ PyDMSlider
 
 .. autoclass:: pydm.widgets.slider.PyDMSlider
    :members:
+   :inherited-members:
+   :show-inheritance:

--- a/docs/source/widgets/spinbox.rst
+++ b/docs/source/widgets/spinbox.rst
@@ -4,3 +4,5 @@ PyDMSpinbox
 
 .. autoclass:: pydm.widgets.spinbox.PyDMSpinbox
    :members:
+   :inherited-members:
+   :show-inheritance:

--- a/docs/source/widgets/symbol.rst
+++ b/docs/source/widgets/symbol.rst
@@ -4,3 +4,5 @@ PyDMSymbol
 
 .. autoclass:: pydm.widgets.symbol.PyDMSymbol
    :members:
+   :inherited-members:
+   :show-inheritance:

--- a/docs/source/widgets/tab_widget.rst
+++ b/docs/source/widgets/tab_widget.rst
@@ -33,3 +33,5 @@ API Documentation
 
 .. autoclass:: pydm.widgets.tab_bar.PyDMTabWidget
    :members:
+   :inherited-members:
+   :show-inheritance:

--- a/docs/source/widgets/template_repeater.rst
+++ b/docs/source/widgets/template_repeater.rst
@@ -4,3 +4,5 @@ PyDMTemplateRepeater
 
 .. autoclass:: pydm.widgets.template_repeater.PyDMTemplateRepeater
    :members:
+   :inherited-members:
+   :show-inheritance:

--- a/docs/source/widgets/timeplot.rst
+++ b/docs/source/widgets/timeplot.rst
@@ -4,6 +4,14 @@ PyDMTimePlot
 
 .. autoclass:: pydm.widgets.timeplot.PyDMTimePlot
    :members:
+   :inherited-members:
+   :show-inheritance:
+
+#######################
+TimePlotCurveItem
+#######################
+
 .. autoclass:: pydm.widgets.timeplot.TimePlotCurveItem
    :members:
-
+   :inherited-members:
+   :show-inheritance:

--- a/docs/source/widgets/waveformplot.rst
+++ b/docs/source/widgets/waveformplot.rst
@@ -4,6 +4,14 @@ PyDMWaveformPlot
 
 .. autoclass:: pydm.widgets.waveformplot.PyDMWaveformPlot
    :members:
+   :inherited-members:
+   :show-inheritance:
+
+#######################
+WaveformCurveItem
+#######################
 
 .. autoclass:: pydm.widgets.waveformplot.WaveformCurveItem
    :members:
+   :inherited-members:
+   :show-inheritance:

--- a/docs/source/widgets/waveformtable.rst
+++ b/docs/source/widgets/waveformtable.rst
@@ -4,3 +4,5 @@ PyDMWaveformTable
 
 .. autoclass:: pydm.widgets.waveformtable.PyDMWaveformTable
    :members:
+   :inherited-members:
+   :show-inheritance:

--- a/pydm/widgets/waveformplot.py
+++ b/pydm/widgets/waveformplot.py
@@ -138,7 +138,7 @@ class WaveformCurveItem(BasePlotCurveItem):
         The address of the channel used to get the y axis waveform data.
 
         Parameters
-        -------
+        ----------
         new_address: str
         """
         if new_address is None or len(str(new_address)) < 1:


### PR DESCRIPTION
@tashasummers noticed that our documentation is missing key properties that are inherited from the base classes at the widgets API.
This PR enables `inherited-members` and also `show-inheritance`.

Better too much information than no information at all.
