### PR TITLE
ENH: add pyepics callback in background thread

### DIFF
--- a/pydm/data_plugins/epics_plugins/pyepics_plugin_component.py
+++ b/pydm/data_plugins/epics_plugins/pyepics_plugin_component.py
@@ -1,5 +1,6 @@
 import atexit
 import logging
+import sys
 from concurrent.futures import ThreadPoolExecutor
 
 import epics
@@ -29,7 +30,10 @@ float_types = set((epics.dbr.CTRL_FLOAT, epics.dbr.FLOAT, epics.dbr.TIME_FLOAT,
 
 
 thread_pool = ThreadPoolExecutor()
-atexit.register(thread_pool.shutdown, wait=False, cancel_futures=True)
+if sys.version_info >= (3, 9):
+    atexit.register(thread_pool.shutdown, wait=False, cancel_futures=True)
+else:
+    atexit.register(thread_pool.shutdown, wait=False)
 
 
 class Connection(PyDMConnection):

--- a/pydm/data_plugins/epics_plugins/pyepics_plugin_component.py
+++ b/pydm/data_plugins/epics_plugins/pyepics_plugin_component.py
@@ -1,6 +1,6 @@
 import atexit
 import logging
-from multiprocessing.pool import ThreadPool
+from concurrent.futures import ThreadPoolExecutor
 
 import epics
 import numpy as np
@@ -28,8 +28,8 @@ float_types = set((epics.dbr.CTRL_FLOAT, epics.dbr.FLOAT, epics.dbr.TIME_FLOAT,
                    epics.dbr.CTRL_DOUBLE, epics.dbr.DOUBLE, epics.dbr.TIME_DOUBLE))
 
 
-thread_pool = ThreadPool(4)
-atexit.register(thread_pool.terminate)
+thread_pool = ThreadPoolExecutor()
+atexit.register(thread_pool.shutdown, wait=False, cancel_futures=True)
 
 
 class Connection(PyDMConnection):
@@ -52,7 +52,7 @@ class Connection(PyDMConnection):
         self._upper_warning_limit = None
         self._lower_warning_limit = None
 
-        thread_pool.apply_async(self.setup_callbacks, args=(channel,))
+        thread_pool.submit(self.setup_callbacks, channel)
 
     def setup_callbacks(self, channel):
         use_initial_context()

--- a/pydm/data_plugins/epics_plugins/pyepics_plugin_component.py
+++ b/pydm/data_plugins/epics_plugins/pyepics_plugin_component.py
@@ -33,9 +33,6 @@ class Connection(PyDMConnection):
         self.pv = epics.PV(pv, connection_callback=self.send_connection_state,
                            form='ctrl', auto_monitor=epics.dbr.DBE_VALUE|epics.dbr.DBE_ALARM|epics.dbr.DBE_PROPERTY,
                            access_callback=self.send_access_state)
-        thread = CAThread(target=self.setup_callbacks, args=(channel,))
-        thread.start()
-
         self._value = None
         self._severity = None
         self._precision = None
@@ -47,6 +44,9 @@ class Connection(PyDMConnection):
         self._lower_alarm_limit = None
         self._upper_warning_limit = None
         self._lower_warning_limit = None
+
+        thread = CAThread(target=self.setup_callbacks, args=(channel,))
+        thread.start()
 
     def setup_callbacks(self, channel):
         self.pv.add_callback(self.send_new_value, with_ctrlvars=True)


### PR DESCRIPTION
Simple idea I had while ruminating over this slack thread: https://slac.slack.com/archives/C6B8GRCPQ/p1652395534927249

Since this can block up to 5 seconds, just do it in a thread maybe?
Does this have any terrible downstream effects? I'm not sure, but my uis are opening notably faster.