### PR TITLE
ENH: New Date/Time widgets

### DIFF
--- a/docs/source/widgets/datetime_edit.rst
+++ b/docs/source/widgets/datetime_edit.rst
@@ -1,0 +1,8 @@
+#######################
+PyDMDateTimeEdit
+#######################
+
+.. autoclass:: pydm.widgets.datetime.PyDMDateTimeEdit
+   :members:
+   :inherited-members:
+   :show-inheritance:

--- a/docs/source/widgets/datetime_label.rst
+++ b/docs/source/widgets/datetime_label.rst
@@ -1,0 +1,8 @@
+#######################
+PyDMDateTimeLabel
+#######################
+
+.. autoclass:: pydm.widgets.datetime.PyDMDateTimeLabel
+   :members:
+   :inherited-members:
+   :show-inheritance:

--- a/docs/source/widgets/index.rst
+++ b/docs/source/widgets/index.rst
@@ -10,6 +10,7 @@ Display Widgets
    :maxdepth: 1
 
    byte.rst
+   datetime_label.rst
    image.rst
    label.rst
    log.rst
@@ -23,6 +24,7 @@ Input Widgets
    :maxdepth: 1
 
    checkbox.rst
+   datetime_edit.rst
    enum_button.rst
    enum_combo_box.rst
    line_edit.rst

--- a/examples/datetime/datetime.ui
+++ b/examples/datetime/datetime.ui
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>208</width>
+    <height>149</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,1,1,0,0,0">
+   <item>
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>Configurable Value:</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="PyDMDateTimeEdit" name="PyDMDateTimeEdit">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="channel" stdset="0">
+      <string>ca://MTEST:ConfigTime</string>
+     </property>
+     <property name="timeBase" stdset="0">
+      <enum>PyDMDateTimeEdit::Milliseconds</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="PyDMDateTimeLabel" name="PyDMDateTimeLabel">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="channel" stdset="0">
+      <string>ca://MTEST:ConfigTime</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="Line" name="line">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Current Time:</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="PyDMDateTimeLabel" name="PyDMDateTimeLabel_2">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="channel" stdset="0">
+      <string>ca://MTEST:CurrentTimeSec</string>
+     </property>
+     <property name="format" stdset="0">
+      <string>yyyy/MM/dd hh:mm:ss.zzz</string>
+     </property>
+     <property name="timeBase" stdset="0">
+      <enum>PyDMDateTimeLabel::Seconds</enum>
+     </property>
+     <property name="relative" stdset="0">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>PyDMDateTimeEdit</class>
+   <extends>QDateTimeEdit</extends>
+   <header>pydm.widgets.datetime</header>
+  </customwidget>
+  <customwidget>
+   <class>PyDMDateTimeLabel</class>
+   <extends>QLabel</extends>
+   <header>pydm.widgets.datetime</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/examples/testing_ioc/pydm-testing-ioc
+++ b/examples/testing_ioc/pydm-testing-ioc
@@ -2,6 +2,7 @@
 import os
 import threading
 import numpy
+import time
 
 from pcaspy import Driver, SimpleServer
 
@@ -49,7 +50,9 @@ pvdb = {
         'CosVal'           : { 'type' : 'float', 'value': 0.0, 'asg': 'default' },
         'Normal'           : { 'type' : 'float', 'value': 0.0, 'asg': 'default' },
         'Infinity'         : { 'count': MAX_POINTS,
-                              'prec' : 5, 'asg' : 'default', 'value': numpy.array([numpy.inf]*MAX_POINTS)}
+                              'prec' : 5, 'asg' : 'default', 'value': numpy.array([numpy.inf]*MAX_POINTS)},
+        'CurrentTimeSec'   : {'type': 'float', 'value': 0},
+        'ConfigTime'       : { 'type': 'float', 'value': 0, 'asg': 'default'}
 
 }
 
@@ -91,6 +94,7 @@ class myDriver(Driver):
         y = numpy.linspace(-5.0, 5.0, IMAGE_SIZE)
         xgrid, ygrid = numpy.meshgrid(x, y)
         i = 0
+
         while True:
             run = self.getParam('Run')
             updateTime = self.getParam('UpdateTime')
@@ -99,7 +103,10 @@ class myDriver(Driver):
             else:
                 self.eid.wait()
             run = self.getParam('Run')
-            if not run: continue
+            self.setParam('CurrentTimeSec', time.time())
+            if not run:
+                self.updatePV('CurrentTimeSec')
+                continue
             # retrieve parameters
             noiseAmplitude = self.getParam('NoiseAmplitude')
             timePerDivision = self.getParam('TimePerDivision')

--- a/pydm/widgets/datetime.py
+++ b/pydm/widgets/datetime.py
@@ -1,0 +1,178 @@
+import logging
+from qtpy import QtWidgets, QtCore
+
+from .base import PyDMWritableWidget, PyDMWidget
+
+logger = logging.getLogger(__name__)
+
+
+class TimeBase(object):
+    Milliseconds = 0
+    Seconds = 1
+
+
+class PyDMDateTimeEdit(QtWidgets.QDateTimeEdit, PyDMWritableWidget, TimeBase):
+    QtCore.Q_ENUMS(TimeBase)
+    returnPressed = QtCore.Signal()
+    """
+    A QDateTimeEdit with support for setting the text via a PyDM Channel, or
+    through the PyDM Rules system.
+
+    Parameters
+    ----------
+    parent : QWidget
+        The parent widget for the Label
+    init_channel : str, optional
+        The channel to be used by the widget.
+    """
+    def __init__(self, parent=None, init_channel=None):
+        self._block_past_date = True
+        self._relative = True
+        self._time_base = TimeBase.Milliseconds
+
+        QtWidgets.QDateTimeEdit.__init__(self, parent=parent)
+        PyDMWritableWidget.__init__(self, init_channel=init_channel)
+        self.setDisplayFormat("yyyy/MM/dd hh:mm:ss.zzz")
+        self.setDateTime(QtCore.QDateTime.currentDateTime())
+        self.setCalendarPopup(True)
+        self.returnPressed.connect(self.send_value)
+
+    @QtCore.Property(TimeBase)
+    def timeBase(self):
+        """Whether to use milliseconds or seconds as time base for the widget"""
+        return self._time_base
+
+    @timeBase.setter
+    def timeBase(self, base):
+        if self._time_base != base:
+            self._time_base = base
+
+    @QtCore.Property(bool)
+    def relative(self):
+        """
+        Whether the value in milliseconds is relative to current date or if it
+        is milliseconds since epoch.
+        """
+        return self._relative
+
+    @relative.setter
+    def relative(self, checked):
+        if self._relative != checked:
+            self._relative = checked
+
+    @QtCore.Property(bool)
+    def blockPastDate(self):
+        """Error out if user tries to set value to a date older than current."""
+        return self._block_past_date
+
+    @blockPastDate.setter
+    def blockPastDate(self, block):
+        if block != self._block_past_date:
+            self._block_past_date = block
+
+    def keyPressEvent(self, key_event):
+        ret = super(PyDMDateTimeEdit, self).keyPressEvent(key_event)
+        if key_event.key() in [QtCore.Qt.Key_Return, QtCore.Qt.Key_Enter]:
+            self.returnPressed.emit()
+        return ret
+
+    def send_value(self):
+        val = self.dateTime()
+        now = QtCore.QDateTime.currentDateTime()
+        if self._block_past_date and val < now:
+            logger.error('Selected date cannot be lower than current date.')
+            return
+
+        if self.relative:
+            new_value = now.msecsTo(val)
+        else:
+            new_value = val.currentMSecsSinceEpoch()
+
+        if self.timeBase == TimeBase.Seconds:
+            new_value /= 1000.0
+        self.send_value_signal.emit(new_value)
+
+    def value_changed(self, new_val):
+        super(PyDMDateTimeEdit, self).value_changed(new_val)
+
+        if self.timeBase == TimeBase.Seconds:
+            new_val *= 1000
+
+        val = QtCore.QDateTime.currentDateTime()
+        if self._relative:
+            val = val.addMSecs(new_val)
+        else:
+            val.setMSecsSinceEpoch(new_val)
+        self.setDateTime(val)
+
+
+class PyDMDateTimeLabel(QtWidgets.QLabel, PyDMWidget, TimeBase):
+    QtCore.Q_ENUMS(TimeBase)
+    """
+    A QLabel with support for setting the text via a PyDM Channel, or
+    through the PyDM Rules system.
+
+    Parameters
+    ----------
+    parent : QWidget
+        The parent widget for the Label
+    init_channel : str, optional
+        The channel to be used by the widget.
+    """
+
+    def __init__(self, parent=None, init_channel=None):
+        QtWidgets.QLabel.__init__(self, parent=parent)
+        PyDMWidget.__init__(self, init_channel=init_channel)
+
+        self._block_past_date = True
+        self._relative = True
+        self._time_base = TimeBase.Milliseconds
+        self._text_format = "yyyy/MM/dd hh:mm:ss.zzz"
+        self.setText("")
+
+    @QtCore.Property(str)
+    def textFormat(self):
+        """The format to use when displaying the date/time values."""
+        return self._text_format
+
+    @textFormat.setter
+    def textFormat(self, text_format):
+        if self._text_format != text_format:
+            self._text_format = text_format
+            self.value_changed(self.value)
+
+    @QtCore.Property(TimeBase)
+    def timeBase(self):
+        """Whether to use milliseconds or seconds as time base for the widget"""
+        return self._time_base
+
+    @timeBase.setter
+    def timeBase(self, base):
+        if self._time_base != base:
+            self._time_base = base
+
+    @QtCore.Property(bool)
+    def relative(self):
+        """
+        Whether the value in milliseconds is relative to current date or if it
+        is milliseconds since epoch.
+        """
+        return self._relative
+
+    @relative.setter
+    def relative(self, checked):
+        if self._relative != checked:
+            self._relative = checked
+
+    def value_changed(self, new_val):
+        super(PyDMDateTimeLabel, self).value_changed(new_val)
+
+        if self.timeBase == TimeBase.Seconds:
+            new_val *= 1000
+
+        val = QtCore.QDateTime.currentDateTime()
+        if self._relative:
+            val = val.addMSecs(new_val)
+        else:
+            val.setMSecsSinceEpoch(new_val)
+        self.setText(val.toString(self.textFormat))

--- a/pydm/widgets/qtplugins.py
+++ b/pydm/widgets/qtplugins.py
@@ -9,6 +9,7 @@ from .tab_bar_qtplugin import TabWidgetPlugin
 from .byte import PyDMByteIndicator
 
 from .checkbox import PyDMCheckbox
+from .datetime import (PyDMDateTimeEdit, PyDMDateTimeLabel)
 from .drawing import (PyDMDrawingLine, PyDMDrawingRectangle,
                       PyDMDrawingTriangle,
                       PyDMDrawingEllipse, PyDMDrawingCircle, PyDMDrawingArc,
@@ -69,6 +70,15 @@ PyDMByteIndicatorPlugin = qtplugin_factory(PyDMByteIndicator,
 # Checkbox plugin
 PyDMCheckboxPlugin = qtplugin_factory(PyDMCheckbox, group=WidgetCategory.INPUT,
                                       extensions=BASE_EXTENSIONS)
+
+# Date/Time plugins
+PyDMDateTimeEditPlugin = qtplugin_factory(PyDMDateTimeEdit,
+                                          group=WidgetCategory.INPUT,
+                                          extensions=BASE_EXTENSIONS)
+
+PyDMDateTimeLabelPlugin = qtplugin_factory(PyDMDateTimeLabel,
+                                           group=WidgetCategory.DISPLAY,
+                                           extensions=BASE_EXTENSIONS)
 
 # Drawing plugins
 PyDMDrawingArcPlugin = qtplugin_factory(PyDMDrawingArc,


### PR DESCRIPTION
This PR adds two new widgets to the set of PyDM widgets.
- PyDMDateTimeEdit
This widget inherits from QDateTimeEdit and allow users to use a channel providing either a timestamp with seconds or milliseconds as time-base.

- PyDMDateTimeLabel
This widget inherits from QLabel  and allow users to use a channel providing either a timestamp with seconds or milliseconds as time-base.

For both widgets users can configure the Display/Text format. By default it follow the ISO format.

Motivation
-----------
https://github.com/pcdshub/pmps-ui/issues/2

Screenshot
------------
<img width="320" alt="Screen Shot 2020-07-06 at 2 51 05 PM" src="https://user-images.githubusercontent.com/8185425/86656767-91320800-bf9c-11ea-9203-db8a1948648b.png">
