### PR TITLE
Make the confirm close dialog optional.

### DIFF
--- a/pydm/config.py
+++ b/pydm/config.py
@@ -3,7 +3,8 @@ import os
 __all__ = ['DEFAULT_PROTOCOL',
            'DESIGNER_ONLINE',
            'STYLESHEET',
-           'STYLESHEET_INCLUDE_DEFAULT'
+           'STYLESHEET_INCLUDE_DEFAULT',
+           'CONFIRM_QUIT'
            ]
 
 

--- a/pydm/config.py
+++ b/pydm/config.py
@@ -17,3 +17,5 @@ DESIGNER_ONLINE = os.getenv("PYDM_DESIGNER_ONLINE", None) is not None
 STYLESHEET = os.getenv("PYDM_STYLESHEET", None)
 
 STYLESHEET_INCLUDE_DEFAULT = os.getenv("PYDM_STYLESHEET_INCLUDE_DEFAULT", False)
+
+CONFIRM_QUIT = os.getenv("PYDM_CONFIRM_QUIT", "n").lower() in ("y", "t", "1", "true")

--- a/pydm/main_window.py
+++ b/pydm/main_window.py
@@ -471,9 +471,10 @@ class PyDMMainWindow(QMainWindow):
 
     def _confirm_quit(self, callback):
         if not config.CONFIRM_QUIT:
-            return callback()
-        quit_message = QMessageBox.question(
-            self, 'Quitting Application', 'Exit Application?',
-            QMessageBox.Yes | QMessageBox.No)
-        if quit_message == QMessageBox.Yes:
             callback()
+        else:
+            quit_message = QMessageBox.question(
+                self, 'Quitting Application', 'Exit Application?',
+                QMessageBox.Yes | QMessageBox.No)
+            if quit_message == QMessageBox.Yes:
+                callback()

--- a/pydm/main_window.py
+++ b/pydm/main_window.py
@@ -12,6 +12,7 @@ from .about_pydm import AboutWindow
 from . import data_plugins
 from . import tools
 from .widgets.rules import register_widget_rules, unregister_widget_rules
+from . import config
 import subprocess
 import platform
 import logging
@@ -469,6 +470,8 @@ class PyDMMainWindow(QMainWindow):
         self._confirm_quit(callback=self.app.quit)
 
     def _confirm_quit(self, callback):
+        if not config.CONFIRM_QUIT:
+            return callback()
         quit_message = QMessageBox.question(
             self, 'Quitting Application', 'Exit Application?',
             QMessageBox.Yes | QMessageBox.No)


### PR DESCRIPTION
This PR adds a new config option that specifies whether PyDM displays the quit confirmation dialog box or not when closing a window.  This option is driven by an environment variable, `PYDM_CONFIRM_QUIT`.  If this variable is set to "Y", "T", "1", or "TRUE" (case insensitive), PyDM will show the quit dialog.  If the environment variable is set to any other value, or if it is not set at all, PyDM will not show the dialog.

@ivany4 This is relevant to you - to keep the current behavior, you'll have to set this environment variable.