### PR TITLE
ENH: Calculation Data Plugin

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -21,6 +21,7 @@ requirements:
     - qtpy
   run:
     - python
+    - jsonschema
     - six
     - numpy
     - scipy

--- a/examples/calc/README.md
+++ b/examples/calc/README.md
@@ -1,0 +1,21 @@
+# Calculation Plugin Example
+
+# Running the Examples
+This example uses an EPICS IOC via the `demo.db`.
+The Process Variables available are:
+
+- `DEMO:ANGLE`, the angle in degrees which increments by one every 0.1s
+- `DEMO:SIN`, the sine of the angle
+- `DEMO:COS`, the cosine of the angle
+- `DEMO:TAN`, the tangent of the angle
+
+To run the IOC do:
+```shell script
+softIoc -d demo.db
+```
+
+To run the screen do:
+
+```shell script
+pydm sin_cos_tan.ui
+```

--- a/examples/calc/demo.db
+++ b/examples/calc/demo.db
@@ -1,0 +1,27 @@
+record(calc, "DEMO:ANGLE")
+{
+   field(PINI, "YES")
+   field(VAL,  0)
+   field(CALC, "(A >= 360) ? 0:A+1")
+   field(INPA, "DEMO:ANGLE.VAL")
+   field(SCAN, ".1 second")
+}
+
+record(calc, "DEMO:SIN")
+{
+    field(CALC, "SIN(A*0.0174533)")
+    field(INPA, "DEMO:ANGLE CP")
+}
+
+record(calc, "DEMO:COS")
+{
+    field(CALC, "COS(A*0.0174533)")
+    field(INPA, "DEMO:ANGLE CP")
+}
+
+record(calc, "DEMO:TAN")
+{
+    field(CALC, "TAN(A*0.0174533)")
+    field(INPA, "DEMO:ANGLE CP")
+}
+

--- a/examples/calc/sin_cos_tan.ui
+++ b/examples/calc/sin_cos_tan.ui
@@ -1,0 +1,204 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>303</width>
+    <height>806</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,1,1,1,1">
+   <item>
+    <layout class="QFormLayout" name="formLayout">
+     <item row="0" column="0">
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>Angle:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="PyDMLabel" name="PyDMLabel">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://DEMO:ANGLE</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="PyDMScatterPlot" name="PyDMScatterPlot">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="showXGrid">
+      <bool>true</bool>
+     </property>
+     <property name="showYGrid">
+      <bool>true</bool>
+     </property>
+     <property name="showRightAxis">
+      <bool>false</bool>
+     </property>
+     <property name="title" stdset="0">
+      <string>Angle</string>
+     </property>
+     <property name="curves">
+      <stringlist>
+       <string>{&quot;y_channel&quot;: &quot;calc://{\&quot;name\&quot;:\&quot;circley\&quot;, \&quot;channels\&quot;:[\&quot;ca://DEMO:ANGLE\&quot;], \&quot;expr\&quot;:\&quot;math.sin(math.radians(180-ch[0]))\&quot;}&quot;, &quot;x_channel&quot;: &quot;calc://{\&quot;name\&quot;:\&quot;circleX\&quot;, \&quot;channels\&quot;:[\&quot;ca://DEMO:ANGLE\&quot;], \&quot;expr\&quot;:\&quot;-1*math.cos(math.radians(180-ch[0]))\&quot;}&quot;, &quot;name&quot;: &quot;Angle&quot;, &quot;color&quot;: &quot;#ffd509&quot;, &quot;lineStyle&quot;: 0, &quot;lineWidth&quot;: 5, &quot;symbol&quot;: &quot;o&quot;, &quot;symbolSize&quot;: 5, &quot;redraw_mode&quot;: 3, &quot;buffer_size&quot;: 1}</string>
+      </stringlist>
+     </property>
+     <property name="autoRangeX">
+      <bool>false</bool>
+     </property>
+     <property name="minXRange">
+      <double>-1.100000000000000</double>
+     </property>
+     <property name="maxXRange">
+      <double>1.100000000000000</double>
+     </property>
+     <property name="autoRangeY">
+      <bool>false</bool>
+     </property>
+     <property name="minYRange">
+      <double>-1.100000000000000</double>
+     </property>
+     <property name="maxYRange">
+      <double>1.100000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="PyDMTimePlot" name="PyDMTimePlot">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="title" stdset="0">
+      <string>Sin &amp; Cos - IOC</string>
+     </property>
+     <property name="showLegend">
+      <bool>true</bool>
+     </property>
+     <property name="curves">
+      <stringlist>
+       <string>{&quot;channel&quot;: &quot;ca://DEMO:SIN&quot;, &quot;name&quot;: &quot;Sine&quot;, &quot;color&quot;: &quot;#23ff07&quot;, &quot;lineStyle&quot;: 1, &quot;lineWidth&quot;: 1, &quot;symbol&quot;: &quot;o&quot;, &quot;symbolSize&quot;: 3}</string>
+       <string>{&quot;channel&quot;: &quot;ca://DEMO:COS&quot;, &quot;name&quot;: &quot;Cosine&quot;, &quot;color&quot;: &quot;#1ff4ff&quot;, &quot;lineStyle&quot;: 1, &quot;lineWidth&quot;: 1, &quot;symbol&quot;: &quot;o&quot;, &quot;symbolSize&quot;: 3}</string>
+      </stringlist>
+     </property>
+     <property name="bufferSize">
+      <number>1000</number>
+     </property>
+     <property name="updatesAsynchronously">
+      <bool>false</bool>
+     </property>
+     <property name="timeSpan">
+      <double>40.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="PyDMTimePlot" name="PyDMTimePlot_3">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="title" stdset="0">
+      <string>Tan - IOC</string>
+     </property>
+     <property name="showLegend">
+      <bool>true</bool>
+     </property>
+     <property name="curves">
+      <stringlist>
+       <string>{&quot;channel&quot;: &quot;ca://DEMO:TAN&quot;, &quot;name&quot;: &quot;Tan&quot;, &quot;color&quot;: &quot;#f68608&quot;, &quot;lineStyle&quot;: 1, &quot;lineWidth&quot;: 1, &quot;symbol&quot;: &quot;o&quot;, &quot;symbolSize&quot;: 3}</string>
+      </stringlist>
+     </property>
+     <property name="bufferSize">
+      <number>1000</number>
+     </property>
+     <property name="updatesAsynchronously">
+      <bool>false</bool>
+     </property>
+     <property name="timeSpan">
+      <double>40.000000000000000</double>
+     </property>
+     <property name="autoRangeY">
+      <bool>false</bool>
+     </property>
+     <property name="minYRange">
+      <double>-10.000000000000000</double>
+     </property>
+     <property name="maxYRange">
+      <double>10.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="PyDMTimePlot" name="PyDMTimePlot_2">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="title" stdset="0">
+      <string>Tan - CalcPlugin</string>
+     </property>
+     <property name="showLegend">
+      <bool>true</bool>
+     </property>
+     <property name="curves">
+      <stringlist>
+       <string>{&quot;channel&quot;: &quot;calc://{\&quot;name\&quot;:\&quot;tanval\&quot;, \&quot;channels\&quot;:[\&quot;ca://DEMO:ANGLE\&quot;], \&quot;expr\&quot;:\&quot;tan(radians(ch[0]))\&quot;}&quot;, &quot;name&quot;: &quot;Calc Tan&quot;, &quot;color&quot;: &quot;#fc0006&quot;, &quot;lineStyle&quot;: 1, &quot;lineWidth&quot;: 1, &quot;symbol&quot;: &quot;o&quot;, &quot;symbolSize&quot;: 3}</string>
+      </stringlist>
+     </property>
+     <property name="bufferSize">
+      <number>1000</number>
+     </property>
+     <property name="updatesAsynchronously">
+      <bool>false</bool>
+     </property>
+     <property name="timeSpan">
+      <double>40.000000000000000</double>
+     </property>
+     <property name="autoRangeY">
+      <bool>false</bool>
+     </property>
+     <property name="minYRange">
+      <double>-10.000000000000000</double>
+     </property>
+     <property name="maxYRange">
+      <double>10.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>PyDMLabel</class>
+   <extends>QLabel</extends>
+   <header>pydm.widgets.label</header>
+  </customwidget>
+  <customwidget>
+   <class>PyDMTimePlot</class>
+   <extends>QGraphicsView</extends>
+   <header>pydm.widgets.timeplot</header>
+  </customwidget>
+  <customwidget>
+   <class>PyDMScatterPlot</class>
+   <extends>QGraphicsView</extends>
+   <header>pydm.widgets.scatterplot</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/examples/calc/sin_cos_tan.ui
+++ b/examples/calc/sin_cos_tan.ui
@@ -57,7 +57,7 @@
      </property>
      <property name="curves">
       <stringlist>
-       <string>{&quot;y_channel&quot;: &quot;calc://{\&quot;name\&quot;:\&quot;circley\&quot;, \&quot;channels\&quot;:[\&quot;ca://DEMO:ANGLE\&quot;], \&quot;expr\&quot;:\&quot;math.sin(math.radians(180-ch[0]))\&quot;}&quot;, &quot;x_channel&quot;: &quot;calc://{\&quot;name\&quot;:\&quot;circleX\&quot;, \&quot;channels\&quot;:[\&quot;ca://DEMO:ANGLE\&quot;], \&quot;expr\&quot;:\&quot;-1*math.cos(math.radians(180-ch[0]))\&quot;}&quot;, &quot;name&quot;: &quot;Angle&quot;, &quot;color&quot;: &quot;#ffd509&quot;, &quot;lineStyle&quot;: 0, &quot;lineWidth&quot;: 5, &quot;symbol&quot;: &quot;o&quot;, &quot;symbolSize&quot;: 5, &quot;redraw_mode&quot;: 3, &quot;buffer_size&quot;: 1}</string>
+       <string>{&quot;y_channel&quot;: &quot;calc://{\&quot;name\&quot;:\&quot;circley\&quot;, \&quot;channels\&quot;:{\&quot;angle\&quot;:\&quot;ca://DEMO:ANGLE\&quot;}, \&quot;expr\&quot;:\&quot;math.sin(math.radians(180-angle))\&quot;}&quot;, &quot;x_channel&quot;: &quot;calc://{\&quot;name\&quot;:\&quot;circleX\&quot;, \&quot;channels\&quot;:{\&quot;angle\&quot;:\&quot;ca://DEMO:ANGLE\&quot;}, \&quot;expr\&quot;:\&quot;-1*math.cos(math.radians(180-angle))\&quot;}&quot;, &quot;name&quot;: &quot;Angle&quot;, &quot;color&quot;: &quot;#ffd509&quot;, &quot;lineStyle&quot;: 0, &quot;lineWidth&quot;: 5, &quot;symbol&quot;: &quot;o&quot;, &quot;symbolSize&quot;: 5, &quot;redraw_mode&quot;: 3, &quot;buffer_size&quot;: 1}</string>
       </stringlist>
      </property>
      <property name="autoRangeX">
@@ -157,7 +157,7 @@
      </property>
      <property name="curves">
       <stringlist>
-       <string>{&quot;channel&quot;: &quot;calc://{\&quot;name\&quot;:\&quot;tanval\&quot;, \&quot;channels\&quot;:[\&quot;ca://DEMO:ANGLE\&quot;], \&quot;expr\&quot;:\&quot;tan(radians(ch[0])) if ch[0] not in [90, 270] else None\&quot;}&quot;, &quot;name&quot;: &quot;Calc Tan&quot;, &quot;color&quot;: &quot;#fc0006&quot;, &quot;lineStyle&quot;: 1, &quot;lineWidth&quot;: 1, &quot;symbol&quot;: &quot;o&quot;, &quot;symbolSize&quot;: 3}</string>
+       <string>{&quot;channel&quot;: &quot;calc://{\&quot;name\&quot;:\&quot;tanval\&quot;, \&quot;channels\&quot;:{\&quot;angle\&quot;:\&quot;ca://DEMO:ANGLE\&quot;}, \&quot;expr\&quot;:\&quot;tan(radians(angle)) if angle not in [90, 270] else None\&quot;}&quot;, &quot;name&quot;: &quot;Calc Tan&quot;, &quot;color&quot;: &quot;#fc0006&quot;, &quot;lineStyle&quot;: 1, &quot;lineWidth&quot;: 1, &quot;symbol&quot;: &quot;o&quot;, &quot;symbolSize&quot;: 3}</string>
       </stringlist>
      </property>
      <property name="bufferSize">

--- a/examples/calc/sin_cos_tan.ui
+++ b/examples/calc/sin_cos_tan.ui
@@ -157,7 +157,7 @@
      </property>
      <property name="curves">
       <stringlist>
-       <string>{&quot;channel&quot;: &quot;calc://{\&quot;name\&quot;:\&quot;tanval\&quot;, \&quot;channels\&quot;:[\&quot;ca://DEMO:ANGLE\&quot;], \&quot;expr\&quot;:\&quot;tan(radians(ch[0]))\&quot;}&quot;, &quot;name&quot;: &quot;Calc Tan&quot;, &quot;color&quot;: &quot;#fc0006&quot;, &quot;lineStyle&quot;: 1, &quot;lineWidth&quot;: 1, &quot;symbol&quot;: &quot;o&quot;, &quot;symbolSize&quot;: 3}</string>
+       <string>{&quot;channel&quot;: &quot;calc://{\&quot;name\&quot;:\&quot;tanval\&quot;, \&quot;channels\&quot;:[\&quot;ca://DEMO:ANGLE\&quot;], \&quot;expr\&quot;:\&quot;tan(radians(ch[0])) if ch[0] not in [90, 270] else None\&quot;}&quot;, &quot;name&quot;: &quot;Calc Tan&quot;, &quot;color&quot;: &quot;#fc0006&quot;, &quot;lineStyle&quot;: 1, &quot;lineWidth&quot;: 1, &quot;symbol&quot;: &quot;o&quot;, &quot;symbolSize&quot;: 3}</string>
       </stringlist>
      </property>
      <property name="bufferSize">

--- a/pydm/__init__.py
+++ b/pydm/__init__.py
@@ -1,6 +1,7 @@
 from .application import PyDMApplication
 from .display import Display
 from .data_plugins import set_read_only
+from .widgets import PyDMChannel
 from ._version import get_versions
 __version__ = get_versions()['version']
 del get_versions

--- a/pydm/data_plugins/calc_plugin.py
+++ b/pydm/data_plugins/calc_plugin.py
@@ -84,7 +84,9 @@ class CalcThread(QThread):
         """
         self._values[ch_index] = value
         if not self.connected:
-            self.warn_unconnected_channels()
+            logger.debug(
+                "Calculation '%s': Not all channels are connected, skipping execution.",
+                self.objectName())
             return
         self._calculate.set()
 
@@ -103,11 +105,6 @@ class CalcThread(QThread):
         """
         self._connections[ch_index] = value
         self._send_update(self.connected, self._value)
-
-    def warn_unconnected_channels(self):
-        logger.debug(
-            "Calculation '%s': Not all channels are connected, skipping execution.",
-            self.objectName())
 
     def calculate_expression(self):
         """

--- a/pydm/data_plugins/calc_plugin.py
+++ b/pydm/data_plugins/calc_plugin.py
@@ -184,6 +184,7 @@ class Connection(PyDMConnection):
     def __init__(self, channel, address, protocol=None, parent=None):
         super(Connection, self).__init__(channel, address, protocol, parent)
         self._calc_thread = None
+        self.value = None
         self._configuration = {}
         self._waiting_config = True
 
@@ -196,6 +197,12 @@ class Connection(PyDMConnection):
     def add_listener(self, channel):
         self._setup_calc(channel)
         super(Connection, self).add_listener(channel)
+        self.broadcast_value()
+
+    def broadcast_value(self):
+        self.connection_state_signal.emit(self.connected)
+        if self.value is not None:
+            self.new_value_signal[type(self.value)].emit(self.value)
 
     def _setup_calc(self, channel):
         if not self._waiting_config:
@@ -235,6 +242,7 @@ class Connection(PyDMConnection):
             logger.debug('Connection was not available yet for calc.')
         try:
             val = data.get('value')
+            self.value = val
             if val is not None:
                 self.new_value_signal[type(val)].emit(val)
         except KeyError:

--- a/pydm/data_plugins/calc_plugin.py
+++ b/pydm/data_plugins/calc_plugin.py
@@ -16,6 +16,10 @@ logger = logging.getLogger(__name__)
 
 
 class CalcThread(QThread):
+    eval_env = {'math': math,
+                'np': np,
+                'numpy': np}
+
     new_data_signal = Signal(dict)
 
     def __init__(self, config, *args, **kwargs):
@@ -115,16 +119,14 @@ class CalcThread(QThread):
             logger.debug('Skipping execution as not all values are set.')
             return
 
-        eval_env = {'math': math,
-                    'np': np,
-                    'numpy': np}
-        eval_env.update({k: v
-                         for k, v in math.__dict__.items()
-                         if k[0] != '_'})
-        eval_env.update(**vals)
+        env = dict(CalcThread.eval_env)
+        env.update({k: v
+                    for k, v in math.__dict__.items()
+                    if k[0] != '_'})
+        env.update(**vals)
 
         try:
-            ret = eval(self._expression, eval_env)
+            ret = eval(self._expression, env)
             self._value = ret
             self._send_update(self.connected, ret)
         except Exception as e:

--- a/pydm/data_plugins/calc_plugin.py
+++ b/pydm/data_plugins/calc_plugin.py
@@ -1,0 +1,216 @@
+import functools
+import logging
+import json
+import math
+import numpy as np
+
+from pydm.data_plugins.plugin import PyDMPlugin, PyDMConnection
+from qtpy.QtCore import Slot, QThread, Signal
+from qtpy.QtWidgets import QApplication
+
+import pydm
+
+logger = logging.getLogger(__name__)
+
+
+class CalcThread(QThread):
+    new_data_signal = Signal(dict)
+
+    def __init__(self, config, *args, **kwargs):
+        QThread.__init__(self, *args, **kwargs)
+        self.app = QApplication.instance()
+        self.app.aboutToQuit.connect(self.requestInterruption)
+
+        self.config = config
+
+        self._channels = []
+        self._calculate = False
+        self._value = None
+        self._values = None
+        self._connections = None
+        self._expression = self.config.get('expr', '')
+
+        for ch_idx, ch in enumerate(self.config.get('channels', [])):
+            conn_cb = functools.partial(self.callback_conn, ch_idx)
+            value_cb = functools.partial(self.callback_value, ch_idx)
+            c = pydm.PyDMChannel(ch, connection_slot=conn_cb,
+                                 value_slot=value_cb)
+            self._channels.append(c)
+
+    @property
+    def connected(self):
+        return all(self._connections)
+
+    @property
+    def value(self):
+        return self._value
+
+    def _connect(self):
+        self._values = [None]*len(self._channels)
+        self._connections = [False]*len(self._channels)
+        for ch in self._channels:
+            ch.connect()
+
+    def _disconnect(self):
+        for ch in self._channels:
+            ch.disconnect()
+
+    def _send_update(self):
+        self.new_data_signal.emit({"connection": self.connected,
+                                   "value": self.value})
+
+    def run(self):
+        self._connect()
+        while not self.isInterruptionRequested():
+            if self._calculate:
+                self.calculate_expression()
+            self.msleep(33)  # 30Hz
+
+    def callback_value(self, ch_index, value):
+        """
+        Callback executed when a channel receives a new value.
+
+        Parameters
+        ----------
+        ch_index : int
+            The channel index on the list for this rule.
+        value : any
+            The new value for this channel.
+
+        Returns
+        -------
+        None
+        """
+        self._values[ch_index] = value
+        if not self.connected:
+            self.warn_unconnected_channels()
+            return
+        self._calculate = True
+
+    def callback_conn(self, ch_index, value):
+        """
+        Callback executed when a channel connection status is changed.
+
+        Parameters
+        ----------
+        ch_index : int
+            The channel index on the list for this rule.
+        value : bool
+            Whether or not this channel is connected.
+
+        Returns
+        -------
+        None
+        """
+        self._connections[ch_index] = value
+        self._send_update()
+
+    def warn_unconnected_channels(self):
+        logger.debug(
+            "Calculation '%s': Not all channels are connected, skipping execution.",
+            self.objectName())
+
+    def calculate_expression(self):
+        """
+        Evaluate the expression defined by the rule and emit the `rule_signal`
+        with the new value.
+
+        .. warning
+
+            This method mutates the input rule in-place
+
+        Returns
+        -------
+        None
+        """
+        self._calculate = False
+        vals = list(self._values)
+
+        eval_env = {'np': np,
+                    'ch': vals}
+        eval_env.update({k: v
+                         for k, v in math.__dict__.items()
+                         if k[0] != '_'})
+
+        try:
+            ret = eval(self._expression, eval_env)
+            self._value = ret
+            self._send_update()
+        except Exception as e:
+            logger.exception("Error while evaluating CalcPlugin connection %s",
+                             self.objectName())
+
+
+class Connection(PyDMConnection):
+    def __init__(self, channel, address, protocol=None, parent=None):
+        super(Connection, self).__init__(channel, address, protocol, parent)
+        self._calc_thread = None
+        self._configuration = {}
+        self._waiting_config = True
+
+        self.add_listener(channel)
+        self._init_connection()
+
+        self._setup_calc(address)
+
+    def _init_connection(self):
+        self.write_access_signal.emit(False)
+
+    def _setup_calc(self, address):
+        if not self._waiting_config:
+            logger.debug('CalcPlugin connection already configured.')
+            return
+        try:
+            self._configuration = json.loads(address)
+        except:
+            logger.info("Invalid configuration for CalcPlugin connection. %s",
+                        address)
+            return
+
+        if self._configuration.get('channels') \
+                and self._configuration.get('expr'):
+            self._waiting_config = False
+
+        name = self._configuration.get('name')
+
+        self._calc_thread = CalcThread(self._configuration)
+        self._calc_thread.setObjectName("calc_{}".format(name))
+        self._calc_thread.new_data_signal.connect(self.receive_new_data)
+        self._calc_thread.start()
+
+    @Slot(dict)
+    def receive_new_data(self, data):
+        if not data:
+            return
+        conn = data.get('connection', False)
+        val = data.get('value', None)
+        self.connected = conn
+        self.connection_state_signal.emit(conn)
+        if val:
+            self.new_value_signal[type(val)].emit(val)
+
+    @Slot(int)
+    @Slot(float)
+    @Slot(str)
+    @Slot(np.ndarray)
+    def put_value(self, new_val):
+        return
+
+    def add_listener(self, channel):
+        super(Connection, self).add_listener(channel)
+
+    def close(self):
+        self._calc_thread.requestInterruption()
+
+
+class CalculationPlugin(PyDMPlugin):
+    protocol = "calc"
+    connection_class = Connection
+
+    @staticmethod
+    def get_connection_id(channel):
+        address = PyDMPlugin.get_address(channel)
+        j_addr = json.loads(address)
+        name = j_addr.get('name')
+        if not name:
+            raise ValueError("Name is a required field for calc plugin")

--- a/pydm/data_plugins/calc_plugin.py
+++ b/pydm/data_plugins/calc_plugin.py
@@ -258,8 +258,6 @@ class CalculationPlugin(PyDMPlugin):
         except:
             try:
                 jsonschema.validate(config, CALC_ADDRESS_MINIMUM_SCHEMA)
-                logger.info('CalcPlugin connection %s got new listener.',
-                             address)
             except:
                 msg = "Invalid configuration for CalcPlugin connection. %s"
                 logger.exception(msg, address)

--- a/pydm/data_plugins/calc_plugin.py
+++ b/pydm/data_plugins/calc_plugin.py
@@ -164,16 +164,19 @@ class Connection(PyDMConnection):
         self.add_listener(channel)
         self._init_connection()
 
-        self._setup_calc(address)
-
     def _init_connection(self):
         self.write_access_signal.emit(False)
 
-    def _setup_calc(self, address):
+    def add_listener(self, channel):
+        self._setup_calc(channel)
+        super(Connection, self).add_listener(channel)
+
+    def _setup_calc(self, channel):
         if not self._waiting_config:
             logger.debug('CalcPlugin connection already configured.')
             return
         try:
+            address = PyDMPlugin.get_address(channel)
             config = json.loads(address)
             jsonschema.validate(config, CALC_ADDRESS_SCHEMA)
         except:

--- a/pydm/data_plugins/calc_plugin.py
+++ b/pydm/data_plugins/calc_plugin.py
@@ -50,6 +50,7 @@ class CalcThread(QThread):
         self.config = config
 
         self._calculate = threading.Event()
+        self._names = []
         self._channels = []
         self._value = None
         self._values = collections.defaultdict(None)
@@ -63,6 +64,7 @@ class CalcThread(QThread):
             c = pydm.PyDMChannel(channel, connection_slot=conn_cb,
                                  value_slot=value_cb)
             self._channels.append(c)
+            self._names.append(name)
 
     @property
     def connected(self):
@@ -134,8 +136,8 @@ class CalcThread(QThread):
         Evaluate the expression defined by the rule and emit the `rule_signal`
         with the new value.
         """
-        vals = dict(self._values)
-        if None in vals:
+        vals = self._values.copy()
+        if None in [vals.get(n) for n in self._names]:
             logger.debug('Skipping execution as not all values are set.')
             return
 

--- a/pydm/data_plugins/calc_plugin.py
+++ b/pydm/data_plugins/calc_plugin.py
@@ -160,8 +160,8 @@ class Connection(PyDMConnection):
                         address)
             return
 
-        if self._configuration.get('channels') \
-                and self._configuration.get('expr'):
+        if (self._configuration.get('channels')
+                and self._configuration.get('expr')):
             self._waiting_config = False
 
         name = self._configuration.get('name')

--- a/pydm/data_plugins/calc_plugin.py
+++ b/pydm/data_plugins/calc_plugin.py
@@ -176,12 +176,18 @@ class Connection(PyDMConnection):
     def receive_new_data(self, data):
         if not data:
             return
-        conn = data.get('connection', False)
-        val = data.get('value', None)
-        self.connected = conn
-        self.connection_state_signal.emit(conn)
-        if val:
-            self.new_value_signal[type(val)].emit(val)
+        try:
+            conn = data.get('connection')
+            self.connected = conn
+            self.connection_state_signal.emit(conn)
+        except KeyError:
+            logger.debug('Connection was not available yet for calc.')
+        try:
+            val = data.get('value')
+            if val is not None:
+                self.new_value_signal[type(val)].emit(val)
+        except KeyError:
+            logger.debug('Value was not available yet for calc.')
 
     def close(self):
         self._calc_thread.requestInterruption()

--- a/pydm/data_plugins/plugin.py
+++ b/pydm/data_plugins/plugin.py
@@ -9,7 +9,7 @@ from qtpy.QtWidgets import QApplication
 
 
 class PyDMConnection(QObject):
-    new_value_signal = Signal([float], [int], [str], [ndarray])
+    new_value_signal = Signal([float], [int], [str], [ndarray], [bool])
     connection_state_signal = Signal(bool)
     new_severity_signal = Signal(int)
     write_access_signal = Signal(bool)

--- a/pydm/data_plugins/plugin.py
+++ b/pydm/data_plugins/plugin.py
@@ -161,26 +161,32 @@ class PyDMPlugin(object):
     def get_address(channel):
         return protocol_and_address(channel.address)[1]
 
+    @staticmethod
+    def get_connection_id(channel):
+        return PyDMPlugin.get_address(channel)
+
     def add_connection(self, channel):
         with self.lock:
-            address = self.get_address(channel)
             # If this channel is already connected to this plugin lets ignore
             if channel in self.channels:
                 return
+            id = self.get_connection_id(channel)
+            address = self.get_address(channel)
+
             self.channels.add(channel)
-            if address in self.connections:
-                self.connections[address].add_listener(channel)
+            if id in self.connections:
+                self.connections[id].add_listener(channel)
             else:
-                self.connections[address] = self.connection_class(channel, address,
-                                                                  self.protocol)
+                self.connections[id] = self.connection_class(channel, address,
+                                                             self.protocol)
 
     def remove_connection(self, channel, destroying=False):
         with self.lock:
-            address = self.get_address(channel)
-            if address in self.connections and channel in self.channels:
-                self.connections[address].remove_listener(channel,
-                                                          destroying=destroying)
+            id = self.get_connection_id(channel)
+            if id in self.connections and channel in self.channels:
+                self.connections[id].remove_listener(channel,
+                                                     destroying=destroying)
                 self.channels.remove(channel)
-                if self.connections[address].listener_count < 1:
-                    self.connections[address].deleteLater()
-                    del self.connections[address]
+                if self.connections[id].listener_count < 1:
+                    self.connections[id].deleteLater()
+                    del self.connections[id]

--- a/pydm/data_plugins/plugin.py
+++ b/pydm/data_plugins/plugin.py
@@ -170,23 +170,24 @@ class PyDMPlugin(object):
             # If this channel is already connected to this plugin lets ignore
             if channel in self.channels:
                 return
-            id = self.get_connection_id(channel)
+            ch_id = self.get_connection_id(channel)
             address = self.get_address(channel)
 
             self.channels.add(channel)
-            if id in self.connections:
-                self.connections[id].add_listener(channel)
+            if ch_id in self.connections:
+                self.connections[ch_id].add_listener(channel)
             else:
-                self.connections[id] = self.connection_class(channel, address,
-                                                             self.protocol)
+                self.connections[ch_id] = self.connection_class(channel,
+                                                                address,
+                                                                self.protocol)
 
     def remove_connection(self, channel, destroying=False):
         with self.lock:
-            id = self.get_connection_id(channel)
-            if id in self.connections and channel in self.channels:
-                self.connections[id].remove_listener(channel,
-                                                     destroying=destroying)
+            ch_id = self.get_connection_id(channel)
+            if ch_id in self.connections and channel in self.channels:
+                self.connections[ch_id].remove_listener(channel,
+                                                        destroying=destroying)
                 self.channels.remove(channel)
-                if self.connections[id].listener_count < 1:
-                    self.connections[id].deleteLater()
-                    del self.connections[id]
+                if self.connections[ch_id].listener_count < 1:
+                    self.connections[ch_id].deleteLater()
+                    del self.connections[ch_id]

--- a/pydm/widgets/__init__.py
+++ b/pydm/widgets/__init__.py
@@ -1,3 +1,4 @@
+from .channel import PyDMChannel
 from .byte import PyDMByteIndicator
 
 from .checkbox import PyDMCheckbox

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ qtpy
 requests>=1.1.0
 scipy>=0.12.0
 six
+jsonschema


### PR DESCRIPTION
The long waited and requested plugin.

I do have some things that I would like input from others such as:
- Should I include a configuration for trigger on the calculation for channels? 
As of now, it will calculate on any value update. With the trigger option (similar to rules) you can control which channels would trigger a new calculation.

- Should I limit the number of calculations to a certain frequency?
As of now, it is calculating as fast as it can based on how fast the event is set and cleared.

I tested this using the example and EPICS database available here.
The values for TAN (calculated and IOC) are consistent and so is the calculation of the point to make the point position plot at the example.

As of this moment the calc channel syntax is a bit annoying but it will be better once PyDM 2.0 is done and we have the Channel Editor.

To create a calc PV you can use this:
```
calc://{"name":"circley", "channels":[ca://DEMO:ANGLE], "expr":"math.sin(math.radians(ch[0]))"}
```
This plugin allow for re-usage of an existing calc without specifying the whole shenanigans of the formula via:
```
calc://{"name":circley"}
```

Screenshot
------------
![calc](https://user-images.githubusercontent.com/8185425/81623449-6ebeac80-93a8-11ea-8f23-86ba28aefb12.gif)

TODO
------
- [ ] Documentation

