### PR TITLE
ENH: Tooltip

### DIFF
--- a/docs/source/widgets/PyDMWidget.rst
+++ b/docs/source/widgets/PyDMWidget.rst
@@ -1,0 +1,59 @@
+#######################
+PyDMWidget
+#######################
+
+API Documentation
+=================
+
+.. autoclass:: pydm.widgets.base.PyDMWidget
+   :members:
+   :inherited-members:
+   :show-inheritance:
+
+PyDMToolTip Instructions
+=================
+The PyDMToolTip property field takes a string. In the PyDMToolTip property field, the user can include the tag $(pv_value) to get the value of the
+channel displayed on the tool tip.
+
+.. note::
+
+    If the toolTip property field is:
+
+        The value of the channel is $(pv_value)
+
+    The toolTip would read (assuming the value is 10 in this example):
+
+        The value of the channel is 10
+
+A period followed by a field name can retrieve other properties of the channel
+(see the table bellow for all channel properties and associated field names.)
+
+.. note::
+
+    If the toolTip property field is:
+
+        The timestamp of the channel is $(pv_value.TIME)
+
+    The toolTip would read:
+
+        The timestamp of the channel is 2022-09-15 09:56:47.099340
+
+======================  ==============  ====================================
+channel properties      pv_value.field  Description
+======================  ==============  ====================================
+channel value           $(pv_value)     Returns the value of the channel
+channel address         .address        Returns the address of the channel
+connection              .connection     Returns the connection status
+alarm severity          .SEVR           Returns the alarm severity
+enum string             .enum_strings
+engineering unit        .EGU            Returns the engineering unit
+precision               .PREC           Returns the precision of the channel
+upper ctrl limit        .DRVH           Returns the upper ctrl limit
+lower ctrl limit        .DRVL           Returns the lower ctrl limit
+upper alarm limit       .HIHI           Returns the upper alarm limit
+lower alarm limit       .LOLO           Returns the lower alarm limit
+upper warning limit     .HIGH           Returns the upper warning limit
+lower warning limit     .LOW            Returns the lower warning limit
+timestamp               .TIME           Returns the timestamp of the channel
+======================  ==============  ====================================
+

--- a/pydm/data_plugins/epics_plugins/caproto_plugin_component.py
+++ b/pydm/data_plugins/epics_plugins/caproto_plugin_component.py
@@ -34,6 +34,7 @@ class Connection(PyDMConnection):
         self._lower_alarm_limit = None
         self._upper_warning_limit = None
         self._lower_warning_limit = None
+        self._timestamp = None
 
         monitor_mask = SubscriptionType.DBE_VALUE | SubscriptionType.DBE_ALARM | SubscriptionType.DBE_PROPERTY
         self.pv = epics.get_pv(pv, connection_callback=self.send_connection_state, form='ctrl',
@@ -53,6 +54,7 @@ class Connection(PyDMConnection):
         self._lower_alarm_limit = None
         self._upper_warning_limit = None
         self._lower_warning_limit = None
+        self._timestamp = None
 
     def send_new_value(self, value=None, char_value=None, count=None, typefull=None, type=None, *args, **kws):
         self.update_ctrl_vars(**kws)
@@ -77,7 +79,7 @@ class Connection(PyDMConnection):
 
     def update_ctrl_vars(self, units=None, enum_strs=None, severity=None, upper_ctrl_limit=None, lower_ctrl_limit=None,
                          upper_alarm_limit=None, lower_alarm_limit=None, upper_warning_limit=None,
-                         lower_warning_limit=None, precision=None, *args, **kws):
+                         lower_warning_limit=None, precision=None, timestamp=None, *args, **kws):
         if severity is not None and self._severity != severity:
             self._severity = severity
             self.new_severity_signal.emit(int(severity))
@@ -114,6 +116,9 @@ class Connection(PyDMConnection):
         if lower_warning_limit is not None and self._lower_warning_limit != lower_warning_limit:
             self._lower_warning_limit = lower_warning_limit
             self.lower_warning_limit_signal.emit(lower_warning_limit)
+        if timestamp is not None and self._timestamp != timestamp:
+            self._timestamp = timestamp
+            self.timestamp_signal.emit(timestamp)
 
     def send_access_state(self, read_access, write_access, *args, **kws):
         if is_read_only():

--- a/pydm/data_plugins/epics_plugins/p4p_plugin_component.py
+++ b/pydm/data_plugins/epics_plugins/p4p_plugin_component.py
@@ -48,6 +48,7 @@ class Connection(PyDMConnection):
         self._lower_alarm_limit = None
         self._upper_warning_limit = None
         self._lower_warning_limit = None
+        self._timestamp = None
 
     def clear_cache(self) -> None:
         """ Clear out all the stored values of this connection. """
@@ -62,6 +63,7 @@ class Connection(PyDMConnection):
         self._lower_alarm_limit = None
         self._upper_warning_limit = None
         self._lower_warning_limit = None
+        self._timestamp = None
 
     def send_new_value(self, value: Value) -> None:
         """ Callback invoked whenever a new value is received by our monitor. Emits signals based on values changed. """
@@ -128,6 +130,10 @@ class Connection(PyDMConnection):
                         value.valueAlarm.lowWarningLimit != self._lower_warning_limit:
                     self._lower_warning_limit = value.valueAlarm.lowWarningLimit
                     self.lower_warning_limit_signal.emit(value.valueAlarm.lowWarningLimit)
+                elif changed_value == 'timeStamp.secondsPastEpoch' and \
+                        value.timeStamp.secondsPastEpoch != self._timestamp:
+                    self._timestamp = value.timeStamp.secondsPastEpoch
+                    self.timestamp_signal.emit(value.timeStamp.secondsPastEpoch)
 
     def put_value(self, value):
         """ Write a value to the PV """

--- a/pydm/data_plugins/epics_plugins/psp_plugin_component.py
+++ b/pydm/data_plugins/epics_plugins/psp_plugin_component.py
@@ -158,6 +158,7 @@ class Connection(PyDMConnection):
 
         self.units = None
         self.prec = None
+        self.time = None
         self.count = None
         self.epics_type = None
         self.read_access = False
@@ -268,6 +269,14 @@ class Connection(PyDMConnection):
                 self.unit_signal.emit(self.units.decode(encoding='ascii') if isinstance(self.units, bytes) else self.units)
 
         try:
+            time = self.timestamp()
+        except KeyError:
+            pass
+        else:
+            if self.time != time:
+                self.time = time
+                self.timestamp_signal.emit(self.time)
+        try:
             ctrl_llim = self.pv.data['ctrl_llim']
         except KeyError:
             pass
@@ -346,6 +355,14 @@ class Connection(PyDMConnection):
                 pass
         if self.prec is not None:
             self.prec_signal.emit(int(self.prec))
+
+        if self.time is None:
+            try:
+                self.time = self.timestamp()
+            except KeyError:
+                pass
+        if self.time is not None:
+            self.timestamp_signal.emit(self.time)
 
         if self.units is None:
             try:

--- a/pydm/data_plugins/epics_plugins/psp_plugin_component.py
+++ b/pydm/data_plugins/epics_plugins/psp_plugin_component.py
@@ -268,14 +268,12 @@ class Connection(PyDMConnection):
                 self.units = units
                 self.unit_signal.emit(self.units.decode(encoding='ascii') if isinstance(self.units, bytes) else self.units)
 
-        try:
-            time = self.timestamp()
-        except KeyError:
-            pass
-        else:
-            if self.time != time:
-                self.time = time
-                self.timestamp_signal.emit(self.time)
+        time = self.timestamp()
+
+        if time is not None and self.time != time:
+            self.time = time
+            self.timestamp_signal.emit(self.time)
+
         try:
             ctrl_llim = self.pv.data['ctrl_llim']
         except KeyError:
@@ -357,10 +355,8 @@ class Connection(PyDMConnection):
             self.prec_signal.emit(int(self.prec))
 
         if self.time is None:
-            try:
-                self.time = self.timestamp()
-            except KeyError:
-                pass
+            self.time = self.timestamp()
+
         if self.time is not None:
             self.timestamp_signal.emit(self.time)
 

--- a/pydm/data_plugins/epics_plugins/pyepics_plugin_component.py
+++ b/pydm/data_plugins/epics_plugins/pyepics_plugin_component.py
@@ -48,6 +48,7 @@ class Connection(PyDMConnection):
         self._lower_alarm_limit = None
         self._upper_warning_limit = None
         self._lower_warning_limit = None
+        self._timestamp = None
 
         PyEPICSPlugin.thread_pool.submit(self.setup_callbacks, channel)
 
@@ -68,6 +69,7 @@ class Connection(PyDMConnection):
         self._lower_alarm_limit = None
         self._upper_warning_limit = None
         self._lower_warning_limit = None
+        self._timestamp = None
 
     def send_new_value(self, value=None, char_value=None, count=None, ftype=None, *args, **kws):
         self.update_ctrl_vars(**kws)
@@ -92,7 +94,7 @@ class Connection(PyDMConnection):
 
     def update_ctrl_vars(self, units=None, enum_strs=None, severity=None, upper_ctrl_limit=None, lower_ctrl_limit=None,
                          precision=None, upper_alarm_limit=None, lower_alarm_limit=None, upper_warning_limit=None,
-                         lower_warning_limit=None, *args, **kws):
+                         lower_warning_limit=None, timestamp=None, *args, **kws):
         """ Callback invoked when there is a change any of these variables. For a full description see:
             https://cars9.uchicago.edu/software/python/pyepics3/pv.html#user-supplied-callback-functions
         """
@@ -132,7 +134,9 @@ class Connection(PyDMConnection):
         if lower_warning_limit is not None and self._lower_warning_limit != lower_warning_limit:
             self._lower_warning_limit = lower_warning_limit
             self.lower_warning_limit_signal.emit(lower_warning_limit)
-
+        if timestamp is not None and self._timestamp != timestamp:
+            self._timestamp = timestamp
+            self.timestamp_signal.emit(timestamp)
 
     def send_access_state(self, read_access, write_access, *args, **kws):
         if is_read_only():

--- a/pydm/data_plugins/plugin.py
+++ b/pydm/data_plugins/plugin.py
@@ -25,6 +25,7 @@ class PyDMConnection(QObject):
     lower_alarm_limit_signal = Signal([float], [int])
     upper_warning_limit_signal = Signal([float], [int])
     lower_warning_limit_signal = Signal([float], [int])
+    timestamp_signal = Signal(float)
 
     def __init__(self, channel, address, protocol=None, parent=None):
         super(PyDMConnection, self).__init__(parent)
@@ -94,6 +95,9 @@ class PyDMConnection(QObject):
 
         if channel.prec_slot is not None:
             self.prec_signal.connect(channel.prec_slot, Qt.QueuedConnection)
+
+        if channel.timestamp_slot is not None:
+            self.timestamp_signal.connect(channel.timestamp_slot, Qt.QueuedConnection)
 
     def remove_listener(self, channel, destroying: Optional[bool] = False) -> None:
         """
@@ -201,6 +205,12 @@ class PyDMConnection(QObject):
         if self._should_disconnect(channel.prec_slot, destroying):
             try:
                 self.prec_signal.disconnect(channel.prec_slot)
+            except (KeyError, TypeError):
+                pass
+
+        if self._should_disconnect(channel.timestamp_slot, destroying):
+            try:
+                self.timestamp_signal.disconnect(channel.timestamp_slot)
             except (KeyError, TypeError):
                 pass
 

--- a/pydm/tests/widgets/test_base.py
+++ b/pydm/tests/widgets/test_base.py
@@ -469,7 +469,8 @@ def test_pydmwidget_channels(qtbot):
                                         lower_alarm_limit_slot=pydm_label.lower_alarm_limit_changed,
                                         lower_warning_limit_slot=pydm_label.lower_warning_limit_changed,
                                         value_signal=None,
-                                        write_access_slot=None)
+                                        write_access_slot=None,
+                                        timestamp_slot=pydm_label.timestamp_changed)
     assert pydm_channels == default_pydm_channels
 
 
@@ -511,7 +512,8 @@ def test_pydmwritablewidget_channels(qtbot):
                                         upper_warning_limit_slot=pydm_lineedit.upper_warning_limit_changed,
                                         lower_warning_limit_slot=pydm_lineedit.lower_warning_limit_changed,
                                         value_signal=pydm_lineedit.send_value_signal,
-                                        write_access_slot=pydm_lineedit.writeAccessChanged)
+                                        write_access_slot=pydm_lineedit.writeAccessChanged,
+                                        timestamp_slot=pydm_lineedit.timestamp_changed)
     assert pydm_channels == default_pydm_channels
 
 

--- a/pydm/tests/widgets/test_base.py
+++ b/pydm/tests/widgets/test_base.py
@@ -473,6 +473,30 @@ def test_pydmwidget_channels(qtbot):
                                         timestamp_slot=pydm_label.timestamp_changed)
     assert pydm_channels == default_pydm_channels
 
+def test_pydmwidget_tooltip(qtbot):
+    """
+       Test the tooltip. This test is for a widget whose base class is PyDMWidget.
+
+       Expectations:
+       1. The widget's tooltip will update
+
+       Parameters
+       ----------
+       qtbot : fixture
+           Window for widget testing
+    """
+    pydm_label = PyDMLabel()
+    qtbot.addWidget(pydm_label)
+
+    assert pydm_label.toolTip() == ""
+
+    pydm_label.toolTip = "hello world"
+    assert pydm_label.toolTip == "hello world"
+
+    pydm_label.value = 5
+    tool_tip = pydm_label.parseTip("$(pv_value)")
+    assert tool_tip == str(pydm_label.value)
+
 
 def test_pydmwritablewidget_channels(qtbot):
     """

--- a/pydm/tests/widgets/test_channel.py
+++ b/pydm/tests/widgets/test_channel.py
@@ -41,7 +41,8 @@ def test_construct(qtbot):
         pydm_channel.upper_warning_limit_slot is None and \
         pydm_channel.lower_warning_limit_slot is None and \
         pydm_channel.write_access_slot is None and \
-        pydm_channel.value_signal is None
+        pydm_channel.value_signal is None and \
+        pydm_channel.timestamp_slot is None
 
     pydm_label = PyDMLabel(init_channel='tst://this')
     qtbot.addWidget(pydm_label)
@@ -61,7 +62,8 @@ def test_construct(qtbot):
                                               upper_warning_limit_slot=pydm_label.upper_warning_limit_changed,
                                               lower_warning_limit_slot=pydm_label.lower_warning_limit_changed,
                                               value_signal=None,
-                                              write_access_slot=None)
+                                              write_access_slot=None,
+                                              timestamp_slot=pydm_label.timestamp_changed)
     assert pydm_label_channels == default_pydm_label_channels
 
     pydm_lineedit = PyDMLineEdit(init_channel='tst://this2')

--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -1131,7 +1131,7 @@ class PyDMWidget(PyDMPrimitiveWidget, new_properties=_positionRuleProperties):
         tip_with_attribute_info : str
             ToolTip string which has had the attribute names replaced with the attribute values.
         """
-        if is_qt_designer:
+        if is_qt_designer():
             return new_tip
 
         if not self._tool_tip_substrings:

--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -17,6 +17,7 @@ from .. import data_plugins, tools, config
 from ..utilities import is_qt_designer, remove_protocol
 from ..display import Display
 from .rules import RulesDispatcher
+from datetime import datetime
 
 try:
     from json.decoder import JSONDecodeError
@@ -1153,11 +1154,16 @@ class PyDMWidget(PyDMPrimitiveWidget, new_properties=_positionRuleProperties):
                     else:
                         attribute = self._tool_tip_channel_table[value[0].split(".", 1)[1]]
                         value_of_attribute = getattr(self, attribute, None)
+
+                        if attribute == "timestamp" and value_of_attribute is not None:
+                            value_of_attribute = datetime.fromtimestamp(value_of_attribute)
                 else:
                     value_of_attribute = getattr(self, value[0], None)
 
-                tool_tip_substrings[index][0] = str(value_of_attribute)
+                if value[0] == "timestamp" and value_of_attribute is not None:
+                    value_of_attribute = datetime.fromtimestamp(value_of_attribute)
 
+                tool_tip_substrings[index][0] = str(value_of_attribute)
 
         tip_with_attribute_info = new_tip
 

--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -637,17 +637,17 @@ class PyDMWidget(PyDMPrimitiveWidget, new_properties=_positionRuleProperties):
         self._tool_tip_substrings = []
         self._tool_tip_channel_table = {"address": '_channel',
                                         "connection": '_connected',
-                                        "severity": '_alarm_state',
+                                        "SEVR": '_alarm_state',
                                         "enum_strings": 'enum_strings',
-                                        "units": '_unit',
-                                        "precision": '_prec',
-                                        "upper_ctrl_limit": '_upper_ctrl_limit',
-                                        "lower_ctrl_limit": '_lower_ctrl_limit',
-                                        "upper_alarm_limit": 'upper_alarm_limit',
-                                        "lower_alarm_limit": 'lower_alarm_limit',
-                                        "upper_warning_limit": 'upper_warning_limit',
-                                        "lower_warning_limit": 'lower_warning_limit',
-                                        "timestamp": "timestamp"}
+                                        "EGU": '_unit',
+                                        "PREC": '_prec',
+                                        "DRVH": '_upper_ctrl_limit',
+                                        "DRVL": '_lower_ctrl_limit',
+                                        "HIHI": 'upper_alarm_limit',
+                                        "LOLO": 'lower_alarm_limit',
+                                        "HIGH": 'upper_warning_limit',
+                                        "LOW": 'lower_warning_limit',
+                                        "TIME": "timestamp"}
 
         # If this label is inside a PyDMApplication (not Designer) start it in
         # the disconnected state.

--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -1112,9 +1112,11 @@ class PyDMWidget(PyDMPrimitiveWidget, new_properties=_positionRuleProperties):
         new_tip : str
             tooltip info
         """
+        print(new_tip)
         if new_tip != self.pydm_tool_tip:
             self.pydm_tool_tip = str(new_tip)
             parsed_tool_tip = self.parseTip(new_tip)
+            print(new_tip)
             self.setToolTip(parsed_tool_tip)
 
     def parseTip(self, new_tip):
@@ -1320,6 +1322,7 @@ class PyDMWidget(PyDMPrimitiveWidget, new_properties=_positionRuleProperties):
             return false.
         """
         if event.type() == QEvent.Enter:
+            print(self._tooltip)
             self.setToolTip(self.parseTip(self.pydm_tool_tip))
             return True
 

--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -1058,6 +1058,48 @@ class PyDMWidget(PyDMPrimitiveWidget, new_properties=_positionRuleProperties):
         self.alarm_severity_changed(self._alarm_state)
 
     @Property(str)
+    def toolTip(self):
+        """
+        The tooltip for this widget.
+
+            Returns
+            -------
+            toolTip : str
+                tooltip info
+        """
+        return self._tooltip
+
+    @toolTip.setter
+    def toolTip(self, new_tip):
+        """
+        The tooltip for this widget.
+
+        Parameters
+        ----------
+        new_tip : str
+            tooltip info
+        """
+        if new_tip != self._tooltip:
+            self.parseTip(new_tip)
+            self.setToolTip(new_tip)
+
+    def parseTip(self, new_tip):
+        # fetch property values
+
+        if False:
+            list_of_properties = []
+
+        for value in list_of_properties:
+            if value == 'pv_value':
+                pass
+            else:
+                eval(self.value)
+
+
+
+
+
+    @Property(str)
     def channel(self):
         """
         The channel address in use for this widget.

--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -1112,11 +1112,9 @@ class PyDMWidget(PyDMPrimitiveWidget, new_properties=_positionRuleProperties):
         new_tip : str
             tooltip info
         """
-        print(new_tip)
         if new_tip != self.pydm_tool_tip:
             self.pydm_tool_tip = str(new_tip)
             parsed_tool_tip = self.parseTip(new_tip)
-            print(new_tip)
             self.setToolTip(parsed_tool_tip)
 
     def parseTip(self, new_tip):
@@ -1321,9 +1319,12 @@ class PyDMWidget(PyDMPrimitiveWidget, new_properties=_positionRuleProperties):
             True to stop the event from being handled further; otherwise
             return false.
         """
+
         if event.type() == QEvent.Enter:
-            print(self._tooltip)
-            self.setToolTip(self.parseTip(self.pydm_tool_tip))
+            if not self.pydm_tool_tip:
+                self.setToolTip(self.parseTip(self.toolTip()))
+            else:
+                self.setToolTip(self.parseTip(self.pydm_tool_tip))
             return True
 
         return False

--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -1131,9 +1131,10 @@ class PyDMWidget(PyDMPrimitiveWidget, new_properties=_positionRuleProperties):
         tip_with_attribute_info : str
             ToolTip string which has had the attribute names replaced with the attribute values.
         """
+        if is_qt_designer:
+            return new_tip
 
         if not self._tool_tip_substrings:
-            print(new_tip)
             list_of_attributes = [substring.start() for substring in re.finditer('\$\(', new_tip)]
             tool_tip_substrings = []
 

--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -806,7 +806,7 @@ class PyDMWidget(PyDMPrimitiveWidget, new_properties=_positionRuleProperties):
 
         Parameters
         ----------
-        new_timestamp : int
+        new_timestamp : float
             The new timestamp value
         """
         if new_timestamp != self.timestamp:

--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -633,7 +633,7 @@ class PyDMWidget(PyDMPrimitiveWidget, new_properties=_positionRuleProperties):
         self.channeltype = None
         self.subtype = None
 
-        self.pydm_tool_tip = ""
+        self._pydm_tool_tip = ""
         self._tool_tip_substrings = []
         self._tool_tip_channel_table = {"address": '_channel',
                                         "connection": '_connected',
@@ -1100,7 +1100,7 @@ class PyDMWidget(PyDMPrimitiveWidget, new_properties=_positionRuleProperties):
             toolTip : str
                 tooltip info
         """
-        return self.pydm_tool_tip
+        return self._pydm_tool_tip
 
     @PyDMToolTip.setter
     def PyDMToolTip(self, new_tip):
@@ -1112,8 +1112,8 @@ class PyDMWidget(PyDMPrimitiveWidget, new_properties=_positionRuleProperties):
         new_tip : str
             tooltip info
         """
-        if new_tip != self.pydm_tool_tip:
-            self.pydm_tool_tip = str(new_tip)
+        if new_tip != self._pydm_tool_tip:
+            self._pydm_tool_tip = str(new_tip)
             parsed_tool_tip = self.parseTip(new_tip)
             self.setToolTip(parsed_tool_tip)
 
@@ -1322,10 +1322,10 @@ class PyDMWidget(PyDMPrimitiveWidget, new_properties=_positionRuleProperties):
         """
 
         if event.type() == QEvent.Enter:
-            if not self.pydm_tool_tip:
+            if not self._pydm_tool_tip:
                 self.setToolTip(self.parseTip(self.toolTip()))
             else:
-                self.setToolTip(self.parseTip(self.pydm_tool_tip))
+                self.setToolTip(self.parseTip(self._pydm_tool_tip))
             return True
 
         return False

--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -626,6 +626,7 @@ class PyDMWidget(PyDMPrimitiveWidget, new_properties=_positionRuleProperties):
         self.upper_warning_limit = None
         self.lower_warning_limit = None
         self.enum_strings = None
+        self.timestamp = None
 
         self.value = None
         self.channeltype = None
@@ -633,6 +634,19 @@ class PyDMWidget(PyDMPrimitiveWidget, new_properties=_positionRuleProperties):
 
         self.pydm_tool_tip = ""
         self._tool_tip_substrings = []
+        self._tool_tip_channel_table = {"address": '_channel',
+                                        "connection": '_connected',
+                                        "severity": '_alarm_state',
+                                        "enum_strings": 'enum_strings',
+                                        "units": '_unit',
+                                        "precision": '_prec',
+                                        "upper_ctrl_limit": '_upper_ctrl_limit',
+                                        "lower_ctrl_limit": '_lower_ctrl_limit',
+                                        "upper_alarm_limit": 'upper_alarm_limit',
+                                        "lower_alarm_limit": 'lower_alarm_limit',
+                                        "upper_warning_limit": 'upper_warning_limit',
+                                        "lower_warning_limit": 'lower_warning_limit',
+                                        "timestamp": "timestamp"}
 
         # If this label is inside a PyDMApplication (not Designer) start it in
         # the disconnected state.
@@ -783,6 +797,19 @@ class PyDMWidget(PyDMPrimitiveWidget, new_properties=_positionRuleProperties):
         if new_enum_strings != self.enum_strings:
             self.enum_strings = new_enum_strings
             self.value_changed(self.value)
+
+    def timestamp_changed(self, new_timestamp):
+        """
+        Callback invoked when the Channel has new timestamp values.
+
+
+        Parameters
+        ----------
+        new_timestamp : int
+            The new timestamp value
+        """
+        if new_timestamp != self.timestamp:
+            self.timestamp = new_timestamp
 
     def get_address(self):
         if not len(self._channels):
@@ -1121,12 +1148,16 @@ class PyDMWidget(PyDMPrimitiveWidget, new_properties=_positionRuleProperties):
                 if value[0] == 'name':
                     value_of_attribute = self.channel
                 elif value[0].split('.')[0] == 'pv_value':
-                    print(value[0])
-                    value_of_attribute = self.value
+                    if value[0].count(".") == 0:
+                        value_of_attribute = self.value
+                    else:
+                        attribute = self._tool_tip_channel_table[value[0].split(".", 1)[1]]
+                        value_of_attribute = getattr(self, attribute, None)
                 else:
                     value_of_attribute = getattr(self, value[0], None)
 
                 tool_tip_substrings[index][0] = str(value_of_attribute)
+
 
         tip_with_attribute_info = new_tip
 
@@ -1184,7 +1215,8 @@ class PyDMWidget(PyDMPrimitiveWidget, new_properties=_positionRuleProperties):
                                   upper_warning_limit_slot=self.upper_warning_limit_changed,
                                   lower_warning_limit_slot=self.lower_warning_limit_changed,
                                   value_signal=None,
-                                  write_access_slot=None)
+                                  write_access_slot=None,
+                                  timestamp_slot=self.timestamp_changed)
             # Load writeable channels if our widget requires them. These should
             # not exist on the base PyDMWidget but prevents us from duplicating
             # the method below to only make two more connections

--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -1091,7 +1091,7 @@ class PyDMWidget(PyDMPrimitiveWidget, new_properties=_positionRuleProperties):
         self.alarm_severity_changed(self._alarm_state)
 
     @Property(str)
-    def toolTip(self):
+    def PyDMToolTip(self):
         """
         The tooltip for this widget.
 
@@ -1100,10 +1100,10 @@ class PyDMWidget(PyDMPrimitiveWidget, new_properties=_positionRuleProperties):
             toolTip : str
                 tooltip info
         """
-        return self._tooltip
+        return self.pydm_tool_tip
 
-    @toolTip.setter
-    def toolTip(self, new_tip):
+    @PyDMToolTip.setter
+    def PyDMToolTip(self, new_tip):
         """
         The tooltip for this widget.
 
@@ -1133,6 +1133,7 @@ class PyDMWidget(PyDMPrimitiveWidget, new_properties=_positionRuleProperties):
         """
 
         if not self._tool_tip_substrings:
+            print(new_tip)
             list_of_attributes = [substring.start() for substring in re.finditer('\$\(', new_tip)]
             tool_tip_substrings = []
 

--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -1112,7 +1112,7 @@ class PyDMWidget(PyDMPrimitiveWidget, new_properties=_positionRuleProperties):
         new_tip : str
             tooltip info
         """
-        if new_tip != self._tooltip:
+        if new_tip != self.pydm_tool_tip:
             self.pydm_tool_tip = str(new_tip)
             parsed_tool_tip = self.parseTip(new_tip)
             self.setToolTip(parsed_tool_tip)

--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -1089,7 +1089,7 @@ class PyDMWidget(PyDMPrimitiveWidget, new_properties=_positionRuleProperties):
 
     def parseTip(self, new_tip):
         """
-        Fetch the data for the tooltip.
+        Fetch the object attribute data for the tooltip.
 
         Parameters
         ----------
@@ -1098,33 +1098,31 @@ class PyDMWidget(PyDMPrimitiveWidget, new_properties=_positionRuleProperties):
 
         Returns
         -------
-        tip : str
-            tip info which replaced values for the properties inside $()
+        tip_with_attribute_info : str
+            ToolTip string which has had the attribute names replaced with the attribute values.
         """
-        list_of_properties = [substring.start() for substring in re.finditer('\$\(', new_tip)]
+        list_of_attributes = [substring.start() for substring in re.finditer('\$\(', new_tip)]
         substrings = []
-        tip = new_tip
+        tip_with_attribute_info = new_tip
 
-        for index in list_of_properties:
+        for index in list_of_attributes:
             substrings.append([new_tip[index+2:new_tip.index(")", index)], new_tip[index:new_tip.index(")", index)+1]])
 
         if substrings:
             for index, value in enumerate(substrings):
                 if value[0] == 'name':
-                    value_of_parameter = self.channel
+                    value_of_attribute = self.channel
                 elif value[0] == 'pv_value':
-                    value_of_parameter = self.value
+                    value_of_attribute = self.value
                 else:
-                    value_of_parameter = getattr(self, value[0], None)
+                    value_of_attribute = getattr(self, value[0], None)
 
-                substrings[index][0] = str(value_of_parameter)
-
-                print(substrings)
+                substrings[index][0] = str(value_of_attribute)
 
         for value in substrings:
-            tip = tip.replace(value[1], value[0])
+            tip_with_attribute_info = tip_with_attribute_info.replace(value[1], value[0])
 
-        return tip
+        return tip_with_attribute_info
 
     @Property(str)
     def channel(self):

--- a/pydm/widgets/channel.py
+++ b/pydm/widgets/channel.py
@@ -94,7 +94,7 @@ class PyDMChannel(object):
                  upper_ctrl_limit_slot=None, lower_ctrl_limit_slot=None,
                  upper_alarm_limit_slot=None, lower_alarm_limit_slot=None,
                  upper_warning_limit_slot=None, lower_warning_limit_slot=None,
-                 value_signal=None):
+                 value_signal=None, timestamp_slot=None):
         self._address = None
         self.address = address
 
@@ -112,6 +112,7 @@ class PyDMChannel(object):
         self.lower_alarm_limit_slot = lower_alarm_limit_slot
         self.upper_warning_limit_slot = upper_warning_limit_slot
         self.lower_warning_limit_slot = lower_warning_limit_slot
+        self.timestamp_slot = timestamp_slot
 
         self.value_signal = value_signal
 
@@ -166,6 +167,7 @@ class PyDMChannel(object):
             upper_warning_slot_matched = self.upper_warning_limit_slot == other.upper_warning_limit_slot
             lower_warning_slot_matched = self.lower_warning_limit_slot == other.lower_warning_limit_slot
             write_access_slot_matched = self.write_access_slot == other.write_access_slot
+            timestamp_slot_matched = self.timestamp_slot == other.timestamp_slot
 
             value_signal_matched = self.value_signal is None and other.value_signal is None
             if self.value_signal and other.value_signal:
@@ -185,7 +187,8 @@ class PyDMChannel(object):
                     upper_warning_slot_matched and
                     lower_warning_slot_matched and
                     write_access_slot_matched and
-                    value_signal_matched)
+                    value_signal_matched and
+                    timestamp_slot_matched)
 
         return NotImplemented
 

--- a/pydm/widgets/channel.py
+++ b/pydm/widgets/channel.py
@@ -87,6 +87,9 @@ class PyDMChannel(object):
         Attach a signal here that emits a desired value to be sent
         through the plugin
 
+    timestamp_slot : Slot, optional
+        A function to be run when the timestamp updates
+
     """
     def __init__(self, address=None, connection_slot=None, value_slot=None,
                  severity_slot=None, write_access_slot=None,


### PR DESCRIPTION
## Description
Creates a PyDMWidget tooltip property that can take in a string which can display current values of object attributes along with the name and value of the channel.
The object attribute is give inside of a tag and when the user hovers over the widget the value is fetched and replaced. For example if "The precision of the widget is $(precision)" is set as the tooltip string, then when the user hovers over the widget they would see "The precision of the widget is 3" (assuming the precision was set to 3 at the time.)

Went ahead and added timestamp to the PyDMChannel class. This was a large addition which should be looked at in detail. Also updated all the plugins to pass the timestamp and the PYDMWidget class
  
## Motivation and Context
Addresses an open request. #876 Also tries to partially address #518, although the issue is mainly targeting a future pydm 2.0 state. 

## How Has This Been Tested?
Tested with a small local example

## Where Has This Been Documented?
new documentation and a couple simple tests have been added 

## Screenshots
<img width="497" alt="Screen Shot 2022-09-01 at 3 04 43 PM" src="https://user-images.githubusercontent.com/2607613/188022662-52c4a5d6-178b-4e0b-b937-ccdc671c6c8f.png">

![Screen Shot 2022-09-01 at 3 04 07 PM](https://user-images.githubusercontent.com/2607613/188022843-e2c92bce-5888-4a1d-9ad4-5a0d8b82f32a.png)
