### PR TITLE
ENH: Move Qt Designer related styling in PyDMEmbeddedDisplay to init_for_designer

### DIFF
--- a/pydm/widgets/embedded_display.py
+++ b/pydm/widgets/embedded_display.py
@@ -43,11 +43,9 @@ class PyDMEmbeddedDisplay(QFrame, PyDMPrimitiveWidget):
         self.layout.addWidget(self.err_label)
         self.layout.setContentsMargins(0, 0, 0, 0)
         self.err_label.hide()
-        if not is_pydm_app():
-            self.setFrameShape(QFrame.Box)
-        else:
-            self.setFrameShape(QFrame.NoFrame)
-        
+
+    def init_for_designer(self):
+        self.setFrameShape(QFrame.Box)
 
     def minimumSizeHint(self):
         """


### PR DESCRIPTION
Avoids Qt Designer related logic in __init__ and rather moves it to init_for_designer.