### PR TITLE
FIX: Get the export to csv functionality working for plots

### DIFF
--- a/pydm/widgets/multi_axis_plot.py
+++ b/pydm/widgets/multi_axis_plot.py
@@ -194,6 +194,7 @@ class MultiAxisPlot(PlotItem):
         if self.legend is not None and plotDataItem.name():
             self.legend.addItem(plotDataItem, name=plotDataItem.name())
 
+        self.curves.append(plotDataItem)
         self.curvesPerAxis[axisName] += 1
 
     def removeAxis(self, axisName):


### PR DESCRIPTION
The CSV exporter for plots reads from the list of curves added to the plot item, which is currently empty because nothing is getting added. This will fix that. Currently choosing to export to CSV and save will result in `ValueError: max() arg is an empty sequence`

After applying this PR it should work.

![export_1](https://user-images.githubusercontent.com/89539359/175719361-aaacda46-d4b8-40e3-b891-0f5c7b569e3c.png)

![export_2](https://user-images.githubusercontent.com/89539359/175719376-9248a485-ed28-42a9-b79a-39aaa4397997.png)


