### PR TITLE
Improve confirmation popup

### DIFF
--- a/pydm/widgets/pushbutton.py
+++ b/pydm/widgets/pushbutton.py
@@ -1,7 +1,7 @@
 import os
 import hashlib
 
-from qtpy.QtWidgets import QPushButton, QMessageBox, QInputDialog, QLineEdit
+from qtpy.QtWidgets import QPushButton, QMessageBox, QInputDialog, QLineEdit, QDialogButtonBox
 from qtpy.QtCore import Slot, Property
 from .base import PyDMWritableWidget
 
@@ -321,6 +321,9 @@ class PyDMPushButton(QPushButton, PyDMWritableWidget):
                 op = "Release"
 
             msg.setText(self._confirm_message)
+
+            # Force "Yes" button to be on the right (as on macOS) to follow common design practice
+            msg.setStyleSheet("button-layout: 1")    # MacLayout
 
             msg.setStandardButtons(QMessageBox.Yes | QMessageBox.No)
             msg.setDefaultButton(QMessageBox.No)

--- a/pydm/widgets/pushbutton.py
+++ b/pydm/widgets/pushbutton.py
@@ -320,15 +320,7 @@ class PyDMPushButton(QPushButton, PyDMWritableWidget):
                 val = self._releaseValue
                 op = "Release"
 
-            message = os.linesep.join(
-                [
-                    self._confirm_message,
-                    "Value: {}".format(val),
-                    "Relative Change: {}".format(relative)
-                ]
-            )
-
-            msg.setText(message)
+            msg.setText(self._confirm_message)
 
             msg.setStandardButtons(QMessageBox.Yes | QMessageBox.No)
             msg.setDefaultButton(QMessageBox.No)


### PR DESCRIPTION
- Text in confirmation dialog simplified to "Are you sure you want to proceed?"
- Yes/No buttons switched to follow common design practice where positive action is on the right



![image](https://user-images.githubusercontent.com/89946206/167511537-6a610416-78cf-483c-a1e3-3a2b4ccc7e4f.png)
