### PR TITLE
DOC: Fixing examples after change on Image widget viewBox.

### DIFF
--- a/examples/camviewer/camviewer.py
+++ b/examples/camviewer/camviewer.py
@@ -110,13 +110,13 @@ class CamViewer(Display):
         self.marker_dict[4]['xlineedit'] = self.ui.marker4XPosLineEdit
         self.marker_dict[4]['ylineedit'] = self.ui.marker4YPosLineEdit
         # Disable auto-ranging the image (it feels strange when the zoom changes as you move markers around.)
-        self.ui.imageView.getView().disableAutoRange()
+        self.ui.imageView.getView().getViewBox().disableAutoRange()
         for d in self.marker_dict:
             marker = self.marker_dict[d]['marker']
             marker.setZValue(20)
             marker.hide()
             marker.sigRegionChanged.connect(self.markerMoved)
-            self.ui.imageView.getView().addItem(marker)
+            self.ui.imageView.getView().getViewBox().addItem(marker)
             self.marker_dict[d]['button'].toggled.connect(self.enableMarker)
             curvepen = QPen(marker.pen)
             curvepen.setWidth(1)
@@ -139,11 +139,11 @@ class CamViewer(Display):
 
     @Slot()
     def zoomIn(self):
-        self.ui.imageView.getView().scaleBy((0.5, 0.5))
+        self.ui.imageView.getView().getViewBox().scaleBy((0.5, 0.5))
 
     @Slot()
     def zoomOut(self):
-        self.ui.imageView.getView().scaleBy((2.0, 2.0))
+        self.ui.imageView.getView().getViewBox().scaleBy((2.0, 2.0))
 
     @Slot()
     def zoomToActualSize(self):

--- a/examples/image_processing/image_view.py
+++ b/examples/image_processing/image_view.py
@@ -3,7 +3,7 @@ import threading
 from os import path
 from skimage.feature import blob_doh
 from marker import ImageMarker
-from pyqtgraph import mkPen
+from pyqtgraph import mkPen, PlotItem
 
 
 class ImageViewer(Display):
@@ -21,15 +21,17 @@ class ImageViewer(Display):
 
     def draw_markers(self, *args, **kwargs):
         with self.markers_lock:
+            view = self.ui.imageView.getView().getViewBox()
+
             for m in self.markers:
-                if m in self.ui.imageView.getView().addedItems:
-                    self.ui.imageView.getView().removeItem(m)
+                if m in view.addedItems:
+                    view.removeItem(m)
 
             for blob in self.blobs:
                 x, y, size = blob
                 m = ImageMarker((y, x), size=size, pen=mkPen((100, 100, 255), width=3))
                 self.markers.append(m)
-                self.ui.imageView.getView().addItem(m)
+                view.addItem(m)
 
             self.ui.numBlobsLabel.setText(str(len(self.blobs)))
 


### PR DESCRIPTION
After merging #514 in, the view returned by `image.getView()` is no longer a `ViewBox` and it is now a `PlotItem`. This PR fixes the examples to reflect this change.