### PR TITLE
BLD: Use pyqtgraph version 0.11.0 when installing PyDM

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy>=1.11.0
 pyepics>=3.2.7
-pyqtgraph>=0.10.0
+pyqtgraph==0.11.0
 qtpy
 requests>=1.1.0
 scipy>=0.12.0


### PR DESCRIPTION
Update the requirements file to use version 0.11.0 of PyQtGraph only. This version is recent enough to support the plotting changes, while still having Python2 support. This can be changed to a more recent version upon upgrading to Python3.