### PR TITLE
BLD: new pyqt seems to break the test suite on the CI, pin for now

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -17,7 +17,7 @@ requirements:
     - python
     - pip
     - setuptools
-    - pyqt >=5
+    - pyqt >=5,<5.15
     - qtpy
   run:
     - python

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -26,7 +26,7 @@ requirements:
     - scipy
     - pyepics
     - requests
-    - pyqt >=5
+    - pyqt >=5,<5.15
     - pyqtgraph
     - qtpy
 


### PR DESCRIPTION
The newest pyqt build is up on conda-forge and coincides with the test failures. Passing builds have:
```
pyqt                      5.12.3           py37h89c1867_8    conda-forge
```
Failing builds have:
```
pyqt                      5.15.4           py37hd23a5d3_0    conda-forge
```

Hopefully, the tests on this PR pass.
If so, let's pin it down until someone has time to figure out the compatibility nuances.