### PR TITLE
FIX: Remove unnecessary init for the multi axis viewbox

### DIFF
--- a/pydm/widgets/multi_axis_viewbox.py
+++ b/pydm/widgets/multi_axis_viewbox.py
@@ -8,11 +8,6 @@ class MultiAxisViewBox(ViewBox):
     PyDM's use cases. Each unique axis will be assigned its own MultiAxisViewBox for managing its
     range and associated curves. Any events handled by the any view box will be propagated through
     to all views in the stack to ensure that the plot remains consistent with user input.
-
-    Parameters
-    ----------
-    parent: QGraphicsWidget, optional
-        The parent widget for this plot
     """
 
     # These signals will be emitted by the view when it handles these events, and will be connected
@@ -21,10 +16,6 @@ class MultiAxisViewBox(ViewBox):
     sigMouseDraggedDone = Signal()
     sigMouseWheelZoomed = Signal(object, object, object)
     sigHistoryChanged = Signal(object)
-
-    def __init__(self, parent=None):
-        GraphicsWidget.__init__(self, parent)
-        super(MultiAxisViewBox, self).__init__(parent=parent)
 
     def wheelEvent(self, ev, axis=None, fromSignal=False):
         """


### PR DESCRIPTION
At some point during the development of this I vaguely remember needing to do something special here, but it got removed at some point and now not only is it useless it inits GraphicsWidget twice for no reason. This was caught by the updated PyQT and will fix at least some of the test suite issues it was showing.