### PR TITLE
BLD: Drop support for python 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ as the abstraction layer for the Qt Python wrappers (PyQt5/PyQt4/PySide2/PySide)
 **All tests are performed with PyQt5**.
 
 # Prerequisites
-* Python 2.7 or 3.6+
+* Python 3.6+
 * Qt 5.6 or higher
 * qtpy
 * PyQt5 >= 5.7 or any other Qt Python wrapper.

--- a/azure-pipelines-linux.yml
+++ b/azure-pipelines-linux.yml
@@ -2,13 +2,6 @@ jobs:
   # Linux
   - template: azure-test-template.yml
     parameters:
-      name: Linux_2_7
-      vmImage: 'Ubuntu 18.04'
-      build_docs: 1
-      python: '2.7'
-      allowFailure: true
-  - template: azure-test-template.yml
-    parameters:
       name: Linux_3_7
       vmImage: 'Ubuntu 18.04'
       build_docs: 1

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,7 +2,7 @@
 [PyDM](https://github.com/slaclab/pydm) is a PyQt-based framework for building user interfaces for control systems.  The goal is to provide a no-code, drag-and-drop system to make simple screens, as well as a straightforward python framework to build complex applications.
 
 # Prerequisites for the examples
-* Python 2.7 or 3.5
+* Python 3.6+
 * pydm
 * Qt 5.7 or higher
 * PyQt5 >= 5.7


### PR DESCRIPTION
Removes Python 2 as an option in the README, and removes the Python 2 test from the azure pipeline.