### PR TITLE
FIX: size hints should be as reported by embedded widget

### DIFF
--- a/pydm/widgets/embedded_display.py
+++ b/pydm/widgets/embedded_display.py
@@ -47,14 +47,40 @@ class PyDMEmbeddedDisplay(QFrame, PyDMPrimitiveWidget):
     def init_for_designer(self):
         self.setFrameShape(QFrame.Box)
 
-    def minimumSizeHint(self):
+    def sizePolicy(self):
         """
-        This property holds the recommended minimum size for the widget.
+        This holds the sizePolicy for the widget.
 
         Returns
         -------
         QSize
         """
+        if self._embedded_widget is not None:
+            return self._embedded_widget.sizePolicy()
+        return super().sizePolicy()
+
+    def sizeHint(self):
+        """
+        This holds the recommended size for the widget.
+
+        Returns
+        -------
+        QSize
+        """
+        if self._embedded_widget is not None:
+            return self._embedded_widget.sizeHint()
+        return QSize(100, 100)
+
+    def minimumSizeHint(self):
+        """
+        This holds the recommended minimum size for the widget.
+
+        Returns
+        -------
+        QSize
+        """
+        if self._embedded_widget is not None:
+            return self._embedded_widget.minimumSizeHint()
         # This is totally arbitrary, I just want *some* visible nonzero size
         return QSize(100, 100)
 


### PR DESCRIPTION
Size hints and size policies can be incorrect - potentially much too large for some embedded displays.
This PR changes the `PyDMEmbeddedDisplay` to match with the size hints and size policies of the embedded widget automatically.

With PyDM master:
<img width="798" alt="image" src="https://user-images.githubusercontent.com/5139267/153687506-10743693-1f08-452e-b150-828603e1ade7.png">

With this PR:
<img width="766" alt="image" src="https://user-images.githubusercontent.com/5139267/153687465-b71700df-7d36-4cd3-a61d-8c0533e70165.png">
