### PR TITLE
BLD: Fix azure pipelines for macOS 11+

### DIFF
--- a/azure-test-template.yml
+++ b/azure-test-template.yml
@@ -103,6 +103,8 @@ jobs:
       displayName: 'Tests - Run'
       continueOnError: false
       env:
+        # Setting this fixes an issue with macOS 11+ and pyqt
+        QT_MAC_WANTS_LAYER: 1
         DISPLAY: :99.0
 
     - bash: |


### PR DESCRIPTION
Setting the same environment variable as needed on macOS for designer/pydm windows will fix the issue currently seen in the macOS test runs. (here for example: https://github.com/slaclab/pydm/runs/8280030600)