### PR TITLE
FIX: Autorange for plots will now work properly when the context menu is opened in the main view and y-axis options are used

### DIFF
--- a/pydm/widgets/multi_axis_plot.py
+++ b/pydm/widgets/multi_axis_plot.py
@@ -182,7 +182,6 @@ class MultiAxisPlot(PlotItem):
         plotDataItem.setFftMode(self.ctrl.fftCheck.isChecked())
         plotDataItem.setDownsampling(*self.downsampleMode())
         plotDataItem.setClipToView(self.clipToViewMode())
-        plotDataItem.setPointMode(self.pointMode())
 
         # Add to average if needed
         self.updateParamList()

--- a/pydm/widgets/multi_axis_plot.py
+++ b/pydm/widgets/multi_axis_plot.py
@@ -1,7 +1,7 @@
 import weakref
 from collections import Counter
 from pyqtgraph import AxisItem, PlotDataItem, PlotItem, ViewBox
-from typing import List
+from typing import List, Optional
 from .multi_axis_viewbox import MultiAxisViewBox
 from .multi_axis_viewbox_menu import MultiAxisViewBoxMenu
 from ..utilities import is_qt_designer
@@ -131,6 +131,10 @@ class MultiAxisPlot(PlotItem):
         view_box_menu.sigRestoreRanges.connect(self.restoreAxisRanges)
         view_box_menu.sigSetAutorange.connect(self.setPlotAutoRange)
         view_box_menu.sigInvertAxis.connect(self.invertAxis)
+        view_box_menu.sigVisibleOnly.connect(self.setPlotAutoRangeVisibleOnly)
+        view_box_menu.sigAutoPan.connect(self.setPlotAutoPan)
+        view_box_menu.sigXManualRange.connect(self.setXRange)
+        view_box_menu.sigYManualRange.connect(self.setYRange)
 
     def updateStackedViews(self):
         """
@@ -344,6 +348,36 @@ class MultiAxisPlot(PlotItem):
         for stackedView in self.stackedViews:
             stackedView.enableAutoRange(x=x, y=y)
         self.getViewBox().enableAutoRange(x=x, y=y)
+
+    def setPlotAutoPan(self, auto_pan_x: Optional[bool] = None, auto_pan_y: Optional[bool] = None) -> None:
+        """
+        Toggle pan only mode (no scaling) when auto range is enabled.
+
+        Parameters
+        ----------
+        auto_pan_x : bool, optional
+            Whether or not the x-axis should be set to auto pan. If omitted, will be unchanged from current value.
+        auto_pan_y : bool, optional
+            Whether or not the y-axis should be set to auto pan. If omitted, will be unchanged from current value.
+        """
+        for stackedView in self.stackedViews:
+            stackedView.setAutoPan(x=auto_pan_x, y=auto_pan_y)
+
+    def setPlotAutoRangeVisibleOnly(self, visible_only_x: Optional[bool] = None,
+                                    visible_only_y: Optional[bool] = None) -> None:
+        """
+        Toggle if auto range should use only visible data when calculating the range to show
+
+        Parameters
+        ----------
+        visible_only_x : bool, optional
+            Whether or not the x-axis should be set to visible only. If omitted, will be unchanged from current value.
+        visible_only_y : bool, optional
+            Whether or not the y-axis should be set to visible only. If omitted, will be unchanged from current value.
+        """
+        for stackedView in self.stackedViews:
+            stackedView.setAutoVisible(x=visible_only_x, y=visible_only_y)
+
 
     def invertAxis(self, axis: int, inverted: bool) -> None:
         """

--- a/pydm/widgets/multi_axis_viewbox_menu.py
+++ b/pydm/widgets/multi_axis_viewbox_menu.py
@@ -27,6 +27,14 @@ class MultiAxisViewBoxMenu(ViewBoxMenu):
     sigYAutoRangeChanged = Signal(object)
     # A signal for inverting the x or y axis
     sigInvertAxis = Signal(int, bool)
+    # Only panning when auto range is enabled (no scaling)
+    sigAutoPan = Signal(object, object)
+    # Auto range using only the visible portion of the plot when checked
+    sigVisibleOnly = Signal(object, object)
+    # Set the x range manually
+    sigXManualRange = Signal(float, float)
+    # Set the y range manually
+    sigYManualRange = Signal(float, float)
 
     def __init__(self, view):
         super(MultiAxisViewBoxMenu, self).__init__(view)
@@ -59,6 +67,12 @@ class MultiAxisViewBoxMenu(ViewBoxMenu):
         super().xManualClicked()
         self.sigXAutoRangeChanged.emit(False)
 
+    def xRangeTextChanged(self):
+        """ Manually set the x-axis range to the user's input. Range will be unchanged if input was invalid """
+        super().xRangeTextChanged()
+        updated_values = self._validateRangeText(ViewBox.XAxis)
+        self.sigXManualRange.emit(*updated_values)
+
     def yAutoClicked(self):
         """ Update the y auto-range value for each view box """
         super().yAutoClicked()
@@ -70,13 +84,39 @@ class MultiAxisViewBoxMenu(ViewBoxMenu):
         super().yManualClicked()
         self.sigYAutoRangeChanged.emit(False)
 
+    def yRangeTextChanged(self):
+        """ Manually set the y-axis range to the user's input. Range will be unchanged if input was invalid """
+        super().yRangeTextChanged()
+        updated_values = self._validateRangeText(ViewBox.YAxis)
+        self.sigYManualRange.emit(*updated_values)
+
+    def xAutoPanToggled(self, autoPan: bool):
+        """ Toggle the auto pan status of the x-axis """
+        super().xAutoPanToggled(autoPan)
+        self.sigAutoPan.emit(autoPan, None)
+
+    def xVisibleOnlyToggled(self, autoVisible: bool):
+        """ Toggle the visible only status of autorange for the x-axis """
+        super().xVisibleOnlyToggled(autoVisible)
+        self.sigVisibleOnly.emit(autoVisible, None)
+
+    def yAutoPanToggled(self, autoPan: bool):
+        """ Toggle the auto pan status of the y-axis """
+        super().yAutoPanToggled(autoPan)
+        self.sigAutoPan.emit(None, autoPan)
+
+    def yVisibleOnlyToggled(self, autoVisible: bool):
+        """ Toggle the visible only status of autorange for the y-axis """
+        super().yVisibleOnlyToggled(autoVisible)
+        self.sigVisibleOnly.emit(None, autoVisible)
+
     def yInvertToggled(self, inverted: bool):
-        """ Toggle the inverted status of the y axis. """
+        """ Toggle the inverted status of the y-axis. """
         super().yInvertToggled(inverted)
         self.sigInvertAxis.emit(ViewBox.YAxis, inverted)
 
     def xInvertToggled(self, inverted: bool):
-        """ Toggle the inverted status of the x axis """
+        """ Toggle the inverted status of the x-axis """
         super().xInvertToggled(inverted)
         self.sigInvertAxis.emit(ViewBox.XAxis, inverted)
 

--- a/pydm/widgets/multi_axis_viewbox_menu.py
+++ b/pydm/widgets/multi_axis_viewbox_menu.py
@@ -1,3 +1,4 @@
+from pyqtgraph.graphicsItems.ViewBox import ViewBox
 from pyqtgraph.graphicsItems.ViewBox.ViewBoxMenu import ViewBoxMenu
 from qtpy.QtCore import QCoreApplication, Signal
 from qtpy.QtWidgets import QAction
@@ -22,6 +23,10 @@ class MultiAxisViewBoxMenu(ViewBoxMenu):
     sigSetAutorange = Signal(bool, bool)
     # A signal for updating the x autorange value
     sigXAutoRangeChanged = Signal(object)
+    # A signal for updating the y autorange value
+    sigYAutoRangeChanged = Signal(object)
+    # A signal for inverting the x or y axis
+    sigInvertAxis = Signal(int, bool)
 
     def __init__(self, view):
         super(MultiAxisViewBoxMenu, self).__init__(view)
@@ -53,6 +58,27 @@ class MultiAxisViewBoxMenu(ViewBoxMenu):
         """ Disable x auto-range for each view box """
         super().xManualClicked()
         self.sigXAutoRangeChanged.emit(False)
+
+    def yAutoClicked(self):
+        """ Update the y auto-range value for each view box """
+        super().yAutoClicked()
+        val = self.ctrl[1].autoPercentSpin.value() * 0.01
+        self.sigYAutoRangeChanged.emit(val)
+
+    def yManualClicked(self):
+        """ Disable y auto-range for each view box """
+        super().yManualClicked()
+        self.sigYAutoRangeChanged.emit(False)
+
+    def yInvertToggled(self, inverted: bool):
+        """ Toggle the inverted status of the y axis. """
+        super().yInvertToggled(inverted)
+        self.sigInvertAxis.emit(ViewBox.YAxis, inverted)
+
+    def xInvertToggled(self, inverted: bool):
+        """ Toggle the inverted status of the x axis """
+        super().xInvertToggled(inverted)
+        self.sigInvertAxis.emit(ViewBox.XAxis, inverted)
 
     def autoRange(self):
         """ Sets autorange to True for all elements on the plot """


### PR DESCRIPTION
Fixes #924 

Only the top-level view should have its menu set to the `MultiAxisViewBoxMenu`, all others can use the regular menus as they each affect only their own associated view boxes.

Adds options to the `MultiAxisViewBoxMenu` for clicking on y-auto range. Also fixes the invert axis option since it's similar and affected by the same issue.

![plot](https://user-images.githubusercontent.com/89539359/192069158-c6c7695f-a129-4406-aac4-4a8d786ce601.gif)
