### PR TITLE
FIX: Wrap GuiHandler emit to avoid RuntimeError.

### DIFF
--- a/pydm/widgets/logdisplay.py
+++ b/pydm/widgets/logdisplay.py
@@ -67,7 +67,10 @@ class GuiHandler(QObject, logging.Handler):
         # Avoid garbage to be presented when master log is running with DEBUG.
         if self.level == logging.NOTSET:
             return
-        self.message.emit(self.format(record))
+        try:
+            self.message.emit(self.format(record))
+        except RuntimeError:
+            logger.debug('Handler was destroyed at the C++ level.')
 
 
 class LogLevels(object):


### PR DESCRIPTION
This should fix https://github.com/pcdshub/typhos/issues/272 .

Probably a race condition between the Ophyd device generating log messages and the widget being destroyed is causing this issue. Simply wrapping the emit with a try/except block will address this issue.