### PR TITLE
BLD: Use a more recent macOS for azure pipelines

### DIFF
--- a/azure-pipelines-macos.yml
+++ b/azure-pipelines-macos.yml
@@ -3,18 +3,18 @@ jobs:
   - template: azure-test-template.yml
     parameters:
       name: MacOS_3_7
-      vmImage: 'macOS-10.15'
+      vmImage: 'macos-12'
       python: '3.7'
       allowFailure: false
   - template: azure-test-template.yml
     parameters:
       name: MacOS_3_8
-      vmImage: 'macOS-10.15'
+      vmImage: 'macos-12'
       python: '3.8'
       allowFailure: false
   - template: azure-test-template.yml
     parameters:
       name: MacOS_3_9
-      vmImage: 'macOS-10.15'
+      vmImage: 'macos-12'
       python: '3.9'
       allowFailure: true


### PR DESCRIPTION
10.15 has been deprecated for use and will be removed soon. See here for example: https://dev.azure.com/pydm/pydm/_build/results?buildId=1111&view=results 

Bumping up to 12.