### PR TITLE
BUG: fix `pydm.widgets.spinbox.precision_changed`

### DIFF
--- a/pydm/widgets/spinbox.py
+++ b/pydm/widgets/spinbox.py
@@ -155,7 +155,7 @@ class PyDMSpinbox(QDoubleSpinBox, TextFormatter, PyDMWritableWidget):
             The new precision value
         """
         super(PyDMSpinbox, self).precision_changed(new_precision)
-        self.setDecimals(new_precision)
+        self.setDecimals(self.precision)
 
     @Property(int)
     def precision(self):


### PR DESCRIPTION
closes #640.

The logic defined in the homonymous base class method to check the
value of `precisionFromPV` before accepting `new_precision` was being
ignored with the call to `setDecimals`.