### PR TITLE
FIX: Don't keep the rolling window moving when zooming in on archiver plots

### DIFF
--- a/pydm/tests/widgets/test_archiver_timeplot.py
+++ b/pydm/tests/widgets/test_archiver_timeplot.py
@@ -129,7 +129,6 @@ def test_request_data_from_archiver(qtbot):
     plot.requestDataFromArchiver(100, 200)
 
     # Verify that the data is requested for the time period specified, and since it is only 100 seconds, it is raw data
-    assert not plot._archive_request_queued  # Request is completed, so this should be false now
     assert inspect_data_request.min_x == 100
     assert inspect_data_request.max_x == 199
     assert inspect_data_request.processing_command == ''
@@ -138,7 +137,6 @@ def test_request_data_from_archiver(qtbot):
     # returned in 10 bins as specified by the "optimized_data_bins" param above
     plot._archive_request_queued = True
     plot.requestDataFromArchiver(100, 100000)
-    assert not plot._archive_request_queued
     assert inspect_data_request.min_x == 100
     assert inspect_data_request.max_x == 99999
     assert inspect_data_request.processing_command == 'optimized_10'
@@ -155,7 +153,6 @@ def test_request_data_from_archiver(qtbot):
     plot._min_x = 50  # This is the minimum timestamp visible on the x-axis, representing what the user panned to
     plot._archive_request_queued = True
     plot.requestDataFromArchiver()
-    assert not plot._archive_request_queued
     # The min_x requested should have defaulted to 50 since that is what the user requested as mentioned above
     assert inspect_data_request.min_x == 50
     # Because the oldest live timestamp in the data buffer was 300, the ending timestamp for the request should


### PR DESCRIPTION
This fixes an issue with archiver plots where the x-axis scroll keeps on going even when manually zooming into a specific region of the plot. Now this update to the x-axis only happens when no zooming has occurred.