### PR TITLE
Add directory of imported module to sys.path

### DIFF
--- a/pydm/utilities/__init__.py
+++ b/pydm/utilities/__init__.py
@@ -451,6 +451,10 @@ def import_module_by_filename(
     module : types.ModuleType
         The imported module.
     """
+    module_dir = os.path.dirname(os.path.abspath(source_filename))
+    if module_dir not in sys.path:
+        sys.path.append(module_dir)
+
     module_name = str(uuid.uuid4())
     spec = importlib.util.spec_from_file_location(module_name, source_filename)
     module = importlib.util.module_from_spec(spec)


### PR DESCRIPTION
``import_module_by_filename`` is having trouble importing files that contain imports of modules that are just files that live in the same directory as ``source_filename``. It results in a ``ModuleNotFoundError``. We used to just add the directory to the path to ensure it could find these as in this PR.

I'm open to other suggestions to solve this issue, but this would at least get it working again.