### PR TITLE
FIX: added a method to address issue with PyDMByteIndicator where color would not update when alarm state changes  

### DIFF
--- a/pydm/widgets/byte.py
+++ b/pydm/widgets/byte.py
@@ -531,3 +531,25 @@ class PyDMByteIndicator(QWidget, PyDMWidget):
         opt.initFrom(self)
         self.style().drawPrimitive(QStyle.PE_Widget, opt, painter, self)
         painter.setRenderHint(QPainter.Antialiasing)
+
+    def alarm_severity_changed(self, new_alarm_severity):
+        """
+                Callback invoked when the Channel alarm severity is changed.
+
+                Parameters
+                ----------
+                new_alarm_severity : int
+                    The new severity where 0 = NO_ALARM, 1 = MINOR, 2 = MAJOR
+                    and 3 = INVALID
+        """
+
+        if new_alarm_severity == self._alarm_state:
+            return
+        else:
+            super(PyDMByteIndicator, self).alarm_severity_changed(new_alarm_severity)
+
+            # Checks if _shift attribute exits because base class can call method
+            # before the object constructor is complete
+            if hasattr(self, '_shift'):
+                self.update_indicators()
+


### PR DESCRIPTION
## Description
override the base class alarm_severity_changed method to address issue with PyDMByteIndicator where color would not update when alarm state changed from invalid or to invalid.  

## How Has This Been Tested?
tested on pydm example ui file.

## Where Has This Been Documented?
No new documentation has been made at the moment