### PR TITLE
Proof-of-concept automatic MEDM ADL converter and loader

### DIFF
--- a/pydm/display.py
+++ b/pydm/display.py
@@ -62,7 +62,7 @@ def load_file(file, macros=None, args=None, target=ScreenTarget.NEW_PROCESS):
 
     _, extension = os.path.splitext(file)
     loader = _extension_to_loader.get(extension, load_py_file)
-    logger.error("Loading %s file by way of %s...", file, loader.__name__)
+    logger.debug("Loading %s file by way of %s...", file, loader.__name__)
     w = loader(file, args=args, macros=macros)
     if target == ScreenTarget.DIALOG:
         w.show()
@@ -120,7 +120,7 @@ def load_ui_file(uifile, macros=None, args=None):
     return d
 
 
-def load_adl_file(filename, args=None, macros=None):
+def load_adl_file(filename, macros=None, args=None):
     """
     Load an MEDM ADL display with adl2pydm.
 

--- a/pydm/display.py
+++ b/pydm/display.py
@@ -8,6 +8,7 @@ import sys
 import uuid
 import warnings
 from os import path
+from string import Template
 
 from qtpy import uic
 from qtpy.QtWidgets import QWidget, QApplication
@@ -152,17 +153,11 @@ def load_adl_file(filename, args=None, macros=None):
 
     d = Display(macros=macros)
     merge_widget_stylesheet(d)
-
-    if macros is not None:
-        ui_contents = macro.replace_macros_in_template(ui_contents, macros)
-
     d._loaded_file = filename
 
-    with six.StringIO() as fp:
-        fp.write(ui_contents)
-        fp.seek(0)
-
-        _load_ui_into_display(fp, d)
+    fp = macro.replace_macros_in_template(Template(ui_contents), macros or {})
+    _load_ui_into_display(fp, d)
+    fp.close()
     return d
 
 

--- a/pydm/display.py
+++ b/pydm/display.py
@@ -59,10 +59,9 @@ def load_file(file, macros=None, args=None, target=ScreenTarget.NEW_PROCESS):
         app.new_pydm_process(file, macros=macros, command_line_args=args)
         return None
     else:
-        if file.endswith('.ui'):
-            w = load_ui_file(file, macros=macros)
-        else:
-            w = load_py_file(file, args=args, macros=macros)
+        _, extension = os.path.splitext(file)
+        loader = _extension_to_loader.get(extension, load_py_file)
+        w = loader(file, args=args, macros=macros)
 
         if target == ScreenTarget.DIALOG:
             w.show()
@@ -86,7 +85,7 @@ def _load_ui_into_display(uifile, display):
     display.ui = display
 
 
-def load_ui_file(uifile, macros=None):
+def load_ui_file(uifile, macros=None, args=None):
     """
     Load a .ui file, perform macro substitution, then return the resulting QWidget.
 
@@ -99,6 +98,8 @@ def load_ui_file(uifile, macros=None):
     macros : dict, optional
         A dictionary of macro variables to supply to the file
         to be opened.
+    args : list, optional
+        This is ignored for UI files.
 
     Returns
     -------
@@ -191,6 +192,12 @@ def load_py_file(pyfile, args=None, macros=None):
     instance._loaded_file = pyfile
     merge_widget_stylesheet(instance)
     return instance
+
+
+_extension_to_loader = {
+    ".ui": load_ui_file,
+    ".py": load_py_file,
+}
 
 
 class Display(QWidget):


### PR DESCRIPTION
Considered a proof-of-concept because 1 prerequisite~s~ ~are~ is not yet merged.

Prerequisites
-------------

~#578 (merged here for convenience, or rather out of necessity for the converter to work)~
My branch of adl2pydm https://github.com/klauer/adl2pydm/tree/ref_in_memory (tweak to allow in-memory conversion of ADL screens)

Functionality
-------------
Actual functionality only in 2 small commits: bf560cb, 753e8f7 

Result
--------
```bash
$ pydm ~/Repos/adl2pydm/tests/medm/mca-R7-7-mca.adl
[2021-03-18 17:00:10,549] [ERROR   ] - Loading /Users/klauer/Repos/adl2pydm/tests/medm/mca-R7-7-mca.adl file by way of load_adl_file...
[2021-03-18 17:00:10,607] [INFO    ] - Environment variable PYDM_DISPLAYS_PATH is not defined.
[2021-03-18 17:00:10,607] [INFO    ] - file not found: stylesheet.qss
[2021-03-18 17:00:10,607] [INFO    ] - writing screen file: None
```

Screenshot
------------
<img width="572" alt="image" src="https://user-images.githubusercontent.com/5139267/111712718-70000780-880b-11eb-9d2e-e7b7adea05d1.png">

Why?
------
* We want areaDetector screens and other community-provided ones easily available at some point.
* areaDetector provides ADL screens in its standard distribution as do many other packages.
* Ideally, EDL (EDM) loading would be added at some point with a similar hook. This is _really_ what PCDS would like in the end.