### PR TITLE
FIX: Use quit confirmation on all close scenarios, not just menu click

### DIFF
--- a/pydm/main_window.py
+++ b/pydm/main_window.py
@@ -452,14 +452,25 @@ class PyDMMainWindow(QMainWindow):
             self.resize(self._new_widget_size)
 
     def closeEvent(self, event):
-        self.clear_display_widget()
+        event.ignore()
+
+        def do_close():
+            self.clear_display_widget()
+            event.accept()
+
+        main_windows = [w for w in self.app.topLevelWidgets() if isinstance(w, QMainWindow)]
+        if len(main_windows) == 1 and main_windows[0] == self:
+            self._confirm_quit(callback=do_close)
+        else:
+            do_close()
 
     @Slot(bool)
     def quit_main_window(self, checked):
+        self._confirm_quit(callback=self.app.quit)
+
+    def _confirm_quit(self, callback):
         quit_message = QMessageBox.question(
             self, 'Quitting Application', 'Exit Application?',
             QMessageBox.Yes | QMessageBox.No)
         if quit_message == QMessageBox.Yes:
-            self.app.quit()
-        else:
-            pass
+            callback()

--- a/pydm/tests/conftest.py
+++ b/pydm/tests/conftest.py
@@ -2,6 +2,7 @@
 # Fixtures for PyDM Unit Tests
 
 import pytest
+
 from pytestqt.qt_compat import qt_api
 
 import numpy as np
@@ -10,12 +11,20 @@ import logging
 
 from qtpy.QtCore import QObject, Signal, Slot
 from pydm.application import PyDMApplication
+from pydm.main_window import PyDMMainWindow
 from pydm.data_plugins import PyDMPlugin, add_plugin
 
 logger = logging.getLogger(__name__)
 _, file_path = tempfile.mkstemp(suffix=".log")
 handler = logging.FileHandler(file_path)
 logger.addHandler(handler)
+
+
+def mock_method(*args, **kwargs):
+    pass
+
+
+PyDMMainWindow.closeEvent = mock_method
 
 
 class ConnectionSignals(QObject):


### PR DESCRIPTION
This PR enables Quit confirmation dialog when closing application via title bar close button, Alt+F4 or any other scenarios, involving the closure of main window.
Previously, it would bypass the confirmation dialog, while menu File->Quit would issue it.