### PR TITLE
ENH: Add utilities.shortcuts and initial shortcut ConnectionInspector

### DIFF
--- a/pydm/utilities/__init__.py
+++ b/pydm/utilities/__init__.py
@@ -15,6 +15,7 @@ from .connection import establish_widget_connections, close_widget_connections
 from .iconfont import IconFont
 from ..qtdesigner import DesignerHooks
 
+from . import shortcuts
 
 logger = logging.getLogger(__name__)
 

--- a/pydm/utilities/shortcuts.py
+++ b/pydm/utilities/shortcuts.py
@@ -1,0 +1,29 @@
+from qtpy import QtWidgets, QtGui, QtCore
+
+
+def install_connection_inspector(parent, keys=None):
+    """
+    Install a QShortcut at the application which opens the PyDM Connection
+    Inspector
+
+    Parameters
+    ----------
+    parent : QWidget
+        A shortcut is "listened for" by Qt's event loop when the shortcut's
+        parent widget is receiving events.
+    keys : QKeySequence, optional
+        Default value is `Alt+C`
+    """
+    from pydm.connection_inspector import ConnectionInspector
+
+    def show_inspector():
+        c = ConnectionInspector(parent=parent)
+        c.show()
+
+    parent = parent or QtWidgets.QApplication.desktop()
+
+    if keys is None:
+        keys = QtGui.QKeySequence(QtCore.Qt.ALT + QtCore.Qt.Key_C)
+    shortcut = QtWidgets.QShortcut(keys, parent);
+    shortcut.setContext(QtCore.Qt.ApplicationShortcut)
+    shortcut.activated.connect(show_inspector)

--- a/pydm_launcher/main.py
+++ b/pydm_launcher/main.py
@@ -123,6 +123,9 @@ def main():
         stylesheet_path=pydm_args.stylesheet
         )
 
+    pydm.utilities.shortcuts.install_connection_inspector(
+        parent=app.main_window)
+
     sys.exit(app.exec_())
 
 


### PR DESCRIPTION
For now the default for the Inspector is `Alt+C` but users are allowed to specify a custom KeySequence if desired.