### PR TITLE
ENH: basic Z-plot widget 

### DIFF
--- a/pydm/widgets/__init__.py
+++ b/pydm/widgets/__init__.py
@@ -26,3 +26,4 @@ from .waveformplot import PyDMWaveformPlot
 from .scatterplot import PyDMScatterPlot
 from .tab_bar import PyDMTabWidget
 from .template_repeater import PyDMTemplateRepeater
+from .z_plot import PyDMZPlot

--- a/pydm/widgets/z_plot.py
+++ b/pydm/widgets/z_plot.py
@@ -8,8 +8,25 @@ from .channel import PyDMChannel
 
 class PyDMZPlot(QWidget):
     """
+      The PyDMZPlot, is a plotting widget that couples a PyDMScatterPlot and a pyqtgraph PlotWidget to create a plot
+      widget that has a corresponding dynamic diagram that can represent a positional direction of a machine
+      or facility.
 
-    """
+      Note:
+
+      Parameters
+      ----------
+      parent : QWidget
+          The parent widget for the plot
+      y_axis_channels : str, optional
+          The channels to be used by the widget.
+      x_axis_channels : str, optional
+          The channels to be used by the widget.
+      symbol_list : list, optional
+          The symbols to be used by the data points in the diagram.
+      y_axis_symbol : str, optional
+          The symbol to be used by the y-axis data points.
+      """
 
     def __init__(self, parent=None, y_axis_channels=None, x_axis_channels=None, symbol_list=[], y_axis_symbol='o'):
         super().__init__()
@@ -42,7 +59,7 @@ class PyDMZPlot(QWidget):
 
     def ui_components(self):
         """
-
+        creates the layout and widgets for the z-plot
         """
         self.setGeometry(100, 100, 800, 500)
         self.text = 'z-plot'
@@ -81,7 +98,7 @@ class PyDMZPlot(QWidget):
 
     def establish_channel_connections(self):
         """
-
+        Sets up the pydm channels for the given x_axis addresses.
         """
         channels = []
         for address in self._x_axis_channels:

--- a/pydm/widgets/z_plot.py
+++ b/pydm/widgets/z_plot.py
@@ -1,9 +1,12 @@
 import typing
+import logging
 import pyqtgraph as pg
 from functools import partial
 from qtpy.QtWidgets import QWidget, QLabel, QVBoxLayout
 from pydm.widgets import PyDMScatterPlot
 from .channel import PyDMChannel
+
+logger = logging.getLogger(__name__)
 
 
 class PyDMZPlot(QWidget):
@@ -11,8 +14,6 @@ class PyDMZPlot(QWidget):
       The PyDMZPlot, is a plotting widget that couples a PyDMScatterPlot and a pyqtgraph PlotWidget to create a plot
       widget that has a corresponding dynamic diagram that can represent a positional direction of a machine
       or facility.
-
-      Note:
 
       Parameters
       ----------
@@ -110,7 +111,7 @@ class PyDMZPlot(QWidget):
 
     def update_x_values(self, new_value, address):
         """
-
+        Update the x values of the self.accelerator_diagram (pyqtgraph PlotWidget) plot.
         """
         self.x_points_table.update({address: new_value})
         self.x_points.clear()
@@ -123,7 +124,8 @@ class PyDMZPlot(QWidget):
         if len(self._symbol_list) == len(self.x_points):
             symbols = self._symbol_list
         else:
-            # should throw a warning here
+            logger.debug("The length of the list of symbols did not match the "
+                         "number of x points so the default symbol was set.")
             symbols = 's'
 
         self.accelerator_diagram.clear()
@@ -204,6 +206,7 @@ class PyDMZPlot(QWidget):
     @property
     def symbol_list(self):
         """
+        list of symbols to be passed to the self.accelerator_diagram (pyqtgraph PlotWidget) plot.
 
         Returns
         -------
@@ -215,6 +218,7 @@ class PyDMZPlot(QWidget):
     @symbol_list.setter
     def symbol_list(self, symbols):
         """
+        list of symbols to be passed to the self.accelerator_diagram (pyqtgraph PlotWidget) plot.
 
         Parameters
         -------

--- a/pydm/widgets/z_plot.py
+++ b/pydm/widgets/z_plot.py
@@ -1,0 +1,208 @@
+import typing
+import pyqtgraph as pg
+from functools import partial
+from qtpy.QtWidgets import QWidget, QLabel, QVBoxLayout
+from pydm.widgets import PyDMScatterPlot
+from .channel import PyDMChannel
+
+
+class PyDMZPlot(QWidget):
+    """
+
+    """
+
+    def __init__(self, parent=None, y_axis_channels=None, x_axis_channels=None, symbol_list=[], y_axis_symbol='o'):
+        super().__init__()
+        if y_axis_channels is not None:
+            self._y_axis_channels = y_axis_channels
+        else:
+            self._y_axis_channels = list()
+
+        if x_axis_channels is not None:
+            self._x_axis_channels = x_axis_channels
+        else:
+            self._x_axis_channels = list()
+
+        self._symbol_list = symbol_list
+        self._y_axis_symbol = y_axis_symbol
+        self.z_values = []
+        self.x_points_table = {}
+        self.x_points = []
+        self.y_points = []
+
+        # ui elements
+        self.text = None
+        self.label = None
+        self.z_plot = None
+        self.accelerator_diagram = None
+
+        # build ui
+        self.ui_components()
+        self.show()
+
+    def ui_components(self):
+        """
+
+        """
+        self.setGeometry(100, 100, 800, 500)
+        self.text = 'z-plot'
+        self.label = QLabel(self.text)
+        self.label.setMinimumWidth(130)
+        self.label.setWordWrap(True)
+
+        pg.setConfigOptions(antialias=True)
+
+        self.z_plot = PyDMScatterPlot()
+
+        for i in range(0, len(self.y_axis_channels)):
+            self.z_plot.addChannel(y_channel=self._y_axis_channels[i],
+                                   x_channel=self._x_axis_channels[i], symbol=self._y_axis_symbol)
+
+        self.accelerator_diagram = pg.PlotWidget()
+        self.accelerator_diagram.setMouseEnabled(x=True, y=False)
+        self.accelerator_diagram.getPlotItem().hideAxis('left')
+        self.accelerator_diagram.getPlotItem().hideAxis('bottom')
+
+        for view in self.z_plot.plotItem.stackedViews:
+            view.setXLink(self.accelerator_diagram)
+
+        # Get values from the x channels and populate the data into the accelerator diagram
+        self.establish_channel_connections()
+
+        z_plot_layout = QVBoxLayout()
+        z_plot_layout.setContentsMargins(0, 0, 0, 0)
+        z_plot_layout.setSpacing(0)
+
+        z_plot_layout.addWidget(self.z_plot, stretch=3)
+        z_plot_layout.addWidget(self.accelerator_diagram, stretch=1)
+        #z_plot_layout.addWidget(self.label)
+
+        self.setLayout(z_plot_layout)
+
+    def establish_channel_connections(self):
+        """
+
+        """
+        channels = []
+        for address in self._x_axis_channels:
+            new_channel = PyDMChannel(address=address, value_slot=partial(self.update_x_values, address))
+            new_channel.connect()
+            channels.append(new_channel)
+
+        return channels
+
+    def update_x_values(self, new_value, address):
+        """
+
+        """
+        self.x_points_table.update({address: new_value})
+        self.x_points.clear()
+
+        for value in self.x_points_table:
+            self.x_points.append(value)
+
+        self.y_points = [1] * len(self.x_points)
+
+        if len(self._symbol_list) == len(self.x_points):
+            symbols = self._symbol_list
+        else:
+            # should throw a warning here
+            symbols = 's'
+
+        self.accelerator_diagram.clear()
+        self.accelerator_diagram.plot(y=self.y_points, x=self.x_points, symbol=symbols, symbolSizes=14)
+
+    @property
+    def y_axis_channels(self):
+        """
+        list of channels to be plotted.
+
+        Returns
+        -------
+        list of strings
+        """
+
+        return self._y_axis_channels
+
+    @y_axis_channels.setter
+    def y_axis_channels(self, channels):
+        """
+        list of channels to be plotted.
+
+        Parameters
+        -------
+        channels : list of strings
+        """
+
+        if self._y_axis_channels != channels:
+            self._y_axis_channels = channels
+
+            if len(self._y_axis_channels) == len(self.x_axis_channels):
+                self.z_plot.clearCurves()
+                for i in range(0, len(self.y_axis_channels)):
+                    self.z_plot.addChannel(y_channel=self._y_axis_channels[i],
+                                           x_channel=self._x_axis_channels[i], symbol=self._y_axis_symbol)
+
+                for view in self.z_plot.plotItem.stackedViews:
+                    view.setXLink(self.accelerator_diagram)
+
+    @property
+    def x_axis_channels(self):
+        """
+        list of channels to be plotted.
+
+        Returns
+        -------
+        list of strings
+        """
+
+        return self._x_axis_channels
+
+    @x_axis_channels.setter
+    def x_axis_channels(self, channels):
+        """
+        list of channels to be plotted.
+
+        Parameters
+        -------
+        channels : list of strings
+        """
+
+        if self._x_axis_channels != channels:
+            self._x_axis_channels = channels
+
+            # update the accelerator diagram
+            self.establish_channel_connections()
+
+            # update the z plot graph if both the x and y list are the same size.
+            if len(self._y_axis_channels) == len(self.x_axis_channels):
+                self.z_plot.clearCurves()
+                for i in range(0, len(self.y_axis_channels)):
+                    self.z_plot.addChannel(y_channel=self._y_axis_channels[i],
+                                           x_channel=self._x_axis_channels[i], symbol=self._y_axis_symbol)
+
+                for view in self.z_plot.plotItem.stackedViews:
+                    view.setXLink(self.accelerator_diagram)
+
+    @property
+    def symbol_list(self):
+        """
+
+        Returns
+        -------
+        list of strings
+        """
+
+        return self._symbol_list
+
+    @symbol_list.setter
+    def symbol_list(self, symbols):
+        """
+
+        Parameters
+        -------
+        symbols : list of strings
+        """
+
+        if self._symbol_list != symbols:
+            self._symbol_list = symbols


### PR DESCRIPTION
## Description
A basic Z-plot widget. 

The Z-plot widget is to plot data along a physical dimension of a facility (at SLAC the z-dimension of the accelerator) and provide a dynamic symbolic diagram of the facility corresponding to the given data points. 

The idea here is that this basic Z-plot widget could serve as a base template z-plot widget. It provides a basic plotting widget, which could be used on it's own, but lacks more convenient methods for gathering data and corresponding symbols for the plot. 

Question: 

This is a draft PR because documentation is still being written at the moment. In the mean time I wanted to see if this would be something which would be a good fit for PyDM. If it is a good fit, are there any additional features or changes which could enhance this basic z-plot widget? 
  
## Motivation and Context
SLAC had a need for a z-plot to plot PVs along the accelerator. Offering up this stripped down version as a base z-plot widget in case other users of PyDM may have need for a similar widget.  

## How Has This Been Tested?
Tested on an example Gui.

## Where Has This Been Documented?
documentation is still being worked on. 

## Screenshots:
![Screen Shot 2022-08-26 at 9 26 44 AM](https://user-images.githubusercontent.com/2607613/186950274-3d5b7d1c-2b63-4b4e-859d-486666390c3d.png)
