### PR TITLE
ENH: New embedded display method which can update macros and filename without a reload in between 

### DIFF
--- a/pydm/widgets/embedded_display.py
+++ b/pydm/widgets/embedded_display.py
@@ -159,6 +159,23 @@ class PyDMEmbeddedDisplay(QFrame, PyDMPrimitiveWidget, new_properties=_embeddedD
                 self.clear_error_text()
             self.load_if_needed()
 
+    def macros_and_filename(self, new_filename, new_macros):
+        """
+        A method to change both macros and the filename of an embedded display.
+        the method takes in a Filename of the display to embed and a
+        JSON-formatted string containing macro variables to pass to the embedded file.
+
+        Parameters
+        ----------
+        new_macros : str
+        new_filename : str
+        """
+        new_macros = str(new_macros)
+        if new_macros != self._macros:
+            self._macros = new_macros
+
+        self.filename(new_filename)
+
     def parsed_macros(self):
         """
         Dictionary containing the key value pair for each macro specified.

--- a/pydm/widgets/embedded_display.py
+++ b/pydm/widgets/embedded_display.py
@@ -159,7 +159,7 @@ class PyDMEmbeddedDisplay(QFrame, PyDMPrimitiveWidget, new_properties=_embeddedD
                 self.clear_error_text()
             self.load_if_needed()
 
-    def macros_and_filename(self, new_filename, new_macros):
+    def set_macros_and_filename(self, new_filename, new_macros):
         """
         A method to change both macros and the filename of an embedded display.
         the method takes in a Filename of the display to embed and a
@@ -174,7 +174,7 @@ class PyDMEmbeddedDisplay(QFrame, PyDMPrimitiveWidget, new_properties=_embeddedD
         if new_macros != self._macros:
             self._macros = new_macros
 
-        self.filename(new_filename)
+        self.filename = new_filename
 
     def parsed_macros(self):
         """


### PR DESCRIPTION
## Description
Adds a method to the PyDMEmbeddedDisplay widget, so it can have both its filename and macros changed without reloading the page, which can lead to errors in between changes. 

## How Has This Been Tested?
Tested with a small local example

## Where Has This Been Documented?
new documentation will have been added via the auto documentation in the embedded display rst file.  