### PR TITLE
FIX: Make so that ALARM_NONE widgets don't loose their original border.

### DIFF
--- a/pydm/default_stylesheet.qss
+++ b/pydm/default_stylesheet.qss
@@ -17,7 +17,7 @@ ALARM_DISCONNECTED = 4
 
 /* Alarm severity == ALARM_NONE */
 *[alarmSensitiveBorder="true"][alarmSeverity="0"] {
-    border: 2px solid transparent;
+    padding: 2px;
 }
 
 /* Alarm severity == ALARM_MINOR */


### PR DESCRIPTION
Closes #727 

Screenshots
-------------

Before the PR:
![image](https://user-images.githubusercontent.com/8185425/113069443-3a491000-9175-11eb-9081-3e9302f7d164.png)

After the PR:
![image](https://user-images.githubusercontent.com/8185425/113069430-30bfa800-9175-11eb-98ac-39b271822f42.png)

