### PR TITLE
Fix data type for PyDMSymbol's 'index' rule property

### DIFF
--- a/pydm/widgets/symbol.py
+++ b/pydm/widgets/symbol.py
@@ -28,7 +28,7 @@ class PyDMSymbol(QWidget, PyDMWidget):
         if 'Index' not in PyDMSymbol.RULE_PROPERTIES:
             PyDMSymbol.RULE_PROPERTIES = PyDMWidget.RULE_PROPERTIES.copy()
             PyDMSymbol.RULE_PROPERTIES.update(
-                {'Index': ['set_current_key', object]})
+                {'Index': ['set_current_key', int]})
         self.app = QApplication.instance()
         self._current_key = 0
         self._state_images_string = ""


### PR DESCRIPTION
PyDMSymbol has an extra property in widget rules to change the index.  The data type of this property was 'object', but this doesn't actually work - the index must be an integer.