### PR TITLE
ENH: Better error handling for data plugin loading

### DIFF
--- a/pydm/tests/test_data_plugins_import.py
+++ b/pydm/tests/test_data_plugins_import.py
@@ -24,10 +24,12 @@ def test_plugin_directory_loading(qapp):
         handle.flush()
 
     try:
-        # Load plugins
+        # Load plugins. One of them will raise an exception during initialization. This will
+        # prevent it from being added to the available plugins, but the others should still load.
         load_plugins_from_path([cur_dir], 'foo.py')
         assert 'tst1' in plugin_modules
         assert 'tst2' in plugin_modules
+        assert 'fail' not in plugin_modules
     finally:
         os.remove(os.path.join(cur_dir, 'plugin_foo.py'))
 
@@ -50,6 +52,12 @@ from pydm.data_plugins import PyDMPlugin
 class TestPlugin1(PyDMPlugin):
     protocol = 'tst1'
 
+
+class FailingPlugin(PyDMPlugin):
+    protocol = 'fail'
+
+    def __init__(self, *args, **kwargs):
+        raise Exception  # Purposefully fail to initialize for testing purposes
 
 class TestPlugin2(PyDMPlugin):
     protocol = 'tst2'


### PR DESCRIPTION
Currently when data plugins are loaded for the first time, if any of them encounters an exception we are not checking for, it will cause all further plugin loading to stop. For example, an error in initializing the pva plugin will also cause the channel access plugin to not load.

This PR will change this behavior so that a failure in one plugin will not affect any of the others. Instead, an error message along with the exception will be logged, and loading of the other plugins will continue.

Tested this by adding an exception to the pva plugin, and verified that all other plugins loaded fine even when the pva plugin initialization failed. Also added a check to a unit test for this.