### PR TITLE
ENH: Unsigned calc helper and TST: calc_plugin tests

### DIFF
--- a/docs/source/data_plugins/calc_plugin.rst
+++ b/docs/source/data_plugins/calc_plugin.rst
@@ -90,8 +90,30 @@ Here is a simple example of a channel address format with some optional attribut
 
 -------------
 
+
+Built-in Calc Helpers
+---------------------
+
+Certain helper functions are built in to PyDM because they get semi-frequent use in
+the context of EPICS values.
+
+================== ================================================== ====================================================================
+Helpers            Description                                        Usage Example
+================== ================================================== ====================================================================
+**epics_string**   Force a string to end at the null-terminator.      `calc://my_string?var=ca://STRING:PV&expr=epics_string(var)`
+**epics_unsigned** Force a signed integer to be unsigned.             `calc://my_int?var=ca://SOME:16BIT:INT&expr=epics_unsigned(var, 16)`
+================== ================================================== ====================================================================
+
+You should use epics_string when you have a string PV that looks like a normal string
+up until some corrupted segment.
+
+You should use epics_unsigned when you are dealing with a PV that is supposed to be
+interpreted as a positive integer but is instead a negative integer because channel
+access does not support any unsigned types and we have overflowed to negative values.
+
+
 Simple Calc Plugin Example
----------------------------------
+--------------------------
 
 
 The picture below represents an example of using the Calc Plugin.

--- a/docs/source/data_plugins/calc_plugin.rst
+++ b/docs/source/data_plugins/calc_plugin.rst
@@ -100,12 +100,12 @@ the context of EPICS values.
 ================== ================================================== ====================================================================
 Helpers            Description                                        Usage Example
 ================== ================================================== ====================================================================
-**epics_string**   Force a string to end at the null-terminator.      `calc://my_string?var=ca://STRING:PV&expr=epics_string(var)`
+**epics_string**   Convert a char waveform to a string.               `calc://my_string?var=ca://WAVEFORM:PV&expr=epics_string(var)`
 **epics_unsigned** Force a signed integer to be unsigned.             `calc://my_int?var=ca://SOME:16BIT:INT&expr=epics_unsigned(var, 16)`
 ================== ================================================== ====================================================================
 
-You should use epics_string when you have a string PV that looks like a normal string
-up until some corrupted segment.
+You should use epics_string when you have a string PV that is expressed as a char
+waveform, but you need to use the corresponding string value internally.
 
 You should use epics_unsigned when you are dealing with a PV that is supposed to be
 interpreted as a positive integer but is instead a negative integer because channel

--- a/pydm/data_plugins/calc_plugin.py
+++ b/pydm/data_plugins/calc_plugin.py
@@ -16,20 +16,19 @@ from pydm.data_plugins.plugin import PyDMPlugin, PyDMConnection
 logger = logging.getLogger(__name__)
 
 
-def epics_string(value: str, string_encoding: str = "utf-8") -> str:
+def epics_string(value: np.ndarray, string_encoding: str = "utf-8") -> str:
     """
-    Interpret as a null-terminated string.
+    Interpret numpy array as a null-terminated string.
 
-    Certain strings can come through corrupted with junk values after
-    the null termination. This helper function makes them readable
-    by terminating them at the null terminator.
+    Certain PVs give us char waveforms instead of strings.
+    This calculation utility lets us convert these to strings.
     """
     # Stop at the first zero
     # Assume the ndarray is one-dimensional
     value = value.tobytes()
     try:
         value = value[:value.index(0)]
-    except IndexError:
+    except (IndexError, ValueError):
         pass
     return value.decode(string_encoding, "replace")  # <-- ignore decoding errors, just in case
 

--- a/pydm/data_plugins/calc_plugin.py
+++ b/pydm/data_plugins/calc_plugin.py
@@ -291,7 +291,7 @@ class UrlToPython:
                     raise
                 logger.debug('Calc Plugin  connection %s got new listener.', self.address)
                 return None, self.name, self.address
-            except Exeption:
+            except Exception:
                 msg = "Invalid configuration for Calc Plugin  connection. %s"
                 logger.exception(msg, self.address, exc_info=True)
                 raise ValueError("error in Calc Plugin plugin input")

--- a/pydm/tests/data_plugins/test_calc_plugin.py
+++ b/pydm/tests/data_plugins/test_calc_plugin.py
@@ -1,0 +1,86 @@
+from typing import Any
+import pytest
+
+from pytestqt.qtbot import QtBot
+from qtpy.QtCore import Signal
+
+from pydm.application import PyDMApplication
+from pydm.data_plugins.calc_plugin import epics_string, epics_unsigned
+from pydm.widgets.channel import PyDMChannel
+
+
+@pytest.mark.parametrize(
+    "input_string,expected",
+    [
+        ("okay\x00garbageinmemorysomewhere", "okay"),
+        ("normal_string", "normal_string"),
+        ("\x00nullgivesempty", ""),
+    ],
+)
+def test_epics_string(input_string: str, expected: str):
+    assert epics_string(input_string) == expected
+
+
+@pytest.mark.parametrize(
+    "input_int,bits,expected",
+    [
+        (100, 32, 100),
+        (-1, 8, 129),
+        (-0b111, 4, 0b1111),
+    ],
+)
+def test_epics_unsigned(input_int: int, bits: int, expected: int):
+    assert epics_unsigned(input_int, bits, expected)
+
+
+@pytest.mark.parametrize(
+    "calc,input1,expected1,input2,expected2",
+    [
+        ('val + 3', 0, 3, 1, 4),
+        ('np.abs(val)', -5, 5, -10, 10),
+        ('math.floor(val)', 3.4, 3, 5.7, 5),
+        ('epics_string(val)', 'data\x00asdf', 'data', 'calc', 'calc'),
+        ('epics_unsigned(val, 8)', -1, 256, -2, 255),
+    ]
+)
+def test_calc_plugin(
+    qapp: PyDMApplication,
+    qtbot: QtBot,
+    calc: str,
+    input1: Any,
+    expected1: Any,
+    input2: Any,
+    expected2: Any,
+):
+    sig = Signal(type(input1))
+    type_str = str(type(input1))
+    local_addr = f'local://test_calc_plugin_local_{calc}'
+    local_ch = PyDMChannel(
+        address=f'{local_addr}?type={type_str}&init={input1}',
+        value_signal=sig,
+    )
+    local_ch.connect()
+    calc_values = []
+
+    def new_calc_value(val: Any):
+        calc_values.append(val)
+
+    calc_addr = f'calc://test_calc_plugin_calc_{calc}'
+    calc_ch = PyDMChannel(
+        address=f'{calc_addr}?var={local_addr}&expr={calc}',
+        value_slot=new_calc_value,
+    )
+    calc_ch.connect()
+
+    def has_first_value():
+        assert len(calc_values) == 1
+
+    qtbot.wait_until(has_first_value)
+    sig.emit(input2)
+
+    def has_second_value():
+        assert len(calc_values) == 2
+
+    qtbot.wait_until(has_second_value)
+    assert calc_values[0] == expected1
+    assert calc_values[1] == expected2

--- a/pydm/tests/data_plugins/test_calc_plugin.py
+++ b/pydm/tests/data_plugins/test_calc_plugin.py
@@ -31,7 +31,7 @@ def test_epics_string(input_string: str, expected: str):
     ],
 )
 def test_epics_unsigned(input_int: int, bits: int, expected: int):
-    assert epics_unsigned(input_int, bits, expected)
+    assert epics_unsigned(input_int, bits) == expected
 
 
 @pytest.mark.parametrize(

--- a/pydm/tests/data_plugins/test_calc_plugin.py
+++ b/pydm/tests/data_plugins/test_calc_plugin.py
@@ -57,7 +57,7 @@ def test_calc_plugin(
 ):
     sig = Signal(type(input1))
     type_str = str(type(input1))
-    local_addr = f'local://test_calc_plugin_local_{calc}'
+    local_addr = f'loc://test_calc_plugin_local_{calc}'
     local_ch = PyDMChannel(
         address=f'{local_addr}?type={type_str}&init={input1}',
         value_signal=sig,

--- a/pydm/tests/data_plugins/test_calc_plugin.py
+++ b/pydm/tests/data_plugins/test_calc_plugin.py
@@ -38,7 +38,7 @@ def test_epics_unsigned(input_int: int, bits: int, expected: int):
     "calc,input1,expected1,input2,expected2",
     [
         ('val + 3', 0, 3, 1, 4),
-        ('np.abs(val)', -5, 5, -10, 10),
+        ('int(np.abs(val))', -5, 5, -10, 10),
         ('math.floor(val)', 3.4, 3, 5.7, 5),
         ('epics_string(val)',
          np.array((0x61, 0), dtype=np.int8), 'a',

--- a/pydm/tests/data_plugins/test_calc_plugin.py
+++ b/pydm/tests/data_plugins/test_calc_plugin.py
@@ -43,7 +43,7 @@ def test_epics_unsigned(input_int: int, bits: int, expected: int):
         ('epics_string(val)',
          np.array((0x61, 0), dtype=np.int8), 'a',
          np.array((0x62, 0), dtype=np.int8), 'b'),
-        ('epics_unsigned(val, 8)', -1, 256, -2, 255),
+        ('epics_unsigned(val, 8)', -1, 255, -2, 254),
     ]
 )
 def test_calc_plugin(
@@ -79,15 +79,12 @@ def test_calc_plugin(
     calc_ch.connect()
     sig_holder.sig.emit(input1)
 
-    def has_first_value():
-        assert len(calc_values) == 1
+    def has_value():
+        assert len(calc_values) >= 1
 
-    qtbot.wait_until(has_first_value)
-    sig_holder.sig.emit(input2)
-
-    def has_second_value():
-        assert len(calc_values) == 2
-
-    qtbot.wait_until(has_second_value)
+    qtbot.wait_until(has_value)
     assert calc_values[0] == expected1
-    assert calc_values[1] == expected2
+    calc_values.clear()
+    sig_holder.sig.emit(input2)
+    qtbot.wait_until(has_value)
+    assert calc_values[0] == expected2

--- a/pydm/tests/data_plugins/test_calc_plugin.py
+++ b/pydm/tests/data_plugins/test_calc_plugin.py
@@ -73,7 +73,7 @@ def test_calc_plugin(
 
     calc_addr = f'calc://test_calc_plugin_calc_{calc}'
     calc_ch = PyDMChannel(
-        address=f'{calc_addr}?var={local_addr}&expr={calc}',
+        address=f'{calc_addr}?val={local_addr}&expr={calc}',
         value_slot=new_calc_value,
     )
     calc_ch.connect()

--- a/pydm/tests/data_plugins/test_calc_plugin.py
+++ b/pydm/tests/data_plugins/test_calc_plugin.py
@@ -77,6 +77,7 @@ def test_calc_plugin(
         value_slot=new_calc_value,
     )
     calc_ch.connect()
+    sig_holder.sig.emit(input1)
 
     def has_first_value():
         assert len(calc_values) == 1

--- a/pydm/tests/data_plugins/test_calc_plugin.py
+++ b/pydm/tests/data_plugins/test_calc_plugin.py
@@ -3,6 +3,7 @@ import pytest
 
 from pytestqt.qtbot import QtBot
 from qtpy.QtCore import Signal
+import numpy as np
 
 from pydm.application import PyDMApplication
 from pydm.data_plugins.calc_plugin import epics_string, epics_unsigned
@@ -12,9 +13,9 @@ from pydm.widgets.channel import PyDMChannel
 @pytest.mark.parametrize(
     "input_string,expected",
     [
-        ("okay\x00garbageinmemorysomewhere", "okay"),
-        ("normal_string", "normal_string"),
-        ("\x00nullgivesempty", ""),
+        (np.array((0x6f, 0x6b, 0x61, 0x79, 0, 42), dtype=np.int8), "okay"),
+        (np.array((0x6f, 0x6b, 0x61, 0x79), dtype=np.int8), "okay"),
+        (np.array((0, 0x6f, 0x6b, 0x61, 0x79, 0, 42, 42), dtype=np.int8), ""),
     ],
 )
 def test_epics_string(input_string: str, expected: str):
@@ -39,7 +40,9 @@ def test_epics_unsigned(input_int: int, bits: int, expected: int):
         ('val + 3', 0, 3, 1, 4),
         ('np.abs(val)', -5, 5, -10, 10),
         ('math.floor(val)', 3.4, 3, 5.7, 5),
-        ('epics_string(val)', 'data\x00asdf', 'data', 'calc', 'calc'),
+        ('epics_string(val)',
+         np.array((0x61, 0), dtype=np.int8), 'a',
+         np.array((0x62, 0), dtype=np.int8), 'b'),
         ('epics_unsigned(val, 8)', -1, 256, -2, 255),
     ]
 )

--- a/pydm/tests/data_plugins/test_calc_plugin.py
+++ b/pydm/tests/data_plugins/test_calc_plugin.py
@@ -26,8 +26,8 @@ def test_epics_string(input_string: str, expected: str):
     "input_int,bits,expected",
     [
         (100, 32, 100),
-        (-1, 8, 129),
-        (-0b111, 4, 0b1111),
+        (-1, 8, 255),
+        (-2, 4, 0b1110),
     ],
 )
 def test_epics_unsigned(input_int: int, bits: int, expected: int):


### PR DESCRIPTION
- Add a helper function, `epics_unsigned` to be used in the `calc` plugin for converting signed EPICS integers to unsigned versions to close #767. Philosophically, it didn't feel right to build this into the EPICS plugins since the EPICS plugins are producing the true values as appropriate, and since there would be three plugins to modify. Building this into the widgets seemed similarly annoying due to proliferation of widget types. Building this into the `calc` plugin allows me to re-use this for my various unsigned longs that are wrapping around to negative values, and to be very explicit about what I'm doing.
- Add basic unit tests for calc_plugin, including my added functionality. These tests are in no way exhaustive, but they are a start.
- Add some docstrings and doc page info for `epics_string` and `epics_unsigned`
- Fix some minor issues that I saw while looking through the `calc_plugin.py` file
- Remove py2 compatibility imports from `calc_plugin.py` for code cleanliness and because I was adding a few type annotations