### PR TITLE
FIX: Address race condition at establish_queued_connections.

### DIFF
--- a/pydm/data_plugins/__init__.py
+++ b/pydm/data_plugins/__init__.py
@@ -42,7 +42,8 @@ def establish_queued_connections():
     if __CONNECTION_QUEUE__ is None:
         return
     try:
-        while not len(__CONNECTION_QUEUE__) == 0:
+        while (__CONNECTION_QUEUE__ is not None and
+               len(__CONNECTION_QUEUE__) == 0):
             channel = __CONNECTION_QUEUE__.popleft()
             establish_connection_immediately(channel)
             QApplication.instance().processEvents()


### PR DESCRIPTION
Closes #679 and https://github.com/pcdshub/lucid/issues/78

I tested this fix against my reproducible case and the issue is gone.
I also confirmed that all channels are connecting at all embedded and template repeated widgets.