### PR TITLE
FIX: Remove auto-added y-axis when not specifically requested

### DIFF
--- a/pydm/tests/widgets/test_baseplot.py
+++ b/pydm/tests/widgets/test_baseplot.py
@@ -229,3 +229,39 @@ def test_timeplot_add_multiple_axes(qtbot):
     assert time_plot.plotItem.curvesPerAxis['Axis 2'] == 1
     assert time_plot.plotItem.curvesPerAxis['Axis 3'] == 1
     assert time_plot.plotItem.curvesPerAxis['Axis 4'] == 1
+
+
+def test_multiaxis_plot_no_designer_flow(qtbot):
+    """ Similar to the tests above except don't use the qt designer flow at all. Verify the correct axes get
+        added to the plot in this case as well. """
+
+    # Setup a plot with three test data channels, 2 assigned to the same axis, the third to its own
+    plot = PyDMTimePlot()
+    plot.addYChannel(y_channel='ca://test_channel', yAxisName='Axis 1')
+    plot.addYChannel(y_channel='ca://test_channel_2', yAxisName='Axis 1')
+    plot.addYChannel(y_channel='ca://test_channel_3', yAxisName='Axis 2')
+
+    # There should be 5 axes, the 2 we definitely expect ('Axis 1' 'Axis 2', and the default 'bottom' x-axis). But
+    # pyqtgraph also adds a mirrored 'right' axis and a mirrored 'top' axis. These do not display by
+    # default so we'll keep them.
+    assert len(plot.plotItem.axes) == 5
+    assert 'bottom' in plot.plotItem.axes
+    assert 'Axis 1' in plot.plotItem.axes
+    assert 'Axis 2' in plot.plotItem.axes
+    assert 'right' in plot.plotItem.axes
+    assert 'top' in plot.plotItem.axes
+    assert plot.plotItem.curvesPerAxis['Axis 1'] == 2
+    assert plot.plotItem.curvesPerAxis['Axis 2'] == 1
+
+    # Now check the case where no new y-axis name is specified for any of the new channels.
+    plot = PyDMTimePlot()
+    plot.addYChannel(y_channel='ca://test_channel')
+    plot.addYChannel(y_channel='ca://test_channel_2')
+    plot.addYChannel(y_channel='ca://test_channel_3')
+
+    # Since no new axes were created, we just have the default ones provided by pyqtgraph
+    assert len(plot.plotItem.axes) == 4
+    assert 'bottom' in plot.plotItem.axes
+    assert 'left' in plot.plotItem.axes
+    assert 'right' in plot.plotItem.axes
+    assert 'top' in plot.plotItem.axes

--- a/pydm/tests/widgets/test_baseplot.py
+++ b/pydm/tests/widgets/test_baseplot.py
@@ -241,7 +241,7 @@ def test_multiaxis_plot_no_designer_flow(qtbot):
     plot.addYChannel(y_channel='ca://test_channel_2', yAxisName='Axis 1')
     plot.addYChannel(y_channel='ca://test_channel_3', yAxisName='Axis 2')
 
-    # There should be 5 axes, the 2 we definitely expect ('Axis 1' 'Axis 2', and the default 'bottom' x-axis). But
+    # There should be 5 axes, the 3 we definitely expect ('Axis 1' 'Axis 2', and the default 'bottom' x-axis). But
     # pyqtgraph also adds a mirrored 'right' axis and a mirrored 'top' axis. These do not display by
     # default so we'll keep them.
     assert len(plot.plotItem.axes) == 5

--- a/pydm/tests/widgets/test_timeplot.py
+++ b/pydm/tests/widgets/test_timeplot.py
@@ -206,4 +206,3 @@ def test_pydmtimeplot_construct(qtbot):
 
     assert isinstance(pydm_timeplot._bottom_axis, AxisItem)
     assert pydm_timeplot._bottom_axis.orientation == "bottom"
-    assert pydm_timeplot._left_axis.orientation == "left"

--- a/pydm/widgets/baseplot.py
+++ b/pydm/widgets/baseplot.py
@@ -456,6 +456,10 @@ class BasePlot(PlotWidget, PyDMPrimitiveWidget):
         # First create a custom MultiAxisPlot to pass to the base PlotWidget class to support multiple y axes. Note
         # that this plot will still function just fine in the case the user doesn't need additional y axes.
         plotItem = MultiAxisPlot(axisItems=axisItems)
+        if axisItems is None or 'left' not in axisItems:
+            # The pyqtgraph PlotItem.setAxisItems() will always add an an AxisItem called left whether you asked
+            # it to or not. This will clear it if not specifically requested.
+            plotItem.removeAxis('left')
         super(BasePlot, self).__init__(parent=parent, background=background, plotItem=plotItem)
 
         self.plotItem = plotItem
@@ -820,7 +824,8 @@ class BasePlot(PlotWidget, PyDMPrimitiveWidget):
             if len(self._y_labels) > 0:
                 # Hardcoded for now as we only have one axis
                 label = self._y_labels[0]
-            self.setLabel("left", text=label)
+            if 'left' in self.plotItem.axes:
+                self.setLabel("left", text=label)
 
     def resetYLabels(self):
         warnings.warn("Y Labels should now be set on the AxisItem itself. See: AxisItem.setLabel() "

--- a/pydm/widgets/multi_axis_plot.py
+++ b/pydm/widgets/multi_axis_plot.py
@@ -184,7 +184,8 @@ class MultiAxisPlot(PlotItem):
 
         oldAxis = self.axes[axisName]['item']
         self.layout.removeItem(oldAxis)
-        oldAxis.scene().removeItem(oldAxis)
+        if oldAxis.scene() is not None:
+            oldAxis.scene().removeItem(oldAxis)
         oldAxis.unlinkFromView()
         del self.axes[axisName]
 
@@ -258,7 +259,8 @@ class MultiAxisPlot(PlotItem):
         for oldAxis in allAxes:
             if oldAxis.orientation != 'bottom':   # Currently only multiple y axes are supported
                 self.layout.removeItem(oldAxis)
-                oldAxis.scene().removeItem(oldAxis)
+                if oldAxis.scene() is not None:
+                    oldAxis.scene().removeItem(oldAxis)
                 oldAxis.unlinkFromView()
 
         # Retain the x axis

--- a/pydm/widgets/timeplot.py
+++ b/pydm/widgets/timeplot.py
@@ -339,7 +339,6 @@ class PyDMTimePlot(BasePlot):
         """
         self._plot_by_timestamps = plot_by_timestamps
 
-        self._left_axis = AxisItem("left")
         if plot_by_timestamps:
             self._bottom_axis = TimeAxisItem('bottom')
         else:
@@ -347,7 +346,7 @@ class PyDMTimePlot(BasePlot):
             self._bottom_axis = AxisItem('bottom')
 
         super(PyDMTimePlot, self).__init__(parent=parent, background=background,
-                                           axisItems={"bottom": self._bottom_axis, "left": self._left_axis})
+                                           axisItems={"bottom": self._bottom_axis})
 
         # Removing the downsampling while PR 763 is not merged at pyqtgraph
         # Reference: https://github.com/pyqtgraph/pyqtgraph/pull/763


### PR DESCRIPTION
When creating a multi-axis plot using python code only, an additional y-axis names "left" gets added automatically even if it was not specified by name in the addChannel() or addAxis() flow in the user's code. This removes that axis.

Also removed PyDMTimePlot specifically setting the left axis on intialization, which will also cause this issue separate of the other two types of plots. There is no need to do this, either the user will create their own axis, or pyqtgraph will create the default left one.

Added additional test covering this case. Re-ran existing examples/designer flow as well.