### PR TITLE
FIX: Ensure time plot x-axis receives all mouse events

### DIFF
--- a/pydm/tests/widgets/test_baseplot.py
+++ b/pydm/tests/widgets/test_baseplot.py
@@ -142,7 +142,6 @@ def test_baseplot_no_added_y_axes(qtbot):
     """ Confirm that if the user does not name or create any new y-axes, the plot will still work just fine """
     base_plot = BasePlot()
     base_plot.clear()
-    base_plot.clearAxes()
 
     # Add 3 curves to our plot, but don't bother to use any of the y-axis parameters
     # in addCurve() leaving them to their default of None

--- a/pydm/widgets/archiver_time_plot.py
+++ b/pydm/widgets/archiver_time_plot.py
@@ -216,14 +216,13 @@ class PyDMArchiverTimePlot(PyDMTimePlot):
     def __init__(self, parent: Optional[QObject] = None, init_y_channels: List[str] = [],
                  background: str = 'default', optimized_data_bins: int = 2000):
         super(PyDMArchiverTimePlot, self).__init__(parent=parent, init_y_channels=init_y_channels,
-                                                   plot_by_timestamps=True, background=background)
+                                                   plot_by_timestamps=True, background=background,
+                                                   bottom_axis=DateAxisItem('bottom'))
         self.optimized_data_bins = optimized_data_bins
         self._min_x = None
         self._prev_x = None  # Holds the minimum x-value of the previous update of the plot
         self._starting_timestamp = time.time()  # The timestamp at which the plot was first rendered
         self._archive_request_queued = False
-        self._bottom_axis = DateAxisItem('bottom')  # Nice for displaying data across long periods of time
-        self.plotItem.setAxisItems({'bottom': self._bottom_axis})
 
     def updateXAxis(self, update_immediately: bool = False) -> None:
         """ Manages the requests to archiver appliance. When the user pans or zooms the x axis to the left,

--- a/pydm/widgets/baseplot.py
+++ b/pydm/widgets/baseplot.py
@@ -636,9 +636,11 @@ class BasePlot(PlotWidget, PyDMPrimitiveWidget):
         self._curves.append(plot_data_item)
 
         if y_axis_name is None:
-            # If the user did not name the axis, use the default ones. Note: multiple calls to setAxisItems() are ok
-            self.plotItem.setAxisItems()
-            self.addItem(plot_data_item)
+            # If the user did not name the axis, use the pyqtgraph default one named left
+            if 'left' not in self.plotItem.axes:
+                self.addAxis(plot_data_item=plot_data_item, name='left', orientation='left')
+            else:
+                self.plotItem.linkDataToAxis(plot_data_item, 'left')
         elif y_axis_name in self.plotItem.axes:
             # If the user has chosen an axis that already exists for this curve, simply link the data to that axis
             self.plotItem.linkDataToAxis(plot_data_item, y_axis_name)

--- a/pydm/widgets/timeplot.py
+++ b/pydm/widgets/timeplot.py
@@ -362,13 +362,16 @@ class PyDMTimePlot(BasePlot):
     background: optional
         The background color for the plot.  Accepts any arguments that
         pyqtgraph.mkColor will accept.
+    bottom_axis: AxisItem, optional
+        Will set the bottom axis of this plot to the input axis. If not set, will default
+        to either a TimeAxisItem if plot_by_timestamps is true, or a regular AxisItem otherwise
     """
     SynchronousMode = 1
     AsynchronousMode = 2
 
     plot_redrawn_signal = Signal(TimePlotCurveItem)
 
-    def __init__(self, parent=None, init_y_channels=[], plot_by_timestamps=True, background='default'):
+    def __init__(self, parent=None, init_y_channels=[], plot_by_timestamps=True, background='default', bottom_axis=None):
         """
         Parameters
         ----------
@@ -387,7 +390,9 @@ class PyDMTimePlot(BasePlot):
         """
         self._plot_by_timestamps = plot_by_timestamps
 
-        if plot_by_timestamps:
+        if bottom_axis is not None:
+            self._bottom_axis = bottom_axis
+        elif plot_by_timestamps:
             self._bottom_axis = TimeAxisItem('bottom')
         else:
             self.starting_epoch_time = time.time()


### PR DESCRIPTION
There is an issue where a time plot created with default axis settings only will not receive mouse events on the x-axis. (For one example, run the timeplot.ui file under the examples directory and see that the x axis is not interactable) This is much more noticeable when using archive plots and trying to move the x-axis.

The fix is in 2 parts. The change to baseplot.py will now create/link data to the default left axis only when no other y-axis is specified. This will ensure the view box remains linked to the x-axis. 

The second part is the change to timeplot/archiver_time_plot which is the same fix as the change to timeplot here but applied to archive plots as well: #803 

The easiest way to test is just to run the time plot under examples/timeplot but it will also work with any custom created plot as well. 
