### PR TITLE
ENH: Add a column in curve editor for setting y-axis labels

### DIFF
--- a/docs/source/widgets/curve_editor.rst
+++ b/docs/source/widgets/curve_editor.rst
@@ -30,7 +30,7 @@ The following is a description of some of the columns available in the editor, f
 
 
 * Label
-   The label that will be applied to this curve, both in the  legend and on the y-axis
+   The label that will be applied to this curve shown in the legend.
 
 * Y-Axis Name
    The name of the y-axis that will be assigned to this curve. It may be named anything you
@@ -48,6 +48,9 @@ And for the axes tab:
 
 * Y-Axis Orientation
    A simple option for placing the y-axis either on the left or the right of the plot.
+
+* Y-Axis Label
+   The label that will be displayed along this axis.
 
 * Min Y Range
    The minimum value that will be displayed on the axis. Can be left to its default if using auto range.

--- a/pydm/widgets/axis_table_model.py
+++ b/pydm/widgets/axis_table_model.py
@@ -11,8 +11,8 @@ class BasePlotAxesModel(QAbstractTableModel):
     def __init__(self, plot, parent=None):
         super(BasePlotAxesModel, self).__init__(parent=parent)
         self._plot = plot
-        self._column_names = ("Y-Axis Name", "Y-Axis Orientation", "Min Y Range",
-                              "Max Y Range", "Enable Auto Range")
+        self._column_names = ("Y-Axis Name", "Y-Axis Orientation", "Y-Axis Label",
+                              "Min Y Range", "Max Y Range", "Enable Auto Range")
 
     @property
     def plot(self):
@@ -52,6 +52,8 @@ class BasePlotAxesModel(QAbstractTableModel):
             return axis.name
         elif column_name == "Y-Axis Orientation":
             return self.name_for_orientations.get(axis.orientation, 'Left')
+        elif column_name == "Y-Axis Label":
+            return axis.label_text
         elif column_name == "Min Y Range":
             return axis.min_range
         elif column_name == "Max Y Range":
@@ -86,6 +88,8 @@ class BasePlotAxesModel(QAbstractTableModel):
                 axis.orientation = 'left'  # The PyQtGraph default is the left axis
             else:
                 axis.orientation = str(value)
+        elif column_name == "Y-Axis Label":
+            axis.label_text = str(value)
         elif column_name == "Min Y Range":
             axis.min_range = float(value)
         elif column_name == "Max Y Range":

--- a/pydm/widgets/baseplot.py
+++ b/pydm/widgets/baseplot.py
@@ -1,6 +1,7 @@
 import functools
 import json
 import warnings
+from typing import Optional
 from qtpy.QtGui import QColor, QBrush
 from qtpy.QtCore import Signal, Slot, Property, QTimer, Qt, QEvent, QRect
 from qtpy.QtWidgets import QToolTip
@@ -299,6 +300,8 @@ class BasePlotAxisItem(AxisItem):
     axisOrientation: str, optional
         The orientation of this axis. The default for this value is 'left'. Must be set to either 'right', 'top',
         'bottom', or 'left'. See: https://pyqtgraph.readthedocs.io/en/latest/graphicsItems/axisitem.html
+    label: str, optional
+        The label to be displayed along the axis
     axisMinRange: float, optional
         The minimum value to be displayed on this axis
     axisMaxRange: float, optional
@@ -312,12 +315,13 @@ class BasePlotAxisItem(AxisItem):
     axis_orientations = OrderedDict([('Left', 'left'),
                                      ('Right', 'right')])
 
-    def __init__(self, name, orientation='left', minRange=-1.0,
+    def __init__(self, name, orientation='left', label=None, minRange=-1.0,
                  maxRange=1.0, autoRange=True, **kws):
         super(BasePlotAxisItem, self).__init__(orientation, **kws)
 
         self._name = name
         self._orientation = orientation
+        self._label = label
         self._min_range = minRange
         self._max_range = maxRange
         self._auto_range = autoRange
@@ -366,6 +370,16 @@ class BasePlotAxisItem(AxisItem):
         orientation: str
         """
         self._orientation = orientation
+
+    @property
+    def label_text(self) -> str:
+        """ Return the label to be displayed along this axis. """
+        return self._label
+
+    @label_text.setter
+    def label_text(self, label: str):
+        """ Set the label to be displayed along this axis """
+        self._label = label
 
     @property
     def min_range(self):
@@ -444,6 +458,7 @@ class BasePlotAxisItem(AxisItem):
         """
         return OrderedDict([("name", self._name),
                             ("orientation", self._orientation),
+                            ("label", self._label),
                             ("minRange", self._min_range),
                             ("maxRange", self._max_range),
                             ("autoRange", self._auto_range)])
@@ -560,7 +575,9 @@ class BasePlot(PlotWidget, PyDMPrimitiveWidget):
             if chan:
                 chan.connect()
 
-    def addAxis(self, plot_data_item, name, orientation, min_range=-1.0, max_range=1.0, enable_auto_range=True):
+    def addAxis(self, plot_data_item: BasePlotCurveItem, name: str, orientation: str,
+                label: Optional[str] = None, min_range: Optional[float] = -1.0,
+                max_range: Optional[float] = 1.0, enable_auto_range: Optional[bool] = True):
         """
         Create an AxisItem with the input name and orientation, and add it to this plot.
         Parameters
@@ -571,6 +588,8 @@ class BasePlot(PlotWidget, PyDMPrimitiveWidget):
             The name that will be assigned to this axis
         orientation: str
             The orientation of this axis, must be in 'left' or 'right'
+        label: str, optional
+            The label to be displayed along this axis
         min_range: float
             The minimum range to display on the axis
         max_range: float
@@ -588,8 +607,9 @@ class BasePlot(PlotWidget, PyDMPrimitiveWidget):
         if name in self.plotItem.axes:
             return
 
-        axis = BasePlotAxisItem(name=name, orientation=orientation, minRange=min_range,
+        axis = BasePlotAxisItem(name=name, orientation=orientation, label=label, minRange=min_range,
                                 maxRange=max_range, autoRange=enable_auto_range)
+        axis.setLabel(text=label)
         axis.enableAutoSIPrefix(False)
         self._axes.append(axis)
         # If the x axis is just timestamps, we don't want autorange on the x axis
@@ -731,7 +751,7 @@ class BasePlot(PlotWidget, PyDMPrimitiveWidget):
         self.clearAxes()
         for d in new_list:
             self.addAxis(plot_data_item=None, name=d.get('name'), orientation=d.get('orientation'),
-                         min_range=d.get('minRange'), max_range=d.get('maxRange'),
+                         label=d.get('label'), min_range=d.get('minRange'), max_range=d.get('maxRange'),
                          enable_auto_range=d.get('autoRange'))
 
     yAxes = Property("QStringList", getYAxes, setYAxes, designable=False)

--- a/pydm/widgets/multi_axis_plot.py
+++ b/pydm/widgets/multi_axis_plot.py
@@ -1,8 +1,4 @@
 import weakref
-try:
-    from html import escape  # Python 3
-except ImportError:
-    from cgi import escape  # Can't only use this since it was removed in Python 3.8 and up
 from collections import Counter
 from pyqtgraph import PlotItem, ViewBox
 from .multi_axis_viewbox import MultiAxisViewBox

--- a/pydm/widgets/multi_axis_plot.py
+++ b/pydm/widgets/multi_axis_plot.py
@@ -159,14 +159,12 @@ class MultiAxisPlot(PlotItem):
         if self.ctrl.averageGroup.isChecked():
             self.addAvgCurve(plotDataItem)
 
-        if plotDataItem.name():
-            if axisToLink.labelText:
-                # Joins together the labels from the curves for display on their shared axis. The label
-                # text expects html, so this will set it to be, for example, "label 1  &  label 2"
-                axisToLink.setLabel(escape(axisToLink.labelText + ' & ' + plotDataItem.name()),
-                                    color=plotDataItem.color_string)
-            else:
-                axisToLink.setLabel(plotDataItem.name(), color=plotDataItem.color_string)
+        if plotDataItem.name() and not axisToLink.labelText:
+            axisToLink.setLabel(plotDataItem.name(), color=plotDataItem.color_string)
+        elif axisToLink.labelText and plotDataItem.color_string and axisToLink.labelStyle['color'] == '#969696':
+            # The color for the axis was not specified by the user (#969696 is default) so set it appropriately
+            axisToLink.labelStyle['color'] = plotDataItem.color_string
+            axisToLink._updateLabel()
         if self.legend is not None and plotDataItem.name():
             self.legend.addItem(plotDataItem, name=plotDataItem.name())
 


### PR DESCRIPTION
Adds a column for setting the y-axis label in the axes tab of the curve editor in designer for all PyDM plots, instead of using the label value of each PV added to the plot.

## Screenshot

![axis_label](https://user-images.githubusercontent.com/89539359/158275219-16f120dc-542b-43f9-a4b5-be1a2136f9d9.png)
