### PR TITLE
FIX: do not create QIcons on import

### DIFF
--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -140,8 +140,6 @@ class PyDMPrimitiveWidget(object):
         'Opacity': ['set_opacity', float]
     }
 
-    designer_icon = QIcon()
-
     def __init__(self, **kwargs):
         self.app = QApplication.instance()
         self._rules = None
@@ -150,6 +148,11 @@ class PyDMPrimitiveWidget(object):
             # We should  install the Event Filter only if we are running
             # and not at the Designer
             self.installEventFilter(self)
+
+    @staticmethod
+    def get_designer_icon():
+        """Icon for usage in Qt designer."""
+        return QIcon()
 
     def eventFilter(self, obj, event):
         """

--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -29,21 +29,22 @@ except NameError:
     str_types = (str,)
 
 
-def get_icon_file(name):
+def get_icon_file(name: str) -> str:
     """
-    Returns the full path to the icon represented by name.
+    Returns the absolute path to the icon filename provided.
 
     Parameters
     ----------
     name : str
-        The filename to load the file path.
+        The filename of the icon, relative to ``pydm.icons``.
 
     Returns
     -------
     str
+        The absolute path to the icon file.
     """
     base_path = os.path.dirname(os.path.realpath(__file__))
-    icon_path = os.path.join(base_path, "icons", "terminator.png")
+    icon_path = os.path.join(base_path, "icons", name)
     return icon_path
 
 

--- a/pydm/widgets/qtplugin_base.py
+++ b/pydm/widgets/qtplugin_base.py
@@ -117,7 +117,10 @@ class PyDMDesignerPlugin(QtDesigner.QPyDesignerCustomWidgetPlugin):
         if icon is None and get_designer_icon is not None:
             icon = get_designer_icon()
 
-        self._icon = icon or QtGui.QIcon()
+        if icon is None and QtWidgets.QApplication.instance() is not None:
+            icon = QtGui.QIcon()
+
+        self._icon = icon
         self.extensions = extensions
         self.manager = None
 

--- a/pydm/widgets/qtplugin_base.py
+++ b/pydm/widgets/qtplugin_base.py
@@ -113,12 +113,13 @@ class PyDMDesignerPlugin(QtDesigner.QPyDesignerCustomWidgetPlugin):
         self.cls = cls
         self._group = group
 
-        get_designer_icon = getattr(cls, "get_designer_icon", None)
-        if icon is None and get_designer_icon is not None:
-            icon = get_designer_icon()
-
         if icon is None and QtWidgets.QApplication.instance() is not None:
-            icon = QtGui.QIcon()
+            get_designer_icon = getattr(cls, "get_designer_icon", None)
+            if get_designer_icon is not None:
+                icon = get_designer_icon()
+
+            if icon is None:
+                icon = QtGui.QIcon()
 
         self._icon = icon
         self.extensions = extensions

--- a/pydm/widgets/qtplugin_base.py
+++ b/pydm/widgets/qtplugin_base.py
@@ -112,8 +112,11 @@ class PyDMDesignerPlugin(QtDesigner.QPyDesignerCustomWidgetPlugin):
         self.is_container = is_container
         self.cls = cls
         self._group = group
-        if not icon:
-            icon = getattr(cls, "designer_icon", None)
+
+        get_designer_icon = getattr(cls, "get_designer_icon", None)
+        if icon is None and get_designer_icon is not None:
+            icon = get_designer_icon()
+
         self._icon = icon or QtGui.QIcon()
         self.extensions = extensions
         self.manager = None

--- a/pydm/widgets/terminator.py
+++ b/pydm/widgets/terminator.py
@@ -18,7 +18,6 @@ class PyDMTerminator(QLabel, PyDMPrimitiveWidget):
     """
     A watchdog widget to close a window after X seconds of inactivity.
     """
-    designer_icon = QIcon(get_icon_file("terminator.png"))
 
     def __init__(self, parent=None, timeout=60, *args, **kwargs):
         super(PyDMTerminator, self).__init__(parent=parent, *args, **kwargs)
@@ -40,6 +39,11 @@ class PyDMTerminator(QLabel, PyDMPrimitiveWidget):
 
         self._setup_activity_hook()
         self._update_label()
+
+    @staticmethod
+    def get_designer_icon():
+        """Icon for usage in Qt designer."""
+        return QIcon(get_icon_file("terminator.png"))
 
     def _find_window(self):
         """


### PR DESCRIPTION
## Bug

With PyDM master, try the following:
```bash
$ python -c "import pydm.widgets.terminator"
QPixmap: Must construct a QGuiApplication before a QPixmap
Aborted
```

```bash
$ python -c "import pydm.widgets.qtplugins"
QPixmap: Must construct a QGuiApplication before a QPixmap
Aborted
```

I think it's not controversial to say that importing _any_ module in Python should not cause a segfault based on some assumption about what was imported before it (or otherwise, for that matter).  So I investigated what could be done to avoid creating `QIcon` instances on import.

## Proposed fix
* Do not create `QIcon` instances on import
* Instead, tweak the API to optionally have a `get_designer_icon` static (or class) method
* Fallback for all widgets remains an empty `QIcon`
* Adjust `IconFont` to only load fonts if a QApplication is available such that `pydm.widgets.qtplugins` can be imported

If the pydm developers have a preference as to how to handle the situation differently than the above, I'm happy to adjust these. This was a first-pass attempt at getting them to import - and it does work, at least!