### PR TITLE
Account for custom scalar subtypes in incoming values

### DIFF
--- a/pydm/tests/widgets/test_base.py
+++ b/pydm/tests/widgets/test_base.py
@@ -2,6 +2,7 @@
 
 import pytest
 import json
+import numpy as np
 import logging
 logger = logging.getLogger(__name__)
 
@@ -222,6 +223,51 @@ def test_pydmwidget_alarm_severity_changed(qtbot):
     assert pydm_label.alarmSeverity == PyDMWidget.ALARM_NONE
     pydm_label.alarmSeverity = PyDMWidget.ALARM_MAJOR
     assert pydm_label.alarmSeverity == PyDMWidget.ALARM_MAJOR
+
+
+class FloatSubclass(float):
+    pass
+
+
+class StrSubclass(str):
+    pass
+
+
+@pytest.mark.parametrize("value, expected_type", [
+    (123, int),
+    (123.47, float),
+    (1e2, float),
+    (0x1FF, int),
+    (0b100, int),
+    (True, bool),
+    (False, bool),
+    (np.array([123, 456]), np.ndarray),
+    ("text", str),
+    (FloatSubclass(0.5), float),
+    (StrSubclass(0.5), str),
+])
+def test_pydmwidget_channeltype(qtbot, value, expected_type):
+    """
+    Test the registered channel type on in coming value of a PyDMWritableWidget object.
+
+    Expectations:
+    Channel type is a type of incoming value or its base class.
+
+    Parameters
+    ----------
+    qtbot : fixture
+        Window for widget testing
+    value : str
+        The incoming value from the channel
+    expected_type: int, float, str, bool, np.ndarray, FloatSubclass, StrSubclass
+        The type to be registered in channeltype
+    """
+    pydm_label = PyDMLabel()
+    qtbot.addWidget(pydm_label)
+
+    pydm_label.value_changed(value)
+
+    assert pydm_label.channeltype == expected_type
 
 
 @pytest.mark.parametrize("init_channel", [

--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -680,6 +680,12 @@ class PyDMWidget(PyDMPrimitiveWidget):
         """
         self.value = new_val
         self.channeltype = type(self.value)
+        for base_type in [int, float, str, np.ndarray]:
+            if self.channeltype != base_type and issubclass(self.channeltype, base_type):
+                # Leave bool and int separate, we're concerned about user-defined subclasses, not native Python ones
+                if self.channeltype != bool:
+                    self.channeltype = base_type
+                break
         if self.channeltype == np.ndarray:
             self.subtype = self.value.dtype.type
         else:


### PR DESCRIPTION
We are using [JPype](https://jpype.readthedocs.io/en/latest/), which translates Java objects to Python. Recent versions of this library convert Java `int`, `double` and similar to `JInt`, `JDouble`, which are custom subclasses of corresponding Python types.

Now, when such value arrives on a channel, it results in broken logic, when once its type is recorded with `self.channeltype = type(value)`, namely:
1. Checks such as `self.channeltype == float` will evaluate to `False`, when `JDouble` is in play
2. PyQt signals may break, e.g. `self.send_value_signal[self.channeltype].emit()` will enumerate through all available subscripts, not finding an overload for `JDouble`, it will pick the last available, i.e. `np.ndarray`. The resulting exception is very confusing:
```
TypeError: PyDMWritableWidget.send_value_signal[numpy.ndarray].emit(): argument 1 has unexpected type 'float'
```

This PR tries to record `self.channeltype` as base types, where appropriate.