### PR TITLE
FIX: possible fix for pydm ImageView with pyqtgraph 0.11

### DIFF
--- a/pydm/tests/widgets/test_colormaps.py
+++ b/pydm/tests/widgets/test_colormaps.py
@@ -20,16 +20,6 @@ def test_construct():
     Expecations:
     The default values are assigned to the attributes correctly.
     """
-    pydm_colormap = PyDMColorMap()
-
-    for (name, data) in ((PyDMColorMap.Magma, np.array(_magma_data)),
-                         (PyDMColorMap.Inferno, np.array(_inferno_data)),
-                         (PyDMColorMap.Plasma, np.array(_plasma_data)),
-                         (PyDMColorMap.Viridis, np.array(_viridis_data)),
-                         (PyDMColorMap.Jet, np.array(_jet_data)),
-                         (PyDMColorMap.Monochrome, np.array(_monochrome_data)),
-                         (PyDMColorMap.Hot, np.array(_hot_data))):
-        assert np.array_equal(cmaps[name], data)
 
     assert np.array_equal(magma, cmaps[PyDMColorMap.Magma])
     assert np.array_equal(inferno, cmaps[PyDMColorMap.Inferno])

--- a/pydm/widgets/colormaps.py
+++ b/pydm/widgets/colormaps.py
@@ -1070,11 +1070,9 @@ for (name, data) in ((PyDMColorMap.Magma, np.array(_magma_data)),
     cmaps[name] = data
 # This is a temporary fix with pyqtgraph
 if LooseVersion(pyqtgraph.__version__) > LooseVersion('0.10.0'):
-    for (name, data) in ((PyDMColorMap.Magma, np.array(_magma_data)),
-                         (PyDMColorMap.Inferno, np.array(_inferno_data)),
-                         (PyDMColorMap.Plasma, np.array(_plasma_data)),
-                         (PyDMColorMap.Viridis, np.array(_viridis_data))):
-        cmaps[name] = data*255
+    for name in (PyDMColorMap.Magma, PyDMColorMap.Inferno,
+                 PyDMColorMap.Plasma, PyDMColorMap.Viridis):
+        cmaps[name] *= 255
 
 magma = cmaps[PyDMColorMap.Magma]
 inferno = cmaps[PyDMColorMap.Inferno]

--- a/pydm/widgets/colormaps.py
+++ b/pydm/widgets/colormaps.py
@@ -13,6 +13,8 @@
 # You should have received a copy of the CC0 legalcode along with this
 # work.  If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 
+from distutils.version import LooseVersion
+import pyqtgraph
 __all__ = ['magma', 'inferno', 'plasma', 'viridis', 'jet', 'monochrome', 'hot']
 
 _magma_data = [[0.001462, 0.000466, 0.013866],
@@ -1066,6 +1068,13 @@ for (name, data) in ((PyDMColorMap.Magma, np.array(_magma_data)),
                      (PyDMColorMap.Monochrome, np.array(_monochrome_data)),
                      (PyDMColorMap.Hot, np.array(_hot_data))):
     cmaps[name] = data
+# This is a temporary fix with pyqtgraph
+if LooseVersion(pyqtgraph.__version__) > LooseVersion('0.10.0'):
+    for (name, data) in ((PyDMColorMap.Magma, np.array(_magma_data)),
+                         (PyDMColorMap.Inferno, np.array(_inferno_data)),
+                         (PyDMColorMap.Plasma, np.array(_plasma_data)),
+                         (PyDMColorMap.Viridis, np.array(_viridis_data))):
+        cmaps[name] = data*255
 
 magma = cmaps[PyDMColorMap.Magma]
 inferno = cmaps[PyDMColorMap.Inferno]

--- a/pydm/widgets/image.py
+++ b/pydm/widgets/image.py
@@ -1,3 +1,4 @@
+from distutils.version import LooseVersion
 from qtpy.QtWidgets import QActionGroup
 from qtpy.QtCore import Signal, Slot, Property, QTimer, Q_ENUMS, QThread
 from pyqtgraph import ImageView, PlotItem
@@ -310,7 +311,21 @@ class PyDMImageView(ImageView, PyDMWidget, PyDMColorMap, ReadingOrder):
                 return
             # Take default values
             pos = np.linspace(0.0, 1.0, num=len(self._cm_colors))
-            cmap = ColorMap(pos, self._cm_colors)
+            # This is a temporary fix with pyqtgraph 0.11
+            logger.debug(
+                'Using pyqtgraph version: {}'.format(pyqtgraph.__version__))
+            if LooseVersion(pyqtgraph.__version__) > LooseVersion('0.10.0'):
+                if self._colormap not in {
+                    PyDMColorMap.Jet,
+                    PyDMColorMap.Monochrome,
+                    PyDMColorMap.Hot
+                }:
+                    cmap = ColorMap(pos, self._cm_colors*255)
+                else:
+                    cmap = ColorMap(pos, self._cm_colors)
+            else:
+                print(pyqtgraph.__version__)
+                cmap = ColorMap(pos, self._cm_colors)
         self.getView().getViewBox().setBackgroundColor(cmap.map(0))
         lut = cmap.getLookupTable(0.0, 1.0, alpha=False)
         self.getImageItem().setLookupTable(lut)

--- a/pydm/widgets/image.py
+++ b/pydm/widgets/image.py
@@ -1,4 +1,3 @@
-from distutils.version import LooseVersion
 from qtpy.QtWidgets import QActionGroup
 from qtpy.QtCore import Signal, Slot, Property, QTimer, Q_ENUMS, QThread
 from pyqtgraph import ImageView, PlotItem
@@ -311,21 +310,7 @@ class PyDMImageView(ImageView, PyDMWidget, PyDMColorMap, ReadingOrder):
                 return
             # Take default values
             pos = np.linspace(0.0, 1.0, num=len(self._cm_colors))
-            # This is a temporary fix with pyqtgraph 0.11
-            logger.debug(
-                'Using pyqtgraph version: {}'.format(pyqtgraph.__version__))
-            if LooseVersion(pyqtgraph.__version__) > LooseVersion('0.10.0'):
-                if self._colormap not in {
-                    PyDMColorMap.Jet,
-                    PyDMColorMap.Monochrome,
-                    PyDMColorMap.Hot
-                }:
-                    cmap = ColorMap(pos, self._cm_colors*255)
-                else:
-                    cmap = ColorMap(pos, self._cm_colors)
-            else:
-                print(pyqtgraph.__version__)
-                cmap = ColorMap(pos, self._cm_colors)
+            cmap = ColorMap(pos, self._cm_colors)
         self.getView().getViewBox().setBackgroundColor(cmap.map(0))
         lut = cmap.getLookupTable(0.0, 1.0, alpha=False)
         self.getImageItem().setLookupTable(lut)


### PR DESCRIPTION
Should fix the image View with `pyqtgraph 0.11`, and should work with `pyqtgraph < 0.11` as it used to.
Closes #616 