### PR TITLE
BLD: Update azure pipeline so that style warnings are no longer reported as a failure of the pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,13 +14,13 @@
 #  - After the tests pass 3 Publish jobs go into action:
 #      - Documentation
 #        This job is executed on commits to master and tags.
-#        It deployes the new docs to the gh-pages branch at GitHub.
+#        It deploys the new docs to the gh-pages branch at GitHub.
 #      - PyPI
 #        This job is executed on tags only.
-#        It deploy the package to the Python Package Index.
+#        It deploys the package to the Python Package Index.
 #      - Anaconda
 #        This job is executed on commits to master and tags.
-#        It deploy the package to the DEV or TAG channels at Anaconda Cloud.
+#        It deploys the package to the DEV or TAG channels at Anaconda Cloud.
 ############################################################################################
 
 trigger:
@@ -58,7 +58,7 @@ stages:
         - script: pip install flake8
           displayName: 'Python - Install flake8'
         - bash: |
-            flake8 pydm
+            flake8 --max-line-length=120 --exit-zero pydm
           displayName: 'Flake8'
   - stage: "Build"
     dependsOn: []


### PR DESCRIPTION
Still run the job, but a warning no longer results in a non-zero exit code. Also update max line length.