### PR TITLE
ENH: Set log mode on or off on a per-axis basis in designer

### DIFF
--- a/docs/source/widgets/curve_editor.rst
+++ b/docs/source/widgets/curve_editor.rst
@@ -68,6 +68,10 @@ And for the axes tab:
    max values specified will not be respected, so set this to false if you wish to only view data falling
    within those values.
 
+* Log Mode
+   When set to true this axis will plot data using a logarithmic scale. Setting it to false will keep
+   the scale as the linear default.
+
 .. Note::
   This is not applicable for users interacting with widgets via Python code.
   In this case you will need to serialize the list of JSON strings and use the

--- a/pydm/tests/widgets/test_multiaxis_plot.py
+++ b/pydm/tests/widgets/test_multiaxis_plot.py
@@ -1,6 +1,6 @@
 import pytest
 from unittest import mock
-from pyqtgraph import AxisItem, ViewBox
+from pyqtgraph import AxisItem, PlotDataItem, ViewBox
 from qtpy.QtWidgets import QGraphicsScene
 from ...widgets.multi_axis_plot import MultiAxisPlot
 
@@ -52,3 +52,80 @@ def test_restore_axis_ranges(mocked_y_range, mocked_x_range, mocked_auto_range, 
     mocked_auto_range.assert_any_call(axis=ViewBox.YAxis, enable=True)  # Auto-range enabled for our auto-range axis
     mocked_y_range.assert_called_once_with(-5.0, 7.5)  # Fixed range restored for the other axis
     mocked_x_range.assert_called_once_with(0.0, 10.0, padding=0)  # X-axis restored to the values specified above
+
+
+def test_link_data_to_logarithmic_axis(qtbot, monkeypatch):
+    """ Verify that when a curve is added to an axis with log mode on, that curve is set to log mode as well """
+    plot = MultiAxisPlot()
+    scene = QGraphicsScene()
+    monkeypatch.setattr(plot, "scene", lambda: scene)  # Have the plot return a dummy scene when needed
+
+    # Create one linear axis and one logarithmic axis
+    linear_axis = AxisItem('left')
+    log_axis = AxisItem('left')
+    log_axis.setLogMode(True)
+
+    plot.addAxis(linear_axis, 'Linear Axis')
+    plot.addAxis(log_axis, 'Log Axis')
+
+    # Create a data item to go along with each axis
+    linear_data = PlotDataItem()
+    log_data = PlotDataItem()
+
+    # Upon creation, all data should default to non-log mode
+    assert linear_data.opts['logMode'] == [False, False]
+    assert log_data.opts['logMode'] == [False, False]
+
+    plot.linkDataToAxis(linear_data, 'Linear Axis')
+    plot.linkDataToAxis(log_data, 'Log Axis')
+
+    # Now that we've linked the data to their associated axes, the log_data should have logMode set to true, while
+    # linear data should still have it set to false
+    assert linear_data.opts['logMode'] == [False, False]
+    assert log_data.opts['logMode'] == [False, True]
+
+
+def test_update_log_mode(qtbot):
+    """ Verify toggling log mode on and off for the entire plot works as expected """
+    plot = MultiAxisPlot()
+    data_item = PlotDataItem()
+    plot.addItem(data_item)
+
+    # For a brand new plot, log mode defaults to false for everything. Verify this is the case.
+    assert data_item.opts['logMode'] == [False, False]
+    for axis in plot.getAxes():
+        assert not axis.logMode
+
+    # Now set log mode on for y-values only. Verify this gets set correctly, and x-values are left alone.
+    plot.setLogMode(False, True)
+    assert data_item.opts['logMode'] == [False, True]
+    for axis in plot.getAxes():
+        if axis.orientation in ('bottom', 'top'):
+            assert not axis.logMode
+        elif axis.orientation in ('left', 'right'):
+            assert axis.logMode
+        else:
+            raise ValueError(f'Invalid value for axis orientation: {axis.orientation}')
+
+    # Now set log mode on for x-values only. Verify this gets set correctly, and y-values are left alone.
+    plot.setLogMode(True, False)
+    assert data_item.opts['logMode'] == [True, False]
+    for axis in plot.getAxes():
+        if axis.orientation in ('bottom', 'top'):
+            assert axis.logMode
+        elif axis.orientation in ('left', 'right'):
+            assert not axis.logMode
+        else:
+            raise ValueError(f'Invalid value for axis orientation: {axis.orientation}')
+
+    # Now set log mode on for everything. Verify this is set across all items.
+    plot.setLogMode(True, True)
+    assert data_item.opts['logMode'] == [True, True]
+    for axis in plot.getAxes():
+        assert axis.logMode
+
+    # And finally return everything back to non-log mode. Verify all items are no longer in log mode for x or y.
+    plot.setLogMode(False, False)
+    assert data_item.opts['logMode'] == [False, False]
+    for axis in plot.getAxes():
+        assert not axis.logMode

--- a/pydm/tests/widgets/test_multiaxis_plot.py
+++ b/pydm/tests/widgets/test_multiaxis_plot.py
@@ -54,19 +54,16 @@ def test_restore_axis_ranges(mocked_y_range, mocked_x_range, mocked_auto_range, 
     mocked_x_range.assert_called_once_with(0.0, 10.0, padding=0)  # X-axis restored to the values specified above
 
 
-def test_link_data_to_logarithmic_axis(qtbot, monkeypatch):
+def test_link_data_to_logarithmic_axis(qtbot, monkeypatch, sample_plot):
     """ Verify that when a curve is added to an axis with log mode on, that curve is set to log mode as well """
-    plot = MultiAxisPlot()
-    scene = QGraphicsScene()
-    monkeypatch.setattr(plot, "scene", lambda: scene)  # Have the plot return a dummy scene when needed
 
     # Create one linear axis and one logarithmic axis
     linear_axis = AxisItem('left')
     log_axis = AxisItem('left')
     log_axis.setLogMode(True)
 
-    plot.addAxis(linear_axis, 'Linear Axis')
-    plot.addAxis(log_axis, 'Log Axis')
+    sample_plot.addAxis(linear_axis, 'Linear Axis')
+    sample_plot.addAxis(log_axis, 'Log Axis')
 
     # Create a data item to go along with each axis
     linear_data = PlotDataItem()
@@ -76,8 +73,8 @@ def test_link_data_to_logarithmic_axis(qtbot, monkeypatch):
     assert linear_data.opts['logMode'] == [False, False]
     assert log_data.opts['logMode'] == [False, False]
 
-    plot.linkDataToAxis(linear_data, 'Linear Axis')
-    plot.linkDataToAxis(log_data, 'Log Axis')
+    sample_plot.linkDataToAxis(linear_data, 'Linear Axis')
+    sample_plot.linkDataToAxis(log_data, 'Log Axis')
 
     # Now that we've linked the data to their associated axes, the log_data should have logMode set to true, while
     # linear data should still have it set to false
@@ -85,21 +82,20 @@ def test_link_data_to_logarithmic_axis(qtbot, monkeypatch):
     assert log_data.opts['logMode'] == [False, True]
 
 
-def test_update_log_mode(qtbot):
+def test_update_log_mode(qtbot, sample_plot):
     """ Verify toggling log mode on and off for the entire plot works as expected """
-    plot = MultiAxisPlot()
     data_item = PlotDataItem()
-    plot.addItem(data_item)
+    sample_plot.addItem(data_item)
 
     # For a brand new plot, log mode defaults to false for everything. Verify this is the case.
     assert data_item.opts['logMode'] == [False, False]
-    for axis in plot.getAxes():
+    for axis in sample_plot.getAxes():
         assert not axis.logMode
 
     # Now set log mode on for y-values only. Verify this gets set correctly, and x-values are left alone.
-    plot.setLogMode(False, True)
+    sample_plot.setLogMode(False, True)
     assert data_item.opts['logMode'] == [False, True]
-    for axis in plot.getAxes():
+    for axis in sample_plot.getAxes():
         if axis.orientation in ('bottom', 'top'):
             assert not axis.logMode
         elif axis.orientation in ('left', 'right'):
@@ -108,9 +104,9 @@ def test_update_log_mode(qtbot):
             raise ValueError(f'Invalid value for axis orientation: {axis.orientation}')
 
     # Now set log mode on for x-values only. Verify this gets set correctly, and y-values are left alone.
-    plot.setLogMode(True, False)
+    sample_plot.setLogMode(True, False)
     assert data_item.opts['logMode'] == [True, False]
-    for axis in plot.getAxes():
+    for axis in sample_plot.getAxes():
         if axis.orientation in ('bottom', 'top'):
             assert axis.logMode
         elif axis.orientation in ('left', 'right'):
@@ -119,13 +115,13 @@ def test_update_log_mode(qtbot):
             raise ValueError(f'Invalid value for axis orientation: {axis.orientation}')
 
     # Now set log mode on for everything. Verify this is set across all items.
-    plot.setLogMode(True, True)
+    sample_plot.setLogMode(True, True)
     assert data_item.opts['logMode'] == [True, True]
-    for axis in plot.getAxes():
+    for axis in sample_plot.getAxes():
         assert axis.logMode
 
     # And finally return everything back to non-log mode. Verify all items are no longer in log mode for x or y.
-    plot.setLogMode(False, False)
+    sample_plot.setLogMode(False, False)
     assert data_item.opts['logMode'] == [False, False]
-    for axis in plot.getAxes():
+    for axis in sample_plot.getAxes():
         assert not axis.logMode

--- a/pydm/widgets/axis_table_model.py
+++ b/pydm/widgets/axis_table_model.py
@@ -12,7 +12,7 @@ class BasePlotAxesModel(QAbstractTableModel):
         super(BasePlotAxesModel, self).__init__(parent=parent)
         self._plot = plot
         self._column_names = ("Y-Axis Name", "Y-Axis Orientation", "Y-Axis Label",
-                              "Min Y Range", "Max Y Range", "Enable Auto Range")
+                              "Min Y Range", "Max Y Range", "Enable Auto Range", "Log Mode")
 
     @property
     def plot(self):
@@ -60,6 +60,9 @@ class BasePlotAxesModel(QAbstractTableModel):
             return axis.max_range
         elif column_name == "Enable Auto Range":
             return axis.auto_range
+        elif column_name == "Log Mode":
+            return axis.log_mode
+
 
     def setData(self, index, value, role=Qt.EditRole):
         if not index.isValid():
@@ -96,6 +99,8 @@ class BasePlotAxesModel(QAbstractTableModel):
             axis.max_range = float(value)
         elif column_name == "Enable Auto Range":
             axis.auto_range = bool(value)
+        elif column_name == "Log Mode":
+            axis.log_mode = bool(value)
         else:
             return False
         return True

--- a/pydm/widgets/baseplot.py
+++ b/pydm/widgets/baseplot.py
@@ -374,7 +374,7 @@ class BasePlotAxisItem(AxisItem):
         'bottom', or 'left'. See: https://pyqtgraph.readthedocs.io/en/latest/graphicsItems/axisitem.html
     label: str, optional
         The label to be displayed along the axis
-    axisMinRange: float, optional
+    minRange: float, optional
         The minimum value to be displayed on this axis
     maxRange: float, optional
         The maximum value to be displayed on this axis

--- a/pydm/widgets/baseplot.py
+++ b/pydm/widgets/baseplot.py
@@ -367,19 +367,21 @@ class BasePlotAxisItem(AxisItem):
 
     Parameters
     ----------
-    axisName: str
+    name: str
         The name of the axis
-    axisOrientation: str, optional
+    orientation: str, optional
         The orientation of this axis. The default for this value is 'left'. Must be set to either 'right', 'top',
         'bottom', or 'left'. See: https://pyqtgraph.readthedocs.io/en/latest/graphicsItems/axisitem.html
     label: str, optional
         The label to be displayed along the axis
     axisMinRange: float, optional
         The minimum value to be displayed on this axis
-    axisMaxRange: float, optional
+    maxRange: float, optional
         The maximum value to be displayed on this axis
-    axisAutoRange: bool, optional
+    autoRange: bool, optional
         Whether or not this axis should automatically update its range as it receives new data
+    logMode: bool, optional
+        If true, this axis will start in logarithmic mode, will be linear otherwise
     **kws: optional
         Extra arguments for CSS style options for this axis
     """
@@ -388,7 +390,7 @@ class BasePlotAxisItem(AxisItem):
                                      ('Right', 'right')])
 
     def __init__(self, name, orientation='left', label=None, minRange=-1.0,
-                 maxRange=1.0, autoRange=True, **kws):
+                 maxRange=1.0, autoRange=True, logMode=False, **kws):
         super(BasePlotAxisItem, self).__init__(orientation, **kws)
 
         self._name = name
@@ -397,6 +399,7 @@ class BasePlotAxisItem(AxisItem):
         self._min_range = minRange
         self._max_range = maxRange
         self._auto_range = autoRange
+        self._log_mode = logMode
 
     @property
     def name(self):
@@ -519,6 +522,28 @@ class BasePlotAxisItem(AxisItem):
         """
         self._auto_range = auto_range
 
+    @property
+    def log_mode(self):
+        """
+        Return whether or not this axis is using logarithmic mode
+
+        Returns
+        -------
+        bool
+        """
+        return self._log_mode
+
+    @log_mode.setter
+    def log_mode(self, log_mode):
+        """
+        Set whether or not this axis is using logarithmic mode
+
+        Parameters
+        ----------
+        log_mode: bool
+        """
+        self._log_mode = log_mode
+
     def to_dict(self):
         """
         Returns an OrderedDict representation with values for all properties
@@ -533,7 +558,8 @@ class BasePlotAxisItem(AxisItem):
                             ("label", self._label),
                             ("minRange", self._min_range),
                             ("maxRange", self._max_range),
-                            ("autoRange", self._auto_range)])
+                            ("autoRange", self._auto_range),
+                            ("logMode", self._log_mode)])
 
 
 class BasePlot(PlotWidget, PyDMPrimitiveWidget):
@@ -662,7 +688,8 @@ class BasePlot(PlotWidget, PyDMPrimitiveWidget):
 
     def addAxis(self, plot_data_item: BasePlotCurveItem, name: str, orientation: str,
                 label: Optional[str] = None, min_range: Optional[float] = -1.0,
-                max_range: Optional[float] = 1.0, enable_auto_range: Optional[bool] = True):
+                max_range: Optional[float] = 1.0, enable_auto_range: Optional[bool] = True,
+                log_mode: Optional[bool] = False):
         """
         Create an AxisItem with the input name and orientation, and add it to
         this plot.
@@ -681,10 +708,11 @@ class BasePlot(PlotWidget, PyDMPrimitiveWidget):
             The minimum range to display on the axis
         max_range: float
             The maximum range to display on the axis
-        enable_auto_range: bool
-            Whether or not to use autorange for this axis. Min and max range
-            will not be respected when data goes out of range if this is set to
-            True.
+        enable_auto_range: bool, optional
+            Whether or not to use autorange for this axis. Min and max range will not be respected
+            when data goes out of range if this is set to True
+        log_mode: bool, optional
+            Whether or not this axis should start out in logarithmic mode.
 
         Raises
         ------
@@ -696,9 +724,12 @@ class BasePlot(PlotWidget, PyDMPrimitiveWidget):
             return
 
         axis = BasePlotAxisItem(name=name, orientation=orientation, label=label, minRange=min_range,
-                                maxRange=max_range, autoRange=enable_auto_range)
+                                maxRange=max_range, autoRange=enable_auto_range, logMode=log_mode)
         axis.setLabel(text=label)
         axis.enableAutoSIPrefix(False)
+        if plot_data_item is not None:
+            plot_data_item.setLogMode(False, log_mode)
+        axis.setLogMode(log_mode)
         self._axes.append(axis)
         # If the x axis is just timestamps, we don't want autorange on the x axis
         setXLink = hasattr(self, '_plot_by_timestamps') and self._plot_by_timestamps
@@ -837,7 +868,7 @@ class BasePlot(PlotWidget, PyDMPrimitiveWidget):
         for d in new_list:
             self.addAxis(plot_data_item=None, name=d.get('name'), orientation=d.get('orientation'),
                          label=d.get('label'), min_range=d.get('minRange'), max_range=d.get('maxRange'),
-                         enable_auto_range=d.get('autoRange'))
+                         enable_auto_range=d.get('autoRange'), log_mode=d.get('logMode'))
         if 'bottom' in self.plotItem.axes:
             # Ensure the added y axes get the color that was set
             self.setAxisColor(self.getAxis('bottom')._pen.color())


### PR DESCRIPTION
When creating a new plot in designer, users can now set whether or not to use a logarithmic scale on each axis added to the plot. Also updates the functionality of the transform log options in the right-click menu to work on all axes and data items. Adds associated unit tests.


![log_axis_editor](https://user-images.githubusercontent.com/89539359/151869346-e538ced6-e04f-4ccb-8ced-6222f5e32021.png)

![out4](https://user-images.githubusercontent.com/89539359/151870349-68225be0-6767-4205-b452-911f20817332.gif)


