### PR TITLE
ENH: Change default text of PyDMLabel to ###### and display channel name when PV is not connected

### DIFF
--- a/pydm/tests/widgets/test_label.py
+++ b/pydm/tests/widgets/test_label.py
@@ -337,7 +337,8 @@ def test_label_channel_connection_changes_with_alarm(qtbot, signals, alarm_sensi
     5. The tooltip will change when the channel is disconnected, having additional text, i.e. "PV is disconnected"
        appended to the existing text, to inform the user about the channel disconnection status. This tooltip will be
        reverted to the original content when the data channel is re-connected.
-    6. The widget will be disabled during the disconnection, and become enabled again at the reconnection.
+    6. The text of the label will also change when the channel is disconnected to display the address of the PV.
+    7. The widget will be disabled during the disconnection, and become enabled again at the reconnection.
 
     Parameters
     ----------
@@ -353,6 +354,7 @@ def test_label_channel_connection_changes_with_alarm(qtbot, signals, alarm_sensi
         The tooltip for the widget. This can be an empty string
     """
     pydm_label = PyDMLabel()
+    pydm_label.setText('Custom Text')
     qtbot.addWidget(pydm_label)
 
     pydm_label.alarmSensitiveContent = alarm_sensitive_content
@@ -375,8 +377,9 @@ def test_label_channel_connection_changes_with_alarm(qtbot, signals, alarm_sensi
     assert pydm_label._connected == True
     assert pydm_label.toolTip() == tooltip
     assert pydm_label.isEnabled() == True
+    assert pydm_label.text() == 'Custom Text'
 
-    # Next, disconnect the alarm, and check for the alarm severity, style, connection state, enabling state, and
+    # Next, disconnect the alarm, and check for the alarm severity, style, text, connection state, enabling state, and
     # tooltip
     alarm_severity = PyDMWidget.ALARM_DISCONNECTED
 
@@ -385,6 +388,7 @@ def test_label_channel_connection_changes_with_alarm(qtbot, signals, alarm_sensi
     assert pydm_label._connected == False
     assert all(i in pydm_label.toolTip() for i in (tooltip, "PV is disconnected."))
     assert pydm_label.isEnabled() == False
+    assert pydm_label.text() == 'CA://MTEST'
 
     # Finally, reconnect the alarm, and check for the same attributes
     signals.connection_state_signal.emit(True)

--- a/pydm/widgets/label.py
+++ b/pydm/widgets/label.py
@@ -4,6 +4,7 @@ from qtpy.QtCore import Qt, Property, Q_ENUMS
 from .display_format import DisplayFormat, parse_value_for_display
 from pydm.utilities import is_pydm_app, is_qt_designer
 from pydm import config
+from pydm.widgets.base import only_if_channel_set
 
 
 class PyDMLabel(QLabel, TextFormatter, PyDMWidget, DisplayFormat):
@@ -35,7 +36,7 @@ class PyDMLabel(QLabel, TextFormatter, PyDMWidget, DisplayFormat):
         self.app = QApplication.instance()
         self.setTextFormat(Qt.PlainText)
         self.setTextInteractionFlags(Qt.NoTextInteraction)
-        self.setText("PyDMLabel")
+        self.setText("######")
         self._display_format_type = self.DisplayFormat.Default
         self._string_encoding = "utf_8"
         if is_pydm_app():
@@ -92,3 +93,10 @@ class PyDMLabel(QLabel, TextFormatter, PyDMWidget, DisplayFormat):
         # If you made it this far, just turn whatever the heck the value
         # is into a string and display it.
         self.setText(str(new_value))
+
+    @only_if_channel_set
+    def check_enable_state(self):
+        """ If the channel this label is connected to becomes disconnected, display only the name of the channel. """
+        if not self._connected:
+            self.setText(self.channel)
+        super().check_enable_state()


### PR DESCRIPTION
Updates PyDMLabel's default text to ###### and displays just the channel name if the PV it is connected to is disconnected. Setting the text via a rule is unaffected.