### PR TITLE
FIX: Address issue of inconsistent file loading when creating Displays and Connection Queue drain

### DIFF
--- a/pydm/data_plugins/__init__.py
+++ b/pydm/data_plugins/__init__.py
@@ -36,6 +36,7 @@ def connection_queue(defer_connections=False):
         return
     establish_queued_connections()
 
+
 def establish_queued_connections():
     global __DEFER_CONNECTIONS__
     global __CONNECTION_QUEUE__
@@ -47,6 +48,8 @@ def establish_queued_connections():
             channel = __CONNECTION_QUEUE__.popleft()
             establish_connection_immediately(channel)
             QApplication.instance().processEvents()
+    except IndexError:
+        pass
     finally:
         __CONNECTION_QUEUE__ = None
         __DEFER_CONNECTIONS__ = False


### PR DESCRIPTION
Came across this issue via report from Lisa Zacarias that the loaded UI files was missing widgets.
While investigating I noticed that we were still using two different methods to load UI files which was due to my lack of attention when refactoring that. Now it is back to consistency and loading files properly.

Another issue that I noticed is that when we have multiple Template Repeater widgets it can be that the connection Queue is fully drained by the first and the remaining widgets end up raising an `IndexError`. This PR protects against that.