### PR TITLE
REF/ENH: Entrypoints for external tools and data plugins

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -29,6 +29,7 @@ requirements:
     - pyqt >=5
     - pyqtgraph
     - qtpy
+    - entrypoints
 
 test:
   imports:

--- a/docs/source/data_plugins/external_plugins.rst
+++ b/docs/source/data_plugins/external_plugins.rst
@@ -1,0 +1,65 @@
+External Data Plugins
+=====================
+
+To add an external data plugin to PyDM, you will need to subclass the following
+base class and customize its methods:
+
+.. autoclass:: pydm.data_plugins.PyDMPlugin
+   :members:
+   :inherited-members:
+   :show-inheritance:
+
+
+You will also need to create a connection class and refer to it with the
+``connection_class`` class variable.  It should be subclassed from the
+following:
+
+.. autoclass:: pydm.data_plugins.plugin.PyDMConnection
+   :members:
+   :inherited-members:
+   :show-inheritance:
+
+
+Configuration
+-------------
+
+There are two options for telling PyDM where your external data plugin can
+be found.
+
+The first is the ``PYDM_DATA_PLUGINS_PATH`` environment variable, which is an
+delimited list of paths to search for files that match the pattern
+``*_plugin.py``. They can be in the provided path or any subdirectory of that
+path. On Linux, the delimiter is ":" whereas on Windows it is ";".
+
+Alternatively, for Python packages that contain external data plugins, an
+entrypoint may be used to locate it.
+
+Here is an example ``setup.py`` that could be used to locate a PyDM data plugin
+in your own Python package:
+
+.. code:: python
+
+    from setuptools import setup, find_packages
+
+    setup(
+        name="my_package",
+        # ... other settings will go here
+        entry_points={
+            "gui_scripts": ["my_package_gui=my_package.main:main"],
+            "pydm.data_plugin": [
+                "my_package=my_package.data:PluginClassName",
+            ],
+        },
+        install_requires=[],
+    )
+
+
+This would assume that you have the following:
+
+1. A package named "my_package" with ``my_package/__init__.py`` and
+   ``my_package/data.py``.
+2. In ``my_package/data.py``, a ``PluginClassName`` that inherits from
+   :class:`~pydm.data_plugins.PyDMPlugin`.
+
+After running ``pip install`` on the package, it should be readily available
+in PyDM.

--- a/docs/source/development/external_tools.rst
+++ b/docs/source/development/external_tools.rst
@@ -1,0 +1,93 @@
+External Tools
+==============
+
+To add an external tool to PyDM, you will need to subclass the following
+base class and customize its methods:
+
+.. autoclass:: pydm.tools.ExternalTool
+   :members:
+   :inherited-members:
+   :show-inheritance:
+
+
+Example:
+
+.. code:: python
+
+    from pydm.tools import ExternalTool
+    from pydm.utilities.iconfont import IconFont
+
+
+    class DummyTool(ExternalTool):
+
+        def __init__(self):
+            icon = IconFont().icon("cogs")
+            name = "Dummy Tool"
+            group = "Example"
+            use_with_widgets = False
+            super().__init__(
+                icon=icon,
+                name=name,
+                group=group,
+                use_with_widgets=use_with_widgets
+            )
+
+        def call(self, channels, sender):
+            print("Called Dummy Tool from: {} with:".format(sender))
+            print("Channels: ", channels)
+            print("My info: ", self.get_info())
+
+        def to_json(self):
+            return ""
+
+        def from_json(self, content):
+            print("Received from_json: ", content)
+
+        def get_info(self):
+            ret = ExternalTool.get_info(self)
+            ret.update({'file': __file__})
+            return ret
+
+
+Configuration
+-------------
+
+There are two options for telling PyDM where your external tools are.
+
+The first is the ``PYDM_TOOLS_PATH`` environment variable, which is an
+delimited list of paths to search for files that match the pattern
+``*_tool.py``. They can be in the provided path or any subdirectory of that
+path. On Linux, the delimiter is ":" whereas on Windows it is ";".
+
+Alternatively, for Python packages that contain external tools, an entrypoint
+may be used to locate the tool class.
+
+Here is an example ``setup.py`` that could be used to locate a PyDM external
+tool in your own Python package:
+
+.. code:: python
+
+    from setuptools import setup, find_packages
+
+    setup(
+        name="my_package",
+        # ... other settings will go here
+        entry_points={
+            "gui_scripts": ["my_package_gui=my_package.main:main"],
+            "pydm.tool": [
+                "my_package=my_package.tool_name:ToolClassName",
+            ],
+        },
+        install_requires=[],
+    )
+
+
+This would assume that you have the following:
+
+1. A package named "my_package" with ``my_package/__init__.py`` and
+   ``my_package/tool_name.py``.
+2. In ``my_package/tool_name.py``, a ``ToolClassName`` that inherits from
+   :class:`~pydm.tools.ExternalTool`.
+
+After running ``pip install`` on the package, it should be readily available
+in PyDM.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -40,15 +40,17 @@ as well as a straightforward python framework to build complex applications.
 .. toctree::
    :maxdepth: 1
    :caption: Data Plugins
-   
+
    data_plugins/local_plugin.rst
    data_plugins/calc_plugin.rst
+   data_plugins/external_plugins.rst
 
 .. toctree::
    :maxdepth: 1
    :caption: Developers Corner
 
    development/development.rst
+   development/external_tools.rst
    widgets/widget_rules/customizing.rst
    development/resources.rst
 

--- a/examples/external_tool/dummy_tool.py
+++ b/examples/external_tool/dummy_tool.py
@@ -9,7 +9,12 @@ class DummyTool(ExternalTool):
         name = "Dummy Tool"
         group = "Example"
         use_with_widgets = False
-        super(DummyTool, self).__init__(icon=icon, name=name, group=group, use_with_widgets=use_with_widgets)
+        super().__init__(
+            icon=icon,
+            name=name,
+            group=group,
+            use_with_widgets=use_with_widgets
+        )
 
     def call(self, channels, sender):
         print("Called Dummy Tool from: {} with:".format(sender))
@@ -35,7 +40,12 @@ class DummyTool3(ExternalTool):
         name = "Dummy Tool 3"
         group = ""
         use_with_widgets = False
-        super(DummyTool3, self).__init__(icon=icon, name=name, group=group, use_with_widgets=use_with_widgets)
+        super().__init__(
+            icon=icon,
+            name=name,
+            group=group,
+            use_with_widgets=use_with_widgets
+        )
 
     def call(self, channels, sender):
         print("Called Dummy Tool 3 from: {} with:".format(sender))

--- a/examples/external_tool/dummy_tool.py
+++ b/examples/external_tool/dummy_tool.py
@@ -9,7 +9,7 @@ class DummyTool(ExternalTool):
         name = "Dummy Tool"
         group = "Example"
         use_with_widgets = False
-        ExternalTool.__init__(self, icon=icon, name=name, group=group, use_with_widgets=use_with_widgets)
+        super(DummyTool, self).__init__(icon=icon, name=name, group=group, use_with_widgets=use_with_widgets)
 
     def call(self, channels, sender):
         print("Called Dummy Tool from: {} with:".format(sender))
@@ -35,7 +35,7 @@ class DummyTool3(ExternalTool):
         name = "Dummy Tool 3"
         group = ""
         use_with_widgets = False
-        ExternalTool.__init__(self, icon=icon, name=name, group=group, use_with_widgets=use_with_widgets)
+        super(DummyTool3, self).__init__(icon=icon, name=name, group=group, use_with_widgets=use_with_widgets)
 
     def call(self, channels, sender):
         print("Called Dummy Tool 3 from: {} with:".format(sender))

--- a/examples/external_tool/lookup_path/new_tool.py
+++ b/examples/external_tool/lookup_path/new_tool.py
@@ -10,9 +10,13 @@ class DummyTool2(ExternalTool):
         group = "Example"
         use_with_widgets = True
         use_without_widget = False
-        ExternalTool.__init__(self, icon=icon, name=name, group=group,
-                              use_with_widgets=use_with_widgets,
-                              use_without_widget=use_without_widget)
+        super().__init__(
+            icon=icon,
+            name=name,
+            group=group,
+            use_with_widgets=use_with_widgets,
+            use_without_widget=use_without_widget,
+        )
 
     def call(self, channels, sender):
         print("Called Dummy Tool 2 from: {} with:".format(sender))

--- a/examples/external_tool/lookup_path/root_tool.py
+++ b/examples/external_tool/lookup_path/root_tool.py
@@ -9,7 +9,12 @@ class RootTool(ExternalTool):
         name = "Root Tool"
         group = ""
         use_with_widgets = True
-        ExternalTool.__init__(self, icon=icon, name=name, group=group, use_with_widgets=use_with_widgets)
+        super().__init__(
+            icon=icon,
+            name=name,
+            group=group,
+            use_with_widgets=use_with_widgets
+        )
 
     def call(self, channels, sender):
         print("Called Root Tool from: {} with:".format(sender))

--- a/pydm/config.py
+++ b/pydm/config.py
@@ -20,3 +20,7 @@ STYLESHEET = os.getenv("PYDM_STYLESHEET", None)
 STYLESHEET_INCLUDE_DEFAULT = os.getenv("PYDM_STYLESHEET_INCLUDE_DEFAULT", False)
 
 CONFIRM_QUIT = os.getenv("PYDM_CONFIRM_QUIT", "n").lower() in ("y", "t", "1", "true")
+
+ENTRYPOINT_EXTERNAL_TOOL = "pydm.external_tool"
+ENTRYPOINT_DATA_PLUGIN = "pydm.data_plugin"
+EXTERNAL_TOOL_SUFFIX = "_tool.py"

--- a/pydm/config.py
+++ b/pydm/config.py
@@ -21,6 +21,6 @@ STYLESHEET_INCLUDE_DEFAULT = os.getenv("PYDM_STYLESHEET_INCLUDE_DEFAULT", False)
 
 CONFIRM_QUIT = os.getenv("PYDM_CONFIRM_QUIT", "n").lower() in ("y", "t", "1", "true")
 
-ENTRYPOINT_EXTERNAL_TOOL = "pydm.external_tool"
+ENTRYPOINT_EXTERNAL_TOOL = "pydm.tool"
 ENTRYPOINT_DATA_PLUGIN = "pydm.data_plugin"
 EXTERNAL_TOOL_SUFFIX = "_tool.py"

--- a/pydm/config.py
+++ b/pydm/config.py
@@ -24,3 +24,4 @@ CONFIRM_QUIT = os.getenv("PYDM_CONFIRM_QUIT", "n").lower() in ("y", "t", "1", "t
 ENTRYPOINT_EXTERNAL_TOOL = "pydm.tool"
 ENTRYPOINT_DATA_PLUGIN = "pydm.data_plugin"
 EXTERNAL_TOOL_SUFFIX = "_tool.py"
+DATA_PLUGIN_SUFFIX = "_plugin.py"

--- a/pydm/data_plugins/__init__.py
+++ b/pydm/data_plugins/__init__.py
@@ -3,27 +3,31 @@ Loads all the data plugins available at the given PYDM_DATA_PLUGINS_PATH
 environment variable and subfolders that follows the *_plugin.py and have
 classes that inherits from the pydm.data_plugins.PyDMPlugin class.
 """
-import os
-import sys
+import imp
 import inspect
 import logging
-import imp
+import os
+import sys
 import uuid
 from collections import deque
 from contextlib import contextmanager
+from typing import Any, Dict, Generator, List, Type
+
 from qtpy.QtWidgets import QApplication
-from .plugin import PyDMPlugin
-from ..utilities import protocol_and_address
+
 from .. import config
+from ..utilities import log_failures, path_info, protocol_and_address
+from .plugin import PyDMPlugin
 
 logger = logging.getLogger(__name__)
-plugin_modules = {}
+plugin_modules: Dict[str, PyDMPlugin] = {}
 __read_only = False
 global __CONNECTION_QUEUE__
 __CONNECTION_QUEUE__ = None
 global __DEFER_CONNECTIONS__
 __DEFER_CONNECTIONS__ = False
 __plugins_initialized = False
+
 
 @contextmanager
 def connection_queue(defer_connections=False):
@@ -54,8 +58,8 @@ def establish_queued_connections():
     finally:
         __CONNECTION_QUEUE__ = None
         __DEFER_CONNECTIONS__ = False
-    
-        
+
+
 def establish_connection(channel):
     global __CONNECTION_QUEUE__
     if __CONNECTION_QUEUE__ is not None:
@@ -63,11 +67,13 @@ def establish_connection(channel):
     else:
         establish_connection_immediately(channel)
 
+
 def establish_connection_immediately(channel):
     plugin = plugin_for_address(channel.address)
     plugin.add_connection(channel)
 
-def plugin_for_address(address):
+
+def plugin_for_address(address: str) -> PyDMPlugin:
     """
     Find the correct PyDMPlugin for a channel
     """
@@ -85,7 +91,7 @@ def plugin_for_address(address):
         initialize_plugins_if_needed()
         try:
             return plugin_modules[str(protocol)]
-        except KeyError as exc:
+        except KeyError:
             logger.exception("Could not find protocol for %r", address)
     # Catch all in case of improper plugin specification
     logger.error("Channel {addr} did not specify a valid protocol "
@@ -96,31 +102,112 @@ def plugin_for_address(address):
     return None
 
 
-def add_plugin(plugin):
+def add_plugin(plugin: Type[PyDMPlugin]) -> PyDMPlugin:
     """
     Add a PyDM plugin to the global registry of protocol vs. plugins
 
     Parameters
     ----------
-    plugin: PyDMPlugin
+    plugin : PyDMPlugin type
         The class of plugin to instantiate
+
+    Returns
+    -------
+    plugin : PyDMPlugin
+        The instantiated PyDMPlugin.
     """
     # Warn users if we are overwriting a protocol which already has a plugin
     if plugin.protocol in plugin_modules:
-        logger.warning("Replacing %s plugin with %s for use with protocol %s",
-                       plugin, plugin_modules[plugin.protocol],
-                       plugin.protocol)
-    plugin_modules[plugin.protocol] = plugin()
+        logger.warning(
+            "Replacing %s plugin with %s for use with protocol %s",
+            plugin,
+            plugin_modules[plugin.protocol],
+            plugin.protocol,
+        )
+    instance = plugin()
+    plugin_modules[plugin.protocol] = instance
+    return instance
 
 
-def load_plugins_from_path(locations, token):
+@log_failures(
+    logger,
+    explanation=(
+        "Unable to import plugin file: {args[0]}.  "
+        "This plugin will be skipped."
+    ),
+    include_traceback=True,
+)
+def _get_plugins_from_source(source_filename: str) -> List[Type[PyDMPlugin]]:
     """
-    Load plugins from file locations that match a specific token
-
+    For a given source filename, find PyDMPlugin classes.
 
     Parameters
     ----------
-    locations: list
+    source_filename : str
+        The source code filename.
+
+    Returns
+    -------
+    plugins : list of PyDMPlugin classes
+        The plugin classes.
+    """
+    base_dir, _, _ = path_info(source_filename)
+    if base_dir not in sys.path:
+        sys.path.append(base_dir)
+    temp_name = str(uuid.uuid4())
+    module = imp.load_source(temp_name, source_filename)
+    return list(
+        set(
+            obj
+            for _, obj in inspect.getmembers(module)
+            if _is_valid_plugin_class(obj)
+        )
+    )
+
+
+def find_plugins_from_path(
+    path: str, token: str = config.DATA_PLUGIN_SUFFIX
+) -> Generator[Type[PyDMPlugin], None, None]:
+    """
+    Yield all data plugins found in the provided path.
+
+    Parameters
+    ----------
+    path : str
+        The path to look for plugins.
+    token : str, optional
+        The suffix that plugin files are expected to have.
+    """
+
+    for root, _, files in os.walk(path):
+        if root.split(os.path.sep)[-1].startswith("__"):
+            continue
+
+        logger.debug("Looking for PyDM Data Plugins at: %s", root)
+        for name in files:
+            if name.endswith(token):
+                yield from _get_plugins_from_source(os.path.join(root, name))
+
+
+def _is_valid_plugin_class(obj: Any) -> bool:
+    """Is the object a data plugin class?"""
+    return (
+        inspect.isclass(obj)
+        and issubclass(obj, PyDMPlugin)
+        and obj is not PyDMPlugin
+    )
+
+
+def load_plugins_from_path(
+    locations: List[str],
+    token: str = config.DATA_PLUGIN_SUFFIX
+) -> Dict[str, PyDMPlugin]:
+    """
+    Load plugins from file locations that match a specific token
+
+    Parameters
+    ----------
+    locations : list of str
         List of file locations
 
     token : str
@@ -129,42 +216,14 @@ def load_plugins_from_path(locations, token):
 
     Returns
     -------
-    plugins: dict
+    plugins : dict
         Dictionary of plugins add from this folder
     """
     added_plugins = dict()
     for loc in locations:
-        for root, _, files in os.walk(loc):
-            if root.split(os.path.sep)[-1].startswith("__"):
-                continue
-
-            logger.debug("Looking for PyDM Data Plugins at: %s", root)
-            for name in files:
-                if name.endswith(token):
-                    try:
-                        logger.debug("Trying to load %s...", name)
-                        sys.path.append(root)
-                        temp_name = str(uuid.uuid4())
-                        module = imp.load_source(temp_name,
-                                                 os.path.join(root, name))
-                    except Exception as e:
-                        logger.exception("Unable to import plugin file %s."
-                                         "This plugin will be skipped."
-                                         "The exception raised was: %s",
-                                         name, e)
-                        continue
-                    classes = [obj for name, obj in inspect.getmembers(module)
-                               if (inspect.isclass(obj)
-                                   and issubclass(obj, PyDMPlugin)
-                                   and obj is not PyDMPlugin)]
-                    # De-duplicate classes.
-                    classes = list(set(classes))
-                    for plugin in classes:
-                        if plugin.protocol is not None:
-                            # Add to global plugin list
-                            add_plugin(plugin)
-                            # Add to return dictionary of added plugins
-                            added_plugins[plugin.protocol] = plugin
+        for plugin in find_plugins_from_path(loc, token=token):
+            if plugin.protocol is not None:
+                added_plugins[plugin.protocol] = add_plugin(plugin)
     return added_plugins
 
 
@@ -207,7 +266,6 @@ def initialize_plugins_if_needed():
     logger.debug("* Loading PyDM Data Plugins")
     logger.debug("*"*80)
 
-    DATA_PLUGIN_TOKEN = "_plugin.py"
     path = os.getenv("PYDM_DATA_PLUGINS_PATH", None)
     if path is None:
         locations = []
@@ -218,4 +276,5 @@ def initialize_plugins_if_needed():
     plugin_dir = os.path.dirname(os.path.realpath(__file__))
     locations.insert(0, plugin_dir)
 
-    load_plugins_from_path(locations, DATA_PLUGIN_TOKEN)
+    load_plugins_from_path(locations)
+    # load_plugins_from_entrypoints(config.ENTRYPOINT_DATA_PLUGIN)

--- a/pydm/data_plugins/__init__.py
+++ b/pydm/data_plugins/__init__.py
@@ -3,21 +3,19 @@ Loads all the data plugins available at the given PYDM_DATA_PLUGINS_PATH
 environment variable and subfolders that follows the *_plugin.py and have
 classes that inherits from the pydm.data_plugins.PyDMPlugin class.
 """
-import imp
 import inspect
 import logging
 import os
-import sys
-import uuid
 from collections import deque
 from contextlib import contextmanager
-from typing import Any, Dict, Generator, List, Type
+from typing import Any, Dict, Generator, List, Optional, Type
 
 import entrypoints
 from qtpy.QtWidgets import QApplication
 
 from .. import config
-from ..utilities import log_failures, path_info, protocol_and_address
+from ..utilities import (import_module_by_filename, log_failures,
+                         protocol_and_address)
 from .plugin import PyDMPlugin
 
 logger = logging.getLogger(__name__)
@@ -74,7 +72,7 @@ def establish_connection_immediately(channel):
     plugin.add_connection(channel)
 
 
-def plugin_for_address(address: str) -> PyDMPlugin:
+def plugin_for_address(address: str) -> Optional[PyDMPlugin]:
     """
     Find the correct PyDMPlugin for a channel
     """
@@ -152,11 +150,7 @@ def _get_plugins_from_source(source_filename: str) -> List[Type[PyDMPlugin]]:
     plugins : list of PyDMPlugin classes
         The plugin classes.
     """
-    base_dir, _, _ = path_info(source_filename)
-    if base_dir not in sys.path:
-        sys.path.append(base_dir)
-    temp_name = str(uuid.uuid4())
-    module = imp.load_source(temp_name, source_filename)
+    module = import_module_by_filename(source_filename)
     return list(
         set(
             obj

--- a/pydm/data_plugins/__init__.py
+++ b/pydm/data_plugins/__init__.py
@@ -247,8 +247,14 @@ def load_plugins_from_entrypoints(
     """
     added_plugins = dict()
     for plugin in find_plugins_from_entrypoints(key):
-        if plugin.protocol is not None:
-            added_plugins[plugin.protocol] = add_plugin(plugin)
+        if not plugin.protocol:
+            logger.warning(
+                "No protocol specified for data plugin: %s.%s",
+                plugin.__module__,
+                plugin,
+            )
+            continue
+        added_plugins[plugin.protocol] = add_plugin(plugin)
     return added_plugins
 
 
@@ -276,8 +282,16 @@ def load_plugins_from_path(
     added_plugins = dict()
     for loc in locations:
         for plugin in find_plugins_from_path(loc, token=token):
-            if plugin.protocol is not None:
-                added_plugins[plugin.protocol] = add_plugin(plugin)
+            if not plugin.protocol:
+                logger.warning(
+                    "No protocol specified for data plugin: %s.%s",
+                    plugin.__module__,
+                    plugin,
+                )
+                continue
+
+            added_plugins[plugin.protocol] = add_plugin(plugin)
+
     return added_plugins
 
 

--- a/pydm/display.py
+++ b/pydm/display.py
@@ -1,19 +1,17 @@
 import functools
-import imp
-import six
 import inspect
 import logging
 import os
 import sys
-import uuid
 import warnings
 from os import path
 from string import Template
 
+import six
 from qtpy import uic
-from qtpy.QtWidgets import QWidget, QApplication
+from qtpy.QtWidgets import QApplication, QWidget
 
-from .utilities import macro, is_pydm_app
+from .utilities import import_module_by_filename, is_pydm_app, macro
 from .utilities.stylesheet import merge_widget_stylesheet
 
 
@@ -137,9 +135,8 @@ def load_adl_file(filename, macros=None, args=None):
         Ignored for load_adl_file.
     """
     try:
-        import adl2pydm
-        from adl2pydm import adl_parser
-        from adl2pydm import output_handler
+        import adl2pydm  # noqa: F401
+        from adl2pydm import adl_parser, output_handler
     except ImportError:
         raise RuntimeError("Sorry, adl2pydm is not installed.")
 
@@ -188,13 +185,8 @@ def load_py_file(pyfile, args=None, macros=None):
     # submodules can be loaded.
     # Eventually, this should go away, and intelligence modules should behave
     # as real python modules.
-    module_dir = os.path.dirname(os.path.abspath(pyfile))
-    if module_dir not in sys.path:
-        sys.path.append(module_dir)
-    temp_name = str(uuid.uuid4())
+    module = import_module_by_filename(os.path.abspath(pyfile))
 
-    # Now load the intelligence module.
-    module = imp.load_source(temp_name, pyfile)
     if hasattr(module, 'intelclass'):
         cls = module.intelclass
         if not issubclass(cls, Display):

--- a/pydm/tests/test_data_plugins_import.py
+++ b/pydm/tests/test_data_plugins_import.py
@@ -1,8 +1,9 @@
 import os
 
-from pydm.data_plugins import (initialize_plugins_if_needed, plugin_modules,
-                               load_plugins_from_path, plugin_for_address)
 from pydm import config
+from pydm.data_plugins import (initialize_plugins_if_needed,
+                               load_plugins_from_path, plugin_for_address,
+                               plugin_modules)
 
 
 def test_data_plugin_add(qapp, test_plugin):
@@ -18,11 +19,14 @@ def test_plugin_directory_loading(qapp):
     with open(os.path.join(cur_dir, 'plugin_foo.py'), 'w+') as handle:
         handle.write(fake_file)
         handle.flush()
-    # Load plugins
-    load_plugins_from_path([cur_dir], 'foo.py')
-    assert 'tst1' in plugin_modules
-    assert 'tst2' in plugin_modules
-    os.remove(os.path.join(cur_dir, 'plugin_foo.py'))
+
+    try:
+        # Load plugins
+        load_plugins_from_path([cur_dir], 'foo.py')
+        assert 'tst1' in plugin_modules
+        assert 'tst2' in plugin_modules
+    finally:
+        os.remove(os.path.join(cur_dir, 'plugin_foo.py'))
 
 
 def test_plugin_for_address(test_plugin):

--- a/pydm/tests/test_data_plugins_import.py
+++ b/pydm/tests/test_data_plugins_import.py
@@ -1,7 +1,10 @@
 import os
 
+import entrypoints
+
 from pydm import config
-from pydm.data_plugins import (initialize_plugins_if_needed,
+from pydm.data_plugins import (PyDMPlugin, initialize_plugins_if_needed,
+                               load_plugins_from_entrypoints,
                                load_plugins_from_path, plugin_for_address,
                                plugin_modules)
 
@@ -51,3 +54,23 @@ class TestPlugin1(PyDMPlugin):
 class TestPlugin2(PyDMPlugin):
     protocol = 'tst2'
 """
+
+
+def test_entrypoint_import(monkeypatch):
+    class MyTestPlugin(PyDMPlugin):
+        protocol = "__test_suite_protocol__"
+
+    class Entrypoint:
+        name = "MyTestPlugin"
+
+        def load(self):
+            return MyTestPlugin
+
+    def get_group_all(key):
+        yield Entrypoint()
+
+    monkeypatch.setattr(entrypoints, "get_group_all", get_group_all)
+    loaded = load_plugins_from_entrypoints()
+
+    assert "__test_suite_protocol__" in loaded
+    assert isinstance(loaded["__test_suite_protocol__"], MyTestPlugin)

--- a/pydm/tests/test_tools.py
+++ b/pydm/tests/test_tools.py
@@ -8,6 +8,7 @@ from typing import Any, Set
 import pytest
 
 from .. import tools
+from ..application import PyDMApplication
 
 EXAMPLE_PATH = pathlib.Path(__file__).parents[2] / "examples"
 EXAMPLE_EXT_TOOL_PATH = EXAMPLE_PATH / "external_tool"
@@ -62,7 +63,7 @@ def test_valid_external_tool(cls: Any, valid: bool):
 def test_tools_from_source(
     source_file: pathlib.Path,
     expected_tools: Set[str],
-    qapp
+    qapp: PyDMApplication
 ):
     assert source_file.exists()
     loaded_tools = [

--- a/pydm/tests/test_tools.py
+++ b/pydm/tests/test_tools.py
@@ -1,0 +1,84 @@
+"""
+External tool tests
+"""
+
+import pathlib
+from typing import Any, Set
+
+import pytest
+
+from .. import tools
+
+EXAMPLE_PATH = pathlib.Path(__file__).parents[2] / "examples"
+EXAMPLE_EXT_TOOL_PATH = EXAMPLE_PATH / "external_tool"
+
+examples_required = pytest.mark.skipif(
+    not EXAMPLE_PATH.exists(),
+    reason="Not a source checkout - no examples available"
+)
+
+
+class ValidTool(tools.ExternalTool):
+    ...
+
+
+class InvalidTool:
+    ...
+
+
+@pytest.mark.parametrize(
+    "cls, valid",
+    [
+        pytest.param(ValidTool, True, id="valid"),
+        pytest.param(InvalidTool, False, id="invalid"),
+        pytest.param(None, False, id="invalid-none"),
+    ]
+)
+def test_valid_external_tool(cls: Any, valid: bool):
+    assert tools._is_valid_external_tool_class(cls) is valid
+
+
+@examples_required
+@pytest.mark.parametrize(
+    "source_file, expected_tools",
+    [
+        pytest.param(
+            EXAMPLE_EXT_TOOL_PATH / "dummy_tool.py",
+            {"DummyTool", "DummyTool3"},
+            id="dummy_tool",
+        ),
+        pytest.param(
+            EXAMPLE_EXT_TOOL_PATH / "lookup_path" / "new_tool.py",
+            {"DummyTool2"},
+            id="new_tool",
+        ),
+        pytest.param(
+            EXAMPLE_EXT_TOOL_PATH / "lookup_path" / "root_tool.py",
+            {"RootTool"},
+            id="root_tool",
+        ),
+    ]
+)
+def test_tools_from_source(
+    source_file: pathlib.Path,
+    expected_tools: Set[str],
+    qapp
+):
+    assert source_file.exists()
+    loaded_tools = [
+        tool.__class__.__name__
+        for tool in tools._get_tools_from_source(str(source_file))
+    ]
+    assert set(loaded_tools) == expected_tools
+
+
+def test_smoke_get_entrypoint_tools(qapp):
+    list(tools.get_entrypoint_tools())
+
+
+def test_smoke_get_tools_from_path(qapp):
+    list(tools.get_tools_from_path())
+
+
+def test_smoke_load_external_tools(qapp):
+    tools.load_external_tools()

--- a/pydm/tools/__init__.py
+++ b/pydm/tools/__init__.py
@@ -190,7 +190,7 @@ def get_entrypoint_tools() -> Generator[ExternalTool, None, None]:
     Yield all external tool classes specified by entrypoints.
 
     Uses ``entrypoints`` to find packaged external tools in packages that
-    configure the ``pydm.external_tool`` entrypoint.
+    configure the ``pydm.tool`` entrypoint.
     """
     for entry in entrypoints.get_group_all(ENTRYPOINT_EXTERNAL_TOOL):
         logger.debug("Found external tool entrypoint: %s", entry.name)
@@ -244,7 +244,7 @@ def load_external_tools():
        ``*_tool.py`` which contain classes that inherit from
        :class:`pydm.tools.ExternalTool`.
     2. Uses ``entrypoints`` to find packaged external tools in packages that
-       configure the ``pydm.external_tool`` entrypoint.
+       configure the ``pydm.tool`` entrypoint.
 
     If called previously, this function is a no-operation.
     """

--- a/pydm/tools/__init__.py
+++ b/pydm/tools/__init__.py
@@ -1,18 +1,15 @@
 import collections
 import functools
-import imp
 import inspect
 import logging
 import os
-import sys
-import uuid
 from typing import Any, Dict, Generator, List, Optional, Union
 
 import entrypoints
 from qtpy.QtWidgets import QMenu, QWidget
 
 from ..config import ENTRYPOINT_EXTERNAL_TOOL, EXTERNAL_TOOL_SUFFIX
-from ..utilities import log_failures, path_info
+from ..utilities import import_module_by_filename, log_failures
 from .tools import ExternalTool
 
 logger = logging.getLogger(__name__)
@@ -49,11 +46,7 @@ def _get_tools_from_source(source_filename: str) -> List[ExternalTool]:
     ValueError
         If no subclassed external tools are found.
     """
-    base_dir, _, _ = path_info(source_filename)
-    if base_dir not in sys.path:
-        sys.path.append(base_dir)
-    temp_name = str(uuid.uuid4())
-    module = imp.load_source(temp_name, source_filename)
+    module = import_module_by_filename(source_filename)
     classes = list(
         set(
             obj
@@ -96,7 +89,6 @@ def install_external_tool(tool: Union[str, ExternalTool]) -> None:
                 f"expected."
             )
 
-            # The actual tool to be installed...
         if tool_obj.group is not None and tool_obj.group:
             if tool_obj.group not in ext_tools:
                 ext_tools[tool_obj.group] = {}

--- a/pydm/tools/__init__.py
+++ b/pydm/tools/__init__.py
@@ -1,26 +1,78 @@
-import os
-import sys
+import collections
+import functools
 import imp
-import uuid
 import inspect
 import logging
+import os
 import platform
-import functools
-import collections
+import sys
+import uuid
+from typing import Any, Dict, List, Optional, Union
 
-from qtpy.QtWidgets import QMenu
+from qtpy.QtWidgets import QMenu, QWidget
 
-from .tools import *
-from ..utilities import path_info
+from ..config import ENTRYPOINT_EXTERNAL_TOOL, EXTERNAL_TOOL_SUFFIX
+from ..utilities import log_failures, path_info
+from .tools import ExternalTool
 
 logger = logging.getLogger(__name__)
-ext_tools = {}
+ext_tools: Dict[str, Any] = {}
+_ext_tools_loaded: bool = False
 
 
-def install_external_tool(tool):
+def _is_valid_external_tool_class(obj: Any) -> bool:
+    """Is the object a valid external tool?"""
+    return (
+        inspect.isclass(obj)
+        and issubclass(obj, ExternalTool)
+        and obj is not ExternalTool
+    )
+
+
+@log_failures(logger, explanation="Failed to load External Tool: {args[0]}")
+def _get_tools_from_source(source_filename: str) -> List[ExternalTool]:
     """
-    Install an External Tool at the PyDMApplication and add it to the
-    main window Tools menu.
+    For a given source filename, find ExternalTool classes.
+
+    Parameters
+    ----------
+    source_filename : str
+        The source code filename.
+
+    Returns
+    -------
+    tools : list of ExternalTool
+        Instantiated external tools.
+
+    Raises
+    ------
+    ValueError
+        If no subclassed external tools are found.
+    """
+    base_dir, _, _ = path_info(source_filename)
+    if base_dir not in sys.path:
+        sys.path.append(base_dir)
+    temp_name = str(uuid.uuid4())
+    module = imp.load_source(temp_name, source_filename)
+    classes = [
+        obj
+        for _, obj in inspect.getmembers(module)
+        if _is_valid_external_tool_class(obj)
+    ]
+
+    if not classes:
+        raise ValueError(
+            f"Invalid File Format. {source_filename} has no class inheriting "
+            "from ExternalTool. Nothing to open at this time."
+        )
+    return [c() for c in classes]
+
+
+@log_failures(logger, explanation="Failed to load External Tool: {args[0]}")
+def install_external_tool(tool: Union[str, ExternalTool]) -> None:
+    """
+    Install an External Tool at the PyDMApplication and add it to the main
+    window Tools menu.
 
     Parameters
     ----------
@@ -30,47 +82,41 @@ def install_external_tool(tool):
     """
     global ext_tools
 
-    try:
-        if isinstance(tool, str):
-            base_dir, _, _ = path_info(tool)
-            sys.path.append(base_dir)
-            temp_name = str(uuid.uuid4())
+    if isinstance(tool, str):
+        objects = _get_tools_from_source(tool) or []
+    else:
+        objects = [tool]
 
-            module = imp.load_source(temp_name, tool)
-            classes = [obj for _, obj in inspect.getmembers(module)
-                       if inspect.isclass(obj) and issubclass(obj,
-                                                              ExternalTool) and obj != ExternalTool]
-            if len(classes) == 0:
-                raise ValueError(
-                    "Invalid File Format. {} has no class inheriting from ExternalTool. Nothing to open at this time.".format(
-                        tool))
-            obj = [c() for c in classes]
-        elif isinstance(tool, ExternalTool):
-            # The actual tool to be installed...
-            obj = [tool]
-        else:
+    for tool_obj in objects:
+        if not isinstance(tool_obj, ExternalTool):
             raise ValueError(
-                "Invalid argument for parameter 'tool'. String or ExternalTool expected.")
+                f"Invalid tool found: {tool}. String or ExternalTool "
+                f"expected."
+            )
 
-        for o in obj:
-            if o.group is not None and o.group != "":
-                if o.group not in ext_tools:
-                    ext_tools[o.group] = dict()
-                ext_tools[o.group][o.name] = o
-            else:
-                ext_tools[o.name] = o
+            # The actual tool to be installed...
+        if tool_obj.group is not None and tool_obj.group:
+            if tool_obj.group not in ext_tools:
+                ext_tools[tool_obj.group] = {}
+            ext_tools[tool_obj.group][tool_obj.name] = tool_obj
+        else:
+            ext_tools[tool_obj.name] = tool_obj
 
-        ext_tools = collections.OrderedDict(sorted(ext_tools.items()))
-        for k in ext_tools.keys():
-            if isinstance(ext_tools[k], dict):
-                ext_tools[k] = collections.OrderedDict(
-                    sorted(ext_tools[k].items()))
-    except Exception as e:
-        logger.exception("Failed to load External Tool: %s." % tool)
+    ext_tools = collections.OrderedDict(sorted(ext_tools.items()))
+    for ext_tool_name in ext_tools:
+        if isinstance(ext_tools[ext_tool_name], dict):
+            ext_tools[ext_tool_name] = collections.OrderedDict(
+                sorted(ext_tools[ext_tool_name].items())
+            )
 
 
-def assemble_tools_menu(parent_menu, clear_menu=False, widget_only=False,
-                        widget=None, **kwargs):
+def assemble_tools_menu(
+    parent_menu: QMenu,
+    clear_menu: bool = False,
+    widget_only: bool = False,
+    widget: Optional[QWidget] = None,
+    **kwargs
+) -> None:
     """
     Assemble the Tools menu for a given parent menu.
 
@@ -78,22 +124,21 @@ def assemble_tools_menu(parent_menu, clear_menu=False, widget_only=False,
     ----------
     parent_menu : QMenu
         The main menu item to hold the tools menu tree.
-    clear_menu : bool
+    clear_menu : bool, optional
         Whether of not we should clear the menu before adding the tools.
-    widget_only : bool
+    widget_only : bool, optional
         Whether or not generate only the menu for widgets compatible
         tools. This should be True when creating the menu for the
         PyDMWidgets and False for most of the other cases.
-    widget: QWidget
+    widget : QWidget, optional
         The widget for which the menu is being assembled. This allow for the
         tools to filter if they are compatible or not with the widget based
         on properties, types and etc. Default is None which means all tools
         will be assembled.
-    kwargs : dict
+    **kwargs :
         Parameters sent directly to the `call` method of the ExternalTool
         instance. In general this dict is composed by `channels` which
         is a list and `sender` which is a QWidget.
-
     """
     def assemble_action(menu, tool_obj):
         if tool_obj.icon is not None:
@@ -121,9 +166,8 @@ def assemble_tools_menu(parent_menu, clear_menu=False, widget_only=False,
                     if widget is not None and not t.is_compatible_with(widget):
                         logger.debug('Skipping tool {} as it is incompatible with widget {}.'.format(t.name, widget))
                         continue
-                else:
-                    if not t.use_without_widget:
-                        continue
+                elif not t.use_without_widget:
+                    continue
                 assemble_action(m, t)
                 should_create_menu = True
             if should_create_menu:
@@ -134,28 +178,60 @@ def assemble_tools_menu(parent_menu, clear_menu=False, widget_only=False,
             assemble_action(parent_menu, v)
 
 
-def load_external_tools():
+def _load_external_tools_from_entrypoints():
+    """
+    Loads all the external tools from entrypoints.
+
+    Uses ``entrypoints`` to find packaged external tools in packages that
+    configure the ``pydm.external_tool`` entrypoint.
+    """
+
+
+def _load_external_tools_from_tools_path():
     """
     Loads all the external tools available at the given
     `PYDM_TOOLS_PATH` environment variable and subfolders that
     follows the `*_tool.py` and have classes that inherits from
     the `pydm.tools.ExternalTool` class.
     """
-    if not ext_tools:
-        EXT_TOOLS_TOKEN = "_tool.py"
-        path = os.getenv("PYDM_TOOLS_PATH", None)
+    tools_path = os.getenv("PYDM_TOOLS_PATH", None)
 
-        if path is not None:
-            logger.debug("Looking for external tools at: {}".format(path))
-            if platform.system() == "Windows":
-                locations = path.split(";")
-            else:
-                locations = path.split(":")
-            for loc in locations:
-                for root, _, files in os.walk(loc):
-                    for name in files:
-                        if name.endswith(EXT_TOOLS_TOKEN):
-                            install_external_tool(os.path.join(root, name))
-        else:
-            logger.debug(
-                "External Tools not loaded. No External Tools Path specified.")
+    if not tools_path:
+        logger.debug(
+            "External Tools not loaded from PYDM_TOOLS_PATH as no path "
+            "was specified."
+        )
+        return
+
+    logger.debug("Looking for external tools at: %s", tools_path)
+    for loc in tools_path.split(os.pathsep):
+        for root, _, files in os.walk(loc):
+            for name in files:
+                if name.endswith(EXTERNAL_TOOL_SUFFIX):
+                    tool_path = os.path.join(root, name)
+                    logger.debug("Found tool in %s", tool_path)
+                    install_external_tool(tool_path)
+
+
+def load_external_tools():
+    """
+    Loads all the external tools available.
+
+    1. Uses ``PYDM_TOOLS_PATH`` environment variable. Searches all directories
+       and subdirectories for Python source code that matches the the pattern
+       ``*_tool.py`` which contain classes that inherit from
+       :class:`pydm.tools.ExternalTool`.
+    2. Uses ``entrypoints`` to find packaged external tools in packages that
+       configure the ``pydm.external_tool`` entrypoint.
+
+    If called previously, this function is a no-operation.
+    """
+    global _ext_tools_loaded
+
+    if _ext_tools_loaded:
+        return
+
+    _ext_tools_loaded = True
+
+    _load_external_tools_from_entrypoints()
+    _load_external_tools_from_tools_path()

--- a/pydm/tools/__init__.py
+++ b/pydm/tools/__init__.py
@@ -232,7 +232,7 @@ def load_external_tools():
     Loads all the external tools available.
 
     1. Uses ``PYDM_TOOLS_PATH`` environment variable. Searches all directories
-       and subdirectories for Python source code that matches the the pattern
+       and subdirectories for Python source code that matches the pattern
        ``*_tool.py`` which contain classes that inherit from
        :class:`pydm.tools.ExternalTool`.
     2. Uses ``entrypoints`` to find packaged external tools in packages that

--- a/pydm/tools/__init__.py
+++ b/pydm/tools/__init__.py
@@ -54,11 +54,13 @@ def _get_tools_from_source(source_filename: str) -> List[ExternalTool]:
         sys.path.append(base_dir)
     temp_name = str(uuid.uuid4())
     module = imp.load_source(temp_name, source_filename)
-    classes = [
-        obj
-        for _, obj in inspect.getmembers(module)
-        if _is_valid_external_tool_class(obj)
-    ]
+    classes = list(
+        set(
+            obj
+            for _, obj in inspect.getmembers(module)
+            if _is_valid_external_tool_class(obj)
+        )
+    )
 
     if not classes:
         raise ValueError(

--- a/pydm/tools/__init__.py
+++ b/pydm/tools/__init__.py
@@ -194,22 +194,22 @@ def get_entrypoint_tools() -> Generator[ExternalTool, None, None]:
         logger.debug("Found external tool entrypoint: %s", entry.name)
         try:
             tool_cls = entry.load()
-        except Exception:
+        except Exception as ex:
             logger.exception(
-                "Failed to load %s entry: %s",
-                ENTRYPOINT_EXTERNAL_TOOL, entry.name
+                "Failed to load %s entry %s: %s",
+                ENTRYPOINT_EXTERNAL_TOOL, entry.name, ex
             )
             continue
 
         if not _is_valid_external_tool_class(tool_cls):
             logger.warning(
                 "Invalid external tool class specified in entrypoint "
-                "%s: %",
+                "%s: %s",
                 entry.name, tool_cls
             )
             continue
 
-        yield tool_cls
+        yield tool_cls()
 
 
 def get_tools_from_path() -> Generator[ExternalTool, None, None]:

--- a/pydm/utilities/__init__.py
+++ b/pydm/utilities/__init__.py
@@ -8,7 +8,6 @@ import sys
 
 from qtpy import QtCore, QtWidgets
 
-from ..qtdesigner import DesignerHooks
 from . import colors, macro, shortcuts
 from .connection import close_widget_connections, establish_widget_connections
 from .iconfont import IconFont
@@ -78,6 +77,7 @@ def is_qt_designer():
     bool
         True if inside Designer, False otherwise.
     """
+    from ..qtdesigner import DesignerHooks
     return DesignerHooks().form_editor is not None
 
 
@@ -93,6 +93,8 @@ def get_designer_current_path():
     """
     if not is_qt_designer():
         return None
+
+    from ..qtdesigner import DesignerHooks
     form_editor = DesignerHooks().form_editor
     win_manager = form_editor.formWindowManager()
     form_window = win_manager.activeFormWindow()

--- a/pydm/utilities/__init__.py
+++ b/pydm/utilities/__init__.py
@@ -398,7 +398,7 @@ def log_failures(
         The logger instance to log messages to.
     explanation : str, optional
         The explanation message to include.  Format arguments include:
-            ``func``, ``args``, and ``kwargs``
+            ``func``, ``args``, ``kwargs``, and the exception ``ex``.
     include_traceback : bool, optional
         Include traceback information in the log message.
     level : int, optional
@@ -410,7 +410,9 @@ def log_failures(
             try:
                 return func(*args, **kwargs)
             except Exception as ex:
-                msg = explanation.format(func=func, args=args, kwargs=kwargs)
+                msg = explanation.format(
+                    func=func, args=args, kwargs=kwargs, ex=ex
+                )
                 if include_traceback:
                     logger.log(level, msg, exc_info=ex)
                 else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+entrypoints
 numpy>=1.11.0
 pyepics>=3.2.7
 pyqtgraph>=0.12.0


### PR DESCRIPTION
## Purpose

### External tools loading

Allow for external tools to be loaded by one of two mechanisms:
* `PYDM_TOOLS_PATH` environment variable, which is an `os.pathsep`-delimited list of paths to search for `*_tool.py` files
* entrypoint-exposed classes in other packages' `setup.py` files.
    * Example: https://github.com/slaclab/timechart/pull/77

Add some basic tests for the new functionality and some of the old. Some holes in coverage still, but I think this is probably better than the status quo.

### Data plugin loading

Allow for data plugins to be loaded by one of two mechanisms:
* `PYDM_DATA_PLUGINS_PATH` environment variable, which is an `os.pathsep`-delimited list of paths to search for `*_plugin.py` files
* entrypoint-exposed classes in other packages' `setup.py` files.
    * No example for this yet

### `imp` deprecation

* Removes references to deprecated `imp` library
* Replaces with `importlib`

### Issues

Closes #719
Closes #720 
Closes #846 

## Details

* Refactors external tool loading, splitting up functionality into smaller functions
* Moves tool suffix + entrypoint keys to `settings.py` (something of a constants file, so I noticed)
* Add some annotations
* Retain basic `load_external_tools` call and `install_external_tool` API
* Cleaned up some imports with `isort`, which found a circular import. Moved the import inside the functions that used `DesignerHooks` for now. 

## Screenshots

<img width="178" alt="image" src="https://user-images.githubusercontent.com/5139267/167721805-56cc0256-2298-4e02-a11b-b265a0b001db.png">
which pops open:
<img width="1207" alt="image" src="https://user-images.githubusercontent.com/5139267/167721848-b0e83bfb-d917-4f39-9ee2-f92e74bed6b9.png">