### PR TITLE
FIX: PYDMByteIndicator was not changing color when invalid alarm was set  

### DIFF
--- a/pydm/widgets/byte.py
+++ b/pydm/widgets/byte.py
@@ -204,7 +204,10 @@ class PyDMByteIndicator(QWidget, PyDMWidget):
                 for i in range(self._num_bits)]
         for bit, indicator in zip(bits, self._indicators):
             if self._connected:
-                c = self._on_color if bit else self._off_color
+                if self._alarm_state == 3:
+                    c = self._invalid_color
+                else:
+                    c = self._on_color if bit else self._off_color
             else:
                 c = self._disconnected_color
             indicator.setColor(c)


### PR DESCRIPTION
## Description
This PR fixes an issue with the PYDMByteIndicator where when alarm state was set to invalid the color of the indicator would not switch to the invalid color.  

## Motivation and Context

## How Has This Been Tested?
created a custom widget to test the invalid case. 

## Where Has This Been Documented?
No new documentation has been made at the moment

## Screenshots:

