### PR TITLE
Fix: Ensure the main view box for plot widgets is also set to auto range when "View All" is clicked

### DIFF
--- a/pydm/widgets/multi_axis_plot.py
+++ b/pydm/widgets/multi_axis_plot.py
@@ -318,8 +318,7 @@ class MultiAxisPlot(PlotItem):
         if len(self.stackedViews) > 0:
             for stackedView in self.stackedViews:
                 stackedView.enableAutoRange(x=x, y=y)
-        else:
-            self.getViewBox().enableAutoRange(x=x, y=y)
+        self.getViewBox().enableAutoRange(x=x, y=y)
 
     def clearLayout(self):
         """

--- a/pydm/widgets/multi_axis_plot.py
+++ b/pydm/widgets/multi_axis_plot.py
@@ -315,9 +315,8 @@ class MultiAxisPlot(PlotItem):
         y: bool, optional
             Set to true to enable y autorange or false to disable it. Defaults to None which will result in no change
         """
-        if len(self.stackedViews) > 0:
-            for stackedView in self.stackedViews:
-                stackedView.enableAutoRange(x=x, y=y)
+        for stackedView in self.stackedViews:
+            stackedView.enableAutoRange(x=x, y=y)
         self.getViewBox().enableAutoRange(x=x, y=y)
 
     def clearLayout(self):


### PR DESCRIPTION
There was an issue where the primary view box on a PyDM plot was not being set to auto-range when the view all button was clicked. Fixed here - it should not be an if/else, every view box should always be set.

Verified the in-progress sparkline widget now looks good (where this bug was discovered) as well as existing example plots.