### PR TITLE
ENH: Move the default mouse mode to RectMode (1-button).

### DIFF
--- a/pydm/widgets/baseplot.py
+++ b/pydm/widgets/baseplot.py
@@ -296,6 +296,11 @@ class BasePlot(PlotWidget, PyDMPrimitiveWidget):
         self.vertical_crosshair_line = None
         self.horizontal_crosshair_line = None
         self.crosshair_movement_proxy = None
+
+        # Mouse mode to 1 button (left button draw rectangle for zoom)
+        self.plotItem.getViewBox().setMouseMode(ViewBox.RectMode)
+
+
         if utilities.is_qt_designer():
             self.installEventFilter(self)
 


### PR DESCRIPTION
The current plot zoom is very counterintuitive. This PR sets the mode to be RectMode (aka 1-button) mode in which when the user clicks and drags with the left button of the mouse it draws a rectangle for the Zoom.