### PR TITLE
FIX: Pass destroying only if widget reference is gone.

### DIFF
--- a/pydm/widgets/rules.py
+++ b/pydm/widgets/rules.py
@@ -205,7 +205,7 @@ class RulesEngine(QThread):
 
         for rule in w_data:
             for ch in rule['channels']:
-                ch.disconnect(destroying=True)
+                ch.disconnect(destroying=widget_ref() is None)
 
         del w_data
 


### PR DESCRIPTION
If we don't do that connections will multiply at the callbacks at rules.