### PR TITLE
FIX: Align label to center Vertical/Horizontal of Bit widget at ByteIndicator.

### DIFF
--- a/pydm/widgets/byte.py
+++ b/pydm/widgets/byte.py
@@ -151,10 +151,10 @@ class PyDMByteIndicator(QWidget, PyDMWidget):
             for i, (label, indicator) in enumerate(pairs):
                 if self.labelPosition == QTabWidget.East:
                     self.layout().addWidget(indicator, i, 0)
-                    self.layout().addWidget(label, i, 1)
+                    self.layout().addWidget(label, i, 1, 1, 1, Qt.AlignVCenter)
                     label.setVisible(self._show_labels)
                 elif self.labelPosition == QTabWidget.West:
-                    self.layout().addWidget(label, i, 0)
+                    self.layout().addWidget(label, i, 0, 1, 1, Qt.AlignVCenter)
                     self.layout().addWidget(indicator, i, 1)
                     label.setVisible(self._show_labels)
                 else:
@@ -164,12 +164,12 @@ class PyDMByteIndicator(QWidget, PyDMWidget):
         elif self.orientation == Qt.Horizontal:
             for i, (label, indicator) in enumerate(pairs):
                 if self.labelPosition == QTabWidget.North:
-                    self.layout().addWidget(label, 0, i)
+                    self.layout().addWidget(label, 0, i, 1, 1, Qt.AlignHCenter)
                     self.layout().addWidget(indicator, 1, i)
                     label.setVisible(self._show_labels)
                 elif self.labelPosition == QTabWidget.South:
                     self.layout().addWidget(indicator, 0, i)
-                    self.layout().addWidget(label, 1, i)
+                    self.layout().addWidget(label, 1, i, 1, 1, Qt.AlignHCenter)
                     label.setVisible(self._show_labels)
                 else:
                     self.layout().addWidget(indicator, 0, i)


### PR DESCRIPTION
Before:
<img width="522" alt="Screen Shot 2020-08-04 at 4 40 17 PM" src="https://user-images.githubusercontent.com/8185425/89355845-407ffe80-d671-11ea-8090-b204658007a5.png">

After:
<img width="522" alt="Screen Shot 2020-08-04 at 4 40 03 PM" src="https://user-images.githubusercontent.com/8185425/89355857-4675df80-d671-11ea-9890-4c054b1f5f98.png">

Closes #675 