### PR TITLE
ENH: Add an "Open in New Window" option to embedded displays

### DIFF
--- a/pydm/widgets/embedded_display.py
+++ b/pydm/widgets/embedded_display.py
@@ -1,14 +1,15 @@
-from qtpy.QtWidgets import QFrame, QApplication, QLabel, QVBoxLayout, QWidget
+from qtpy.QtWidgets import QAction, QFrame, QApplication, QLabel, QMenu, QVBoxLayout, QWidget
 from qtpy.QtCore import Qt, QSize, Property, QTimer
 
 import copy
 import os.path
 import logging
 from .base import PyDMPrimitiveWidget
+from .baseplot import BasePlot
 from ..utilities import (is_pydm_app, establish_widget_connections,
                          close_widget_connections, macro, is_qt_designer,
                          find_file)
-from ..display import (load_file)
+from ..display import (load_file, ScreenTarget)
 
 logger = logging.getLogger(__name__)
 
@@ -41,6 +42,11 @@ class PyDMEmbeddedDisplay(QFrame, PyDMPrimitiveWidget):
         self._needs_load = True
         self._load_error_timer = None
         self._load_error = None
+        self.setContextMenuPolicy(Qt.CustomContextMenu)
+        self.customContextMenuRequested.connect(self.show_context_menu)
+        self.open_in_new_window_action = QAction('Open in New Window', self)
+        self.open_in_new_window_action.triggered.connect(self.open_display_in_new_window)
+
         self.layout = QVBoxLayout(self)
         self.err_label = QLabel(self)
         self.err_label.setAlignment(Qt.AlignHCenter)
@@ -355,3 +361,38 @@ class PyDMEmbeddedDisplay(QFrame, PyDMPrimitiveWidget):
         logger.exception("Exception while opening embedded display file.", exc_info=self._load_error)
         if self._load_error:
             self.display_error_text(self._load_error)
+
+    def open_display_in_new_window(self):
+        """ Open the file at the input filename in a new window """
+        if not self.filename:
+            return
+        file_path = find_file(self.filename, base_path='')
+        macros = self.parsed_macros()
+
+        if is_pydm_app():
+            load_file(file_path, macros=macros)
+        else:
+            w = load_file(file_path, macros=macros, target=ScreenTarget.DIALOG)
+
+    def context_menu(self, pos):
+        if self._embedded_widget is None:
+            return
+        menu = None
+        children = self.findChildren(BasePlot)
+        for child in children:
+            if child.geometry().contains(pos):
+                menu = child.getViewBox().getMenu(None)
+        if menu is None:
+            try:
+                menu = self._embedded_widget.context_menu()
+            except AttributeError:
+                menu = QMenu(self)
+        if len(menu.findChildren(QAction)) > 0:
+            menu.addSeparator()
+        menu.addAction(self.open_in_new_window_action)
+        return menu
+
+    def show_context_menu(self, pos):
+        menu = self.context_menu(pos)
+        if menu is not None:
+            menu.exec_(self.mapToGlobal(pos))


### PR DESCRIPTION
## Description

When right clicking on the space of an embedded display, a context menu will now be created that allows opening that embedded display in its own window. 

Because plots use special event handling code, their context menu will be re-used for this with an extra option added to the bottom (see screenshot below) rather than creating a new menu.

## Screenshots
The widgets in the top half of this display are all in one embedded widget:

![open_new_window](https://user-images.githubusercontent.com/89539359/165621690-f8e292e9-4f26-4a64-8c22-79caec86556e.png)

Clicking on the new window option results in this:

![Screenshot from 2022-04-27 12-49-24](https://user-images.githubusercontent.com/89539359/165621726-153d8f05-9303-4e52-bf6b-425fe1fa6696.png)

The option when clicking on a plot will be added to the bottom of the existing menu:

![plot_new_window](https://user-images.githubusercontent.com/89539359/165621739-92785ddf-7046-466d-8d83-5e911c5bbaa0.png)

