### PR TITLE
ENH: Add monitoring of alarm limits to the PyCA based data plugin

### DIFF
--- a/azure-test-template-win.yml
+++ b/azure-test-template-win.yml
@@ -60,7 +60,7 @@ jobs:
 
   - script: |
       call activate test-environment-$(python_name)
-      python run_tests.py --timeout 30 --show-cov --test-run-title="Tests for $(Agent.OS) - Python $(python)" --ignore=pydm/tests/data_plugins/test_psp_plugin_component.py --napoleon-docstrings
+      python run_tests.py --timeout 30 --show-cov --test-run-title="Tests for $(Agent.OS) - Python $(python)" --napoleon-docstrings
     displayName: 'Tests - Run'
     continueOnError: false
 

--- a/azure-test-template-win.yml
+++ b/azure-test-template-win.yml
@@ -47,7 +47,7 @@ jobs:
 
   - script: |
       call activate test-environment-$(python_name)
-      conda install python=$(python) pytest-azurepipelines pydm --file dev-requirements.txt --update-deps
+      conda install python=$(python) pytest-azurepipelines pydm --file windows-dev-requirements.txt --update-deps
     displayName: 'Anaconda - Install Dependencies'
 
   - script: |
@@ -60,7 +60,7 @@ jobs:
 
   - script: |
       call activate test-environment-$(python_name)
-      python run_tests.py --timeout 30 --show-cov --test-run-title="Tests for $(Agent.OS) - Python $(python)" --napoleon-docstrings
+      python run_tests.py --timeout 30 --show-cov --test-run-title="Tests for $(Agent.OS) - Python $(python)" --ignore=pydm/tests/data_plugins/test_psp_plugin_component.py --napoleon-docstrings
     displayName: 'Tests - Run'
     continueOnError: false
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,3 +3,4 @@ pytest>=3.6
 pytest-qt
 pytest-cov
 pytest-timeout
+pyca

--- a/pydm/data_plugins/epics_plugins/psp_plugin_component.py
+++ b/pydm/data_plugins/epics_plugins/psp_plugin_component.py
@@ -251,67 +251,75 @@ class Connection(PyDMConnection):
 
         try:
             prec = self.pv.data['precision']
+        except KeyError:
+            pass
+        else:
             if self.prec != prec:
                 self.prec = prec
                 self.prec_signal.emit(int(self.prec))
-        except KeyError:
-            pass
 
         try:
             units = self.pv.data['units']
+        except KeyError:
+            pass
+        else:
             if self.units != units:
                 self.units = units
                 self.unit_signal.emit(self.units.decode(encoding='ascii') if isinstance(self.units, bytes) else self.units)
-        except KeyError:
-            pass
 
         try:
             ctrl_llim = self.pv.data['ctrl_llim']
+        except KeyError:
+            pass
+        else:
             if self.ctrl_llim != ctrl_llim:
                 self.ctrl_llim = ctrl_llim
                 self.lower_ctrl_limit_signal.emit(self.ctrl_llim)
-        except KeyError:
-            pass
 
         try:
             ctrl_hlim = self.pv.data['ctrl_hlim']
+        except KeyError:
+            pass
+        else:
             if self.ctrl_hlim != ctrl_hlim:
                 self.ctrl_hlim = ctrl_hlim
                 self.upper_ctrl_limit_signal.emit(self.ctrl_hlim)
-        except KeyError:
-            pass
 
         try:
             alarm_hlim = self.pv.data['alarm_hlim']
+        except KeyError:
+            pass
+        else:
             if self.alarm_hlim != alarm_hlim:
                 self.alarm_hlim = alarm_hlim
                 self.upper_alarm_limit_signal.emit(self.alarm_hlim)
-        except KeyError:
-            pass
 
         try:
             alarm_llim = self.pv.data['alarm_llim']
+        except KeyError:
+            pass
+        else:
             if self.alarm_llim != alarm_llim:
                 self.alarm_llim = alarm_llim
                 self.lower_alarm_limit_signal.emit(self.alarm_llim)
-        except KeyError:
-            pass
 
         try:
             warn_hlim = self.pv.data['warn_hlim']
+        except KeyError:
+            pass
+        else:
             if self.warn_hlim != warn_hlim:
                 self.warn_hlim = warn_hlim
                 self.upper_warning_limit_signal.emit(self.warn_hlim)
-        except KeyError:
-            pass
 
         try:
             warn_llim = self.pv.data['warn_llim']
+        except KeyError:
+            pass
+        else:
             if self.warn_llim != warn_llim:
                 self.warn_llim = warn_llim
                 self.lower_warning_limit_signal.emit(self.warn_llim)
-        except KeyError:
-            pass
 
         if self.count > 1:
             self.new_value_signal[np.ndarray].emit(value)

--- a/pydm/data_plugins/epics_plugins/psp_plugin_component.py
+++ b/pydm/data_plugins/epics_plugins/psp_plugin_component.py
@@ -336,7 +336,7 @@ class Connection(PyDMConnection):
                 self.prec = self.pv.data['precision']
             except KeyError:
                 pass
-        if self.prec:
+        if self.prec is not None:
             self.prec_signal.emit(int(self.prec))
 
         if self.units is None:
@@ -354,7 +354,7 @@ class Connection(PyDMConnection):
                 self.ctrl_llim = self.pv.data['ctrl_llim']
             except KeyError:
                 pass
-        if self.ctrl_llim:
+        if self.ctrl_llim is not None:
             self.lower_ctrl_limit_signal.emit(self.ctrl_llim)
 
         if self.ctrl_hlim is None:
@@ -362,7 +362,7 @@ class Connection(PyDMConnection):
                 self.ctrl_hlim = self.pv.data['ctrl_hlim']
             except KeyError:
                 pass
-        if self.ctrl_hlim:
+        if self.ctrl_hlim is not None:
             self.upper_ctrl_limit_signal.emit(self.ctrl_hlim)
 
         if self.alarm_hlim is None:
@@ -370,7 +370,7 @@ class Connection(PyDMConnection):
                 self.alarm_hlim = self.pv.data['alarm_hlim']
             except KeyError:
                 pass
-        if self.alarm_hlim:
+        if self.alarm_hlim is not None:
             self.upper_alarm_limit_signal.emit(self.alarm_hlim)
 
         if self.alarm_llim is None:
@@ -378,7 +378,7 @@ class Connection(PyDMConnection):
                 self.alarm_llim = self.pv.data['alarm_llim']
             except KeyError:
                 pass
-        if self.alarm_llim:
+        if self.alarm_llim is not None:
             self.lower_alarm_limit_signal.emit(self.alarm_llim)
 
         if self.warn_hlim is None:
@@ -386,7 +386,7 @@ class Connection(PyDMConnection):
                 self.warn_hlim = self.pv.data['warn_hlim']
             except KeyError:
                 pass
-        if self.warn_hlim:
+        if self.warn_hlim is not None:
             self.upper_warning_limit_signal.emit(self.warn_hlim)
 
         if self.warn_llim is None:
@@ -394,7 +394,7 @@ class Connection(PyDMConnection):
                 self.warn_llim = self.pv.data['warn_llim']
             except KeyError:
                 pass
-        if self.warn_llim:
+        if self.warn_llim is not None:
             self.lower_warning_limit_signal.emit(self.warn_llim)
 
     def send_connection_state(self, conn=None):

--- a/pydm/data_plugins/epics_plugins/psp_plugin_component.py
+++ b/pydm/data_plugins/epics_plugins/psp_plugin_component.py
@@ -106,7 +106,7 @@ def setup_pv(pvname, con_cb=None, mon_cb=None, rwaccess_cb=None, signal=None, mo
     :type mon_cb_once: bool
     :rtype: Pv
     """
-    pv = Pv(pvname, use_numpy=True)
+    pv = Pv(pvname, use_numpy=True, control=True)
 
     if signal is None:
         default_mon_cb = lambda e: None
@@ -148,6 +148,11 @@ class Connection(PyDMConnection):
         self.sevr = None
         self.ctrl_llim = None
         self.ctrl_hlim = None
+        self.alarm_hlim = None
+        self.alarm_llim = None
+        self.warn_hlim = None
+        self.warn_llim = None
+
         self.units = None
         self.prec = None
         self.count = None
@@ -264,12 +269,44 @@ class Connection(PyDMConnection):
                 self.lower_ctrl_limit_signal.emit(self.ctrl_llim)
         except KeyError:
             pass
-        
+
         try:
             ctrl_hlim = self.pv.data['ctrl_hlim']
             if self.ctrl_hlim != ctrl_hlim:
                 self.ctrl_hlim = ctrl_hlim
                 self.upper_ctrl_limit_signal.emit(self.ctrl_hlim)
+        except KeyError:
+            pass
+
+        try:
+            alarm_hlim = self.pv.data['alarm_hlim']
+            if self.alarm_hlim != alarm_hlim:
+                self.alarm_hlim = alarm_hlim
+                self.upper_alarm_limit_signal.emit(self.alarm_hlim)
+        except KeyError:
+            pass
+
+        try:
+            alarm_llim = self.pv.data['alarm_llim']
+            if self.alarm_llim != alarm_llim:
+                self.alarm_llim = alarm_llim
+                self.lower_alarm_limit_signal.emit(self.alarm_llim)
+        except KeyError:
+            pass
+
+        try:
+            warn_hlim = self.pv.data['warn_hlim']
+            if self.warn_hlim != warn_hlim:
+                self.warn_hlim = warn_hlim
+                self.upper_warning_limit_signal.emit(self.warn_hlim)
+        except KeyError:
+            pass
+
+        try:
+            warn_llim = self.pv.data['warn_llim']
+            if self.warn_llim != warn_llim:
+                self.warn_llim = warn_llim
+                self.lower_warning_limit_signal.emit(self.warn_llim)
         except KeyError:
             pass
 
@@ -298,7 +335,7 @@ class Connection(PyDMConnection):
                 pass
         if self.prec:
             self.prec_signal.emit(int(self.prec))
-            
+
         if self.units is None:
             try:
                 self.units = self.pv.data['units']
@@ -316,7 +353,7 @@ class Connection(PyDMConnection):
                 pass
         if self.ctrl_llim:
             self.lower_ctrl_limit_signal.emit(self.ctrl_llim)
-            
+
         if self.ctrl_hlim is None:
             try:
                 self.ctrl_hlim = self.pv.data['ctrl_hlim']
@@ -324,6 +361,38 @@ class Connection(PyDMConnection):
                 pass
         if self.ctrl_hlim:
             self.upper_ctrl_limit_signal.emit(self.ctrl_hlim)
+
+        if self.alarm_hlim is None:
+            try:
+                self.alarm_hlim = self.pv.data['alarm_hlim']
+            except KeyError:
+                pass
+        if self.alarm_hlim:
+            self.upper_alarm_limit_signal.emit(self.alarm_hlim)
+
+        if self.alarm_llim is None:
+            try:
+                self.alarm_llim = self.pv.data['alarm_llim']
+            except KeyError:
+                pass
+        if self.alarm_llim:
+            self.lower_alarm_limit_signal.emit(self.alarm_llim)
+
+        if self.warn_hlim is None:
+            try:
+                self.warn_hlim = self.pv.data['warn_hlim']
+            except KeyError:
+                pass
+        if self.warn_hlim:
+            self.upper_warning_limit_signal.emit(self.warn_hlim)
+
+        if self.warn_llim is None:
+            try:
+                self.warn_llim = self.pv.data['warn_llim']
+            except KeyError:
+                pass
+        if self.warn_llim:
+            self.lower_warning_limit_signal.emit(self.warn_llim)
 
     def send_connection_state(self, conn=None):
         """
@@ -410,7 +479,7 @@ class Connection(PyDMConnection):
         """
         try:
             scan = scan_list[self.scan_pv.value]
-        except:
+        except Exception:
             scan = float("inf")
         if 0 < refresh_rate < 1 / scan:
             self.pv.monitor_stop()

--- a/pydm/data_plugins/epics_plugins/psp_plugin_component.py
+++ b/pydm/data_plugins/epics_plugins/psp_plugin_component.py
@@ -84,7 +84,7 @@ def generic_mon_cb(source, signal):
     return cb
 
 
-def setup_pv(pvname, con_cb=None, mon_cb=None, rwaccess_cb=None, signal=None, mon_cb_once=False):
+def setup_pv(pvname, con_cb=None, mon_cb=None, rwaccess_cb=None, signal=None, mon_cb_once=False, control=False):
     """
     Initialize an EPICS PV using psp with proper callbacks.
 
@@ -104,9 +104,11 @@ def setup_pv(pvname, con_cb=None, mon_cb=None, rwaccess_cb=None, signal=None, mo
     :type signal:  Signal
     :param mon_cb_once: True if we only want the monitor callback to run once.
     :type mon_cb_once: bool
+    :param control: True if we want to monitor control values
+    :type control: bool
     :rtype: Pv
     """
-    pv = Pv(pvname, use_numpy=True, control=True)
+    pv = Pv(pvname, use_numpy=True, control=control)
 
     if signal is None:
         default_mon_cb = lambda e: None
@@ -143,7 +145,8 @@ class Connection(PyDMConnection):
         self.pv = setup_pv(pv,
                            con_cb=self.connected_cb,
                            mon_cb=self.monitor_cb,
-                           rwaccess_cb=self.rwaccess_cb)
+                           rwaccess_cb=self.rwaccess_cb,
+                           control=True)
         self.enums = None
         self.sevr = None
         self.ctrl_llim = None

--- a/pydm/tests/conftest.py
+++ b/pydm/tests/conftest.py
@@ -1,11 +1,8 @@
 # coding: utf-8
 # Fixtures for PyDM Unit Tests
 
-import pytest
-
-from pytestqt.qt_compat import qt_api
-
 import numpy as np
+import pytest
 import tempfile
 import logging
 

--- a/pydm/tests/conftest.py
+++ b/pydm/tests/conftest.py
@@ -51,9 +51,11 @@ class ConnectionSignals(QObject):
     def __init__(self):
         super(ConnectionSignals, self).__init__()
         self._value = None
+        self._received_values = {}
 
     def reset(self):
         self._value = None
+        self._received_values = None
 
     @property
     def value(self):
@@ -80,6 +82,23 @@ class ConnectionSignals(QObject):
             The value received from a PyDM widget
         """
         self._value = val
+
+    @Slot(object)
+    def receive_value(self, name: str, value: object) -> None:
+        """
+        Slot for receiving a value from a signal.
+
+        Parameters
+        ----------
+        name : str
+            Name to associate with the value received
+        value : object
+            The value that was sent by the signal
+        """
+        self._received_values[name] = value
+
+    def __getitem__(self, name):
+        return self._received_values[name]
 
 
 @pytest.fixture(scope="function")

--- a/pydm/tests/conftest.py
+++ b/pydm/tests/conftest.py
@@ -52,7 +52,7 @@ class ConnectionSignals(QObject):
 
     def reset(self):
         self._value = None
-        self._received_values = None
+        self._received_values.clear()
 
     @property
     def value(self):

--- a/pydm/tests/data_plugins/test_psp_plugin_component.py
+++ b/pydm/tests/data_plugins/test_psp_plugin_component.py
@@ -1,0 +1,65 @@
+import functools
+import pydm.data_plugins.epics_plugins.psp_plugin_component
+from pydm.data_plugins.epics_plugins.psp_plugin_component import Connection
+from pydm.tests.conftest import ConnectionSignals
+from pydm.widgets.channel import PyDMChannel
+from pytest import MonkeyPatch
+
+
+class MockPV:
+    """ A simple mock of the psp Pv object """
+    def __init__(self):
+        self.data = {}
+
+    @staticmethod
+    def severity(self):
+        return None
+
+
+def test_update_ctrl_vars(monkeypatch: MonkeyPatch, signals: ConnectionSignals):
+    """ Invoke our callback for updating the control values for a PV as if we had a monitor on it. Verify
+        that the signals sent are received as expected.
+    """
+    # Initialize a mock channel and connection for testing
+    mock_channel = PyDMChannel()
+    mock_pv = MockPV()
+    monkeypatch.setattr(pydm.data_plugins.epics_plugins.psp_plugin_component,
+                        'setup_pv',
+                        lambda *args, **kwargs: mock_pv)
+    monkeypatch.setattr(Connection, 'add_listener', lambda *args, **kwargs: None)
+    psp_connection = Connection(mock_channel, 'Test:PV:1')
+    psp_connection.count = 1
+
+    # Create some control values for our PV as if we had received them using psp
+    mock_pv.data['precision'] = 3
+    mock_pv.data['units'] = 'mV'
+    mock_pv.data['ctrl_llim'] = 5.5
+    mock_pv.data['ctrl_hlim'] = 30.5
+    mock_pv.data['alarm_hlim'] = 28
+    mock_pv.data['alarm_llim'] = 8
+    mock_pv.data['warn_hlim'] = 22.5
+    mock_pv.data['warn_llim'] = 10.25
+
+    # Connect the signals to a slot that allows us to inspect the value received
+    psp_connection.new_value_signal[float].connect(lambda: None)  # Only testing control variables here
+    psp_connection.prec_signal.connect(functools.partial(signals.receive_value, 'precision'))
+    psp_connection.unit_signal.connect(functools.partial(signals.receive_value, 'units'))
+    psp_connection.lower_ctrl_limit_signal.connect(functools.partial(signals.receive_value, 'ctrl_llim'))
+    psp_connection.upper_ctrl_limit_signal.connect(functools.partial(signals.receive_value, 'ctrl_hlim'))
+    psp_connection.upper_alarm_limit_signal.connect(functools.partial(signals.receive_value, 'alarm_hlim'))
+    psp_connection.lower_alarm_limit_signal.connect(functools.partial(signals.receive_value, 'alarm_llim'))
+    psp_connection.upper_warning_limit_signal.connect(functools.partial(signals.receive_value, 'warn_hlim'))
+    psp_connection.lower_warning_limit_signal.connect(functools.partial(signals.receive_value, 'warn_llim'))
+
+    psp_connection.python_type = float
+    psp_connection.send_new_value(10.0)
+
+    # Verify all the signals were emitted as expected
+    assert signals['precision'] == 3
+    assert signals['units'] == 'mV'
+    assert signals['ctrl_llim'] == 5.5
+    assert signals['ctrl_hlim'] == 30.5
+    assert signals['alarm_hlim'] == 28
+    assert signals['alarm_llim'] == 8
+    assert signals['warn_hlim'] == 22.5
+    assert signals['warn_llim'] == 10.25

--- a/pydm/tests/data_plugins/test_psp_plugin_component.py
+++ b/pydm/tests/data_plugins/test_psp_plugin_component.py
@@ -6,6 +6,8 @@ from pydm.widgets.channel import PyDMChannel
 from pytest import MonkeyPatch
 
 
+# Note: This test cannot be run on any Windows OS as a build of PyCA is not available there
+
 class MockPV:
     """ A simple mock of the psp Pv object """
     def __init__(self):

--- a/run_tests.py
+++ b/run_tests.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+import os
 import sys
 import pytest
 
@@ -15,6 +16,10 @@ if __name__ == '__main__':
     if '--show-cov' in args:
         args.extend(['--cov=pydm', '--cov-report', 'term-missing'])
         args.remove('--show-cov')
+
+    # Exclude tests that don't run on Windows since a Windows compatible of PyCA does not currently exist
+    if os.name == 'nt':
+        args.append('--ignore=pydm/tests/data_plugins/test_psp_plugin_component.py')
 
     print('pytest arguments: {}'.format(args))
 

--- a/windows-dev-requirements.txt
+++ b/windows-dev-requirements.txt
@@ -1,0 +1,5 @@
+codecov
+pytest>=3.6
+pytest-qt
+pytest-cov
+pytest-timeout


### PR DESCRIPTION
## Description

This includes the alarm limit monitoring added here: #847 to the `psp_plugin_component`. It's mostly the same, but one thing to point out is that I've updated the creation of the psp Pv object to use` control=True`. This change was needed to actually get updates to control values to be sent to the widgets. This does cause the loss of timestamp data, but since we currently aren't doing anything with it in this plugin, no functionality should change.

## Testing

Added a test case to confirm all the signals are being sent correctly. Verified that a label widget received updates to the alarm limits as expected.