### PR TITLE
FIX: Error when setting axis colors on a plot through designer

### DIFF
--- a/pydm/widgets/baseplot.py
+++ b/pydm/widgets/baseplot.py
@@ -788,11 +788,8 @@ class BasePlot(PlotWidget, PyDMPrimitiveWidget):
         return self.getAxis('bottom')._pen.color()
 
     def setAxisColor(self, color):
-        if self.getAxis('bottom')._pen.color() != color:
-            self.getAxis('bottom').setPen(color)
-            self.getAxis('left').setPen(color)
-            self.getAxis('top').setPen(color)
-            self.getAxis('right').setPen(color)
+        for axis in self.plotItem.axes.values():
+            axis['item'].setPen(color)
 
     axisColor = Property(QColor, getAxisColor, setAxisColor)
 
@@ -829,6 +826,9 @@ class BasePlot(PlotWidget, PyDMPrimitiveWidget):
             self.addAxis(plot_data_item=None, name=d.get('name'), orientation=d.get('orientation'),
                          label=d.get('label'), min_range=d.get('minRange'), max_range=d.get('maxRange'),
                          enable_auto_range=d.get('autoRange'))
+        if 'bottom' in self.plotItem.axes:
+            # Ensure the added y axes get the color that was set
+            self.setAxisColor(self.getAxis('bottom')._pen.color())
 
     yAxes = Property("QStringList", getYAxes, setYAxes, designable=False)
 


### PR DESCRIPTION
Currently an error will occur when setting axis colors in designer if one of the specified axis names does not exist. This will make it so that it just iterates through each axis on the plot instead of looking for specific ones, as well as applying the color correctly after setting any additional axes through designer.

![Screenshot from 2022-04-20 13-27-20](https://user-images.githubusercontent.com/89539359/164317058-ad27f1dc-1a9b-41f9-859f-811851fa9819.png)

