### PR TITLE
ENH: Update to PyDM StyleSheet mechanism

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -8,38 +8,44 @@ for configuration and customization.
 The following table describe the environment variable as well as its usage and
 default values.
 
-======================== ===================================================================
-Variable                 What is it used for?
-======================== ===================================================================
-PYDM_DEFAULT_PROTOCOL    | The default protocol to be used when specifing channels.
-                         | This option eliminates the need for users to specify the protocol
-                         | for a given Data Plugin. E.g.: `ca`.
-                         | **Default:** None
-PYDM_DOCS_URL            | This variable point to the base URL for the documentation.
-                         | **Default:** https://slaclab.github.io/pydm
-PYDM_ARCHIVER_URL        | This is the base URL for the Archiver Appliance Data Plugin it is
-                         | concatenated with ``/retrieval/data/getData`` to generate the
-                         | retrieval URL.
-                         | **Default:** http://lcls-archapp.slac.stanford.edu
-PYDM_EPICS_LIB           | Which library to use for Channel Access (ca://) data
-                         | plugin. PyDM offers two options: PYCA and PYEPICS.
-                         | **Default:** PYEPICS
-PYDM_PATH                | Path to `pydm` executable for child processes, such as new windows.
-                         | It will only be used if `pydm` is not found in the standard `$PATH`.
-                         | **Default:** None
-PYDM_DISPLAYS_PATH       | Path in which PyDM should look for ``.ui`` and ``.py`` files when
-                         | they are not found. **Note: This is not a recursive search.**
-                         | **Default:** None
-PYDM_DATA_PLUGINS_PATH   | Path in which PyDM should look for Data Plugins to be loaded.
-                         | **Default:** None
-PYDM_TOOLS_PATH          | Path in which PyDM should look for External Tools to be loaded.
-                         | **Default:** None
-PYDM_STRING_ENCODING     | The string encoding to be used when converting arrays to strings.
-                         | **Default:** utf-8
-PYDM_STYLESHEET          | Path to the QSS file defining the global stylesheet for the
-                         | PyDM application. When used, it will override the default look.
-                         | **Default:** None
-PYDM_DESIGNER_ONLINE     | This flag enables receiving live data in Qt Designer. If disabled,
-                         | channels will not be connected to in Qt Designer.
-                         | **Default:** None
-======================== ===================================================================
+=============================== ==================================================================================
+Variable                        What is it used for?
+=============================== ==================================================================================
+PYDM_DEFAULT_PROTOCOL           | The default protocol to be used when specifing channels.
+                                | This option eliminates the need for users to specify the protocol
+                                | for a given Data Plugin. E.g.: `ca`.
+                                | **Default:** None
+PYDM_DOCS_URL                   | This variable point to the base URL for the documentation.
+                                | **Default:** https://slaclab.github.io/pydm
+PYDM_ARCHIVER_URL               | This is the base URL for the Archiver Appliance Data Plugin it is
+                                | concatenated with ``/retrieval/data/getData`` to generate the
+                                | retrieval URL.
+                                | **Default:** http://lcls-archapp.slac.stanford.edu
+PYDM_EPICS_LIB                  | Which library to use for Channel Access (ca://) data
+                                | plugin. PyDM offers two options: PYCA and PYEPICS.
+                                | **Default:** PYEPICS
+PYDM_PATH                       | Path to `pydm` executable for child processes, such as new windows.
+                                | It will only be used if `pydm` is not found in the standard `$PATH`.
+                                | **Default:** None
+PYDM_DISPLAYS_PATH              | Path in which PyDM should look for ``.ui`` and ``.py`` files when
+                                | they are not found. **Note: This is not a recursive search.**
+                                | **Default:** None
+PYDM_DATA_PLUGINS_PATH          | Path in which PyDM should look for Data Plugins to be loaded.
+                                | **Default:** None
+PYDM_TOOLS_PATH                 | Path in which PyDM should look for External Tools to be loaded.
+                                | **Default:** None
+PYDM_STRING_ENCODING            | The string encoding to be used when converting arrays to strings.
+                                | **Default:** utf-8
+PYDM_STYLESHEET                 | Path to the QSS files defining the global stylesheets for the
+                                | PyDM application. When used, it will override the default look.
+                                | If using multiple files they must be separated by the path separator.
+                                | E.g.: ``/path_to/my_style_1.qss:/path_to/other/my_other_style.qss``
+                                | **Default:** None
+PYDM_STYLESHEET_INCLUDE_DEFAULT | Whether or not to include the PyDM Default stylesheet along with customized
+                                | files. Note that the PyDM default stylesheet will have lower precedence compared
+                                | to files specified at ``PYDM_STYLESHEET``
+                                | **Default:** False
+PYDM_DESIGNER_ONLINE            | This flag enables receiving live data in Qt Designer. If disabled,
+                                | channels will not be connected to in Qt Designer.
+                                | **Default:** None
+=============================== ==================================================================================

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -39,6 +39,8 @@ PYDM_STRING_ENCODING            | The string encoding to be used when converting
 PYDM_STYLESHEET                 | Path to the QSS files defining the global stylesheets for the
                                 | PyDM application. When used, it will override the default look.
                                 | If using multiple files they must be separated by the path separator.
+                                | Only files are supported, not directories. On this list, like a PATH
+                                | variable, the first elements will take precedence over others.
                                 | E.g.: ``/path_to/my_style_1.qss:/path_to/other/my_other_style.qss``
                                 | **Default:** None
 PYDM_STYLESHEET_INCLUDE_DEFAULT | Whether or not to include the PyDM Default stylesheet along with customized

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -29,6 +29,7 @@ as well as a straightforward python framework to build complex applications.
    :maxdepth: 2
    :caption: User & API Documentation
 
+   stylesheets.rst
    widgets/index.rst
    widgets/widget_rules/index.rst
    add_data_plugins.rst

--- a/docs/source/stylesheets.rst
+++ b/docs/source/stylesheets.rst
@@ -1,0 +1,44 @@
+=============================
+Customizing the Look and Feel
+=============================
+
+Instead of rolling out hardcoded styles or reinvent the wheel, PyDM leverages
+the existing Qt Style Sheet mechanism.
+
+Qt Style Sheet terminology and syntactic rules are almost identical to those of
+HTML CSS. More on the rules, selectors and syntax can be found at this
+`link <https://doc.qt.io/Qt-5/stylesheet-syntax.html>`_.
+
+By default PyDM ships with a `default stylesheet file <https://github.com/slaclab/pydm/blob/master/pydm/default_stylesheet.qss>`_
+that is used unless an user specify a file to be used either via the PyDM
+launcher argument `–-stylesheet STYLESHEET` or via the `PYDM_STYLESHEET`
+environment variable.
+
+To help users extend this feature, PyDM offers two main configurations that can
+be used:
+
+- **PYDM_STYLESHEET**
+Path to the QSS files defining the global stylesheets for the PyDM application.
+When used, it will override the default look. If using multiple files they
+must be separated by the path separator.
+E.g.: ``/path_to/my_style_1.qss:/path_to/other/my_other_style.qss``
+
+- **PYDM_STYLESHEET_INCLUDE_DEFAULT**
+Whether or not to include the PyDM Default stylesheet along with customized
+files. Note that the PyDM default stylesheet will have lower precedence compared
+to files specified at ``PYDM_STYLESHEET``
+
+Processing Order of Style Sheets
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The file will be processed from top to bottom and the bottom-most rules will
+take precedence over rules defined at the top in case of repeated/conflicts.
+
+Rules defined at widgets will always take precedence over general rules defined
+at higher levels.
+
+Important Notes
+^^^^^^^^^^^^^^^
+
+When writing your own style sheet rules please be always mindful about your
+selectors since, as with HTML CSS, the style rules will cascade to child widgets.

--- a/pydm/config.py
+++ b/pydm/config.py
@@ -1,7 +1,9 @@
 import os
 
 __all__ = ['DEFAULT_PROTOCOL',
-           'DESIGNER_ONLINE'
+           'DESIGNER_ONLINE',
+           'STYLESHEET',
+           'STYLESHEET_INCLUDE_DEFAULT'
            ]
 
 
@@ -11,3 +13,7 @@ if DEFAULT_PROTOCOL is not None:
     DEFAULT_PROTOCOL = DEFAULT_PROTOCOL.split("://")[0]
 
 DESIGNER_ONLINE = os.getenv("PYDM_DESIGNER_ONLINE", None) is not None
+
+STYLESHEET = os.getenv("PYDM_STYLESHEET", None)
+
+STYLESHEET_INCLUDE_DEFAULT = os.getenv("PYDM_STYLESHEET_INCLUDE_DEFAULT", False)

--- a/pydm/display.py
+++ b/pydm/display.py
@@ -13,6 +13,7 @@ from qtpy import uic
 from qtpy.QtWidgets import QWidget, QApplication
 
 from .utilities import macro, is_pydm_app
+from .utilities.stylesheet import merge_widget_stylesheet
 
 
 class ScreenTarget:
@@ -89,6 +90,8 @@ def load_ui_file(uifile, macros=None):
     """
 
     d = Display(macros=macros)
+    merge_widget_stylesheet(d)
+
     if macros:
         f = macro.substitute_in_file(uifile, macros)
     else:
@@ -182,6 +185,7 @@ def load_py_file(pyfile, args=None, macros=None):
         kwargs['macros'] = macros
     instance = cls(**kwargs)
     instance._loaded_file = pyfile
+    merge_widget_stylesheet(instance)
     return instance
 
 
@@ -261,3 +265,4 @@ class Display(QWidget):
             else:
                 f = self.ui_filepath()
             self.ui = uic.loadUi(f, baseinstance=self)
+            merge_widget_stylesheet(self.ui)

--- a/pydm/tests/utilities/test_stylesheet.py
+++ b/pydm/tests/utilities/test_stylesheet.py
@@ -11,10 +11,6 @@ test_stylesheet_path = os.path.join(
     "..", "test_data", "global_stylesheet.css")
 
 
-def test_stylesheet_init():
-    assert stylesheet.__style_data is None
-
-
 def test_stylesheet_apply(qtbot):
     # Backup of the variable
     env_backup = os.getenv("PYDM_STYLESHEET", None)
@@ -67,7 +63,7 @@ def test_stylesheet_get_style_data(caplog):
     os.environ["PYDM_STYLESHEET"] = ""
     assert os.getenv("PYDM_STYLESHEET", None) == ""
 
-    with caplog.at_level(logging.INFO):
+    with caplog.at_level(logging.DEBUG):
         # Cleanup the cache
         stylesheet.clear_cache()
 
@@ -80,9 +76,8 @@ def test_stylesheet_get_style_data(caplog):
         assert ret
         assert stylesheet.__style_data == ret
 
-        # Make sure logging capture the error, and have the correct error message
-        for record in caplog.records:
-            assert record.levelno == logging.INFO
+        # Make sure logging capture the error, and have the correct error
+        # message
         assert "Opening the default stylesheet" in caplog.text
 
         caplog.clear()
@@ -122,8 +117,6 @@ def test_stylesheet_get_style_data(caplog):
         # Exercise the proper loading
         ret = stylesheet._get_style_data(test_stylesheet_path)
         # Make sure logging capture the error, and have the correct error message
-        for record in caplog.records:
-            assert record.levelno == logging.INFO
         assert "Opening style file" in caplog.text
 
         caplog.clear()


### PR DESCRIPTION
- Add support for multiple files at `PYDM_STYLESHEET`. Files must be separated with `os.pathsep`.
- Add support for usage of the PyDM default stylesheet along with a custom one via definition of the `PYDM_STYLESHEET_INCLUDE_DEFAULT` configuration variable. The default is False to keep current behavior.
This solves an issue with users that just want to add or extend the default stylesheet without keeping track of it or copying it from PyDM and risking get it sync.
- Fixes an issue that stylesheets were never applied to Display instances if not using a PyDMApplication/PyDMMainWindow.
- Update docs to reflect new variable and new behavior for `PYDM_STYLESHEET`.