### PR TITLE
MNT: use filename instead of None in error message.

### DIFF
--- a/pydm/widgets/template_repeater.py
+++ b/pydm/widgets/template_repeater.py
@@ -328,7 +328,7 @@ class PyDMTemplateRepeater(QFrame, PyDMPrimitiveWidget, LayoutType):
 
                         if not fname:
                             if not is_qt_designer():
-                                logger.error('Cannot locate data source file {} for PyDMTemplateRepeater.'.format(fname))
+                                logger.error('Cannot locate data source file {} for PyDMTemplateRepeater.'.format(self._data_source))
                             self.data = []
                         else:
                             with open(fname) as f:


### PR DESCRIPTION
The `PyDMTemplateRepeater` has a malformed error message. In this case, `fname` is actually `None` after being processed above in `find_file`, so it is not a useful string for the error message.

Fixed by replacing the `fname` (always `None` if file not found) with `self._data_source` (always set to a string if we've gotten to this point).

We encountered this while debugging issues related to https://github.com/pcdshub/typhos/issues/429

Before:
```
[2021-03-12 15:48:20] - ERROR - Cannot locate data source file None for PyDMTemplateRepeater.
```
After:
```
[2021-03-12 15:53:36] - ERROR - Cannot locate data source file at2l0_filters.json for PyDMTemplateRepeater.
```