### PR TITLE
Disable axis label behavior where it automatically changes tick values when a unit is set on the axis

### DIFF
--- a/pydm/widgets/baseplot.py
+++ b/pydm/widgets/baseplot.py
@@ -496,6 +496,11 @@ class BasePlot(PlotWidget, PyDMPrimitiveWidget):
         # Mouse mode to 1 button (left button draw rectangle for zoom)
         self.plotItem.getViewBox().setMouseMode(ViewBox.RectMode)
 
+        if self.getAxis('bottom') is not None:
+            # Disables unexpected axis tick behavior described here:
+            # https://pyqtgraph.readthedocs.io/en/latest/graphicsItems/axisitem.html
+            self.getAxis('bottom').enableAutoSIPrefix(False)
+
         if utilities.is_qt_designer():
             self.installEventFilter(self)
 
@@ -584,6 +589,7 @@ class BasePlot(PlotWidget, PyDMPrimitiveWidget):
 
         axis = BasePlotAxisItem(name=name, orientation=orientation, minRange=min_range,
                                 maxRange=max_range, autoRange=enable_auto_range)
+        axis.enableAutoSIPrefix(False)
         self._axes.append(axis)
         # If the x axis is just timestamps, we don't want autorange on the x axis
         setXLink = hasattr(self, '_plot_by_timestamps') and self._plot_by_timestamps


### PR DESCRIPTION
Currently the default is to automatically (and unexpectedly) change the tick values on an axis when zooming in or out on it and a unit is set in the label (seconds in the below example). This will disable that behavior by default. Can be re-enabled for individual plots if wanted through setting it back to true.

From:

![out6](https://user-images.githubusercontent.com/89539359/152208325-a720a89a-f934-4f0c-a3d3-6baab8d8c550.gif)

To:

![out7](https://user-images.githubusercontent.com/89539359/152208351-305ba9fe-9417-4114-b4d1-5404518c3b3b.gif)

