### PR TITLE
FIX: PyDMLogDisplay would incorrectly reset logger level

### DIFF
--- a/pydm/widgets/logdisplay.py
+++ b/pydm/widgets/logdisplay.py
@@ -185,7 +185,7 @@ class PyDMLogDisplay(QWidget, LogLevels):
         self.log = logging.getLogger(name)
         # Ensure that the log matches level of handler
         # only if the handler level is less than the log.
-        if self.log.level < self.handler.level:
+        if self.handler.level < self.log.level:
             self.log.setLevel(self.handler.level)
         # Attach preconfigured handler
         self.log.addHandler(self.handler)


### PR DESCRIPTION
PyDMLogDisplay could reduce the levels of the parent log display. This becomes a problem when the logger is used for output in multiple places.
The comparison was incorrect in logName setter. Instead of setting parent logger to more verbose output, it would set it to less verbose. (comment was correct, the actual condition was not)

There's still a problem with setLevel, which I did not change for now: when logger has NOTSET, widget potentially can make it less verbose. I understand that it is made to counteract potentially inherited level of the parent logger, but it brings a bigger architectural problem here. PyDMLogDisplay controls the logger configuration that may be shared and can be even worse when nested. What I would do, is forbid the view from resetting logger's levels completely, and instead show a user warning in UI, if he is attempting to display something more verbose than logger is configured to.