### PR TITLE
Rename PyDMTimePlot's update modes #828

### DIFF
--- a/pydm/tests/widgets/test_timeplot.py
+++ b/pydm/tests/widgets/test_timeplot.py
@@ -26,7 +26,7 @@ def test_timeplotcurveitem_construct(qtbot, channel_address, name):
             not pydm_timeplot_curve_item.to_dict()["name"]
 
     assert pydm_timeplot_curve_item._bufferSize == MINIMUM_BUFFER_SIZE
-    assert pydm_timeplot_curve_item._update_mode == PyDMTimePlot.SynchronousMode
+    assert pydm_timeplot_curve_item._update_mode == PyDMTimePlot.OnValueChange
     assert np.array_equal(pydm_timeplot_curve_item.data_buffer, np.zeros((2, pydm_timeplot_curve_item._bufferSize),
                                                                          order='f', dtype=float))
     assert pydm_timeplot_curve_item.connected is False
@@ -104,12 +104,12 @@ def test_timeplotcurveitem_receive_value(qtbot, signals, async_update, new_data)
     """
     pydm_timeplot_curve_item = TimePlotCurveItem()
 
-    assert pydm_timeplot_curve_item._update_mode == PyDMTimePlot.SynchronousMode
+    assert pydm_timeplot_curve_item._update_mode == PyDMTimePlot.OnValueChange
 
     pydm_timeplot_curve_item.setUpdatesAsynchronously(async_update)
     if async_update:
-        assert pydm_timeplot_curve_item._update_mode == PyDMTimePlot.AsynchronousMode if async_update else \
-            pydm_timeplot_curve_item._update_mode == PyDMTimePlot.SynchronousMode
+        assert pydm_timeplot_curve_item._update_mode == PyDMTimePlot.AtFixedRated if async_update else \
+            pydm_timeplot_curve_item._update_mode == PyDMTimePlot.OnValueChange
 
     expected_data_buffer = np.zeros((2, pydm_timeplot_curve_item._bufferSize), order='f', dtype=float)
     expected_data_buffer[0] = pydm_timeplot_curve_item.data_buffer[0]
@@ -126,7 +126,7 @@ def test_timeplotcurveitem_receive_value(qtbot, signals, async_update, new_data)
         assert pydm_timeplot_curve_item.points_accumulated == 1
 
     pydm_timeplot_curve_item.resetUpdatesAsynchronously()
-    assert pydm_timeplot_curve_item._update_mode == PyDMTimePlot.SynchronousMode
+    assert pydm_timeplot_curve_item._update_mode == PyDMTimePlot.OnValueChange
 
 
 @pytest.mark.parametrize("async_update, new_data", [
@@ -138,7 +138,7 @@ def test_timeplotcurveitem_receive_value(qtbot, signals, async_update, new_data)
 def test_timeplotcurveitem_async_update(qtbot, signals, async_update, new_data):
     pydm_timeplot_curve_item = TimePlotCurveItem()
 
-    assert pydm_timeplot_curve_item._update_mode == PyDMTimePlot.SynchronousMode
+    assert pydm_timeplot_curve_item._update_mode == PyDMTimePlot.OnValueChange
 
     pydm_timeplot_curve_item.setUpdatesAsynchronously(async_update)
 

--- a/pydm/widgets/timeplot.py
+++ b/pydm/widgets/timeplot.py
@@ -320,6 +320,7 @@ class TimePlotCurveItem(BasePlotCurveItem):
         else:
             self._update_mode = PyDMTimePlot.SynchronousMode
         self.initialize_buffer()
+        
     def resetUpdatesAsynchronously(self):
         self._update_mode = PyDMTimePlot.SynchronousMode
         self.initialize_buffer()

--- a/pydm/widgets/timeplot.py
+++ b/pydm/widgets/timeplot.py
@@ -827,9 +827,7 @@ class PyDMTimePlot(BasePlot,updateMode):
         """
         if new_type != self._updateMode:
             self._updateMode = new_type
-            self.getUpdatesAsynchronously
             self.setUpdatesAsynchronously(self._updateMode)
-            self.resetUpdatesAsynchronously
 
     def getTimeSpan(self):
         """

--- a/pydm/widgets/timeplot.py
+++ b/pydm/widgets/timeplot.py
@@ -376,9 +376,6 @@ class PyDMTimePlot(BasePlot,updateMode):
         Will set the bottom axis of this plot to the input axis. If not set, will default
         to either a TimeAxisItem if plot_by_timestamps is true, or a regular AxisItem otherwise
     """
-    #SynchronousMode = 1
-    #AsynchronousMode = 2
-
     OnValueChange = 1
     AtFixedRated = 2
 


### PR DESCRIPTION
Add updateMode as enum as property for TimePlot widget selection. Keeping updatesAsynchronously as backward compatible but remove accessibility from Designer. Tested with PyDMLineEdit-testing-ioc, MeanValue as PV channel.