### PR TITLE
ENH: Set a display to return to when the home button is clicked in the nav bar

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -36,6 +36,10 @@ PYDM_DATA_PLUGINS_PATH          | Path in which PyDM should look for Data Plugin
                                 | **Default:** None
 PYDM_TOOLS_PATH                 | Path in which PyDM should look for External Tools to be loaded.
                                 | **Default:** None
+PYDM_HOME_FILE                  | Path to a PyDM display file to use as the home display in the navigation bar.
+                                | Will be returned to when the user clicks on the home button. If not set, the
+                                | first display opened will be used as the home display. If the command line option
+                                | ``--homefile`` is set, that will take precedence over this environment variable.
 PYDM_STRING_ENCODING            | The string encoding to be used when converting arrays to strings.
                                 | **Default:** utf-8
 PYDM_STYLESHEET                 | Path to the QSS files defining the global stylesheets for the

--- a/pydm/config.py
+++ b/pydm/config.py
@@ -21,6 +21,9 @@ STYLESHEET_INCLUDE_DEFAULT = os.getenv("PYDM_STYLESHEET_INCLUDE_DEFAULT", False)
 
 CONFIRM_QUIT = os.getenv("PYDM_CONFIRM_QUIT", "n").lower() in ("y", "t", "1", "true")
 
+# Environment variable pointing to a pydm display to return to when the home button is clicked
+HOME_FILE = os.getenv("PYDM_HOME_FILE")
+
 ENTRYPOINT_EXTERNAL_TOOL = "pydm.tool"
 ENTRYPOINT_DATA_PLUGIN = "pydm.data_plugin"
 ENTRYPOINT_WIDGET = "pydm.widget"

--- a/pydm/display.py
+++ b/pydm/display.py
@@ -18,6 +18,7 @@ from .utilities.stylesheet import merge_widget_stylesheet, global_style
 class ScreenTarget:
     NEW_PROCESS = 0
     DIALOG = 1
+    HOME = 2
 
 
 logger = logging.getLogger(__file__)

--- a/pydm/main_window.py
+++ b/pydm/main_window.py
@@ -24,7 +24,8 @@ logger = logging.getLogger(__name__)
 
 class PyDMMainWindow(QMainWindow):
 
-    def __init__(self, parent=None, hide_nav_bar=False, hide_menu_bar=False, hide_status_bar=False):
+    def __init__(self, parent=None, hide_nav_bar=False, hide_menu_bar=False, hide_status_bar=False,
+                 home_file=None, macros=None, command_line_args=None):
         super(PyDMMainWindow, self).__init__(parent)
         self.app = QApplication.instance()
         self.font_factor = 1
@@ -38,8 +39,11 @@ class PyDMMainWindow(QMainWindow):
 
         self.default_font_size = QApplication.instance().font().pointSizeF()
 
-        self.home_file = None
+        self.home_file = home_file
         self.home_widget = None
+        if home_file:
+            self.home_widget = load_file(home_file, macros=macros, args=command_line_args, target=ScreenTarget.HOME)
+            close_widget_connections(self.home_widget)
 
         self.designer_path = None
 
@@ -200,6 +204,10 @@ class PyDMMainWindow(QMainWindow):
                       args=args,
                       target=ScreenTarget.NEW_PROCESS)
         else:
+            if self.home_widget != self.display_widget():
+                self.home_widget.previous_display = self.display_widget()
+            establish_widget_connections(self.home_widget)
+            register_widget_rules(self.home_widget)
             self.set_display_widget(self.home_widget)
 
     def enable_disable_navigation(self):

--- a/pydm_launcher/main.py
+++ b/pydm_launcher/main.py
@@ -40,6 +40,10 @@ def main():
         default=None
         )
     parser.add_argument(
+        '--homefile',
+        help='Path to a PyDM file to return to when the home button is clicked in the navigation bar'
+    )
+    parser.add_argument(
         '--perfmon',
         action='store_true',
         help='Enable performance monitoring,' +
@@ -134,7 +138,8 @@ def main():
         fullscreen=pydm_args.fullscreen,
         read_only=pydm_args.read_only,
         macros=macros,
-        stylesheet_path=pydm_args.stylesheet
+        stylesheet_path=pydm_args.stylesheet,
+        home_file=pydm_args.homefile
         )
 
     pydm.utilities.shortcuts.install_connection_inspector(


### PR DESCRIPTION
Implementation of #905 

Allows setting a display to go to when the home button is clicked via either the `--homefile` command line option, or the `PYDM_HOME_FILE` environment variable. When both are set, the command line option will take precedence. If neither is set, the current behavior will be used where the first display opened is set as the home display.

Example usage - both of these will open the byte indicator display, with the home button set to display the top-level home example.

`pydm --homefile examples/home.ui examples/byte_indicator/byte_indicator.ui`

```
export PYDM_HOME_FILE=examples/home.ui
pydm examples/byte_indicator/byte_indicator.ui
```