### PR TITLE
FIX: make PyDMTabWidget open with the first tab 

### DIFF
--- a/pydm/default_stylesheet.qss
+++ b/pydm/default_stylesheet.qss
@@ -205,4 +205,5 @@ PyDMTabWidget {
     qproperty-majorAlarmIconColor: #FF0000;
     qproperty-invalidAlarmIconColor: #EB00EB;
     qproperty-disconnectedAlarmIconColor: #FFFFFF;
+    qproperty-currentIndex: 0;
 }


### PR DESCRIPTION
Added a line to the default stylesheet to set the currentIndex of the tabs in the PyDMTabWidget to 0. 

Addresses #764  