### PR TITLE
Allow data plugin to force connect at qt designer

### DIFF
--- a/pydm/data_plugins/plugin.py
+++ b/pydm/data_plugins/plugin.py
@@ -152,7 +152,7 @@ class PyDMConnection(QObject):
 class PyDMPlugin(object):
     protocol = None
     connection_class = PyDMConnection
-    designer_online_by_default = True
+    designer_online_by_default = False
 
     def __init__(self):
         self.connections = {}

--- a/pydm/data_plugins/plugin.py
+++ b/pydm/data_plugins/plugin.py
@@ -6,6 +6,7 @@ from numpy import ndarray
 from ..utilities.remove_protocol import protocol_and_address
 from qtpy.QtCore import Signal, QObject, Qt
 from qtpy.QtWidgets import QApplication
+from .. import config
 
 
 class PyDMConnection(QObject):
@@ -151,6 +152,7 @@ class PyDMConnection(QObject):
 class PyDMPlugin(object):
     protocol = None
     connection_class = PyDMConnection
+    designer_online_by_default = True
 
     def __init__(self):
         self.connections = {}
@@ -162,11 +164,17 @@ class PyDMPlugin(object):
         return protocol_and_address(channel.address)[1]
 
     def add_connection(self, channel):
+        from pydm.utilities import is_qt_designer
         with self.lock:
             address = self.get_address(channel)
             # If this channel is already connected to this plugin lets ignore
             if channel in self.channels:
                 return
+
+            if (is_qt_designer() and not config.DESIGNER_ONLINE and
+                    not self.designer_online_by_default):
+                return
+
             self.channels.add(channel)
             if address in self.connections:
                 self.connections[address].add_listener(channel)

--- a/pydm/widgets/channel.py
+++ b/pydm/widgets/channel.py
@@ -1,8 +1,6 @@
 import logging
 
 import pydm.data_plugins
-from pydm.utilities import is_qt_designer
-from pydm import config
 
 logger = logging.getLogger(__name__)
 
@@ -113,8 +111,6 @@ class PyDMChannel(object):
         """
         if not self.address:
             return
-        if is_qt_designer() and not config.DESIGNER_ONLINE:
-            return
         logger.debug("Connecting %r", self.address)
         # Connect to proper PyDMPlugin
         try:
@@ -127,8 +123,6 @@ class PyDMChannel(object):
         """
         Disconnect a PyDMChannel
         """
-        if is_qt_designer() and not config.DESIGNER_ONLINE:
-            return
         try:
             plugin = pydm.data_plugins.plugin_for_address(self.address)
             if not plugin:


### PR DESCRIPTION
I removed the `is_qt_designer() and not config.DESIGNER_ONLINE` check from the `channel.py` and incorporated this check in the `plygin.py`

Removing this check from the `channel.py` allows for automatic DataPlugins' connections at QtDesigner. 

I added an additional attribute (`designer_online_by_default`) at `PyDMPlugin` which is set to `False` by default. If some DataPlugin has this attribute set to `True`, then regardless if they have the `PYDM_DESIGNER_ONLINE` environment variable set or not, the DataPlugin will try to connect at QtDesigner


I only tested this locally, by adding the new attribute to the `PyEPICSPlugin` and it seemed to work: 
```
class PyEPICSPlugin(PyDMPlugin):
    ...
    protocol = None
    connection_class = Connection
    designer_online_by_default = True
 ```

When the attribute is set to True in QtDesigner and `PYDM_DESIGNER_ONLINE` not set:
![designer_plugin](https://user-images.githubusercontent.com/62306310/91360973-45d1f400-e7ac-11ea-8916-d65e754c604b.PNG)

And if I want to Preview it from QtDesigner - i'm loosing the alarm border though: 
![preview](https://user-images.githubusercontent.com/62306310/91361058-68640d00-e7ac-11ea-97ad-78b1371c343c.PNG)


Trying to close #639 