### PR TITLE
WIP/Discussion: Alternate macro loading for UI files

### DIFF
--- a/pydm/display.py
+++ b/pydm/display.py
@@ -90,6 +90,7 @@ def _load_ui_into_display(uifile, display):
 @lru_cache
 def _get_qt_class(uifile):
     klass, _ = uic.loadUiType(uifile)
+    print(f'loaded class from {uifile}')
     return klass
 
 

--- a/pydm/utilities/macro.py
+++ b/pydm/utilities/macro.py
@@ -78,12 +78,13 @@ def substitute_in_widget(
     widget : QWidget
         The same widget back again, with templates filled.
     """
-    for child_name, prop in _get_macro_targets(widget, source_file):
+    for child_name, prop, template in _get_macro_targets(widget, source_file):
         child_widget = getattr(widget, child_name)
         child_widget.setProperty(
             prop,
-            Template(child_widget.property(prop)).safe_substitute(macros)
+            template.safe_substitute(macros)
         )
+    print(f'did macro subs for {widget}')
     return widget
 
 
@@ -93,7 +94,7 @@ _macro_target_cache = {}
 def _get_macro_targets(
     widget: QWidget,
     source_file: str,
-) -> Tuple[Tuple[str, str]]:
+) -> Tuple[Tuple[str, str, Template]]:
     try:
         return _macro_target_cache[source_file]
     except KeyError:
@@ -107,8 +108,9 @@ def _get_macro_targets(
             meta_property = meta_obj.property(index)
             if meta_property.typeName() == 'QString':
                 prop_name = meta_property.name()
+                value = obj.property(prop_name)
                 if "${" in obj.property(prop_name):
-                    targets.append((obj_name, prop_name))
+                    targets.append((obj_name, prop_name, Template(value)))
     targets = tuple(targets)
     _macro_target_cache[source_file] = targets
     return targets


### PR DESCRIPTION
This is something I tried to do during the codeathon but it didn't quite work out. I thought it was interesting enough to put up a draft PR as a food for thought/discussion starting point.

This started from a look at the performance of the largest photon-side pydm application, https://github.com/pcdshub/pmps-ui. This application takes ~40s to start, so it seemed like a good case study for performance monitoring.

Upon profiling, it's clear that about half of the load time (~16s) is taken up by creating widgets from ui files. So, that leads us into an investigation: how does pydm handle the loading/templating of a ui file? Well, here are the steps:
1. Read the file from disc
2. Substitute macros into the file text
3. Invoke the pyqt uic loader to create a widget class
4. Graft the widgets defined by the widget class onto an empty Display object

Now, this repeats every time we re-use the same template. So even though we're using the same designer layout for the widget, we're repeating a lot of work- particularly the file reads and the uic loader.

Is there a way we can re-use the designer layout once? Yes, and that's what this PR does, bringing the ui-file-based load times down to ~12s for a 25% speedup. Unfortunately, this created some bad behavior with the other functionality of PyDM, namely, duplicating all of our PVs with identical template versions that get cleaned up and remade repeatedly as we instantiate all the template widgets, ultimately resulting in a net slowdown.

Here are the steps for loading/templating a ui file laid out in this PR:
1. Load widget class from ui file cache if it exists, otherwise read the file
2. Invoke the pyqt uic loader to create a widget class if it was not in the cache, otherwise this can be skipped
3. Inspect the class for template strings in properties and cache these if needed, otherwise skip
4. Graft the widget class onto an empty Display object
5. If macros were provided, replace all the template string properties of the display as appropriate

Note how for each file we do steps 1-3 exactly once, and then for subsequent re-use we only do steps 4-5.

The unfortunate slowdown comes from the double-setting of `channel` properties, first with the template value, and second with the correct value. Maybe with a bit more thought and work this can be a useful performance boost for large displays with template repeaters.