### PR TITLE
MNT: is autofillbackground necessary?

### DIFF
--- a/pydm/widgets/byte.py
+++ b/pydm/widgets/byte.py
@@ -16,7 +16,6 @@ class PyDMBitIndicator(QWidget):
     """
     def __init__(self, parent=None, circle=False):
         super(PyDMBitIndicator, self).__init__(parent)
-        self.setAutoFillBackground(True)
         self.circle = circle
         self._painter = QPainter()
         self._brush = QBrush(Qt.SolidPattern)


### PR DESCRIPTION
Unsure if this may cause unintended side effects; have not tested thoroughly.

Was curious to see how stacking some byte indicator widgets would look, but ran into opaque background issues:

Before
![image](https://user-images.githubusercontent.com/5139267/89232152-b9ad2200-d59b-11ea-81ee-8c11fce06227.png)

After
![image](https://user-images.githubusercontent.com/5139267/89232158-bd40a900-d59b-11ea-9e54-c0d5c086464d.png)
