### PR TITLE
FIX: Make sure we unregister when setting a new rule even if invalid.

### DIFF
--- a/pydm/tests/widgets/test_rules.py
+++ b/pydm/tests/widgets/test_rules.py
@@ -83,10 +83,11 @@ def test_rules_not_connected(qtbot, caplog):
     assert len(re.widget_map[weakref.ref(widget)]) == 1
     assert re.widget_map[weakref.ref(widget)][0]['rule'] == rules[0]
 
-    re.callback_value(weakref.ref(widget), 0, 0, trigger=True, value=1)
-    for record in caplog.records:
-        assert record.levelno == logging.ERROR
-    assert "Not all channels are connected" in caplog.text
+    with caplog.at_level(logging.DEBUG):
+        re.callback_value(weakref.ref(widget), 0, 0, trigger=True, value=1)
+        for record in caplog.records:
+            assert record.levelno == logging.DEBUG
+        assert "Not all channels are connected" in caplog.text
 
 
 def test_rules_ok(qtbot, caplog):

--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -195,6 +195,7 @@ class PyDMPrimitiveWidget(object):
         """
         if new_rules != self._rules:
             self._rules = new_rules
+            RulesDispatcher().unregister(self)
             try:
                 rules_list = json.loads(self._rules)
                 if rules_list:

--- a/pydm/widgets/rules.py
+++ b/pydm/widgets/rules.py
@@ -276,7 +276,7 @@ class RulesEngine(QThread):
             pass
 
     def warn_unconnected_channels(self, widget_ref, index):
-        logger.error(
+        logger.debug(
             "Rule '%s': Not all channels are connected, skipping execution.",
             self.widget_map[widget_ref][index]['rule']['name'])
 


### PR DESCRIPTION
FIX: Reduce verbosity of Not all channels are connected message which can be very annoying and little informative.

Came across the need for this code while exercising rules at the PMPS-UI for L2S-I.