### PR TITLE
FIX: Remove plot items from the correct view box when calling clear in all cases

### DIFF
--- a/pydm/tests/widgets/test_multiaxis_plot.py
+++ b/pydm/tests/widgets/test_multiaxis_plot.py
@@ -125,3 +125,41 @@ def test_update_log_mode(qtbot, sample_plot):
     assert data_item.opts['logMode'] == [False, False]
     for axis in sample_plot.getAxes():
         assert not axis.logMode
+
+
+def test_remove_item(qtbot, sample_plot: MultiAxisPlot):
+    """ Verify that removing an item from the plot works as expected """
+
+    # First create a couple of mock data items to plot, and add them to the plot
+    data_item_one = PlotDataItem()
+    data_item_two = PlotDataItem()
+
+    sample_plot.addItem(data_item_one)
+    sample_plot.addItem(data_item_two)
+    linked_viewbox = data_item_one.getViewBox()
+
+    assert len(sample_plot.items) == 2
+    assert len(sample_plot.dataItems) == 2
+    assert len(linked_viewbox.addedItems) == 2
+
+    # Now remove them one at a time, and ensure they are cleared out correctly
+    sample_plot.removeItem(data_item_one)
+    assert len(sample_plot.items) == 1
+    assert len(sample_plot.dataItems) == 1
+    assert len(linked_viewbox.addedItems) == 1
+    assert sample_plot.items[0] == data_item_two
+    assert sample_plot.dataItems[0] == data_item_two
+    assert linked_viewbox.addedItems[0] == data_item_two
+
+    sample_plot.removeItem(data_item_two)
+    assert len(sample_plot.items) == 0
+    assert len(sample_plot.dataItems) == 0
+    assert len(linked_viewbox.addedItems) == 0
+
+    # Finally, re-add them and verify that clear() will remove both at the same time
+    sample_plot.addItem(data_item_one)
+    sample_plot.addItem(data_item_two)
+    sample_plot.clear()
+    assert len(sample_plot.items) == 0
+    assert len(sample_plot.dataItems) == 0
+    assert len(linked_viewbox.addedItems) == 0

--- a/pydm/widgets/multi_axis_plot.py
+++ b/pydm/widgets/multi_axis_plot.py
@@ -345,6 +345,31 @@ class MultiAxisPlot(PlotItem):
             stackedView.enableAutoRange(x=x, y=y)
         self.getViewBox().enableAutoRange(x=x, y=y)
 
+    def removeItem(self, item):
+        """
+        Remove an item from this plot. An override of the pyqtgraph implementation which assumes
+        that there is only one view box and will delete items that do not exist on that view if called.
+        """
+
+        # First remove the item from all the lists on the plot itself
+        if item not in self.items:
+            return
+
+        self.items.remove(item)
+        if item in self.dataItems:
+            self.dataItems.remove(item)
+
+        if item in self.curves:
+            self.curves.remove(item)
+            self.updateDecimation()
+            self.updateParamList()
+
+        # Then let any view box it is associated with remove it from its internal lists as well
+        if hasattr(item, 'getViewBox'):
+            linked_view = item.getViewBox()
+            if linked_view is not None:
+                linked_view.removeItem(item)
+
     def clearLayout(self):
         """
         Remove all items from the layout, but leave them intact in the scene so that we can replace them in a new


### PR DESCRIPTION
Right now when editing a plot in designer, an error will be printed, see #912. This is due to a view box which is not associated with the item trying to clear it out. The fix is to ensure we get the view box which is actually linked with the item before attempting the removal.

How to reproduce current issue:
Open up any of the plots under pydm/examples in designer, open up curve editor, click on Done. An exception will be printed. Repeating those steps after applying this PR should clear up the exception.

Also verified clear() behavior outside of designer and during run time works as expected.