### PR TITLE
FIX: Revert to Software Rastering if using PyDM via SSH.

### DIFF
--- a/pydm/utilities/__init__.py
+++ b/pydm/utilities/__init__.py
@@ -20,6 +20,18 @@ from . import shortcuts
 logger = logging.getLogger(__name__)
 
 
+def is_ssh_session():
+    """
+    Whether or not this is a SSH session.
+
+    Returns
+    -------
+    bool
+        True if it is a ssh session, False otherwise.
+    """
+    return os.getenv('SSH_CONNECTION') is not None
+
+
 def is_pydm_app(app=None):
     """
     Check whether or not `QApplication.instance()` is a PyDMApplication.

--- a/pydm/utilities/__init__.py
+++ b/pydm/utilities/__init__.py
@@ -32,6 +32,20 @@ def is_ssh_session():
     return os.getenv('SSH_CONNECTION') is not None
 
 
+def setup_renderer():
+    """
+    This utility function reverts the renderer to Software rendering if it is
+    running in a SSH session.
+    """
+    if is_ssh_session():
+        logger.info('Using PyDM via SSH. Reverting to Software Rendering.')
+        from qtpy.QtCore import QCoreApplication, Qt
+        from qtpy.QtQuick import QQuickWindow, QSGRendererInterface
+
+        QCoreApplication.setAttribute(Qt.AA_UseSoftwareOpenGL)
+        QQuickWindow.setSceneGraphBackend(QSGRendererInterface.Software)
+
+
 def is_pydm_app(app=None):
     """
     Check whether or not `QApplication.instance()` is a PyDMApplication.

--- a/pydm_launcher/main.py
+++ b/pydm_launcher/main.py
@@ -1,6 +1,5 @@
 import sys
 import argparse
-import json
 import logging
 
 
@@ -12,6 +11,16 @@ def main():
     logger.addHandler(handler)
     logger.setLevel("INFO")
     handler.setLevel("INFO")
+
+    from pydm.utilities import is_ssh_session
+
+    if is_ssh_session():
+        logger.info('Using PyDM via SSH. Reverting to Software Rendering.')
+        from qtpy.QtCore import QCoreApplication, Qt
+        from qtpy.QtQuick import QQuickWindow, QSGRendererInterface
+
+        QCoreApplication.setAttribute(Qt.AA_UseSoftwareOpenGL)
+        QQuickWindow.setSceneGraphBackend(QSGRendererInterface.Software)
 
     try:
         """

--- a/pydm_launcher/main.py
+++ b/pydm_launcher/main.py
@@ -12,15 +12,9 @@ def main():
     logger.setLevel("INFO")
     handler.setLevel("INFO")
 
-    from pydm.utilities import is_ssh_session
+    from pydm.utilities import setup_renderer
 
-    if is_ssh_session():
-        logger.info('Using PyDM via SSH. Reverting to Software Rendering.')
-        from qtpy.QtCore import QCoreApplication, Qt
-        from qtpy.QtQuick import QQuickWindow, QSGRendererInterface
-
-        QCoreApplication.setAttribute(Qt.AA_UseSoftwareOpenGL)
-        QQuickWindow.setSceneGraphBackend(QSGRendererInterface.Software)
+    setup_renderer()
 
     try:
         """


### PR DESCRIPTION
When using any Qt Quick widget (such as QWebEngineView) at a screen via SSH the screen would crash or freeze with many OpenGL errors.
Switching the renderer to software when using PyDM over SSH solves the issue.
A new utility function `is_ssh_session` was added to also help other applications if needed.

This was tested with psbuild and other SLAC machines as well as locally.

Kudos to https://github.com/spyder-ide/spyder/issues/7447