### PR TITLE
FIX: Prevent dead child widgets to cause issues when refreshing stylesheet.

### DIFF
--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -87,9 +87,14 @@ def refresh_style(widget):
     widgets = [widget]
     widgets.extend(widget.findChildren(QWidget))
     for child_widget in widgets:
-        child_widget.style().unpolish(child_widget)
-        child_widget.style().polish(child_widget)
-        child_widget.update()
+        try:
+            child_widget.style().unpolish(child_widget)
+            child_widget.style().polish(child_widget)
+            child_widget.update()
+        except Exception as ex:
+            # Widget was probably destroyed
+            logger.debug('Error while refreshing stylesheet. %s ', ex)
+            pass
 
 
 class PyDMPrimitiveWidget(object):

--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -85,7 +85,12 @@ def refresh_style(widget):
     widget : QWidget
     """
     widgets = [widget]
-    widgets.extend(widget.findChildren(QWidget))
+
+    try:
+        widgets.extend(widget.findChildren(QWidget))
+    except:
+        # If we fail it means that widget is probably destroyed
+        return
     for child_widget in widgets:
         try:
             child_widget.style().unpolish(child_widget)

--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -94,7 +94,6 @@ def refresh_style(widget):
         except Exception as ex:
             # Widget was probably destroyed
             logger.debug('Error while refreshing stylesheet. %s ', ex)
-            pass
 
 
 class PyDMPrimitiveWidget(object):


### PR DESCRIPTION
Came across this issue when helping Allen Pai and Bill with a closing Vacuum Screen.
I got an error that a child widget was deleted when refreshing the stylesheet. 🤞 