### PR TITLE
ENH: provide a decorator to add rule properties to a class

### DIFF
--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -127,6 +127,34 @@ def refresh_style(widget):
             # Widget was probably destroyed
             logger.debug('Error while refreshing stylesheet. %s ', ex)
 
+def rule_properties(new_properties):
+    """
+    Returns a decorator that will add new rule properties to the
+    class.
+
+    Parameters
+    ----------
+    new_properties : dict
+        A dictionary containing the properties that can be modified
+        through rule triggers. The format of this dictionary must
+        follow the one for entries in PyDMPrimitiveWidget.RULE_PROPERTIES.
+        Namely, the key should be a name to be displayed by the Rule
+        Editor (in designer), and the value a list containing two elements:
+        a string naming the method in the class that will handle the
+        rule dispatch, and a type matching the one that we expect to
+        receive from the PV value.
+
+    Returns
+    -------
+    callable
+        A decorator function for PyDM classes.
+    """
+    def decorator(cls):
+        cls.RULE_PROPERTIES = cls.RULE_PROPERTIES.copy()
+        cls.RULE_PROPERTIES.update(new_properties)
+        return cls
+    return decorator
+
 
 class PyDMPrimitiveWidget(object):
     """
@@ -560,6 +588,12 @@ class TextFormatter(object):
         self.update_format_string()
 
 
+_positionRuleProperties = {
+    'Position - X': ['setX', int],
+    'Position - Y': ['setY', int]
+    }
+
+@rule_properties(_positionRuleProperties)
 class PyDMWidget(PyDMPrimitiveWidget):
     """
     PyDM base class for Read-Only widgets.
@@ -581,13 +615,6 @@ class PyDMWidget(PyDMPrimitiveWidget):
 
     def __init__(self, init_channel=None):
         super(PyDMWidget, self).__init__()
-
-        if not all([prop in PyDMPrimitiveWidget.RULE_PROPERTIES for prop in
-                    ['Position - X', 'Position - Y']]):
-            PyDMWidget.RULE_PROPERTIES = PyDMPrimitiveWidget.RULE_PROPERTIES.copy()
-            PyDMWidget.RULE_PROPERTIES.update(
-                {'Position - X': ['setX', int],
-                 'Position - Y': ['setY', int]})
 
         self._connected = True
         self._channel = None

--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -149,7 +149,7 @@ class PyDMPrimitiveWidget(object):
             # and not at the Designer
             self.installEventFilter(self)
 
-    def __init_subclass__(cls, /, new_properties={}):
+    def __init_subclass__(cls, new_properties={}):
         """
         Adds or redefines rule-triggered property configuration for derivative
         classes.

--- a/pydm/widgets/embedded_display.py
+++ b/pydm/widgets/embedded_display.py
@@ -5,7 +5,7 @@ from qtpy.QtCore import QPoint, Qt, QSize, Property, QTimer
 import copy
 import os.path
 import logging
-from .base import PyDMPrimitiveWidget
+from .base import PyDMPrimitiveWidget, rule_properties
 from .baseplot import BasePlot
 from ..utilities import (is_pydm_app, establish_widget_connections,
                          close_widget_connections, macro, is_qt_designer,
@@ -14,7 +14,9 @@ from ..display import (load_file, ScreenTarget)
 
 logger = logging.getLogger(__name__)
 
+_embeddedDisplayRuleProperties = {'Filename': ['filename', str]}
 
+@rule_properties(_embeddedDisplayRuleProperties)
 class PyDMEmbeddedDisplay(QFrame, PyDMPrimitiveWidget):
     """
     A QFrame capable of rendering a PyDM Display
@@ -29,10 +31,6 @@ class PyDMEmbeddedDisplay(QFrame, PyDMPrimitiveWidget):
     def __init__(self, parent=None):
         QFrame.__init__(self, parent)
         PyDMPrimitiveWidget.__init__(self)
-        if 'Filename' not in PyDMEmbeddedDisplay.RULE_PROPERTIES:
-            PyDMEmbeddedDisplay.RULE_PROPERTIES = PyDMPrimitiveWidget.RULE_PROPERTIES.copy()
-            PyDMEmbeddedDisplay.RULE_PROPERTIES.update(
-                {'Filename': ['filename', str]})
         self.app = QApplication.instance()
         self._filename = None
         self._macros = None

--- a/pydm/widgets/label.py
+++ b/pydm/widgets/label.py
@@ -1,4 +1,4 @@
-from .base import PyDMWidget, TextFormatter, str_types
+from .base import PyDMWidget, TextFormatter, str_types, rule_properties
 from qtpy.QtWidgets import QLabel, QApplication
 from qtpy.QtCore import Qt, Property, Q_ENUMS
 from .display_format import DisplayFormat, parse_value_for_display
@@ -6,7 +6,9 @@ from pydm.utilities import is_pydm_app, is_qt_designer
 from pydm import config
 from pydm.widgets.base import only_if_channel_set
 
+_labelRuleProperties = {'Text': ['value_changed', str]}
 
+@rule_properties(_labelRuleProperties)
 class PyDMLabel(QLabel, TextFormatter, PyDMWidget, DisplayFormat):
     Q_ENUMS(DisplayFormat)
     DisplayFormat = DisplayFormat
@@ -29,10 +31,6 @@ class PyDMLabel(QLabel, TextFormatter, PyDMWidget, DisplayFormat):
     def __init__(self, parent=None, init_channel=None):
         QLabel.__init__(self, parent)
         PyDMWidget.__init__(self, init_channel=init_channel)
-        if 'Text' not in PyDMLabel.RULE_PROPERTIES:
-            PyDMLabel.RULE_PROPERTIES = PyDMWidget.RULE_PROPERTIES.copy()
-            PyDMLabel.RULE_PROPERTIES.update(
-                {'Text': ['value_changed', str]})
         self.app = QApplication.instance()
         self.setTextFormat(Qt.PlainText)
         self.setTextInteractionFlags(Qt.NoTextInteraction)

--- a/pydm/widgets/related_display_button.py
+++ b/pydm/widgets/related_display_button.py
@@ -8,7 +8,7 @@ from qtpy.QtWidgets import QPushButton, QMenu, QAction, QMessageBox, QInputDialo
 from qtpy.QtGui import QCursor, QIcon
 from qtpy.QtCore import Slot, Property, Qt, QSize, QPoint
 
-from .base import PyDMPrimitiveWidget
+from .base import PyDMPrimitiveWidget, rule_properties
 from ..utilities import IconFont, find_file, is_pydm_app
 from ..utilities.macro import parse_macro_string
 from ..display import (load_file, ScreenTarget)
@@ -16,7 +16,12 @@ from ..display import (load_file, ScreenTarget)
 
 logger = logging.getLogger(__name__)
 
+_relatedDisplayRuleProperties = {
+    'Text': ['setText', str],
+    'Filenames': ['filenames', list]
+    }
 
+@rule_properties(_relatedDisplayRuleProperties)
 class PyDMRelatedDisplayButton(QPushButton, PyDMPrimitiveWidget):
     """
     A QPushButton capable of opening a new Display at the same of at a
@@ -37,16 +42,6 @@ class PyDMRelatedDisplayButton(QPushButton, PyDMPrimitiveWidget):
     def __init__(self, parent=None, filename=None):
         QPushButton.__init__(self, parent)
         PyDMPrimitiveWidget.__init__(self)
-
-        if 'Text' not in PyDMRelatedDisplayButton.RULE_PROPERTIES:
-            PyDMRelatedDisplayButton.RULE_PROPERTIES = PyDMRelatedDisplayButton.RULE_PROPERTIES.copy()
-            PyDMRelatedDisplayButton.RULE_PROPERTIES.update(
-                {'Text': ['setText', str]})
-
-        if 'Filename' not in PyDMRelatedDisplayButton.RULE_PROPERTIES:
-            PyDMRelatedDisplayButton.RULE_PROPERTIES = PyDMRelatedDisplayButton.RULE_PROPERTIES.copy()
-            PyDMRelatedDisplayButton.RULE_PROPERTIES.update(
-                {'Filenames': ['filenames', list]})
 
         self.mouseReleaseEvent = self.push_button_release_event
         self.setContextMenuPolicy(Qt.CustomContextMenu)

--- a/pydm/widgets/symbol.py
+++ b/pydm/widgets/symbol.py
@@ -6,11 +6,13 @@ from qtpy.QtGui import QPainter, QPixmap
 from qtpy.QtCore import Property, Qt, QSize, QSizeF, QRectF, qInstallMessageHandler
 from qtpy.QtSvg import QSvgRenderer
 from ..utilities import is_pydm_app, find_file
-from .base import PyDMWidget
+from .base import PyDMWidget, rule_properties
 
 logger = logging.getLogger(__name__)
 
+_symbolRuleProperties = {'Index': ['set_current_key', int]}
 
+@rule_properties(_symbolRuleProperties)
 class PyDMSymbol(QWidget, PyDMWidget):
     """
     PyDMSymbol will render an image (symbol) for each value of a channel.
@@ -25,10 +27,6 @@ class PyDMSymbol(QWidget, PyDMWidget):
     def __init__(self, parent=None, init_channel=None):
         QWidget.__init__(self, parent)
         PyDMWidget.__init__(self, init_channel=init_channel)
-        if 'Index' not in PyDMSymbol.RULE_PROPERTIES:
-            PyDMSymbol.RULE_PROPERTIES = PyDMWidget.RULE_PROPERTIES.copy()
-            PyDMSymbol.RULE_PROPERTIES.update(
-                {'Index': ['set_current_key', int]})
         self.app = QApplication.instance()
         self._current_key = 0
         self._state_images_string = ""


### PR DESCRIPTION
The current way in which rule-triggered properties are set for `PyDMPrimitiveWidget` derivative classes is a bit cumbersome in that:

* It's done at `__init__` time.
* Requires copying the rules from the parent class, which creates unneeded coupling.
* Forces us to write boilerplate code just to check if it's the first time this is being done, and only then add the extra properties.

The first point is not a big issue in practice because Designer instantiates the classes after loading them, but not ideal (and we're doing class-related stuff from an instance...)

The second point is not a huge problem either because you don't refactor parent class names that often, but not pretty either.

The third point is more salient. Boilerplate code is hard to refactor (if needed), and is prone to bugs.

In this commit I introduce a decorator to be applied on classes that just needs to be provided a `RULE_PROPERTIES`-like dictionary to augment the *inherited* one.