### PR TITLE
ENH: PyDMEnumButton Order options - Inverted & Custom

### DIFF
--- a/examples/enum_buttons/buttons.ui
+++ b/examples/enum_buttons/buttons.ui
@@ -6,14 +6,24 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>583</width>
-    <height>438</height>
+    <width>237</width>
+    <height>339</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="spacing">
+    <number>0</number>
+   </property>
+   <item>
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Orientation: Vertical</string>
+     </property>
+    </widget>
+   </item>
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
@@ -81,44 +91,36 @@
        </property>
       </widget>
      </item>
-     <item>
-      <widget class="PyDMEnumButton" name="PyDMEnumButton_3">
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="whatsThis">
-        <string>
-    A QWidget that renders buttons for every option of Enum Items.
-    For now three types of buttons can be rendered:
-    - Push Button
-    - Radio Button
-    - Check Box
-
-    Parameters
-    ----------
-    parent : QWidget
-        The parent widget for the Label
-    init_channel : str, optional
-        The channel to be used by the widget.
-
-    Signals
-    -------
-    send_value_signal : int, float, str, bool or np.ndarray
-        Emitted when the user changes the value.
-    </string>
-       </property>
-       <property name="channel" stdset="0">
-        <string>ca://MTEST:Run</string>
-       </property>
-       <property name="widgetType" stdset="0">
-        <enum>PyDMEnumButton::CheckBox</enum>
-       </property>
-      </widget>
-     </item>
     </layout>
    </item>
    <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>Orientation: Horizontal</string>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="PyDMEnumButton" name="PyDMEnumButton_5">
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>48</height>
+      </size>
+     </property>
      <property name="toolTip">
       <string/>
      </property>
@@ -153,6 +155,12 @@
    </item>
    <item>
     <widget class="PyDMEnumButton" name="PyDMEnumButton_6">
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>48</height>
+      </size>
+     </property>
      <property name="toolTip">
       <string/>
      </property>
@@ -189,7 +197,33 @@
     </widget>
    </item>
    <item>
-    <widget class="PyDMEnumButton" name="PyDMEnumButton_4">
+    <spacer name="verticalSpacer_2">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <widget class="QLabel" name="label_3">
+     <property name="text">
+      <string>Inverted Order</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="PyDMEnumButton" name="PyDMEnumButton_7">
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>48</height>
+      </size>
+     </property>
      <property name="toolTip">
       <string/>
      </property>
@@ -217,8 +251,80 @@
      <property name="channel" stdset="0">
       <string>ca://MTEST:Run</string>
      </property>
-     <property name="widgetType" stdset="0">
-      <enum>PyDMEnumButton::CheckBox</enum>
+     <property name="invertOrder" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="orientation" stdset="0">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer_3">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <widget class="QLabel" name="label_4">
+     <property name="text">
+      <string>Custom Order: 1, 0</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="PyDMEnumButton" name="PyDMEnumButton_8">
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>48</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="whatsThis">
+      <string>
+    A QWidget that renders buttons for every option of Enum Items.
+    For now three types of buttons can be rendered:
+    - Push Button
+    - Radio Button
+    - Check Box
+
+    Parameters
+    ----------
+    parent : QWidget
+        The parent widget for the Label
+    init_channel : str, optional
+        The channel to be used by the widget.
+
+    Signals
+    -------
+    send_value_signal : int, float, str, bool or np.ndarray
+        Emitted when the user changes the value.
+    </string>
+     </property>
+     <property name="channel" stdset="0">
+      <string>ca://MTEST:Run</string>
+     </property>
+     <property name="useCustomOrder" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="invertOrder" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="customOrder" stdset="0">
+      <stringlist>
+       <string>1</string>
+       <string>0</string>
+      </stringlist>
      </property>
      <property name="orientation" stdset="0">
       <enum>Qt::Horizontal</enum>

--- a/examples/enum_buttons/enum.db
+++ b/examples/enum_buttons/enum.db
@@ -1,0 +1,12 @@
+record(mbbo, "TEST:ENUM")
+{
+   field(PINI, "YES")
+   field(ZRST, "YES")
+   field(ZRVL, "0")
+   field(ONST, "NO")
+   field(ONVL, "1")
+   field(TWST, "MAYBE")
+   field(TWVL, "2")
+   field(VAL,  "0")
+}
+

--- a/examples/enum_buttons/enum.ui
+++ b/examples/enum_buttons/enum.ui
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>323</width>
+    <height>246</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Regular Horizontal Setup</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="PyDMEnumButton" name="PyDMEnumButton">
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>48</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="channel" stdset="0">
+      <string>ca://TEST:ENUM</string>
+     </property>
+     <property name="orientation" stdset="0">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>Inverted Order</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="PyDMEnumButton" name="PyDMEnumButton_2">
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>48</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="channel" stdset="0">
+      <string>ca://TEST:ENUM</string>
+     </property>
+     <property name="invertOrder" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="orientation" stdset="0">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="label_3">
+     <property name="text">
+      <string>Custom Order: 0, 2, 1</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="PyDMEnumButton" name="PyDMEnumButton_3">
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>48</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="channel" stdset="0">
+      <string>ca://TEST:ENUM</string>
+     </property>
+     <property name="useCustomOrder" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="customOrder" stdset="0">
+      <stringlist>
+       <string>0</string>
+       <string>2</string>
+       <string>1</string>
+      </stringlist>
+     </property>
+     <property name="orientation" stdset="0">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>PyDMEnumButton</class>
+   <extends>QWidget</extends>
+   <header>pydm.widgets.enum_button</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/pydm/widgets/enum_button.py
+++ b/pydm/widgets/enum_button.py
@@ -1,8 +1,9 @@
 import logging
+
 from qtpy.QtCore import (Qt, QSize, Property, Slot, Q_ENUMS, QMargins)
+from qtpy.QtGui import QPainter
 from qtpy.QtWidgets import (QWidget, QButtonGroup, QGridLayout, QPushButton,
                             QRadioButton, QStyleOption, QStyle)
-from qtpy.QtGui import QPainter
 
 from .base import PyDMWritableWidget
 from .. import data_plugins
@@ -425,7 +426,14 @@ class PyDMEnumButton(QWidget, PyDMWritableWidget, WidgetType):
             order = order[::-1]
 
         for i, idx in enumerate(order):
-            widget = self._widgets[idx]
+            try:
+                widget = self._widgets[idx]
+            except IndexError:
+                if self._has_enums:
+                    logger.error(
+                        'Invalid index for PyDMEnumButton %s. Index: %s, Range: 0 to %s',
+                        self.objectName(), idx, len(self._widgets) - 1)
+                continue
             if self.orientation == Qt.Vertical:
                 self.layout().addWidget(widget, i, 0)
             elif self.orientation == Qt.Horizontal:

--- a/pydm/widgets/enum_button.py
+++ b/pydm/widgets/enum_button.py
@@ -40,6 +40,9 @@ class PyDMEnumButton(QWidget, PyDMWritableWidget, WidgetType):
     def __init__(self, parent=None, init_channel=None):
         QWidget.__init__(self, parent)
         PyDMWritableWidget.__init__(self, init_channel=init_channel)
+        self._invert_order = False
+        self._use_custom_order = False
+        self._custom_order = []
         self._has_enums = False
         self._checkable = True
         self.setLayout(QGridLayout(self))
@@ -82,6 +85,58 @@ class PyDMEnumButton(QWidget, PyDMWritableWidget, WidgetType):
     @items.setter
     def items(self, value):
         self.enum_strings_changed(value)
+
+    @Property(bool)
+    def useCustomOrder(self):
+        """
+        Whether or not to use custom order for the button group.
+
+        Returns
+        -------
+        bool
+        """
+        return self._use_custom_order
+
+    @useCustomOrder.setter
+    def useCustomOrder(self, value):
+        if value != self._use_custom_order:
+            self._use_custom_order = value
+            self.rebuild_layout()
+
+    @Property(bool)
+    def invertOrder(self):
+        """
+        Whether or not to invert the order for the button group.
+
+        Returns
+        -------
+        bool
+        """
+        return self._use_custom_order
+
+    @invertOrder.setter
+    def invertOrder(self, value):
+        if value != self._invert_order:
+            self._invert_order = value
+            self.rebuild_layout()
+
+    @Property("QStringList")
+    def customOrder(self):
+        """
+        Index list in which items are to be displayed in the button group.
+
+        Returns
+        -------
+        List[str]
+        """
+        return self._custom_order
+
+    @customOrder.setter
+    def customOrder(self, value):
+        if value != self._custom_order:
+            self._custom_order = value
+            if self.useCustomOrder:
+                self.rebuild_layout()
 
     @Property(WidgetType)
     def widgetType(self):


### PR DESCRIPTION
Not always the order coming from the control system will be the best or more logical one for the User Interface.
This PR comes from the need highlighted by users at https://github.com/pcdshub/pcdswidgets/issues/42 in which the `ON/OFF` buttons were being represented as `OFF/ON`.

This PR adds three new properties to the PyDMEnumButton:
- invertOrder (bool) - this just inverts the order
- useCustomOrder (bool) - whether or not to use a custom order
- customOrder (QStringList) - the new order list using here indexes starting at 0.

Here is an example of the outcome:
![Screen Shot 2020-06-26 at 3 55 45 PM](https://user-images.githubusercontent.com/8185425/85907362-0dbb2e80-b7c6-11ea-8ca2-46aa663c88a8.png)

TODO:
- [x] Protection against invalid indexes and proper error message. (Commit coming)