### PR TITLE
FIX: return getautorangex in pydm.widgets.timeplot

### DIFF
--- a/pydm/widgets/timeplot.py
+++ b/pydm/widgets/timeplot.py
@@ -879,8 +879,7 @@ class PyDMTimePlot(BasePlot):
     def getAutoRangeX(self):
         if self._plot_by_timestamps:
             return False
-        else:
-            super(PyDMTimePlot, self).getAutoRangeX()
+        return super(PyDMTimePlot, self).getAutoRangeX()
 
     def setAutoRangeX(self, value):
         if self._plot_by_timestamps:


### PR DESCRIPTION
## Issue

`PyDMTimePlot.getAutoRangeX` returns `None` when `self._plot_by_timestamps` is False (i.e., not plotting by timestamps)

## Fix

Add `return` for the `else` clause

## Related

Found while trying to resurrect timechart.
Should resolve https://github.com/slaclab/timechart/issues/59