### PR TITLE
CI: Add linter stage and adjust dependencies.

### DIFF
--- a/azure-pipelines-linux.yml
+++ b/azure-pipelines-linux.yml
@@ -9,13 +9,6 @@ jobs:
       allowFailure: true
   - template: azure-test-template.yml
     parameters:
-      name: Linux_3_6
-      vmImage: 'Ubuntu 18.04'
-      build_docs: 1
-      python: '3.6'
-      allowFailure: false
-  - template: azure-test-template.yml
-    parameters:
       name: Linux_3_7
       vmImage: 'Ubuntu 18.04'
       build_docs: 1

--- a/azure-pipelines-macos.yml
+++ b/azure-pipelines-macos.yml
@@ -2,12 +2,6 @@ jobs:
   # MacOS
   - template: azure-test-template.yml
     parameters:
-      name: MacOS_3_6
-      vmImage: 'macOS-10.14'
-      python: '3.6'
-      allowFailure: false
-  - template: azure-test-template.yml
-    parameters:
       name: MacOS_3_7
       vmImage: 'macOS-10.14'
       python: '3.7'

--- a/azure-pipelines-windows.yml
+++ b/azure-pipelines-windows.yml
@@ -2,14 +2,6 @@ jobs:
   # Windows
   - template: azure-test-template-win.yml
     parameters:
-      name: Windows_3_6
-      vmImage: 'vs2017-win2016'
-      build_docs: 1
-      python: '3.6'
-      python_name: '3_6'
-      allowFailure: true
-  - template: azure-test-template-win.yml
-    parameters:
       name: Windows_3_7
       vmImage: 'vs2017-win2016'
       build_docs: 1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,17 +42,41 @@ variables:
   OFFICIAL_REPO: 'slaclab/pydm'
 
 stages:
-
+  - stage: "Linter"
+    dependsOn: []
+    jobs:
+      - job: 'Flake8'
+        allowFailure: true
+        displayName: 'Linter - Flake8'
+        pool:
+          vmImage: 'Ubuntu 18.04'
+        steps:
+        - task: UsePythonVersion@0
+          inputs:
+            versionSpec: '3.x'
+            architecture: 'x64'
+        - script: pip install flake8
+          displayName: 'Python - Install flake8'
+        - bash: |
+            flake8 pydm
+          displayName: 'Flake8'
   - stage: "Build"
+    dependsOn: []
     jobs:
       # Build the conda package and docs
       - template: azure-build-template.yml
   - stage: "Tests"
+    dependsOn:
+      - "Build"
     jobs:
       - template: azure-pipelines-linux.yml
       - template: azure-pipelines-macos.yml
       - template: azure-pipelines-windows.yml
   - stage: "Deploy"
+    dependsOn:
+      - "Build"
+      - "Linter"
+      - "Tests"
     jobs:
       - job: 'Control'
         displayName: Build Control

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -46,7 +46,7 @@ stages:
     dependsOn: []
     jobs:
       - job: 'Flake8'
-        allowFailure: true
+        continueOnError: true
         displayName: 'Linter - Flake8'
         pool:
           vmImage: 'Ubuntu 18.04'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -74,7 +74,6 @@ stages:
       - template: azure-pipelines-windows.yml
   - stage: "Deploy"
     dependsOn:
-      - "Build"
       - "Linter"
       - "Tests"
     jobs:


### PR DESCRIPTION
- Adding flake8 into Linter stage as initial step towards some better code.
For now it is classified as `allowFailures: true` until we clean up our own mess...
Once that is done we can start enforcing that on collaborators.

- Removes Python 3.6 from test matrix.
Pursuant of Numpy NEP29 and since we are testing 3.7, 3.8 and 3.9 we are dropping 3.6 from the test matrix.
But what about the Linux Python 2.7? That will remain for a little longer but its end is also near. 🙏 