### PR TITLE
DOC: Add documentation for archiver plots to the index

### DIFF
--- a/docs/source/widgets/index.rst
+++ b/docs/source/widgets/index.rst
@@ -42,6 +42,7 @@ Plot Widgets
    curve_editor.rst
    scatterplot.rst
    timeplot.rst
+   archiver_timeplot.rst
    waveformplot.rst
 
 Container Widgets


### PR DESCRIPTION
Link to the new documentation from the index