### PR TITLE
Reduce the default plotting rate for PyDM plots

### DIFF
--- a/pydm/tests/widgets/test_baseplot.py
+++ b/pydm/tests/widgets/test_baseplot.py
@@ -84,7 +84,7 @@ def test_baseplot_construct(qtbot):
     assert base_plot.getShowXGrid() is False
     assert base_plot.getShowYGrid() is False
     assert isinstance(base_plot.redraw_timer, QTimer)
-    assert base_plot._redraw_rate == 30
+    assert base_plot._redraw_rate == 1
     assert base_plot.maxRedrawRate == base_plot._redraw_rate
     assert len(base_plot._curves) == 0
     assert base_plot._title is None

--- a/pydm/widgets/baseplot.py
+++ b/pydm/widgets/baseplot.py
@@ -569,7 +569,7 @@ class BasePlot(PlotWidget, PyDMPrimitiveWidget):
         self.redraw_timer = QTimer(self)
         self.redraw_timer.timeout.connect(self.redrawPlot)
 
-        self._redraw_rate = 30  # Redraw at 30 Hz by default.
+        self._redraw_rate = 1  # Redraw at 1 Hz by default.
         self.maxRedrawRate = self._redraw_rate
         self._axes = []
         self._curves = []

--- a/pydm/widgets/timeplot.py
+++ b/pydm/widgets/timeplot.py
@@ -20,12 +20,11 @@ DEFAULT_X_MIN = -30
 DEFAULT_Y_MIN = 0
 
 DEFAULT_TIME_SPAN = 5.0
-DEFAULT_UPDATE_INTERVAL = 100
+DEFAULT_UPDATE_INTERVAL = 1000  # Plot update rate for fixed rate mode in milliseconds
+
 
 class updateMode(object):
-    '''
-    updateMode as new type for plot update
-    '''
+    """ updateMode as new type for plot update """
     OnValueChange = 1
     AtFixedRate = 2
 


### PR DESCRIPTION
## Description

Reduces the default redraw rate from 30 Hz to 1 Hz for all plots. Reduces the default update rate of time plots in fixed rate mode from 10 Hz to 1 Hz. This will lead to better performance for plot heavy PyDM applications that are just being left to default values even if they don't need that fast of redraw/update rate. 

Both of these options are user-configurable either in designer or through python code. Will make sure a section is added to the release notes pointing out this change to the default rate, and letting users know they can update to a faster rate if needed.

## Testing

Verified that the plots are redrawing at the slower rate, and that time plots are updating at the slower rate in fixed rate mode. Verified that CPU load was reduced in test applications with many plots.