### PR TITLE
FIX: Address issue with weird chars returned by channel.

### DIFF
--- a/pydm/data_plugins/epics_plugins/pyepics_plugin_component.py
+++ b/pydm/data_plugins/epics_plugins/pyepics_plugin_component.py
@@ -6,6 +6,12 @@ from pydm.data_plugins.plugin import PyDMPlugin, PyDMConnection
 from qtpy.QtCore import Slot, Qt
 from qtpy.QtWidgets import QApplication
 
+try:
+    from epics import utils3
+    utils3.EPICS_STR_ENCODING = "latin-1"
+except:
+    pass
+
 logger = logging.getLogger(__name__)
 
 int_types = set((epics.dbr.INT, epics.dbr.CTRL_INT, epics.dbr.TIME_INT,

--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -22,6 +22,11 @@ except ImportError:
 
 logger = logging.getLogger(__name__)
 
+try:
+    str_types = (str, unicode)
+except NameError:
+    str_types = (str,)
+
 
 def is_channel_valid(channel):
     """

--- a/pydm/widgets/label.py
+++ b/pydm/widgets/label.py
@@ -1,4 +1,4 @@
-from .base import PyDMWidget, TextFormatter
+from .base import PyDMWidget, TextFormatter, str_types
 from qtpy.QtWidgets import QLabel, QApplication
 from qtpy.QtCore import Qt, Property, Q_ENUMS
 from .display_format import DisplayFormat, parse_value_for_display
@@ -71,7 +71,7 @@ class PyDMLabel(QLabel, TextFormatter, PyDMWidget, DisplayFormat):
                                             widget=self)
         # If the value is a string, just display it as-is, no formatting
         # needed.
-        if isinstance(new_value, str):
+        if isinstance(new_value, str_types):
             if self._show_units and self._unit != "":
                 new_value = "{} {}".format(new_value, self._unit)
             self.setText(new_value)

--- a/pydm/widgets/line_edit.py
+++ b/pydm/widgets/line_edit.py
@@ -8,7 +8,7 @@ logger = logging.getLogger(__name__)
 from qtpy.QtWidgets import QLineEdit, QMenu, QApplication
 from qtpy.QtCore import Property, Q_ENUMS
 from .. import utilities
-from .base import PyDMWritableWidget, TextFormatter
+from .base import PyDMWritableWidget, TextFormatter, str_types
 from .display_format import DisplayFormat, parse_value_for_display
 
 
@@ -229,7 +229,7 @@ class PyDMLineEdit(QLineEdit, TextFormatter, PyDMWritableWidget, DisplayFormat):
                                          DisplayFormat.Exponential,
                                          DisplayFormat.Hex,
                                          DisplayFormat.Binary]:
-            if not isinstance(new_value, (str, np.ndarray)):
+            if self.channeltype not in (str, np.ndarray):
                 try:
                     new_value *= self.channeltype(self._scale)
                 except TypeError:
@@ -241,7 +241,10 @@ class PyDMLineEdit(QLineEdit, TextFormatter, PyDMWritableWidget, DisplayFormat):
                                             string_encoding=self._string_encoding,
                                             widget=self)
 
-        self._display = str(new_value)
+        if type(new_value) in str_types:
+            self._display = new_value
+        else:
+            self._display = str(new_value)
 
         if self._display_format_type == DisplayFormat.Default:
             if isinstance(new_value, (int, float)):
@@ -250,7 +253,7 @@ class PyDMLineEdit(QLineEdit, TextFormatter, PyDMWritableWidget, DisplayFormat):
                 return
 
         if self._show_units:
-            self._display += " {}".format(self._unit)
+            self._display = "{} {}".format(self._display, self._unit)
 
         self.setText(self._display)
 


### PR DESCRIPTION
Reported by @jesusvasquez333 via Slack:
```
$ [2020-09-30 11:43:30,358] [INFO    ] - Using PyDM via SSH. Reverting to Software Rendering.
QStandardPaths: XDG_RUNTIME_DIR not set, defaulting to '/tmp/runtime-fsoftegr'
libGL error: No matching fbConfigs or visuals found
libGL error: failed to load driver: swrast
Traceback (most recent call last):
  File "/usr/local/lcls/package/python/python2.7.13/linux-x86_64/lib/python2.7/site-packages/pydm/widgets/base.py", line 758, in channelValueChanged
    self.value_changed(new_val)
  File "/usr/local/lcls/package/python/python2.7.13/linux-x86_64/lib/python2.7/site-packages/pydm/widgets/label.py", line 94, in value_changed
    self.setText(str(new_value))
UnicodeEncodeError: 'ascii' codec can't encode characters in position 0-7: ordinal not in range(128)
```

Root cause were values coming from PV:
```
$ caget KLYS:LI10:31:DIAG:RTM_FIRMVER KLYS:LI10:31:DIAG:RTM_SYSID KLYS:LI10:31:DIAG:RTM_SUBTYPE KLYS:LI10:31:DIAG:RTM_FIRMDATE KLYS:LI10:31:DIAG:RTM_TASKCNT KLYS:LI10:31:DIAG:RTM_PID KLYS:LI10:31:DIAG:RTM_TS
KLYS:LI10:31:DIAG:RTM_FIRMVER  65535
KLYS:LI10:31:DIAG:RTM_SYSID    \377\377\377\377\377\377\377\377
KLYS:LI10:31:DIAG:RTM_SUBTYPE  \377\377\377\377\377\377\377\377
KLYS:LI10:31:DIAG:RTM_FIRMDATE \377\377\377\377\377\377\377\377
KLYS:LI10:31:DIAG:RTM_TASKCNT  59963
KLYS:LI10:31:DIAG:RTM_PID      114882
KLYS:LI10:31:DIAG:RTM_TS       1
```