### PR TITLE
Update test to match default state of use_enum checkbox.

### DIFF
--- a/pydm/tests/widgets/test_rules_editor.py
+++ b/pydm/tests/widgets/test_rules_editor.py
@@ -35,7 +35,7 @@ class DummyWidget:
 @pytest.mark.parametrize(
     "use_enum, visible",
     [
-        (None, True),
+        (None, False),
         (True, True),
         (False, False)
     ]


### PR DESCRIPTION
Whoops - I changed the default state of the use_enum checkbox in the rules editor, but didn't update the test.  This PR rectifies the situation.