### PR TITLE
WIP/BLD: Unpin the version of PyQt5

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -17,7 +17,7 @@ requirements:
     - python
     - pip
     - setuptools
-    - pyqt >=5,<5.15
+    - pyqt >=5
     - qtpy
   run:
     - python
@@ -26,7 +26,7 @@ requirements:
     - scipy
     - pyepics
     - requests
-    - pyqt >=5,<5.15
+    - pyqt >=5
     - pyqtgraph
     - qtpy
     - entrypoints


### PR DESCRIPTION
Undoes the pin in #849 for testing with the newer version of PyQt5. Want to trigger another CI run after the fix in #860. Will also want to test functionality outside of the test suite before merging this.