### PR TITLE
FIX: Address issues with PyDMImageView and initialization.

### DIFF
--- a/azure-pipelines-linux.yml
+++ b/azure-pipelines-linux.yml
@@ -19,7 +19,7 @@ jobs:
       name: Linux_3_7
       vmImage: 'Ubuntu 18.04'
       build_docs: 1
-      python: '3.7.3'
+      python: '3.7'
       allowFailure: false
   - template: azure-test-template.yml
     parameters:

--- a/azure-pipelines-macos.yml
+++ b/azure-pipelines-macos.yml
@@ -10,7 +10,7 @@ jobs:
     parameters:
       name: MacOS_3_7
       vmImage: 'macOS-10.14'
-      python: '3.7.3'
+      python: '3.7'
       allowFailure: false
   - template: azure-test-template.yml
     parameters:

--- a/azure-pipelines-windows.yml
+++ b/azure-pipelines-windows.yml
@@ -13,7 +13,7 @@ jobs:
       name: Windows_3_7
       vmImage: 'vs2017-win2016'
       build_docs: 1
-      python: '3.7.3'
+      python: '3.7'
       python_name: '3_7'
       allowFailure: true
   - template: azure-test-template-win.yml


### PR DESCRIPTION
This PR here requires a lot of explanations.

Today I was poking with pyqtgraph and I noticed that when displaying an Image via the ImageView widget all worked out fine but with PyDM it failed on instantiation with the famous `ConnectSlotsByName` error which up to this point was blamed into Python >= 3.7.4 and also PyQt 5.13.1 not being available.

The reality of the fact is that Python 3.7.4+ now exposes the violations that we were having in which `Qt properties` of the widget were trying to access attributes that were not available yet.

Today after finding out that the issue was entirely on our field I decided to debug it more and I managed to finally fix it.

Closes #533 and unleashes Python > 3.7.3.