### PR TITLE
FIX: Establish queued connection when we have elements in the QUEUE.

### DIFF
--- a/pydm/data_plugins/__init__.py
+++ b/pydm/data_plugins/__init__.py
@@ -44,7 +44,7 @@ def establish_queued_connections():
         return
     try:
         while (__CONNECTION_QUEUE__ is not None and
-               len(__CONNECTION_QUEUE__) == 0):
+               len(__CONNECTION_QUEUE__) > 0):
             channel = __CONNECTION_QUEUE__.popleft()
             establish_connection_immediately(channel)
             QApplication.instance().processEvents()


### PR DESCRIPTION
This was introduced by my somewhat stupid patch (https://github.com/slaclab/pydm/commit/e96f7c895bf6c56d2839ddeb9de773dd065db1f2) in which I failed to notice the `not`.

With this fix the template repeaters will be back to connect properly.