### PR TITLE
PyDMDateTimeEdit widget issue with absolute timestamps

### DIFF
--- a/pydm/widgets/datetime.py
+++ b/pydm/widgets/datetime.py
@@ -86,7 +86,7 @@ class PyDMDateTimeEdit(QtWidgets.QDateTimeEdit, PyDMWritableWidget, TimeBase):
         if self.relative:
             new_value = now.msecsTo(val)
         else:
-            new_value = val.currentMSecsSinceEpoch()
+            new_value = val.toMSecsSinceEpoch()
 
         if self.timeBase == TimeBase.Seconds:
             new_value /= 1000.0


### PR DESCRIPTION
Inside the `PydmDateTimeEdit` widget, if you select the "absolute" timestamps, the code currently converts the value using `val.currentMSecsSinceEpoch()`, which gives you the _current_ timestamp, regardless of what `val` originally was. This means that the only value the widget can send in absolute mode is "right now".

This pull request switches it to use `val.toMSecsSinceEpoch()` instead, which converts the datetime to the integer unix timestamp in milliseconds.

References:
https://doc.qt.io/qt-5/qdatetime.html#currentMSecsSinceEpoch
https://doc.qt.io/qt-5/qdatetime.html#toMSecsSinceEpoch

I've tested this only interactively, using our `pmps-ui` application over the last few months:
https://github.com/pcdshub/pmps-ui/blob/97ddee40b63a72e4543481e5986eb0bc16829e4c/pmps.py#L176-L195

Apologies for not submitting a pull request sooner, I kind of forgot about this.