### PR TITLE
FIX: When launching pydm with --hide-nav-bar or --hide-status-bar, uncheck the corresponding menu options

### DIFF
--- a/pydm/main_window.py
+++ b/pydm/main_window.py
@@ -76,12 +76,14 @@ class PyDMMainWindow(QMainWindow):
 
         if hide_nav_bar:
             self.toggle_nav_bar(False)
+            self.ui.actionShow_Navigation_Bar.setChecked(False)
         if hide_menu_bar:
             # Toggle the menu bar via the QAction so that the menu item
             # stays in sync with menu visibility.
             self.ui.actionShow_Menu_Bar.activate(QAction.Trigger)
         if hide_status_bar:
             self.toggle_status_bar(False)
+            self.ui.actionShow_Status_Bar.setChecked(False)
         #Try to find the designer binary.
         self.ui.actionEdit_in_Designer.setEnabled(False)
 


### PR DESCRIPTION
Currently launching a display with the --hide-nav-bar options leaves the "Show Navigation Bar" option in the view menu still checked requiring two clicks to get it to show up. This is just a small fix to get that to work properly (as well as status bar).

![nav_bar](https://user-images.githubusercontent.com/89539359/189963359-a6eeb606-2ea8-4c25-8969-c916ecfa64d3.png)
