### PR TITLE
Fix the menu option to change mouse mode on plots

### DIFF
--- a/pydm/widgets/multi_axis_plot.py
+++ b/pydm/widgets/multi_axis_plot.py
@@ -111,7 +111,6 @@ class MultiAxisPlot(PlotItem):
         # to the event handling code of the stacked views
         view.sigMouseDragged.connect(self.handleMouseDragEvent)
         view.sigMouseWheelZoomed.connect(self.handleWheelEvent)
-
         self.vb.sigHistoryChanged.connect(view.scaleHistory)
 
     def updateStackedViews(self):

--- a/pydm/widgets/multi_axis_viewbox_menu.py
+++ b/pydm/widgets/multi_axis_viewbox_menu.py
@@ -1,0 +1,30 @@
+from pyqtgraph.graphicsItems.ViewBox.ViewBoxMenu import ViewBoxMenu
+from qtpy.QtCore import Signal
+
+
+class MultiAxisViewBoxMenu(ViewBoxMenu):
+    """
+    MultiAxisViewBoxMenu is a PyQtGraph ViewBoxMenu subclass to be used with MultiAxisViewBox. It can override
+    the menu functionality to ensure that any selected option propagates through to each ViewBox in the plot.
+
+    Parameters
+    ----------
+    view: ViewBox
+        The view box this menu is associated with
+    """
+
+    # A signal indicating that the user has changed the mouse mode (left click panning vs. zooming)
+    sigMouseModeChanged = Signal(object)
+
+    def __init__(self, view):
+        super(MultiAxisViewBoxMenu, self).__init__(view)
+
+    def set3ButtonMode(self):
+        """ Change the mouse left-click functionality to pan the plot """
+        super(MultiAxisViewBoxMenu, self).set3ButtonMode()
+        self.sigMouseModeChanged.emit('pan')
+
+    def set1ButtonMode(self):
+        """ Change the mouse left-click functionality to zoom in on the plot """
+        super(MultiAxisViewBoxMenu, self).set1ButtonMode()
+        self.sigMouseModeChanged.emit('rect')


### PR DESCRIPTION
Right-clicking on a plot will bring up a context menu for making various changes to the plot during runtime. This fix will ensure that the mouse mode change takes effect correctly. (Mouse mode controls what left-clicking on the plot will do. There are two options, panning the plot, and drawing a rectangle to zoom in on)

Currently, this doesn't work properly for multi-axis plots, this will fix it so that it does by propagating the change through every view box on the plot.

<img width="611" alt="mouse_mode" src="https://user-images.githubusercontent.com/89539359/142091688-a03a7418-b3ad-4b6a-a618-414cf1f161fa.png">

