### PR TITLE
FIX: Set archiver address correctly when using a default set with PYDM_DEFAULT_PROTOCOL

### DIFF
--- a/pydm/tests/widgets/test_archiver_timeplot.py
+++ b/pydm/tests/widgets/test_archiver_timeplot.py
@@ -1,8 +1,16 @@
 import numpy as np
+import pytest
 from qtpy.QtCore import Slot
 
 from ..conftest import ConnectionSignals
 from ...widgets.archiver_time_plot import ArchivePlotCurveItem, PyDMArchiverTimePlot
+
+
+@pytest.mark.parametrize('address', ['ca://LINAC:PV1', 'pva://LINAC:PV1', 'LINAC:PV1'])
+def test_set_archive_channel(address):
+    """ Verify the address for the archiver data plugin is set correctly for all possible EPICS address prefixes """
+    curve_item = ArchivePlotCurveItem(channel_address=address)
+    assert curve_item.archive_channel.address == 'archiver://pv=LINAC:PV1'
 
 
 def test_receive_archive_data(signals: ConnectionSignals):

--- a/pydm/widgets/archiver_time_plot.py
+++ b/pydm/widgets/archiver_time_plot.py
@@ -60,11 +60,13 @@ class ArchivePlotCurveItem(TimePlotCurveItem):
 
     def setArchiveChannel(self, address: str) -> None:
         """ Creates the channel for the input address for communicating with the archiver appliance plugin. """
+        archiver_prefix = 'archiver://pv='
         if address.startswith('ca://'):
-            archive_address = address.replace('ca://', 'archiver://pv=', 1)
+            archive_address = address.replace('ca://', archiver_prefix, 1)
+        elif address.startswith('pva://'):
+            archive_address = address.replace('pva://', archiver_prefix, 1)
         else:
-            logger.error(f'Invalid address format for archiver appliance: {address}')
-            return
+            archive_address = archiver_prefix + address
 
         self.archive_channel = PyDMChannel(address=archive_address,
                                            value_slot=self.receiveArchiveData,


### PR DESCRIPTION
If the PYDM_DEFAULT_PROTOCOL environment variable is set, then there is no 'ca://' prefix to replace before creating the channel that should go to the archiver data plugin since it was never explicitly set by the user. In this case just add the archiver prefix directly to the PV address so it gets to the right place.

Removing the error checking here is not a problem, if something invalid somehow gets input to setArchiveChannel, it will be noticed and handled at the data plugin level with the appropriate error raised. Also adds the check for 'pva://' just for future-proofing.

Verified by creating an archive plot with PYDM_DEFAULT_PROTOCOL set to "ca://" and confirmed it worked as expected.