### PR TITLE
FIX: Don't add an extra axis when creating plots through designer

### DIFF
--- a/pydm/widgets/baseplot.py
+++ b/pydm/widgets/baseplot.py
@@ -640,8 +640,11 @@ class BasePlot(PlotWidget, PyDMPrimitiveWidget):
         self._curves.append(plot_data_item)
 
         if y_axis_name is None:
-            # If the user did not name the axis, use the pyqtgraph default one named left
-            if 'left' not in self.plotItem.axes:
+            if utilities.is_qt_designer():
+                # If we are just in designer, add an axis that will not conflict with the pyqtgraph default
+                self.addAxis(plot_data_item=plot_data_item, name='Axis 1', orientation='left')
+            # If not in designer and the user did not name the axis, use the pyqtgraph default one named left
+            elif 'left' not in self.plotItem.axes:
                 self.addAxis(plot_data_item=plot_data_item, name='left', orientation='left')
             else:
                 self.plotItem.linkDataToAxis(plot_data_item, 'left')


### PR DESCRIPTION
Fixes an issue in the qt designer flow only where an extra axis will be created even when not asked for. It can be easily removed but is really annoying.

Current behavior: Create any type of plot, add a curve to it, notice that two left axes will show up.

After this fix: Only the one asked for will show up.