### PR TITLE
Show macros command

### DIFF
--- a/pydm/main_window.py
+++ b/pydm/main_window.py
@@ -46,6 +46,8 @@ class PyDMMainWindow(QMainWindow):
         self.ui = Ui_MainWindow()
         self.ui.setupUi(self)
 
+        self.showMacros = QAction("Show Macros...", self)
+
         self.ui.navbar.setIconSize(QSize(24, 24))
         self.ui.navbar.setToolButtonStyle(Qt.ToolButtonTextUnderIcon)
         self.ui.actionHome.triggered.connect(self.home_triggered)
@@ -69,6 +71,7 @@ class PyDMMainWindow(QMainWindow):
         self.ui.actionAbout_PyDM.triggered.connect(self.show_about_window)
         self.ui.actionLoadTool.triggered.connect(self.load_tool)
         self.ui.actionLoadTool.setIcon(self.iconFont.icon("rocket"))
+        self.showMacros.triggered.connect(self.show_macro_window)
         self.ui.actionQuit.triggered.connect(self.quit_main_window)
 
         if hide_nav_bar:
@@ -382,6 +385,7 @@ class PyDMMainWindow(QMainWindow):
 
         self.ui.menuTools.addSeparator()
         self.ui.menuTools.addAction(self.ui.actionLoadTool)
+        self.ui.menuTools.addAction(self.showMacros)
 
     @Slot(bool)
     def reload_display(self, checked):
@@ -480,13 +484,6 @@ class PyDMMainWindow(QMainWindow):
                 QMessageBox.Yes | QMessageBox.No)
             if quit_message == QMessageBox.Yes:
                 callback()
-
-    def contextMenuEvent(self, event):
-        menu = QMenu()
-        show_macro_action = menu.addAction("Show Macros...")
-        action = menu.exec_(event.globalPos())
-        if action == show_macro_action:
-            self.show_macro_window()
 
     def show_macro_window(self):
         macro_window = MacroWindow(self)

--- a/pydm/main_window.py
+++ b/pydm/main_window.py
@@ -1,7 +1,8 @@
 import os
 from os import path
+
 from qtpy.QtWidgets import (QApplication, QMainWindow, QFileDialog,
-                            QWidget, QAction, QMessageBox)
+                            QAction, QMessageBox, QMenu)
 from qtpy.QtCore import Qt, QTimer, Slot, QSize, QLibraryInfo
 from .utilities import (IconFont, find_file, establish_widget_connections,
                         close_widget_connections)
@@ -9,6 +10,7 @@ from .pydm_ui import Ui_MainWindow
 from .display import Display, ScreenTarget, load_file
 from .connection_inspector import ConnectionInspector
 from .about_pydm import AboutWindow
+from .show_macros import MacroWindow
 from . import data_plugins
 from . import tools
 from .widgets.rules import register_widget_rules, unregister_widget_rules
@@ -478,3 +480,14 @@ class PyDMMainWindow(QMainWindow):
                 QMessageBox.Yes | QMessageBox.No)
             if quit_message == QMessageBox.Yes:
                 callback()
+
+    def contextMenuEvent(self, event):
+        menu = QMenu()
+        show_macro_action = menu.addAction("Show Macros...")
+        action = menu.exec_(event.globalPos())
+        if action == show_macro_action:
+            self.show_macro_window()
+
+    def show_macro_window(self):
+        macro_window = MacroWindow(self)
+        macro_window.show()

--- a/pydm/show_macros/__init__.py
+++ b/pydm/show_macros/__init__.py
@@ -1,0 +1,1 @@
+from .show_macros import MacroWindow

--- a/pydm/show_macros/show_macros.py
+++ b/pydm/show_macros/show_macros.py
@@ -1,7 +1,9 @@
-from qtpy.QtWidgets import QWidget, QPlainTextEdit, QVBoxLayout
+from qtpy.QtWidgets import QWidget, QPlainTextEdit, QVBoxLayout, QHBoxLayout, QGridLayout, QPushButton, QApplication, QLabel
 from qtpy.QtCore import Qt
 from qtpy.QtGui import QFont
+#from qtpy.QtGui
 
+#clipboard = QGuiApplication.clipboard()
 
 class MacroWindow(QWidget):
     """
@@ -13,21 +15,50 @@ class MacroWindow(QWidget):
         self.setFixedWidth(750)
         self.setFixedHeight(500)
 
-        text_box = QPlainTextEdit()
-        text_box.setReadOnly(True)
-        font = QFont()
-        font.setPointSize(16)
-        text_box.setFont(font)
-        text_box.setPlainText("Macros:")
+        self.text_box = QPlainTextEdit()
+        self.text_box.setReadOnly(True)
+        self.font = QFont()
+        self.font.setPointSize(16)
+        self.text_box.setFont(self.font)
+        self.text_box.setPlainText("Macros:")
 
-        # Populate macros
-        if parent is not None:
-            display_widget = parent.display_widget()
-            if display_widget:
-                macros = display_widget.macros()
-                for macro, value in macros.items():
-                    line = "  {}={}".format(macro, value)
-                    text_box.appendPlainText(line)
+        self.macros = {}
+        self.init_macros()
+        self.populate_macros()
 
-        self.setLayout(QVBoxLayout(self))
-        self.layout().addWidget(text_box)
+        self.label = QLabel()
+        self.label.setText('')
+        self.label.setMinimumSize(100, 25)
+
+        self.copy_button = QPushButton()
+        self.copy_button.setCheckable(False)
+        self.copy_button.setMinimumSize(75, 25)
+        self.copy_button.setText("Copy Macros as JSON")
+        self.copy_button.clicked.connect(self.copy_macros)
+
+        self.clipboard = QApplication.clipboard()
+
+        self.vBoxLayout = QVBoxLayout()
+        self.vBoxLayout.addWidget(self.text_box)
+        self.hBoxLayout = QHBoxLayout()
+        self.hBoxLayout.addWidget(self.label, alignment=Qt.AlignRight)
+        self.hBoxLayout.addWidget(self.copy_button, alignment=Qt.AlignRight)
+        self.hBoxLayout.insertStretch(0)
+        self.vBoxLayout.addLayout(self.hBoxLayout)
+
+        self.setLayout(self.vBoxLayout)
+
+    def init_macros(self):
+        if self.parent() is not None:
+            display_widget = self.parent().display_widget()
+            if display_widget is not None:
+                self.macros = display_widget.macros()
+
+    def populate_macros(self):
+        for macro, value in self.macros.items():
+            line = "  {}={}".format(macro, value)
+            self.text_box.appendPlainText(line)
+
+    def copy_macros(self):
+        self.clipboard.setText(str(self.macros))
+        self.label.setText('Macros copied to clipboard!')

--- a/pydm/show_macros/show_macros.py
+++ b/pydm/show_macros/show_macros.py
@@ -1,0 +1,33 @@
+from qtpy.QtWidgets import QWidget, QPlainTextEdit, QVBoxLayout
+from qtpy.QtCore import Qt
+from qtpy.QtGui import QFont
+
+
+class MacroWindow(QWidget):
+    """
+    A replica of EDM's "Show Macros" display
+    """
+    def __init__(self, parent=None):
+        super().__init__(parent, Qt.Window)
+        self.setWindowTitle("Macros")
+        self.setFixedWidth(750)
+        self.setFixedHeight(500)
+
+        text_box = QPlainTextEdit()
+        text_box.setReadOnly(True)
+        font = QFont()
+        font.setPointSize(16)
+        text_box.setFont(font)
+        text_box.setPlainText("Macros:")
+
+        # Populate macros
+        if parent is not None:
+            display_widget = parent.display_widget()
+            if display_widget:
+                macros = display_widget.macros()
+                for macro, value in macros.items():
+                    line = "  {}={}".format(macro, value)
+                    text_box.appendPlainText(line)
+
+        self.setLayout(QVBoxLayout(self))
+        self.layout().addWidget(text_box)

--- a/pydm/show_macros/show_macros.py
+++ b/pydm/show_macros/show_macros.py
@@ -1,3 +1,4 @@
+import json
 from qtpy.QtWidgets import QWidget, QPlainTextEdit, QVBoxLayout, QHBoxLayout, QGridLayout, QPushButton, QApplication, QLabel
 from qtpy.QtCore import Qt
 from qtpy.QtGui import QFont
@@ -60,5 +61,5 @@ class MacroWindow(QWidget):
             self.text_box.appendPlainText(line)
 
     def copy_macros(self):
-        self.clipboard.setText(str(self.macros))
+        self.clipboard.setText(json.dumps(self.macros))
         self.label.setText('Macros copied to clipboard!')

--- a/pydm/show_macros/show_macros.py
+++ b/pydm/show_macros/show_macros.py
@@ -2,9 +2,6 @@ import json
 from qtpy.QtWidgets import QWidget, QPlainTextEdit, QVBoxLayout, QHBoxLayout, QGridLayout, QPushButton, QApplication, QLabel
 from qtpy.QtCore import Qt
 from qtpy.QtGui import QFont
-#from qtpy.QtGui
-
-#clipboard = QGuiApplication.clipboard()
 
 class MacroWindow(QWidget):
     """

--- a/pydm/tests/test_show_macros.py
+++ b/pydm/tests/test_show_macros.py
@@ -1,4 +1,6 @@
 from pydm.show_macros import MacroWindow
+
+
 def test_macro_window_launches(qtbot):
     """Make sure the Macro window doesn't crash."""
     a = MacroWindow(parent=None)

--- a/pydm/tests/test_show_macros.py
+++ b/pydm/tests/test_show_macros.py
@@ -1,0 +1,6 @@
+from pydm.show_macros import MacroWindow
+def test_macro_window_launches(qtbot):
+    """Make sure the Macro window doesn't crash."""
+    a = MacroWindow(parent=None)
+    qtbot.addWidget(a)
+    a.show()


### PR DESCRIPTION
With this PR, users can view macros and their values on display by right clicking in it and selecting "Show Macros..." A new window containing the macros is shown. The text within the window is read-only but selectable and copyable as in EDM.

The display below was instantiated via `pydm -m "macro1=hello,macro2=world" test.ui`:

![image](https://user-images.githubusercontent.com/89946206/167713494-0e4e5955-cd84-441a-bc52-c5f44729d13b.png)

![image](https://user-images.githubusercontent.com/89946206/167714517-cdba5035-2569-4a21-bfff-f62e0e87182a.png)
