### PR TITLE
FIX: Import QtWebEngineWidgets before creating PyDMApplication.

### DIFF
--- a/pydm_launcher/main.py
+++ b/pydm_launcher/main.py
@@ -13,6 +13,16 @@ def main():
     logger.setLevel("INFO")
     handler.setLevel("INFO")
 
+    try:
+        """
+        We must import QtWebEngineWidgets before creating a QApplication
+        otherwise we get the following error if someone adds a WebView at Designer:
+        ImportError: QtWebEngineWidgets must be imported before a QCoreApplication instance is created
+        """
+        from qtpy import QtWebEngineWidgets
+    except ImportError:
+        logger.info('QtWebEngine is not supported.')
+
     import pydm
     from pydm.utilities.macro import parse_macro_string
 


### PR DESCRIPTION
Without this we run into an issue if users add a `QWebEngineView` or similar at the UI.
With this in place users can now add the WebEngineView and render HTML5 webpages inside of the UI file.

I came across this issue when looking for some options for the PMPS screen for PCDS.
If using a custom QApplication developers are responsible for handling this since we have no control over when the QApplication is created.