### PR TITLE
BLD: Try using mac os 11 for CI runs

### DIFF
--- a/azure-pipelines-macos.yml
+++ b/azure-pipelines-macos.yml
@@ -3,18 +3,18 @@ jobs:
   - template: azure-test-template.yml
     parameters:
       name: MacOS_3_7
-      vmImage: 'macos-12'
+      vmImage: 'macos-11'
       python: '3.7'
       allowFailure: false
   - template: azure-test-template.yml
     parameters:
       name: MacOS_3_8
-      vmImage: 'macos-12'
+      vmImage: 'macos-11'
       python: '3.8'
       allowFailure: false
   - template: azure-test-template.yml
     parameters:
       name: MacOS_3_9
-      vmImage: 'macos-12'
+      vmImage: 'macos-11'
       python: '3.9'
       allowFailure: true

--- a/azure-test-template.yml
+++ b/azure-test-template.yml
@@ -103,6 +103,7 @@ jobs:
       displayName: 'Tests - Run'
       continueOnError: false
       env:
+        QT_MAC_WANTS_LAYER: 1
         DISPLAY: :99.0
 
     - bash: |


### PR DESCRIPTION
macOS runs for python 3.7 and 3.8 are hanging without any error message, trying this just to see if it works until I can reproduce locally.