### PR TITLE
ENH: entrypoint for designer widgets

### DIFF
--- a/docs/source/development/designer_widgets.rst
+++ b/docs/source/development/designer_widgets.rst
@@ -1,0 +1,52 @@
+Designer Widgets
+================
+
+If you develop a package which has Qt Designer-compatible widgets, you can use
+PyDM's built-in support for adding widgets to the designer via entrypoints.
+
+Configuration
+-------------
+
+Here is an example ``setup.py`` that could be used to locate a designable
+widget in your own Python package:
+
+.. code:: python
+
+    from setuptools import setup, find_packages
+
+    setup(
+        name="my_package",
+        # ... other settings will go here
+        entry_points={
+            "gui_scripts": ["my_package_gui=my_package.main:main"],
+            "pydm.widget": [
+                "MyWidgetDesigner=my_package.tool_name:MyWidgetClass",
+            ],
+        },
+        install_requires=[],
+    )
+
+
+This would assume that you have the following:
+
+1. A package named "my_package" with ``my_package/__init__.py`` and
+   ``my_package/widget.py``.
+2. In ``my_package/widget.py``, a ``MyWidgetClass`` that inherits from
+   :class:`~QtWidgets.QWidget`.
+
+After running ``pip install`` on the package, it should be readily available
+in the Qt Designer.
+
+The class may specify additional settings by way of this mechanism:
+
+.. code:: python
+
+    class MyWidgetDesigner(QtWidgets.QWidget):
+        """This is your custom widget."""
+        # Add this to customize where/how the widget shows up in the designer:
+        _qt_designer_ = {
+            "group": "My Widget Category",
+            "is_container": False,
+            "extensions": [],
+            "icon": None,  # QtGui.QIcon(...)
+        }

--- a/docs/source/development/designer_widgets.rst
+++ b/docs/source/development/designer_widgets.rst
@@ -1,11 +1,53 @@
 Designer Widgets
 ================
 
+Widgets in PyDM itself
+----------------------
+
+If you are developing a new widget for PyDM, please make it compatible with
+Qt designer by editing ``pydm/widgets/qtplugins.py``.
+
+For example, if you create a widget called ``MyWidget`` and have it in
+``pydm.widgets.my_widget``, you should add the following lines in
+``qtplugins.py``.
+
+.. code:: python
+
+    from .my_widget import MyWidget
+
+    # And further down in the file where the "NOTE" is:
+
+    MyWidgetPlugin = qtplugin_factory(
+        MyWidget,
+        group=WidgetCategory.MISC,
+        extensions=BASE_EXTENSIONS,
+        icon=ifont.icon("calendar-alt"),
+    )
+
+
+The ``group`` parameter may be one of the following attributes from
+``WidgetCategory``.
+
+.. autoclass:: pydm.widgets.qtplugin_base.WidgetCategory
+   :members:
+
+For most widgets, ``extensions`` should remain as the suggested
+``BASE_EXTENSIONS``.  Advanced users who wish to further customize the Qt
+Designer experience will need to poke around in the PyDM internals to figure it
+out.
+
+The ``icon`` can be customized using the PyDM-vendored fontawesome library.
+The available options can be found in ``fontawesome-charmap.json``, and a quick
+Google search should help you find an icon that will fit your scenario.
+
+.. autofunction:: pydm.widgets.qtplugin_base.qtplugin_factory
+
+
+Widgets in external packages
+----------------------------
+
 If you develop a package which has Qt Designer-compatible widgets, you can use
 PyDM's built-in support for adding widgets to the designer via entrypoints.
-
-Configuration
--------------
 
 Here is an example ``setup.py`` that could be used to locate a designable
 widget in your own Python package:
@@ -50,3 +92,6 @@ The class may specify additional settings by way of this mechanism:
             "extensions": [],
             "icon": None,  # QtGui.QIcon(...)
         }
+
+
+The ``_qt_designer_`` dictionary is passed directly to ``qtplugin_factory``.

--- a/docs/source/development/designer_widgets.rst
+++ b/docs/source/development/designer_widgets.rst
@@ -83,7 +83,7 @@ The class may specify additional settings by way of this mechanism:
 
 .. code:: python
 
-    class MyWidgetDesigner(QtWidgets.QWidget):
+    class MyWidgetClass(QtWidgets.QWidget):
         """This is your custom widget."""
         # Add this to customize where/how the widget shows up in the designer:
         _qt_designer_ = {

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -52,6 +52,7 @@ as well as a straightforward python framework to build complex applications.
    development/development.rst
    development/external_tools.rst
    widgets/widget_rules/customizing.rst
+   development/designer_widgets.rst
    development/resources.rst
 
 .. toctree::

--- a/pydm/config.py
+++ b/pydm/config.py
@@ -23,5 +23,7 @@ CONFIRM_QUIT = os.getenv("PYDM_CONFIRM_QUIT", "n").lower() in ("y", "t", "1", "t
 
 ENTRYPOINT_EXTERNAL_TOOL = "pydm.tool"
 ENTRYPOINT_DATA_PLUGIN = "pydm.data_plugin"
+ENTRYPOINT_WIDGET = "pydm.widget"
+
 EXTERNAL_TOOL_SUFFIX = "_tool.py"
 DATA_PLUGIN_SUFFIX = "_plugin.py"

--- a/pydm/widgets/qtplugin_base.py
+++ b/pydm/widgets/qtplugin_base.py
@@ -24,11 +24,10 @@ import logging
 from typing import Dict, List, Optional, Type
 
 import entrypoints
-from qtpy import QtCore, QtDesigner, QtGui
+from qtpy import QtCore, QtDesigner, QtGui, QtWidgets
 
 from .. import config
 from ..qtdesigner import DesignerHooks
-from ..widgets.base import PyDMWidget
 from .qtplugin_extensions import PyDMExtensionFactory
 
 logger = logging.getLogger(__name__)
@@ -45,7 +44,7 @@ class WidgetCategory(str, enum.Enum):
 
 
 def qtplugin_factory(
-    cls: Type[PyDMWidget],
+    cls: Type[QtWidgets.QWidget],
     is_container: bool = False,
     group: str = "PyDM Widgets",
     extensions: Optional[List[Type]] = None,
@@ -76,7 +75,7 @@ class PyDMDesignerPlugin(QtDesigner.QPyDesignerCustomWidgetPlugin):
 
     def __init__(
         self,
-        cls: Type[PyDMWidget],
+        cls: Type[QtWidgets.QWidget],
         is_container: bool = False,
         group: str = "PyDM Widgets",
         extensions: Optional[List[Type]] = None,
@@ -205,15 +204,15 @@ class PyDMDesignerPlugin(QtDesigner.QPyDesignerCustomWidgetPlugin):
 
 
 def create_designer_widget_from_widget(
-    widget_cls: Type[PyDMWidget],
+    widget_cls: Type[QtWidgets.QWidget],
 ) -> Type[PyDMDesignerPlugin]:
     """
     Get a designable widget class.
 
     Accepts either user-provided :class:`PyDMDesignerPlugin` subclasses or
-    :class:`PyDMWidget` subclasses.
+    :class:`QWidget` subclasses.
 
-    In the case of :class:`PyDMWidget` subclasses, designer-specific settings
+    In the case of :class:`QWidget` subclasses, designer-specific settings
     may be specified on a class attribute.  These arguments should match
     what :func:`qtplugin_factory` expects.
     """
@@ -223,14 +222,14 @@ def create_designer_widget_from_widget(
         )
     if issubclass(widget_cls, PyDMDesignerPlugin):
         return widget_cls
-    if issubclass(widget_cls, PyDMWidget):
+    if issubclass(widget_cls, QtWidgets.QWidget):
         designer_kwargs = getattr(
             widget_cls, "_qt_designer_", None
         ) or {}
         return qtplugin_factory(widget_cls, **designer_kwargs)
 
     raise ValueError(
-        f"Expected a PyDMDesignerPlugin or a PyDMWidget subclass, "
+        f"Expected a PyDMDesignerPlugin or a QWidget subclass, "
         f"got a {type(widget_cls).__name__}"
     )
 

--- a/pydm/widgets/qtplugin_base.py
+++ b/pydm/widgets/qtplugin_base.py
@@ -18,14 +18,24 @@ for each PyDMDesignerPlugin that Qt Designer tries to use. This will not
 affect any of your widgets, but it will be annoying.
 
 """
-from qtpy import QtGui, QtDesigner, QtCore
-from .qtplugin_extensions import PyDMExtensionFactory
-from ..qtdesigner import DesignerHooks
+import enum
+import inspect
+import logging
+from typing import Dict, List, Optional, Type
 
-# TODO: Change to Enum once we drop support
-#       for the almost dead and agonizing Python 2.7
-#       <pitchforks> Death to Python 2.7! </ pitchforks>
-class WidgetCategory(object):
+import entrypoints
+from qtpy import QtCore, QtDesigner, QtGui
+
+from .. import config
+from ..qtdesigner import DesignerHooks
+from ..widgets.base import PyDMWidget
+from .qtplugin_extensions import PyDMExtensionFactory
+
+logger = logging.getLogger(__name__)
+
+
+class WidgetCategory(str, enum.Enum):
+    """Categories for PyDM Widgets in the Qt Designer."""
     CONTAINER = "PyDM Container Widgets"
     DISPLAY = "PyDM Display Widgets"
     INPUT = "PyDM Input Widgets"
@@ -34,8 +44,13 @@ class WidgetCategory(object):
     MISC = "PyDM Misc. Widgets"
 
 
-def qtplugin_factory(cls, is_container=False, group='PyDM Widgets',
-                     extensions=None, icon=None):
+def qtplugin_factory(
+    cls: Type[PyDMWidget],
+    is_container: bool = False,
+    group: str = "PyDM Widgets",
+    extensions: Optional[List[Type]] = None,
+    icon: Optional[QtGui.QIcon] = None
+) -> Type["PyDMDesignerPlugin"]:
     """
     Helper function to create a generic PyDMDesignerPlugin class.
 
@@ -59,8 +74,14 @@ class PyDMDesignerPlugin(QtDesigner.QPyDesignerCustomWidgetPlugin):
     All functions have default returns that can be overriden as necessary.
     """
 
-    def __init__(self, cls, is_container=False, group='PyDM Widgets',
-                 extensions=None, icon=None):
+    def __init__(
+        self,
+        cls: Type[PyDMWidget],
+        is_container: bool = False,
+        group: str = "PyDM Widgets",
+        extensions: Optional[List[Type]] = None,
+        icon: Optional[QtGui.QIcon] = None,
+    ):
         """
         Set up the plugin using the class info in cls
 
@@ -181,3 +202,78 @@ class PyDMDesignerPlugin(QtDesigner.QPyDesignerCustomWidgetPlugin):
         Include the class module for the generated qt code
         """
         return self.cls.__module__
+
+
+def create_designer_widget_from_widget(
+    widget_cls: Type[PyDMWidget],
+) -> Type[PyDMDesignerPlugin]:
+    """
+    Get a designable widget class.
+
+    Accepts either user-provided :class:`PyDMDesignerPlugin` subclasses or
+    :class:`PyDMWidget` subclasses.
+
+    In the case of :class:`PyDMWidget` subclasses, designer-specific settings
+    may be specified on a class attribute.  These arguments should match
+    what :func:`qtplugin_factory` expects.
+    """
+    if not inspect.isclass(widget_cls):
+        raise ValueError(
+            f"Expected a class, got a {type(widget_cls).__name__}"
+        )
+    if issubclass(widget_cls, PyDMDesignerPlugin):
+        return widget_cls
+    if issubclass(widget_cls, PyDMWidget):
+        designer_kwargs = getattr(
+            widget_cls, "_qt_designer_", None
+        ) or {}
+        return qtplugin_factory(widget_cls, **designer_kwargs)
+
+    raise ValueError(
+        f"Expected a PyDMDesignerPlugin or a PyDMWidget subclass, "
+        f"got a {type(widget_cls).__name__}"
+    )
+
+
+def get_widgets_from_entrypoints(
+    key: str = config.ENTRYPOINT_WIDGET
+) -> Dict[str, Type[PyDMDesignerPlugin]]:
+    """
+    Get all widgets from entrypoint definitions.
+
+    Parameters
+    ----------
+    key : str, optional
+        The entrypoint key.  Defaults to ``pydm.config.ENTRYPOINT_WIDGET``.
+
+    Returns
+    -------
+    widgets : dict
+        Dictionary of class name to ``PyDMDesignerPlugin`` subclass.
+    """
+    widgets = {}
+    for entry in entrypoints.get_group_all(key):
+        logger.debug("Found widget from entrypoint: %s", entry.name)
+        try:
+            plugin_cls = entry.load()
+        except Exception as ex:
+            logger.exception(
+                "Failed to load %s entry %s: %s",
+                key, entry.name, ex
+            )
+            continue
+
+        try:
+            designer_widget = create_designer_widget_from_widget(
+                plugin_cls
+            )
+        except Exception:
+            logger.warning(
+                "Invalid widget class specified in entrypoint "
+                "%s: %s",
+                entry.name, plugin_cls
+            )
+        else:
+            widgets[entry.name] = designer_widget
+
+    return widgets

--- a/pydm/widgets/qtplugin_base.py
+++ b/pydm/widgets/qtplugin_base.py
@@ -35,11 +35,17 @@ logger = logging.getLogger(__name__)
 
 class WidgetCategory(str, enum.Enum):
     """Categories for PyDM Widgets in the Qt Designer."""
+    #: Widgets which can contain other widgets.
     CONTAINER = "PyDM Container Widgets"
+    #: Widgets which contain displays.
     DISPLAY = "PyDM Display Widgets"
+    #: Widgets which take user input.
     INPUT = "PyDM Input Widgets"
+    #: Widgets which plot data.
     PLOT = "PyDM Plot Widgets"
+    #: Widgets which draw things.
     DRAWING = "PyDM Drawing Widgets"
+    #: Widgets which don't fit into any other category.
     MISC = "PyDM Misc. Widgets"
 
 
@@ -53,8 +59,22 @@ def qtplugin_factory(
     """
     Helper function to create a generic PyDMDesignerPlugin class.
 
-    :param cls: Widget class
-    :type cls:  QWidget
+    Parameters
+    ----------
+    cls : QWidget subclass
+        The widget class.
+
+    is_container : bool, optional
+        True if this widget can contain other widgets (as in a Frame).
+        This will also affect whether or not the widget can be used as the
+        top-level widget of a display. Defaults to False.
+
+    extensions : list of extension classes, optional
+        Extension classes to use with the widget.
+
+    icon : QtGui.QIcon, optional
+        An icon to use with the widget in the designer.  Consider using
+        the PyDM-provided fontawesome ``ifont`` here for simplicity.
     """
 
     class Plugin(PyDMDesignerPlugin):

--- a/pydm/widgets/qtplugins.py
+++ b/pydm/widgets/qtplugins.py
@@ -5,12 +5,12 @@ from ..utilities.iconfont import IconFont
 from .archiver_time_plot import PyDMArchiverTimePlot
 from .byte import PyDMByteIndicator
 from .checkbox import PyDMCheckbox
-from .datetime import (PyDMDateTimeEdit, PyDMDateTimeLabel)
-from .drawing import (PyDMDrawingLine, PyDMDrawingRectangle,
-                      PyDMDrawingTriangle,
-                      PyDMDrawingEllipse, PyDMDrawingCircle, PyDMDrawingArc,
-                      PyDMDrawingPie, PyDMDrawingChord, PyDMDrawingImage,
-                      PyDMDrawingPolygon, PyDMDrawingPolyline, PyDMDrawingIrregularPolygon)
+from .datetime import PyDMDateTimeEdit, PyDMDateTimeLabel
+from .drawing import (PyDMDrawingArc, PyDMDrawingChord, PyDMDrawingCircle,
+                      PyDMDrawingEllipse, PyDMDrawingImage,
+                      PyDMDrawingIrregularPolygon, PyDMDrawingLine,
+                      PyDMDrawingPie, PyDMDrawingPolygon, PyDMDrawingPolyline,
+                      PyDMDrawingRectangle, PyDMDrawingTriangle)
 from .embedded_display import PyDMEmbeddedDisplay
 from .enum_button import PyDMEnumButton
 from .enum_combo_box import PyDMEnumComboBox
@@ -263,4 +263,5 @@ PyDMTerminatorPlugin = qtplugin_factory(PyDMTerminator,
                                         extensions=BASE_EXTENSIONS)
 
 
+# Add in designer widget plugins from other classes via entrypoints:
 globals().update(**get_widgets_from_entrypoints())

--- a/pydm/widgets/qtplugins.py
+++ b/pydm/widgets/qtplugins.py
@@ -1,19 +1,9 @@
 import logging
 import os
 
-from .qtplugin_base import qtplugin_factory, WidgetCategory
-from .qtplugin_extensions import (
-    ArchiveTimeCurveEditorExtension,
-    BasicSettingsExtension,
-    RulesExtension,
-    ScatterCurveEditorExtension,
-    SymbolExtension,
-    TimeCurveEditorExtension,
-    WaveformCurveEditorExtension,
-)
-from .tab_bar_qtplugin import TabWidgetPlugin
+from ..utilities.iconfont import IconFont
+from .archiver_time_plot import PyDMArchiverTimePlot
 from .byte import PyDMByteIndicator
-
 from .checkbox import PyDMCheckbox
 from .datetime import (PyDMDateTimeEdit, PyDMDateTimeLabel)
 from .drawing import (PyDMDrawingLine, PyDMDrawingRectangle,
@@ -21,7 +11,6 @@ from .drawing import (PyDMDrawingLine, PyDMDrawingRectangle,
                       PyDMDrawingEllipse, PyDMDrawingCircle, PyDMDrawingArc,
                       PyDMDrawingPie, PyDMDrawingChord, PyDMDrawingImage,
                       PyDMDrawingPolygon, PyDMDrawingPolyline, PyDMDrawingIrregularPolygon)
-
 from .embedded_display import PyDMEmbeddedDisplay
 from .enum_button import PyDMEnumButton
 from .enum_combo_box import PyDMEnumComboBox
@@ -31,27 +20,33 @@ from .label import PyDMLabel
 from .line_edit import PyDMLineEdit
 from .logdisplay import PyDMLogDisplay
 from .pushbutton import PyDMPushButton
+from .qtplugin_base import (WidgetCategory, get_widgets_from_entrypoints,
+                            qtplugin_factory)
+from .qtplugin_extensions import (ArchiveTimeCurveEditorExtension,
+                                  BasicSettingsExtension, RulesExtension,
+                                  ScatterCurveEditorExtension, SymbolExtension,
+                                  TimeCurveEditorExtension,
+                                  WaveformCurveEditorExtension)
 from .related_display_button import PyDMRelatedDisplayButton
+from .scale import PyDMScaleIndicator
+from .scatterplot import PyDMScatterPlot
 from .shell_command import PyDMShellCommand
 from .slider import PyDMSlider
 from .spinbox import PyDMSpinbox
 from .symbol import PyDMSymbol
-from .waveformtable import PyDMWaveformTable
-from .scale import PyDMScaleIndicator
-from .timeplot import PyDMTimePlot
-from .archiver_time_plot import PyDMArchiverTimePlot
-from .waveformplot import PyDMWaveformPlot
-from .scatterplot import PyDMScatterPlot
+from .tab_bar_qtplugin import TabWidgetPlugin
 from .template_repeater import PyDMTemplateRepeater
 from .terminator import PyDMTerminator
-
-from ..utilities.iconfont import IconFont
+from .timeplot import PyDMTimePlot
+from .waveformplot import PyDMWaveformPlot
+from .waveformtable import PyDMWaveformTable
 
 logger = logging.getLogger(__name__)
 
 ifont = IconFont()
 
 BASE_EXTENSIONS = [BasicSettingsExtension, RulesExtension]
+
 
 # Label plugin
 PyDMLabelPlugin = qtplugin_factory(PyDMLabel, group=WidgetCategory.DISPLAY,
@@ -266,3 +261,6 @@ PyDMTemplateRepeaterPlugin = qtplugin_factory(PyDMTemplateRepeater,
 PyDMTerminatorPlugin = qtplugin_factory(PyDMTerminator,
                                         group=WidgetCategory.MISC,
                                         extensions=BASE_EXTENSIONS)
+
+
+globals().update(**get_widgets_from_entrypoints())

--- a/pydm/widgets/qtplugins.py
+++ b/pydm/widgets/qtplugins.py
@@ -262,6 +262,9 @@ PyDMTerminatorPlugin = qtplugin_factory(PyDMTerminator,
                                         group=WidgetCategory.MISC,
                                         extensions=BASE_EXTENSIONS)
 
+# **********************************************
+# NOTE: Add in new PyDM widgets above this line.
+# **********************************************
 
 # Add in designer widget plugins from other classes via entrypoints:
 globals().update(**get_widgets_from_entrypoints())


### PR DESCRIPTION
## Purpose

Add support for designable widget entrypoints. 

This means that PyDM-related packages which provide designable widgets no longer need to include their own activation scripts, assuming PyDM itself is configured appropriately.

Closes #848 

Example PR from typhos showing all that can be removed: https://github.com/pcdshub/typhos/pull/491

## Note

I have pre-commit configured and inadvertently ran `isort` on plugins.py. I can revert that, if need be.