### PR TITLE
FIX: Ensure all plot options show up in the context menu when a plot is part of an embedded display

### DIFF
--- a/pydm/widgets/embedded_display.py
+++ b/pydm/widgets/embedded_display.py
@@ -1,3 +1,4 @@
+from pyqtgraph.GraphicsScene.mouseEvents import MouseClickEvent
 from qtpy.QtWidgets import QAction, QFrame, QApplication, QLabel, QMenu, QVBoxLayout, QWidget
 from qtpy.QtCore import QPoint, Qt, QSize, Property, QTimer
 
@@ -388,6 +389,13 @@ class PyDMEmbeddedDisplay(QFrame, PyDMPrimitiveWidget):
             try:
                 if plot.geometry().contains(pos):
                     menu = plot.getViewBox().getMenu(None)
+                    if menu is not None:  # Need to add sub-menus still
+                        # Mock up an event that the pyqtgraph api requires. Just want to create it without any
+                        # initialization of attributes (would require more unnecessary object creations)
+                        accept_event = object.__new__(MouseClickEvent)
+                        accept_event.accepted = True
+                        accept_event.acceptedItem = plot.getViewBox()
+                        menu = plot.getViewBox().scene().addParentContextMenus(plot.getViewBox(), menu, accept_event)
             except AttributeError:
                 pass
 


### PR DESCRIPTION
When a plot is put into an embedded display, the "Plot Options" and "Export" sections of the right click context menu are getting dropped. This PR will get them included again using a pyqtgraph function for adding in additional options to the context menu.

Screenshot of the fixed version of the menu on a plot in an embedded display:

![context_menu](https://user-images.githubusercontent.com/89539359/174402400-b95f2670-6991-4454-958d-d775ae9ace17.png)

