### PR TITLE
Spinbox write on press

### DIFF
--- a/pydm/widgets/spinbox.py
+++ b/pydm/widgets/spinbox.py
@@ -218,3 +218,15 @@ class PyDMSpinbox(QDoubleSpinBox, TextFormatter, PyDMWritableWidget):
         bool
         """
         return self._write_on_press
+
+    @writeOnPress.setter
+    def writeOnPress(self, val):
+        """
+        Whether value to write on key press.
+
+        Parameters
+        ----------
+        val : bool
+        """
+        self._write_on_press = val
+        self.update_format_string()

--- a/pydm/widgets/spinbox.py
+++ b/pydm/widgets/spinbox.py
@@ -73,13 +73,20 @@ class PyDMSpinbox(QDoubleSpinBox, TextFormatter, PyDMWritableWidget):
         QMenu or None
             If the return of this method is None a new QMenu will be created by `assemble_tools_menu`.
         """
-        def toggle():
+        def toggle_step():
             self.showStepExponent = not self.showStepExponent
+
+        def toggle_write():
+            self.writeOnPress = not self.writeOnPress
 
         menu = self.lineEdit().createStandardContextMenu()
         menu.addSeparator()
         ac = menu.addAction('Toggle Show Step Size')
-        ac.triggered.connect(toggle)
+        ac.triggered.connect(toggle_step)
+
+        ac_write = menu.addAction('Toggle write on press')
+        ac_write.triggered.connect(toggle_write)
+
         return menu
 
     def update_step_size(self):
@@ -229,4 +236,3 @@ class PyDMSpinbox(QDoubleSpinBox, TextFormatter, PyDMWritableWidget):
         val : bool
         """
         self._write_on_press = val
-        self.update_format_string()

--- a/pydm/widgets/spinbox.py
+++ b/pydm/widgets/spinbox.py
@@ -21,6 +21,7 @@ class PyDMSpinbox(QDoubleSpinBox, TextFormatter, PyDMWritableWidget):
         self.setEnabled(False)
         self._alarm_sensitive_border = False
         self._show_step_exponent = True
+        self._write_on_press = False
         self.step_exponent = 0
         self.setDecimals(0)
         self.app = QApplication.instance()
@@ -52,10 +53,16 @@ class PyDMSpinbox(QDoubleSpinBox, TextFormatter, PyDMWritableWidget):
             self.step_exponent += 1 if ev.key() == Qt.Key_Left else -1
             self.step_exponent = max(-self.decimals(), self.step_exponent)
             self.update_step_size()
+
         elif ev.key() in (Qt.Key_Return, Qt.Key_Enter):
             self.send_value()
+    
         else:
             super(PyDMSpinbox, self).keyPressEvent(ev)
+
+        if self._write_on_press and (ev.key() in (Qt.Key_Left, Qt.Key_Right)) and not ctrl_hold:
+            self.send_value()
+
 
     def widget_ctx_menu(self):
         """
@@ -200,3 +207,14 @@ class PyDMSpinbox(QDoubleSpinBox, TextFormatter, PyDMWritableWidget):
         """
         self._show_step_exponent = val
         self.update_format_string()
+
+    @Property(bool)
+    def writeOnPress(self):
+        """
+        Whether to write value on key press
+
+        Returns
+        -------
+        bool
+        """
+        return self._write_on_press

--- a/pydm/widgets/spinbox.py
+++ b/pydm/widgets/spinbox.py
@@ -32,6 +32,17 @@ class PyDMSpinbox(QDoubleSpinBox, TextFormatter, PyDMWritableWidget):
         child = self.findChild(QLineEdit)
         child.installEventFilter(self)
 
+
+    def stepBy(self, step):
+        """
+        Method triggered whenever user triggers a step.
+
+        """
+        super(PyDMSpinbox, self).stepBy(step)
+        if self._write_on_press:
+            self.send_value()
+
+
     def keyPressEvent(self, ev):
         """
         Method invoked when a key press event happens on the QDoubleSpinBox.
@@ -59,10 +70,7 @@ class PyDMSpinbox(QDoubleSpinBox, TextFormatter, PyDMWritableWidget):
     
         else:
             super(PyDMSpinbox, self).keyPressEvent(ev)
-
-        if self._write_on_press and (ev.key() in (Qt.Key_Up, Qt.Key_Down)) and not ctrl_hold:
-            self.send_value()
-
+            
 
     def widget_ctx_menu(self):
         """

--- a/pydm/widgets/spinbox.py
+++ b/pydm/widgets/spinbox.py
@@ -35,8 +35,12 @@ class PyDMSpinbox(QDoubleSpinBox, TextFormatter, PyDMWritableWidget):
 
     def stepBy(self, step):
         """
-        Method triggered whenever user triggers a step.
+        Method triggered whenever user triggers a step. If the writeOnPress property
+        is enabled, the updated value will be sent.
 
+        Parameters
+        ----------
+        step: int
         """
         super(PyDMSpinbox, self).stepBy(step)
         if self._write_on_press:

--- a/pydm/widgets/spinbox.py
+++ b/pydm/widgets/spinbox.py
@@ -60,7 +60,7 @@ class PyDMSpinbox(QDoubleSpinBox, TextFormatter, PyDMWritableWidget):
         else:
             super(PyDMSpinbox, self).keyPressEvent(ev)
 
-        if self._write_on_press and (ev.key() in (Qt.Key_Left, Qt.Key_Right)) and not ctrl_hold:
+        if self._write_on_press and (ev.key() in (Qt.Key_Up, Qt.Key_Down)) and not ctrl_hold:
             self.send_value()
 
 


### PR DESCRIPTION
This PR implements a `writeOnPress` (bool) parameter for the spinbox widget, which allows for atomic updates to the value without requiring the user to press the `ENTER` key to submit the value. This modified behavior only applies to value adjustments and does not extend to changes to the exponent values. This feature was requested here: https://github.com/slaclab/pydm/issues/686

When `writeOnPress` is `True`:
![spinbox_on](https://user-images.githubusercontent.com/25035114/91218411-fe356480-e6e6-11ea-89b6-178ab0faae16.gif)

When disabled, the spinbox functions as before:
![spinbox_off](https://user-images.githubusercontent.com/25035114/91218415-0097be80-e6e7-11ea-9be1-af0b9806c99d.gif)