### PR TITLE
ENH: Add the ability to monitor changes to alarm limits of PVs

### DIFF
--- a/pydm/data_plugins/epics_plugins/pyepics_plugin_component.py
+++ b/pydm/data_plugins/epics_plugins/pyepics_plugin_component.py
@@ -42,6 +42,10 @@ class Connection(PyDMConnection):
         self._unit = None
         self._upper_ctrl_limit = None
         self._lower_ctrl_limit = None
+        self._upper_alarm_limit = None
+        self._lower_alarm_limit = None
+        self._upper_warning_limit = None
+        self._lower_warning_limit = None
 
     def clear_cache(self):
         self._value = None
@@ -51,6 +55,10 @@ class Connection(PyDMConnection):
         self._unit = None
         self._upper_ctrl_limit = None
         self._lower_ctrl_limit = None
+        self._upper_alarm_limit = None
+        self._lower_alarm_limit = None
+        self._upper_warning_limit = None
+        self._lower_warning_limit = None
 
     def send_new_value(self, value=None, char_value=None, count=None, ftype=None, *args, **kws):
         self.update_ctrl_vars(**kws)
@@ -73,7 +81,12 @@ class Connection(PyDMConnection):
                 else:
                     self.new_value_signal[str].emit(char_value)
 
-    def update_ctrl_vars(self, units=None, enum_strs=None, severity=None, upper_ctrl_limit=None, lower_ctrl_limit=None, precision=None, *args, **kws):
+    def update_ctrl_vars(self, units=None, enum_strs=None, severity=None, upper_ctrl_limit=None, lower_ctrl_limit=None,
+                         precision=None, upper_alarm_limit=None, lower_alarm_limit=None, upper_warning_limit=None,
+                         lower_warning_limit=None, *args, **kws):
+        """ Callback invoked when there is a change any of these variables. For a full description see:
+            https://cars9.uchicago.edu/software/python/pyepics3/pv.html#user-supplied-callback-functions
+        """
         if severity is not None and self._severity != severity:
             self._severity = severity
             self.new_severity_signal.emit(int(severity))
@@ -98,6 +111,19 @@ class Connection(PyDMConnection):
         if lower_ctrl_limit is not None and self._lower_ctrl_limit != lower_ctrl_limit:
             self._lower_ctrl_limit = lower_ctrl_limit
             self.lower_ctrl_limit_signal.emit(lower_ctrl_limit)
+        if upper_alarm_limit is not None and self._upper_alarm_limit != upper_alarm_limit:
+            self._upper_alarm_limit = upper_alarm_limit
+            self.upper_alarm_limit_signal.emit(upper_alarm_limit)
+        if lower_alarm_limit is not None and self._lower_alarm_limit != lower_alarm_limit:
+            self._lower_alarm_limit = lower_alarm_limit
+            self.lower_alarm_limit_signal.emit(lower_alarm_limit)
+        if upper_warning_limit is not None and self._upper_warning_limit != upper_warning_limit:
+            self._upper_warning_limit = upper_warning_limit
+            self.upper_warning_limit_signal.emit(upper_warning_limit)
+        if lower_warning_limit is not None and self._lower_warning_limit != lower_warning_limit:
+            self._lower_warning_limit = lower_warning_limit
+            self.lower_warning_limit_signal.emit(lower_warning_limit)
+
 
     def send_access_state(self, read_access, write_access, *args, **kws):
         if is_read_only():

--- a/pydm/data_plugins/plugin.py
+++ b/pydm/data_plugins/plugin.py
@@ -21,6 +21,10 @@ class PyDMConnection(QObject):
     prec_signal = Signal(int)
     upper_ctrl_limit_signal = Signal([float], [int])
     lower_ctrl_limit_signal = Signal([float], [int])
+    upper_alarm_limit_signal = Signal([float], [int])
+    lower_alarm_limit_signal = Signal([float], [int])
+    upper_warning_limit_signal = Signal([float], [int])
+    lower_warning_limit_signal = Signal([float], [int])
 
     def __init__(self, channel, address, protocol=None, parent=None):
         super(PyDMConnection, self).__init__(parent)
@@ -75,6 +79,18 @@ class PyDMConnection(QObject):
 
         if channel.lower_ctrl_limit_slot is not None:
             self.lower_ctrl_limit_signal.connect(channel.lower_ctrl_limit_slot, Qt.QueuedConnection)
+
+        if channel.upper_alarm_limit_slot is not None:
+            self.upper_alarm_limit_signal.connect(channel.upper_alarm_limit_slot, Qt.QueuedConnection)
+
+        if channel.lower_alarm_limit_slot is not None:
+            self.lower_alarm_limit_signal.connect(channel.lower_alarm_limit_slot, Qt.QueuedConnection)
+
+        if channel.upper_warning_limit_slot is not None:
+            self.upper_warning_limit_signal.connect(channel.upper_warning_limit_slot, Qt.QueuedConnection)
+
+        if channel.lower_warning_limit_slot is not None:
+            self.lower_warning_limit_signal.connect(channel.lower_warning_limit_slot, Qt.QueuedConnection)
 
         if channel.prec_slot is not None:
             self.prec_signal.connect(channel.prec_slot, Qt.QueuedConnection)
@@ -155,6 +171,30 @@ class PyDMConnection(QObject):
         if self._should_disconnect(channel.lower_ctrl_limit_slot, destroying):
             try:
                 self.lower_ctrl_limit_signal.disconnect(channel.lower_ctrl_limit_slot)
+            except (KeyError, TypeError):
+                pass
+
+        if self._should_disconnect(channel.upper_alarm_limit_slot, destroying):
+            try:
+                self.upper_alarm_limit_signal.disconnect(channel.upper_alarm_limit_slot)
+            except (KeyError, TypeError):
+                pass
+
+        if self._should_disconnect(channel.lower_alarm_limit_slot, destroying):
+            try:
+                self.lower_alarm_limit_signal.disconnect(channel.lower_alarm_limit_slot)
+            except (KeyError, TypeError):
+                pass
+
+        if self._should_disconnect(channel.upper_warning_limit_slot, destroying):
+            try:
+                self.upper_warning_limit_signal.disconnect(channel.upper_warning_limit_slot)
+            except (KeyError, TypeError):
+                pass
+
+        if self._should_disconnect(channel.lower_warning_limit_slot, destroying):
+            try:
+                self.lower_warning_limit_signal.disconnect(channel.lower_warning_limit_slot)
             except (KeyError, TypeError):
                 pass
 

--- a/pydm/tests/conftest.py
+++ b/pydm/tests/conftest.py
@@ -43,6 +43,10 @@ class ConnectionSignals(QObject):
     prec_signal = Signal(int)
     upper_ctrl_limit_signal = Signal([float])
     lower_ctrl_limit_signal = Signal([float])
+    upper_alarm_limit_signal = Signal([float])
+    lower_alarm_limit_signal = Signal([float])
+    upper_warning_limit_signal = Signal([float])
+    lower_warning_limit_signal = Signal([float])
 
     def __init__(self):
         super(ConnectionSignals, self).__init__()

--- a/pydm/tests/data_plugins/test_pyepics_plugin_component.py
+++ b/pydm/tests/data_plugins/test_pyepics_plugin_component.py
@@ -1,0 +1,25 @@
+from pydm.data_plugins.archiver_plugin import Connection
+from pydm.data_plugins.epics_plugins.pyepics_plugin_component import Connection
+from pydm.tests.conftest import ConnectionSignals
+from pydm.widgets.channel import PyDMChannel
+
+
+def test_update_ctrl_vars(signals: ConnectionSignals):
+    """ Invoke our callback for updating the control values for a PV as if we had a monitor on it. Verify
+        that the signals sent are received as expected.
+    """
+    values_received = []
+    mock_channel = PyDMChannel()
+    mock_pyepics_connection = Connection(mock_channel, 'Test:PV:1')
+    mock_pyepics_connection.upper_alarm_limit_signal.connect(lambda x: values_received.append(x))
+    mock_pyepics_connection.lower_alarm_limit_signal.connect(lambda x: values_received.append(x))
+    mock_pyepics_connection.lower_warning_limit_signal.connect(lambda x: values_received.append(x))
+    mock_pyepics_connection.upper_warning_limit_signal.connect(lambda x: values_received.append(x))
+    mock_pyepics_connection.upper_ctrl_limit_signal.connect(lambda x: values_received.append(x))
+    mock_pyepics_connection.lower_ctrl_limit_signal.connect(lambda x: values_received.append(x))
+
+    mock_pyepics_connection.update_ctrl_vars(upper_ctrl_limit=70, lower_ctrl_limit=20, upper_alarm_limit=100,
+                                             lower_alarm_limit=2, upper_warning_limit=90, lower_warning_limit=10)
+
+    expected_values = [70, 20, 100, 2, 90, 10]
+    assert values_received == expected_values

--- a/pydm/tests/widgets/test_base.py
+++ b/pydm/tests/widgets/test_base.py
@@ -11,7 +11,7 @@ from qtpy.QtGui import QColor, QMouseEvent
 from ..conftest import ConnectionSignals
 from ...utilities import is_pydm_app
 from ... import data_plugins
-from ...widgets.base import is_channel_valid, PyDMWidget
+from ...widgets.base import AlarmLimit, is_channel_valid, PyDMWidget
 from ...widgets.label import PyDMLabel
 from ...widgets.line_edit import PyDMLineEdit
 from ...widgets.channel import PyDMChannel
@@ -294,10 +294,10 @@ def test_ctrl_limit_changed(qtbot, signals, which_limit, new_limit):
 
 
 @pytest.mark.parametrize("which_limit, new_limit", [
-    ("HIHI", 100.10),
-    ("HIGH", 90),
-    ("LOW", 20.5),
-    ("LOLO", 7)
+    (AlarmLimit.HIHI, 100.10),
+    (AlarmLimit.HIGH, 90),
+    (AlarmLimit.LOW, 20.5),
+    (AlarmLimit.LOLO, 7)
 ])
 def test_alarm_limits_changed(qtbot, signals: ConnectionSignals, which_limit: str, new_limit: float):
     """ Ensure that changes to the alarm limits of a PV get sent to the right place """
@@ -309,16 +309,16 @@ def test_alarm_limits_changed(qtbot, signals: ConnectionSignals, which_limit: st
     signals.upper_warning_limit_signal.connect(pydm_label.upper_warning_limit_changed)
     signals.lower_warning_limit_signal.connect(pydm_label.lower_warning_limit_changed)
 
-    if which_limit == "HIHI":
+    if which_limit is AlarmLimit.HIHI:
         signals.upper_alarm_limit_signal.emit(new_limit)
         assert pydm_label.upper_alarm_limit == new_limit
-    elif which_limit == "HIGH":
+    elif which_limit is AlarmLimit.HIGH:
         signals.upper_warning_limit_signal.emit(new_limit)
         assert pydm_label.upper_warning_limit == new_limit
-    elif which_limit == "LOW":
+    elif which_limit is AlarmLimit.LOW:
         signals.lower_warning_limit_signal.emit(new_limit)
         assert pydm_label.lower_warning_limit == new_limit
-    elif which_limit == "LOLO":
+    elif which_limit is AlarmLimit.LOLO:
         signals.lower_alarm_limit_signal.emit(new_limit)
         assert pydm_label.lower_alarm_limit == new_limit
 

--- a/pydm/tests/widgets/test_base.py
+++ b/pydm/tests/widgets/test_base.py
@@ -8,6 +8,7 @@ logger = logging.getLogger(__name__)
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QMenu
 from qtpy.QtGui import QColor, QMouseEvent
+from ..conftest import ConnectionSignals
 from ...utilities import is_pydm_app
 from ... import data_plugins
 from ...widgets.base import is_channel_valid, PyDMWidget
@@ -292,6 +293,36 @@ def test_ctrl_limit_changed(qtbot, signals, which_limit, new_limit):
         assert pydm_label.get_ctrl_limits()[0] == new_limit
 
 
+@pytest.mark.parametrize("which_limit, new_limit", [
+    ("HIHI", 100.10),
+    ("HIGH", 90),
+    ("LOW", 20.5),
+    ("LOLO", 7)
+])
+def test_alarm_limits_changed(qtbot, signals: ConnectionSignals, which_limit: str, new_limit: float):
+    """ Ensure that changes to the alarm limits of a PV get sent to the right place """
+    pydm_label = PyDMLabel(init_channel="CA://MA_TEST")
+    qtbot.addWidget(pydm_label)
+
+    signals.upper_alarm_limit_signal.connect(pydm_label.upper_alarm_limit_changed)
+    signals.lower_alarm_limit_signal.connect(pydm_label.lower_alarm_limit_changed)
+    signals.upper_warning_limit_signal.connect(pydm_label.upper_warning_limit_changed)
+    signals.lower_warning_limit_signal.connect(pydm_label.lower_warning_limit_changed)
+
+    if which_limit == "HIHI":
+        signals.upper_alarm_limit_signal.emit(new_limit)
+        assert pydm_label.upper_alarm_limit == new_limit
+    elif which_limit == "HIGH":
+        signals.upper_warning_limit_signal.emit(new_limit)
+        assert pydm_label.upper_warning_limit == new_limit
+    elif which_limit == "LOW":
+        signals.lower_warning_limit_signal.emit(new_limit)
+        assert pydm_label.lower_warning_limit == new_limit
+    elif which_limit == "LOLO":
+        signals.lower_alarm_limit_signal.emit(new_limit)
+        assert pydm_label.lower_alarm_limit == new_limit
+
+
 def test_force_redraw(qtbot, signals):
     """
     Test the forced redraw of a PyDMWidget object to ensure no exception will be raised.
@@ -433,6 +464,10 @@ def test_pydmwidget_channels(qtbot):
                                         prec_slot=pydm_label.precisionChanged,
                                         upper_ctrl_limit_slot=pydm_label.upperCtrlLimitChanged,
                                         lower_ctrl_limit_slot=pydm_label.lowerCtrlLimitChanged,
+                                        upper_alarm_limit_slot=pydm_label.upper_alarm_limit_changed,
+                                        upper_warning_limit_slot=pydm_label.upper_warning_limit_changed,
+                                        lower_alarm_limit_slot=pydm_label.lower_alarm_limit_changed,
+                                        lower_warning_limit_slot=pydm_label.lower_warning_limit_changed,
                                         value_signal=None,
                                         write_access_slot=None)
     assert pydm_channels == default_pydm_channels
@@ -471,6 +506,10 @@ def test_pydmwritablewidget_channels(qtbot):
                                         prec_slot=pydm_lineedit.precisionChanged,
                                         upper_ctrl_limit_slot=pydm_lineedit.upperCtrlLimitChanged,
                                         lower_ctrl_limit_slot=pydm_lineedit.lowerCtrlLimitChanged,
+                                        upper_alarm_limit_slot=pydm_lineedit.upper_alarm_limit_changed,
+                                        lower_alarm_limit_slot=pydm_lineedit.lower_alarm_limit_changed,
+                                        upper_warning_limit_slot=pydm_lineedit.upper_warning_limit_changed,
+                                        lower_warning_limit_slot=pydm_lineedit.lower_warning_limit_changed,
                                         value_signal=pydm_lineedit.send_value_signal,
                                         write_access_slot=pydm_lineedit.writeAccessChanged)
     assert pydm_channels == default_pydm_channels

--- a/pydm/tests/widgets/test_channel.py
+++ b/pydm/tests/widgets/test_channel.py
@@ -56,6 +56,10 @@ def test_construct(qtbot):
                                               prec_slot=pydm_label.precisionChanged,
                                               upper_ctrl_limit_slot=pydm_label.upperCtrlLimitChanged,
                                               lower_ctrl_limit_slot=pydm_label.lowerCtrlLimitChanged,
+                                              upper_alarm_limit_slot=pydm_label.upper_alarm_limit_changed,
+                                              lower_alarm_limit_slot=pydm_label.lower_alarm_limit_changed,
+                                              upper_warning_limit_slot=pydm_label.upper_warning_limit_changed,
+                                              lower_warning_limit_slot=pydm_label.lower_warning_limit_changed,
                                               value_signal=None,
                                               write_access_slot=None)
     assert pydm_label_channels == default_pydm_label_channels

--- a/pydm/tests/widgets/test_channel.py
+++ b/pydm/tests/widgets/test_channel.py
@@ -36,6 +36,10 @@ def test_construct(qtbot):
         pydm_channel.prec_slot is None and \
         pydm_channel.upper_ctrl_limit_slot is None and \
         pydm_channel.lower_ctrl_limit_slot is None and \
+        pydm_channel.upper_alarm_limit_slot is None and \
+        pydm_channel.lower_alarm_limit_slot is None and \
+        pydm_channel.upper_warning_limit_slot is None and \
+        pydm_channel.lower_warning_limit_slot is None and \
         pydm_channel.write_access_slot is None and \
         pydm_channel.value_signal is None
 

--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -856,6 +856,7 @@ class PyDMWidget(PyDMPrimitiveWidget):
         """
         self.enum_strings_changed(new_enum_strings)
 
+    @Slot(int)
     @Slot(float)
     def upperCtrlLimitChanged(self, new_limit):
         """
@@ -869,6 +870,7 @@ class PyDMWidget(PyDMPrimitiveWidget):
         """
         self.ctrl_limit_changed("UPPER", new_limit)
 
+    @Slot(int)
     @Slot(float)
     def lowerCtrlLimitChanged(self, new_limit):
         """
@@ -882,6 +884,7 @@ class PyDMWidget(PyDMPrimitiveWidget):
         """
         self.ctrl_limit_changed("LOWER", new_limit)
 
+    @Slot(int)
     @Slot(float)
     def upper_alarm_limit_changed(self, new_limit: float):
         """
@@ -894,6 +897,7 @@ class PyDMWidget(PyDMPrimitiveWidget):
         """
         self.alarm_limit_changed(AlarmLimit.HIHI, new_limit)
 
+    @Slot(int)
     @Slot(float)
     def lower_alarm_limit_changed(self, new_limit: float):
         """
@@ -906,6 +910,7 @@ class PyDMWidget(PyDMPrimitiveWidget):
         """
         self.alarm_limit_changed(AlarmLimit.LOLO, new_limit)
 
+    @Slot(int)
     @Slot(float)
     def upper_warning_limit_changed(self, new_limit: float):
         """
@@ -918,6 +923,7 @@ class PyDMWidget(PyDMPrimitiveWidget):
         """
         self.alarm_limit_changed(AlarmLimit.HIGH, new_limit)
 
+    @Slot(int)
     @Slot(float)
     def lower_warning_limit_changed(self, new_limit: float):
         """

--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -5,7 +5,6 @@ import logging
 import functools
 import json
 import numpy as np
-from typing import Tuple
 from qtpy.QtWidgets import (QApplication, QMenu, QGraphicsOpacityEffect,
                             QToolTip, QWidget)
 from qtpy.QtGui import QCursor, QIcon

--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -1,3 +1,4 @@
+import enum
 import os
 import platform
 import weakref
@@ -320,6 +321,14 @@ class PyDMPrimitiveWidget(object):
                 return widget
             widget = widget.parent()
         return None
+
+
+class AlarmLimit(str, enum.Enum):
+    """ An enum for holding values corresponding to the EPICS alarm limits """
+    HIHI = "HIHI"
+    HIGH = "HIGH"
+    LOW = "LOW"
+    LOLO = "LOLO"
 
 
 class TextFormatter(object):
@@ -771,27 +780,25 @@ class PyDMWidget(PyDMPrimitiveWidget):
         else:
             self._lower_ctrl_limit = new_limit
 
-    def alarm_limit_changed(self, which: str, new_limit: float) -> None:
+    def alarm_limit_changed(self, which: AlarmLimit, new_limit: float) -> None:
         """
         Callback invoked when the channel receives new alarm limit values.
 
         Parameters
         ----------
-        which : str
+        which : AlarmLimit
             Which alarm limit was changed. "HIHI", "HIGH", "LOW", "LOLO"
         new_limit : float
             New value for the alarm limit
         """
-        if which == "HIHI":
+        if which is AlarmLimit.HIHI:
             self.upper_alarm_limit = new_limit
-        elif which == "HIGH":
+        elif which is AlarmLimit.HIGH:
             self.upper_warning_limit = new_limit
-        elif which == "LOW":
+        elif which is AlarmLimit.LOW:
             self.lower_warning_limit = new_limit
-        elif which == "LOLO":
+        elif which is AlarmLimit.LOLO:
             self.lower_alarm_limit = new_limit
-        else:
-            logger.warning(f"Invalid alarm limit specified: {which}")
 
     @Slot(bool)
     def connectionStateChanged(self, connected):
@@ -885,7 +892,7 @@ class PyDMWidget(PyDMPrimitiveWidget):
         new_limit : float
            The new value for the HIHI limit
         """
-        self.alarm_limit_changed("HIHI", new_limit)
+        self.alarm_limit_changed(AlarmLimit.HIHI, new_limit)
 
     @Slot(float)
     def lower_alarm_limit_changed(self, new_limit: float):
@@ -897,7 +904,7 @@ class PyDMWidget(PyDMPrimitiveWidget):
         new_limit : float
            The new value for the LOLO limit
         """
-        self.alarm_limit_changed("LOLO", new_limit)
+        self.alarm_limit_changed(AlarmLimit.LOLO, new_limit)
 
     @Slot(float)
     def upper_warning_limit_changed(self, new_limit: float):
@@ -909,7 +916,7 @@ class PyDMWidget(PyDMPrimitiveWidget):
         new_limit : float
            The new value for the HIGH limit
         """
-        self.alarm_limit_changed("HIGH", new_limit)
+        self.alarm_limit_changed(AlarmLimit.HIGH, new_limit)
 
     @Slot(float)
     def lower_warning_limit_changed(self, new_limit: float):
@@ -921,7 +928,7 @@ class PyDMWidget(PyDMPrimitiveWidget):
         new_limit : float
            The new value for the LOW limit
         """
-        self.alarm_limit_changed("LOW", new_limit)
+        self.alarm_limit_changed(AlarmLimit.LOW, new_limit)
 
     @Slot()
     def force_redraw(self):

--- a/pydm/widgets/channel.py
+++ b/pydm/widgets/channel.py
@@ -71,6 +71,18 @@ class PyDMChannel(object):
     prec_slot : Slot, optional
         A function to be run when the precision value changes
 
+    upper_alarm_limit_slot : Slot, optional
+        A function to be run when the upper alarm limit changes
+
+    lower_alarm_limit_slot : Slot, optional
+        A function to be run when the lower alarm limit changes
+
+    upper_warning_limit_slot : Slot, optional
+        A function to be run when the upper warning limit changes
+
+    lower_warning_limit_slot : Slot, optional
+        A function to be run when the lower warning limit changes
+
     value_signal : Signal, optional
         Attach a signal here that emits a desired value to be sent
         through the plugin
@@ -80,6 +92,8 @@ class PyDMChannel(object):
                  severity_slot=None, write_access_slot=None,
                  enum_strings_slot=None, unit_slot=None, prec_slot=None,
                  upper_ctrl_limit_slot=None, lower_ctrl_limit_slot=None,
+                 upper_alarm_limit_slot=None, lower_alarm_limit_slot=None,
+                 upper_warning_limit_slot=None, lower_warning_limit_slot=None,
                  value_signal=None):
         self._address = None
         self.address = address
@@ -94,6 +108,10 @@ class PyDMChannel(object):
 
         self.upper_ctrl_limit_slot = upper_ctrl_limit_slot
         self.lower_ctrl_limit_slot = lower_ctrl_limit_slot
+        self.upper_alarm_limit_slot = upper_alarm_limit_slot
+        self.lower_alarm_limit_slot = lower_alarm_limit_slot
+        self.upper_warning_limit_slot = upper_warning_limit_slot
+        self.lower_warning_limit_slot = lower_warning_limit_slot
 
         self.value_signal = value_signal
 
@@ -143,6 +161,10 @@ class PyDMChannel(object):
             prec_slot_matched = self.prec_slot == other.prec_slot
             upper_ctrl_slot_matched = self.upper_ctrl_limit_slot == other.upper_ctrl_limit_slot
             lower_ctrl_slot_matched = self.lower_ctrl_limit_slot == other.lower_ctrl_limit_slot
+            upper_alarm_slot_matched = self.upper_alarm_limit_slot == other.upper_alarm_limit_slot
+            lower_alarm_slot_matched = self.lower_alarm_limit_slot == other.lower_alarm_limit_slot
+            upper_warning_slot_matched = self.upper_warning_limit_slot == other.upper_warning_limit_slot
+            lower_warning_slot_matched = self.lower_warning_limit_slot == other.lower_warning_limit_slot
             write_access_slot_matched = self.write_access_slot == other.write_access_slot
 
             value_signal_matched = self.value_signal is None and other.value_signal is None
@@ -158,6 +180,10 @@ class PyDMChannel(object):
                     prec_slot_matched and
                     upper_ctrl_slot_matched and
                     lower_ctrl_slot_matched and
+                    upper_alarm_slot_matched and
+                    lower_alarm_slot_matched and
+                    upper_warning_slot_matched and
+                    lower_warning_slot_matched and
                     write_access_slot_matched and
                     value_signal_matched)
 


### PR DESCRIPTION
Add signals that will be emitted when there are changes to the alarm limits of a PV. These can be monitored by adding the appropriate slot to a PyDMChannel which will be run on any change to the alarm limit value.

Tested with a custom widget to ensure all the signals are working and ending up in the correct place. 