### PR TITLE
FIX: Update column delegate placements for curve editor

### DIFF
--- a/pydm/tests/widgets/test_curve_editor.py
+++ b/pydm/tests/widgets/test_curve_editor.py
@@ -22,8 +22,6 @@ def test_waveform_curve_editor(qtbot):
     table_model = curve_editor.table_model
     table_view = curve_editor.table_view
 
-    assert table_model.columnCount() == 10
-
     # Verify that the drop downs for columns with non built-in types are all put in the correct place
     # Note: We do need to check these on each individual type of curve editor (see below tests) and not just
     # in the base plot editor since each plot type can have varying numbers of columns
@@ -54,8 +52,6 @@ def test_timeplot_curve_editor(qtbot):
     table_model = curve_editor.table_model
     table_view = curve_editor.table_view
 
-    assert table_model.columnCount() == 8
-
     # Verify that the drop downs for columns with non built-in types are all put in the correct place
     color_index = table_model.getColumnIndex('Color')
     line_style_index = table_model.getColumnIndex('Line Style')
@@ -82,8 +78,6 @@ def test_scatterplot_editor(qtbot):
     table_model = curve_editor.table_model
     table_view = curve_editor.table_view
 
-    assert table_model.columnCount() == 11
-
     # Verify that the drop downs for columns with non built-in types are all put in the correct place
     color_index = table_model.getColumnIndex('Color')
     line_style_index = table_model.getColumnIndex('Line Style')
@@ -109,6 +103,5 @@ def test_axis_editor(qtbot):
     axis_view = curve_editor.axis_view
 
     # Verify the column count is correct, and the axis column delegate is placed correctly
-    assert axis_model.columnCount() == 5
     axis_orientation_index = axis_model._column_names.index('Y-Axis Orientation')
     assert type(axis_view.itemDelegateForColumn(axis_orientation_index)) is AxisColumnDelegate

--- a/pydm/tests/widgets/test_curve_editor.py
+++ b/pydm/tests/widgets/test_curve_editor.py
@@ -27,10 +27,10 @@ def test_waveform_curve_editor(qtbot):
     # Verify that the drop downs for columns with non built-in types are all put in the correct place
     # Note: We do need to check these on each individual type of curve editor (see below tests) and not just
     # in the base plot editor since each plot type can have varying numbers of columns
-    color_index = table_model._column_names.index('Color')
-    line_style_index = table_model._column_names.index('Line Style')
-    symbol_index = table_model._column_names.index('Symbol')
-    redraw_mode_index = table_model._column_names.index('Redraw Mode')
+    color_index = table_model.getColumnIndex('Color')
+    line_style_index = table_model.getColumnIndex('Line Style')
+    symbol_index = table_model.getColumnIndex('Symbol')
+    redraw_mode_index = table_model.getColumnIndex('Redraw Mode')
 
     assert type(table_view.itemDelegateForColumn(color_index)) is ColorColumnDelegate
     assert type(table_view.itemDelegateForColumn(line_style_index)) is LineColumnDelegate
@@ -57,9 +57,9 @@ def test_timeplot_curve_editor(qtbot):
     assert table_model.columnCount() == 8
 
     # Verify that the drop downs for columns with non built-in types are all put in the correct place
-    color_index = table_model._column_names.index('Color')
-    line_style_index = table_model._column_names.index('Line Style')
-    symbol_index = table_model._column_names.index('Symbol')
+    color_index = table_model.getColumnIndex('Color')
+    line_style_index = table_model.getColumnIndex('Line Style')
+    symbol_index = table_model.getColumnIndex('Symbol')
 
     assert type(table_view.itemDelegateForColumn(color_index)) is ColorColumnDelegate
     assert type(table_view.itemDelegateForColumn(line_style_index)) is LineColumnDelegate
@@ -85,10 +85,10 @@ def test_scatterplot_editor(qtbot):
     assert table_model.columnCount() == 11
 
     # Verify that the drop downs for columns with non built-in types are all put in the correct place
-    color_index = table_model._column_names.index('Color')
-    line_style_index = table_model._column_names.index('Line Style')
-    symbol_index = table_model._column_names.index('Symbol')
-    redraw_mode_index = table_model._column_names.index('Redraw Mode')
+    color_index = table_model.getColumnIndex('Color')
+    line_style_index = table_model.getColumnIndex('Line Style')
+    symbol_index = table_model.getColumnIndex('Symbol')
+    redraw_mode_index = table_model.getColumnIndex('Redraw Mode')
 
     assert type(table_view.itemDelegateForColumn(color_index)) is ColorColumnDelegate
     assert type(table_view.itemDelegateForColumn(line_style_index)) is LineColumnDelegate

--- a/pydm/tests/widgets/test_curve_editor.py
+++ b/pydm/tests/widgets/test_curve_editor.py
@@ -1,0 +1,114 @@
+from ...widgets.baseplot import BasePlot
+from ...widgets.baseplot_curve_editor import (AxisColumnDelegate, ColorColumnDelegate, LineColumnDelegate,
+                                              SymbolColumnDelegate, RedrawModeColumnDelegate)
+from ...widgets.scatterplot_curve_editor import ScatterPlotCurveEditorDialog
+from ...widgets.timeplot_curve_editor import TimePlotCurveEditorDialog
+from ...widgets.waveformplot_curve_editor import WaveformPlotCurveEditorDialog
+
+
+def test_waveform_curve_editor(qtbot):
+    """
+    Ensure that the waveform curve editor looks and functions as expected
+    """
+
+    # Create waveform plot curve editor along with its associated plot. Ensure it shows.
+    base_plot = BasePlot()
+    qtbot.addWidget(base_plot)
+
+    curve_editor = WaveformPlotCurveEditorDialog(base_plot)
+    qtbot.addWidget(curve_editor)
+    curve_editor.show()
+
+    table_model = curve_editor.table_model
+    table_view = curve_editor.table_view
+
+    assert table_model.columnCount() == 10
+
+    # Verify that the drop downs for columns with non built-in types are all put in the correct place
+    # Note: We do need to check these on each individual type of curve editor (see below tests) and not just
+    # in the base plot editor since each plot type can have varying numbers of columns
+    color_index = table_model._column_names.index('Color')
+    line_style_index = table_model._column_names.index('Line Style')
+    symbol_index = table_model._column_names.index('Symbol')
+    redraw_mode_index = table_model._column_names.index('Redraw Mode')
+
+    assert type(table_view.itemDelegateForColumn(color_index)) is ColorColumnDelegate
+    assert type(table_view.itemDelegateForColumn(line_style_index)) is LineColumnDelegate
+    assert type(table_view.itemDelegateForColumn(symbol_index)) is SymbolColumnDelegate
+    assert type(table_view.itemDelegateForColumn(redraw_mode_index)) is RedrawModeColumnDelegate
+
+
+def test_timeplot_curve_editor(qtbot):
+    """
+    Ensure that the time plot curve editor looks and functions as expected
+    """
+
+    # Create time plot curve editor along with its associated plot. Ensure it shows.
+    base_plot = BasePlot()
+    qtbot.addWidget(base_plot)
+
+    curve_editor = TimePlotCurveEditorDialog(base_plot)
+    qtbot.addWidget(curve_editor)
+    curve_editor.show()
+
+    table_model = curve_editor.table_model
+    table_view = curve_editor.table_view
+
+    assert table_model.columnCount() == 8
+
+    # Verify that the drop downs for columns with non built-in types are all put in the correct place
+    color_index = table_model._column_names.index('Color')
+    line_style_index = table_model._column_names.index('Line Style')
+    symbol_index = table_model._column_names.index('Symbol')
+
+    assert type(table_view.itemDelegateForColumn(color_index)) is ColorColumnDelegate
+    assert type(table_view.itemDelegateForColumn(line_style_index)) is LineColumnDelegate
+    assert type(table_view.itemDelegateForColumn(symbol_index)) is SymbolColumnDelegate
+
+
+def test_scatterplot_editor(qtbot):
+    """
+    Ensure that the scatter plot curve editor looks and functions as expected
+    """
+
+    # Create scatter plot curve editor along with its associated plot. Ensure it shows.
+    base_plot = BasePlot()
+    qtbot.addWidget(base_plot)
+
+    curve_editor = ScatterPlotCurveEditorDialog(base_plot)
+    qtbot.addWidget(curve_editor)
+    curve_editor.show()
+
+    table_model = curve_editor.table_model
+    table_view = curve_editor.table_view
+
+    assert table_model.columnCount() == 11
+
+    # Verify that the drop downs for columns with non built-in types are all put in the correct place
+    color_index = table_model._column_names.index('Color')
+    line_style_index = table_model._column_names.index('Line Style')
+    symbol_index = table_model._column_names.index('Symbol')
+    redraw_mode_index = table_model._column_names.index('Redraw Mode')
+
+    assert type(table_view.itemDelegateForColumn(color_index)) is ColorColumnDelegate
+    assert type(table_view.itemDelegateForColumn(line_style_index)) is LineColumnDelegate
+    assert type(table_view.itemDelegateForColumn(symbol_index)) is SymbolColumnDelegate
+    assert type(table_view.itemDelegateForColumn(redraw_mode_index)) is RedrawModeColumnDelegate
+
+
+def test_axis_editor(qtbot):
+    """
+    Ensure that the axis editor tab in the curve editor looks and functions as expected
+    """
+
+    base_plot = BasePlot()
+    qtbot.addWidget(base_plot)
+    curve_editor = WaveformPlotCurveEditorDialog(base_plot)
+
+    axis_model = curve_editor.axis_model
+    axis_view = curve_editor.axis_view
+
+    # Verify the column count is correct, and the axis column delegate is placed correctly
+    assert axis_model.columnCount() == 5
+    axis_orientation_index = axis_model._column_names.index('Y-Axis Orientation')
+    assert type(axis_view.itemDelegateForColumn(axis_orientation_index)) is AxisColumnDelegate

--- a/pydm/widgets/axis_table_model.py
+++ b/pydm/widgets/axis_table_model.py
@@ -117,3 +117,7 @@ class BasePlotAxesModel(QAbstractTableModel):
         self.beginRemoveRows(QModelIndex(), index.row(), index.row())
         self._plot.removeAxisAtIndex(index.row())
         self.endRemoveRows()
+
+    def getColumnIndex(self, column_name):
+        """ Returns the column index of the name. Raises a ValueError if it's not a valid column name """
+        return self._column_names.index(column_name)

--- a/pydm/widgets/baseplot_curve_editor.py
+++ b/pydm/widgets/baseplot_curve_editor.py
@@ -32,6 +32,7 @@ class BasePlotCurveEditorDialog(QDialog):
         self.axis_model = self.AXIS_MODEL_CLASS(self.plot)
         self.axis_view.setModel(self.axis_model)
         self.axis_model.plot = plot
+        self.setup_delegate_columns()
         # self.table_view.resizeColumnsToContents()
         self.add_button.clicked.connect(self.addCurve)
         self.remove_button.clicked.connect(self.removeSelectedCurve)
@@ -103,15 +104,15 @@ class BasePlotCurveEditorDialog(QDialog):
         self.button_box.rejected.connect(self.reject)
         self.setWindowTitle("Waveform Curve Editor")
 
-    def setup_delegate_columns(self, index=2):
+    def setup_delegate_columns(self):
         symbol_delegate = SymbolColumnDelegate(self)
-        self.table_view.setItemDelegateForColumn(index+4, symbol_delegate)
+        self.table_view.setItemDelegateForColumn(self.table_model.getColumnIndex('Symbol'), symbol_delegate)
         line_delegate = LineColumnDelegate(self)
-        self.table_view.setItemDelegateForColumn(index+2, line_delegate)
+        self.table_view.setItemDelegateForColumn(self.table_model.getColumnIndex('Line Style'), line_delegate)
         color_delegate = ColorColumnDelegate(self)
-        self.table_view.setItemDelegateForColumn(index, color_delegate)
+        self.table_view.setItemDelegateForColumn(self.table_model.getColumnIndex('Color'), color_delegate)
         axis_delegate = AxisColumnDelegate(self)
-        self.axis_view.setItemDelegateForColumn(1, axis_delegate)
+        self.axis_view.setItemDelegateForColumn(self.axis_model.getColumnIndex('Y-Axis Orientation'), axis_delegate)
 
     @Slot()
     def addCurve(self):
@@ -162,7 +163,7 @@ class BasePlotCurveEditorDialog(QDialog):
         self.accept()
 
     @Slot(int)
-    def fillAxisData(self, tab_index, axis_name_col_index=4):
+    def fillAxisData(self, tab_index):
         """ When the user clicks on the axis tab, prefill it with rows based on the curves they have created """
 
         # Toggle visibility of the buttons every time the tab changes
@@ -178,6 +179,7 @@ class BasePlotCurveEditorDialog(QDialog):
         if 'left' in self.plot.plotItem.axes:
             self.plot.plotItem.hideAxis('left')
 
+        axis_name_col_index = self.table_model.getColumnIndex('Y-Axis Name')
         curve_axis_names = [str(self.table_model.index(i, axis_name_col_index).data())
                             for i in range(self.table_model.rowCount())]
 

--- a/pydm/widgets/baseplot_table_model.py
+++ b/pydm/widgets/baseplot_table_model.py
@@ -136,6 +136,10 @@ class BasePlotCurvesModel(QAbstractTableModel):
     def removeAtIndex(self, index):
         pass
 
+    def getColumnIndex(self, column_name):
+        """ Returns the column index of the name. Raises a ValueError if it's not a valid column name """
+        return self._column_names.index(column_name)
+
     def needsColorDialog(self, index):
         column_name = self._column_names[index.column()]
         if column_name == "Color":

--- a/pydm/widgets/scatterplot_curve_editor.py
+++ b/pydm/widgets/scatterplot_curve_editor.py
@@ -70,6 +70,5 @@ class ScatterPlotCurveEditorDialog(BasePlotCurveEditorDialog):
     def __init__(self, plot, parent=None):
         super(ScatterPlotCurveEditorDialog, self).__init__(plot, parent)
 
-        self.setup_delegate_columns(index=3)
         redraw_mode_delegate = RedrawModeColumnDelegate(self)
         self.table_view.setItemDelegateForColumn(self.table_model.getColumnIndex("Redraw Mode"), redraw_mode_delegate)

--- a/pydm/widgets/scatterplot_curve_editor.py
+++ b/pydm/widgets/scatterplot_curve_editor.py
@@ -72,4 +72,4 @@ class ScatterPlotCurveEditorDialog(BasePlotCurveEditorDialog):
 
         self.setup_delegate_columns(index=3)
         redraw_mode_delegate = RedrawModeColumnDelegate(self)
-        self.table_view.setItemDelegateForColumn(9, redraw_mode_delegate)
+        self.table_view.setItemDelegateForColumn(self.table_model.getColumnIndex("Redraw Mode"), redraw_mode_delegate)

--- a/pydm/widgets/scatterplot_curve_editor.py
+++ b/pydm/widgets/scatterplot_curve_editor.py
@@ -72,4 +72,4 @@ class ScatterPlotCurveEditorDialog(BasePlotCurveEditorDialog):
 
         self.setup_delegate_columns(index=3)
         redraw_mode_delegate = RedrawModeColumnDelegate(self)
-        self.table_view.setItemDelegateForColumn(10, redraw_mode_delegate)
+        self.table_view.setItemDelegateForColumn(9, redraw_mode_delegate)

--- a/pydm/widgets/timeplot_curve_editor.py
+++ b/pydm/widgets/timeplot_curve_editor.py
@@ -46,11 +46,3 @@ class TimePlotCurveEditorDialog(BasePlotCurveEditorDialog):
     This thing is mostly just a wrapper for a table view, with a couple
     buttons to add and remove curves, and a button to save the changes."""
     TABLE_MODEL_CLASS = PyDMTimePlotCurvesModel
-
-    def __init__(self, plot, parent=None):
-        super(TimePlotCurveEditorDialog, self).__init__(plot, parent)
-        self.setup_delegate_columns(index=2)
-
-    @Slot(int)
-    def fillAxisData(self, tab_index, axis_name_col_index=3):
-        super(TimePlotCurveEditorDialog, self).fillAxisData(tab_index, axis_name_col_index=axis_name_col_index)

--- a/pydm/widgets/waveformplot_curve_editor.py
+++ b/pydm/widgets/waveformplot_curve_editor.py
@@ -68,4 +68,4 @@ class WaveformPlotCurveEditorDialog(BasePlotCurveEditorDialog):
 
         self.setup_delegate_columns(index=3)
         redraw_mode_delegate = RedrawModeColumnDelegate(self)
-        self.table_view.setItemDelegateForColumn(10, redraw_mode_delegate)
+        self.table_view.setItemDelegateForColumn(9, redraw_mode_delegate)

--- a/pydm/widgets/waveformplot_curve_editor.py
+++ b/pydm/widgets/waveformplot_curve_editor.py
@@ -68,4 +68,4 @@ class WaveformPlotCurveEditorDialog(BasePlotCurveEditorDialog):
 
         self.setup_delegate_columns(index=3)
         redraw_mode_delegate = RedrawModeColumnDelegate(self)
-        self.table_view.setItemDelegateForColumn(9, redraw_mode_delegate)
+        self.table_view.setItemDelegateForColumn(self.table_model.getColumnIndex("Redraw Mode"), redraw_mode_delegate)

--- a/pydm/widgets/waveformplot_curve_editor.py
+++ b/pydm/widgets/waveformplot_curve_editor.py
@@ -66,6 +66,5 @@ class WaveformPlotCurveEditorDialog(BasePlotCurveEditorDialog):
     def __init__(self, plot, parent=None):
         super(WaveformPlotCurveEditorDialog, self).__init__(plot, parent)
 
-        self.setup_delegate_columns(index=3)
         redraw_mode_delegate = RedrawModeColumnDelegate(self)
         self.table_view.setItemDelegateForColumn(self.table_model.getColumnIndex("Redraw Mode"), redraw_mode_delegate)


### PR DESCRIPTION
The indices ended up incorrect as part of the last round of changes on #754 breaking the display of the "Redraw Mode" column for curve editor for waveform plots and scatter plots. It displays just the number corresponding to the mode instead of the readable label, as well as breaking "Buffer Size" in scatter plots.

Broken version:

![broken](https://user-images.githubusercontent.com/89539359/151220292-db04b554-c81d-4bc6-ad7e-f8ea4b9a9726.png)


Fixed version:

![curve_editor](https://user-images.githubusercontent.com/89539359/150412219-0c78e27f-158f-4def-b7a5-25e098f67a1c.png)

Updated all column delegates to just grab index values based on the column name. Manually verified all 3 types of plots look good now. Included additional tests to automatically catch such issues in the future.