### PR TITLE
FIX: Issue with drawing widget using default color not loading unless widget refreshed. 

### DIFF
--- a/pydm/widgets/drawing.py
+++ b/pydm/widgets/drawing.py
@@ -66,7 +66,7 @@ class PyDMDrawing(QWidget, PyDMWidget):
     def __init__(self, parent=None, init_channel=None):
         self._rotation = 0.0
         self._brush = QBrush(Qt.SolidPattern)
-        self._original_brush = None
+        self._original_brush = self._brush
         self._painter = QPainter()
         self._pen = QPen(Qt.NoPen)
         self._pen_style = Qt.NoPen


### PR DESCRIPTION
## Description
A one line changed to address issue #766. Default color was not working because self._original_brush was initializing as None.

## How Has This Been Tested?
tested on pydm example ui file.

## Where Has This Been Documented?
No new documentation has been made at the moment