### PR TITLE
FIX: skip non-file stylesheets such as empty string

### DIFF
--- a/pydm/display.py
+++ b/pydm/display.py
@@ -310,12 +310,12 @@ class Display(QWidget):
         stylesheet_filename = None
         try:
             #First, check if the file is already an absolute path.
-            if os.path.exists(possible_stylesheet_filename):
+            if os.path.isfile(possible_stylesheet_filename):
                 stylesheet_filename = possible_stylesheet_filename
             #Second, check if the css file is specified relative to the display file.
             else:
                 rel_path = os.path.join(os.path.dirname(os.path.abspath(self._loaded_file)), possible_stylesheet_filename)
-                if os.path.exists(rel_path):
+                if os.path.isfile(rel_path):
                     stylesheet_filename = rel_path
         except Exception as e:
             logger.debug("Exception while checking if stylesheet is a filename: %s", e)


### PR DESCRIPTION
Quick follow-up to the feature added in #906 

We found that a few of our screens incidentally had empty strings in the `styleSheet` property, which instead of being interpreted as a blank stylesheet were now being reinterpreted as a relative file path to the current directory, which is never a valid stylesheet. Since the code was only checking that the path exists, and the current directory always exists, it was proceeding to try to open the current directory as a stylesheet and crashing.

This just amends the `exists` checks to `isfile` checks which is a bit more precise and prevents empty strings from being interpreted as filepaths.