### PR TITLE
DOC: Update doc string with correct parameter type

### DIFF
--- a/pydm/widgets/symbol.py
+++ b/pydm/widgets/symbol.py
@@ -51,10 +51,8 @@ class PyDMSymbol(QWidget, PyDMWidget):
 
         Parameters
         ----------
-        current_key : object
-            The current_key parameter can be of any type as long as it matches
-            the type used as key for the imageFiles dictionary.
-
+        current_key : int
+            The index corresponding to the image to be displayed by this symbol.
         """
         if self._current_key != current_key:
             self._current_key = current_key


### PR DESCRIPTION
Just changing from object to int. This will not catch anyone off guard as setting this to anything other than an int will cause multiple errors already.