### PR TITLE
FIX: Ensure PyDMChannel signals/slots are disconnected when a functools.partial is used

### DIFF
--- a/pydm/data_plugins/plugin.py
+++ b/pydm/data_plugins/plugin.py
@@ -1,7 +1,9 @@
+import functools
 import weakref
 import threading
 
 from numpy import ndarray
+from typing import Optional, Callable
 
 from ..utilities.remove_protocol import protocol_and_address
 from qtpy.QtCore import Signal, QObject, Qt
@@ -77,84 +79,116 @@ class PyDMConnection(QObject):
         if channel.prec_slot is not None:
             self.prec_signal.connect(channel.prec_slot, Qt.QueuedConnection)
 
-    def remove_listener(self, channel, destroying=False):
-        if not destroying:
-            if channel.connection_slot is not None:
-                try:
-                    self.connection_state_signal.disconnect(channel.connection_slot)
-                except TypeError:
-                    pass
+    def remove_listener(self, channel, destroying: Optional[bool] = False) -> None:
+        """
+        Removes a listener from this PyDMConnection. If there are no more listeners remaining after
+        removal, then the PyDMConnection will be closed.
 
-            if channel.value_slot is not None:
-                try:
-                    self.new_value_signal[int].disconnect(channel.value_slot)
-                except TypeError:
-                    pass
-                try:
-                    self.new_value_signal[float].disconnect(channel.value_slot)
-                except TypeError:
-                    pass
-                try:
-                    self.new_value_signal[str].disconnect(channel.value_slot)
-                except TypeError:
-                    pass
-                try:
-                    self.new_value_signal[ndarray].disconnect(channel.value_slot)
-                except TypeError:
-                    pass
-                try:
-                    self.new_value_signal[bool].disconnect(channel.value_slot)
-                except TypeError:
-                    pass
+        Parameters
+        ----------
+        channel: PyDMChannel
+            The PyDMChannel containing the signals/slots that were being used to listen to the connected address.
+        destroying: bool, optional
+            Should be set to True if this method is being invoked from a flow in which the PyDMWidget using this
+            channel is being destroyed. Since Qt will automatically handle the disconnect of signals/slots when a
+            QObject is destroyed, setting this to True ensures we do not try to do the disconnection a second time.
+            If set to False, any active signals/slots on the channel will be manually disconnected here.
+        """
+        if self._should_disconnect(channel.connection_slot, destroying):
+            try:
+                self.connection_state_signal.disconnect(channel.connection_slot)
+            except TypeError:
+                pass
 
-            if channel.severity_slot is not None:
-                try:
-                    self.new_severity_signal.disconnect(channel.severity_slot)
-                except (KeyError, TypeError):
-                    pass
+        if self._should_disconnect(channel.value_slot, destroying):
+            try:
+                self.new_value_signal[int].disconnect(channel.value_slot)
+            except TypeError:
+                pass
+            try:
+                self.new_value_signal[float].disconnect(channel.value_slot)
+            except TypeError:
+                pass
+            try:
+                self.new_value_signal[str].disconnect(channel.value_slot)
+            except TypeError:
+                pass
+            try:
+                self.new_value_signal[ndarray].disconnect(channel.value_slot)
+            except TypeError:
+                pass
+            try:
+                self.new_value_signal[bool].disconnect(channel.value_slot)
+            except TypeError:
+                pass
 
-            if channel.write_access_slot is not None:
-                try:
-                    self.write_access_signal.disconnect(channel.write_access_slot)
-                except (KeyError, TypeError):
-                    pass
+        if self._should_disconnect(channel.severity_slot, destroying):
+            try:
+                self.new_severity_signal.disconnect(channel.severity_slot)
+            except (KeyError, TypeError):
+                pass
 
-            if channel.enum_strings_slot is not None:
-                try:
-                    self.enum_strings_signal.disconnect(channel.enum_strings_slot)
-                except (KeyError, TypeError):
-                    pass
+        if self._should_disconnect(channel.write_access_slot, destroying):
+            try:
+                self.write_access_signal.disconnect(channel.write_access_slot)
+            except (KeyError, TypeError):
+                pass
 
-            if channel.unit_slot is not None:
-                try:
-                    self.unit_signal.disconnect(channel.unit_slot)
-                except (KeyError, TypeError):
-                    pass
+        if self._should_disconnect(channel.enum_strings_slot, destroying):
+            try:
+                self.enum_strings_signal.disconnect(channel.enum_strings_slot)
+            except (KeyError, TypeError):
+                pass
 
-            if channel.upper_ctrl_limit_slot is not None:
-                try:
-                    self.upper_ctrl_limit_signal.disconnect(channel.upper_ctrl_limit_slot)
-                except (KeyError, TypeError):
-                    pass
+        if self._should_disconnect(channel.unit_slot, destroying):
+            try:
+                self.unit_signal.disconnect(channel.unit_slot)
+            except (KeyError, TypeError):
+                pass
 
-            if channel.lower_ctrl_limit_slot is not None:
-                try:
-                    self.lower_ctrl_limit_signal.disconnect(channel.lower_ctrl_limit_slot)
-                except (KeyError, TypeError):
-                    pass
+        if self._should_disconnect(channel.upper_ctrl_limit_slot, destroying):
+            try:
+                self.upper_ctrl_limit_signal.disconnect(channel.upper_ctrl_limit_slot)
+            except (KeyError, TypeError):
+                pass
 
-            if channel.prec_slot is not None:
-                try:
-                    self.prec_signal.disconnect(channel.prec_slot)
-                except (KeyError, TypeError):
-                    pass
+        if self._should_disconnect(channel.lower_ctrl_limit_slot, destroying):
+            try:
+                self.lower_ctrl_limit_signal.disconnect(channel.lower_ctrl_limit_slot)
+            except (KeyError, TypeError):
+                pass
+
+        if self._should_disconnect(channel.prec_slot, destroying):
+            try:
+                self.prec_signal.disconnect(channel.prec_slot)
+            except (KeyError, TypeError):
+                pass
 
         self.listener_count = self.listener_count - 1
         if self.listener_count < 1:
             self.close()
 
+    @staticmethod
+    def _should_disconnect(slot: Callable, destroying: bool):
+        """ Return True if the signal/slot should be disconnected, False otherwise """
+        if slot is None:
+            # Nothing to do if the slot does not exist
+            return False
+        if not destroying:
+            # If the PyDMWidget associated with this slot is not being destroyed, then we do need to
+            # manually disconnect the signal/slot
+            return True
+        if isinstance(slot, functools.partial):
+            # If the slot was created as a partial, we also need to manually disconnect it even if the PyDMWidget
+            # is being destroyed since Qt does not handle automatic disconnection when a partial is used
+            return True
+        # This means we are destroying the PyDMWidget and the slot is not a partial, so let Qt
+        # handle the disconnect for us
+        return False
+
     def close(self):
         pass
+
 
 class PyDMPlugin(object):
     protocol = None


### PR DESCRIPTION
## Description

As discussed here #798 when a partial is used as a slot for a PyDMChannel, the code for removing a listener and disconnecting that slot does not work properly since pyqt is not handling the case of automatically disconnecting slots that were created as partials. 

This will specifically handle that case to ensure the disconnect will happen. The check for whether or not to disconnect a slot has been moved to its own method to make it clear what is happening in each case. And additional documentation was added.

## Testing

I tested this by creating a time plot with a channel that uses a silly partial like this:

```
self.channel = PyDMChannel(address=new_address, 
                           connection_slot=self.connectionStateChanged,
                           value_slot=partial(self.receiveNewValue))
```

Before applying this PR confirmed that the log is filled with these if the plot is deleted:
`RuntimeError: wrapped C/C++ object of type TimePlotCurveItem has been deleted`

After applying this change the disconnect is handled properly and the log is clean. Tested existing widgets that don't use partials to verify they are still working as expected too.
