### PR TITLE
ENH: Add a restore default x/y ranges option to the right-click menu in all plots

### DIFF
--- a/pydm/tests/widgets/test_multiaxis_plot.py
+++ b/pydm/tests/widgets/test_multiaxis_plot.py
@@ -1,0 +1,54 @@
+import pytest
+from unittest import mock
+from pyqtgraph import AxisItem, ViewBox
+from qtpy.QtWidgets import QGraphicsScene
+from ...widgets.multi_axis_plot import MultiAxisPlot
+
+
+@pytest.fixture
+def sample_plot(qtbot, monkeypatch):
+    """ Set up a plot with a couple of test axis items for use in test cases below """
+    plot = MultiAxisPlot()
+    scene = QGraphicsScene()
+    monkeypatch.setattr(plot, 'scene', lambda: scene)  # Have the plot return a dummy scene when needed
+
+    # Create two axes, one with a fixed range and one that should auto-range (adjust to always display all data)
+    fixed_range_axis = AxisItem('left')
+    plot.addAxis(fixed_range_axis, 'Fixed Range Axis', enableAutoRangeY=False, minRange=-5.0, maxRange=7.5)
+    auto_range_axis = AxisItem('left')
+    plot.addAxis(auto_range_axis, 'Auto Range Axis', enableAutoRangeY=True)
+
+    return plot
+
+
+def test_original_ranges_set_correctly(sample_plot):
+    """ Check that the original ranges of x and y axes are preserved when adding them into the plot """
+
+    # The axis with a set range should have that preserved
+    assert sample_plot.axesOriginalRanges['Fixed Range Axis'][0] == -5.0
+    assert sample_plot.axesOriginalRanges['Fixed Range Axis'][1] == 7.5
+
+    # And the axis set to auto-range should be set to None indicating there is no fixed range to preserve
+    assert sample_plot.axesOriginalRanges['Auto Range Axis'][0] is None
+    assert sample_plot.axesOriginalRanges['Auto Range Axis'][1] is None
+
+
+@mock.patch('pyqtgraph.ViewBox.enableAutoRange')
+@mock.patch('pyqtgraph.PlotItem.setXRange')
+@mock.patch('pyqtgraph.ViewBox.setYRange')
+def test_restore_axis_ranges(mocked_y_range, mocked_x_range, mocked_auto_range, sample_plot):
+    """
+    Verify that when axis ranges have been changed from their defaults, calling restore will set them back to
+    their original values
+    """
+
+    # First let's set a starting range on the bottom axis as well as those set in the fixture
+    sample_plot.axesOriginalRanges['bottom'] = (0.0, 10.0)
+
+    sample_plot.restoreAxisRanges()
+
+    # After the call to restore axis ranges, ensure the view box calls are made as expected. (Don't want to test
+    # view box functionality here as that is very involved and covered in pyqtgraph itself)
+    mocked_auto_range.assert_any_call(axis=ViewBox.YAxis, enable=True)  # Auto-range enabled for our auto-range axis
+    mocked_y_range.assert_called_once_with(-5.0, 7.5)  # Fixed range restored for the other axis
+    mocked_x_range.assert_called_once_with(0.0, 10.0, padding=0)  # X-axis restored to the values specified above

--- a/pydm/widgets/multi_axis_plot.py
+++ b/pydm/widgets/multi_axis_plot.py
@@ -286,6 +286,7 @@ class MultiAxisPlot(PlotItem):
         if len(self.axes) == 0 or len(self.axesOriginalRanges) == 0:
             return
 
+        # First restore the range for all y-axis items added to this plot
         for axisName, axisValue in self.axes.items():
             axisItem = axisValue['item']
             linkedView = axisItem.linkedView()
@@ -299,6 +300,7 @@ class MultiAxisPlot(PlotItem):
                 print(f'about to call y range set for axis: {axisName}')
                 linkedView.setYRange(original_ranges[0], original_ranges[1])
 
+        # Now restore the x-axis range as well if needed
         if 'bottom' in self.axesOriginalRanges:
             original_x_range = self.axesOriginalRanges['bottom']
             if original_x_range[0] is not None:

--- a/pydm/widgets/multi_axis_plot.py
+++ b/pydm/widgets/multi_axis_plot.py
@@ -300,12 +300,10 @@ class MultiAxisPlot(PlotItem):
                 linkedView.setYRange(original_ranges[0], original_ranges[1])
 
         # Now restore the x-axis range as well if needed
-        if 'bottom' in self.axesOriginalRanges:
-            original_x_range = self.axesOriginalRanges['bottom']
-            if original_x_range[0] is not None:
-                self.setXRange(original_x_range[0], original_x_range[1])
-            else:
-                self.setPlotAutoRange(x=True)
+        if 'bottom' in self.axesOriginalRanges and self.axesOriginalRanges['bottom'][0] is not None:
+            self.setXRange(self.axesOriginalRanges['bottom'][0], self.axesOriginalRanges['bottom'][1])
+        else:
+            self.setPlotAutoRange(x=True)
 
     def setPlotAutoRange(self, x=None, y=None):
         """

--- a/pydm/widgets/multi_axis_plot.py
+++ b/pydm/widgets/multi_axis_plot.py
@@ -297,7 +297,6 @@ class MultiAxisPlot(PlotItem):
             if original_ranges[0] is None:  # If set to None, then autorange was enabled
                 linkedView.enableAutoRange(axis=ViewBox.YAxis, enable=True)
             else:
-                print(f'about to call y range set for axis: {axisName}')
                 linkedView.setYRange(original_ranges[0], original_ranges[1])
 
         # Now restore the x-axis range as well if needed

--- a/pydm/widgets/multi_axis_viewbox_menu.py
+++ b/pydm/widgets/multi_axis_viewbox_menu.py
@@ -1,5 +1,6 @@
 from pyqtgraph.graphicsItems.ViewBox.ViewBoxMenu import ViewBoxMenu
-from qtpy.QtCore import Signal
+from qtpy.QtCore import QCoreApplication, Signal
+from qtpy.QtWidgets import QAction
 
 
 class MultiAxisViewBoxMenu(ViewBoxMenu):
@@ -15,12 +16,22 @@ class MultiAxisViewBoxMenu(ViewBoxMenu):
 
     # A signal indicating that the user has changed the mouse mode (left click panning vs. zooming)
     sigMouseModeChanged = Signal(object)
-
+    # A signal indicating the user wants the default x and y axis ranges restored on this plot
+    sigRestoreRanges = Signal()
+    # A signal to set autorange for every view box on the plot
+    sigSetAutorange = Signal(bool, bool)
     # A signal for updating the x autorange value
     sigXAutoRangeChanged = Signal(object)
 
     def __init__(self, view):
         super(MultiAxisViewBoxMenu, self).__init__(view)
+        self.restoreRangesAction = QAction(QCoreApplication.translate("ViewBox", "Restore default X/Y ranges"), self)
+        self.restoreRangesAction.triggered.connect(self.restoreRanges)
+
+        # Insert/remove/insert because there is no QMenu function for inserting based on index
+        self.insertAction(self.viewAll, self.restoreRangesAction)
+        self.removeAction(self.viewAll)
+        self.insertAction(self.restoreRangesAction, self.viewAll)
 
     def set3ButtonMode(self):
         """ Change the mouse left-click functionality to pan the plot """
@@ -42,3 +53,11 @@ class MultiAxisViewBoxMenu(ViewBoxMenu):
         """ Disable x auto-range for each view box """
         super().xManualClicked()
         self.sigXAutoRangeChanged.emit(False)
+
+    def autoRange(self):
+        """ Sets autorange to True for all elements on the plot """
+        self.sigSetAutorange.emit(True, True)
+
+    def restoreRanges(self):
+        """ Restore the original x and y axis ranges for this plot """
+        self.sigRestoreRanges.emit()


### PR DESCRIPTION
Per request, adds an option in the right-click menu on PyDM plots to restore the x-axis and all y-axes to the original ranges they were specified with when the user created the plot. Will go back to auto-range for any that were left to that option.

Also restores the functionality of the "View All" option to set everything to auto-range. It's a similar option so figured it would be easiest to test both at once here including the interaction between them.

Added unit tests for the new functionality.

![out5](https://user-images.githubusercontent.com/89539359/152053578-ee0274da-05e4-4906-ae55-58e88b41475d.gif)
