### PR TITLE
Support loading stylesheets from files in PyDM Displays

### DIFF
--- a/docs/source/stylesheets.rst
+++ b/docs/source/stylesheets.rst
@@ -27,6 +27,28 @@ be used:
   files. Note that the PyDM default stylesheet will have lower precedence
   compared to files specified at ``PYDM_STYLESHEET``.
 
+Specifying Style Sheets in Displays
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If you would like to use a custom style sheet in your PyDM display, you have a
+few different options:
+
+1. Put QSS code directly into your Display's `styleSheet` property.  This is mostly
+   useful if you only need a small amount of QSS, and you only expect to use it once.
+   The `styleSheet` property can be set in Qt Designer, or with Python code.
+2. Put a path to a QSS file in the Display's `styleSheet` property.  This is useful
+   if you want to reuse the same QSS file for many files, but don't want the custom style
+   to apply to *all* displays, just some subset.
+3. Set the `PYDM_STYLESHEET` environment variable to a path to a QSS file.  This will
+   apply to all displays you load.
+4. Set the `--stylesheet` argument when launching PyDM.  This will apply to all displays
+   you load from this instance of PyDM.  It takes precedence over the `PYDM_STYLESHEET`
+   property.
+
+A combination of 1/2 and 3/4 are also possible - the styles from 3/4 are applied
+first, then the styles from 1/2 are applied.  This gives you the ability to override pieces
+of the global style with the `styleSheet` property.
+
 Processing Order of Style Sheets
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/pydm/tests/test_data/test_stylesheet.css
+++ b/pydm/tests/test_data/test_stylesheet.css
@@ -1,0 +1,1 @@
+PyDMLabel { font-weight: bold; }

--- a/pydm/tests/test_display.py
+++ b/pydm/tests/test_display.py
@@ -2,6 +2,8 @@ import os
 import pytest
 from pydm import Display
 from pydm.display import load_py_file
+from qtpy.QtWidgets import QWidget
+import pydm.utilities.stylesheet
 
 # The path to the .ui file used in these tests
 test_ui_path = os.path.join(
@@ -80,3 +82,26 @@ def test_load_python_file_with_macros(qtbot):
     assert display.loaded_file() == valid_display_test_py_path
     assert display.ui_filename() == 'test.ui'
     assert display.macros() == {'MACRO_1': 7, 'MACRO_2': 'test_string'}
+
+def test_file_path_in_stylesheet_property(qtbot):
+    """If you supply a valid filename argument, you shouldn't get any exceptions."""
+    my_display = Display(parent=None, ui_filename=test_ui_path)
+    qtbot.addWidget(my_display)
+    my_display.setStyleSheet("test_stylesheet.css")
+    test_css_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "test_data", "test_stylesheet.css")
+    with open(test_css_path) as css_file:
+        css = css_file.read()
+        # Assert that the stylesheet property is populated with the contents of the file.
+        assert my_display.styleSheet() == css
+        # Assert that the stylesheet property "hides" the global stylesheet info.
+        assert QWidget.styleSheet(my_display) == pydm.utilities.stylesheet.global_style() + css
+
+def test_stylesheet_property_without_path(qtbot):
+        """If you supply a valid filename argument, you shouldn't get any exceptions."""
+        my_display = Display(parent=None, ui_filename=test_ui_path)
+        qtbot.addWidget(my_display)
+        css = "PyDMLabel { font-weight: bold; }"
+        my_display.setStyleSheet(css)
+        assert my_display.styleSheet() == css
+        # Assert that the stylesheet property "hides" the global stylesheet info.
+        assert QWidget.styleSheet(my_display) == pydm.utilities.stylesheet.global_style() + css

--- a/pydm/utilities/stylesheet.py
+++ b/pydm/utilities/stylesheet.py
@@ -2,7 +2,7 @@
 import os
 import logging
 
-from qtpy.QtWidgets import QApplication
+from qtpy.QtWidgets import QApplication, QWidget
 
 from ..config import STYLESHEET, STYLESHEET_INCLUDE_DEFAULT
 
@@ -58,7 +58,6 @@ def apply_stylesheet(stylesheet_file_path=None, widget=None):
         widget = QApplication.instance()
 
     widget.setStyleSheet(style)
-
 
 def _get_style_data(stylesheet_file_path=None):
     """
@@ -116,3 +115,6 @@ def _get_style_data(stylesheet_file_path=None):
                     GLOBAL_STYLESHEET,
                     str(ex)))
     return __style_data
+
+def global_style():
+    return _get_style_data()


### PR DESCRIPTION
This PR adds a new feature to `pydm.Display`: if you put a path to a CSS file in the `Display.styleSheet` property, the display will load the file, and use the contents of that file as the stylesheet.  This makes it much easier to re-use one stylesheet for a bunch of different displays, without using it for _every_ display (which is what the `PYDM_STYLESHEET` environment variable and `--stylesheet` command line arg are for).

A slight bonus: this PR changes where the "global" stylesheet gets merged with the display's "local" stylesheet, which appears to fix some bugs where setting at the widget's `styleSheet` property un-did the global stylesheet.