### PR TITLE
ENH Customizing the MainWindow and Ui_MainWindow classes.

### DIFF
--- a/pydm/application.py
+++ b/pydm/application.py
@@ -70,6 +70,7 @@ class PyDMApplication(QApplication):
     """
     # Instantiate our plugins.
     plugins = data_plugins.plugin_modules
+    MainWindowClass = PyDMMainWindow
 
     def __init__(self, ui_file=None, command_line_args=[], display_args=[],
                  perfmon=False, hide_nav_bar=False, hide_menu_bar=False,
@@ -202,9 +203,9 @@ class PyDMApplication(QApplication):
         of starting up a new process, because PyDMApplications only have
         one window per process.
         """
-        main_window = PyDMMainWindow(hide_nav_bar=self.hide_nav_bar,
-                                     hide_menu_bar=self.hide_menu_bar,
-                                     hide_status_bar=self.hide_status_bar)
+        main_window = self.MainWindowClass(hide_nav_bar=self.hide_nav_bar,
+                                           hide_menu_bar=self.hide_menu_bar,
+                                           hide_status_bar=self.hide_status_bar)
 
         self.main_window = main_window
         apply_stylesheet(stylesheet_path, widget=self.main_window)

--- a/pydm/main_window.py
+++ b/pydm/main_window.py
@@ -23,6 +23,7 @@ logger = logging.getLogger(__name__)
 
 
 class PyDMMainWindow(QMainWindow):
+    UiClass = Ui_MainWindow
 
     def __init__(self, parent=None, hide_nav_bar=False, hide_menu_bar=False, hide_status_bar=False):
         super(PyDMMainWindow, self).__init__(parent)
@@ -43,7 +44,7 @@ class PyDMMainWindow(QMainWindow):
 
         self.designer_path = None
 
-        self.ui = Ui_MainWindow()
+        self.ui = self.UiClass()
         self.ui.setupUi(self)
 
         self.showMacros = QAction("Show Macros...", self)


### PR DESCRIPTION
I'm developing an application using pydm, and I would like to use the menubar for additional functionality. This PR preserves the current pydm functionality while allow more avoiding code duplication between pydm and the subclasses needed to implement this custom menubar.

The menu setup takes place inside ``Ui_MainWindow``, so I would like to subclass this with my own menu choices as ``MyUi_MainWindow``.

In order for my application to recognize ``MyUi_MainWindow``, I wrote a subclass ``class MyMainWindow(PyDMMainWindow)`` that uses my custom UI, and a subclass ``class MyApplication(PyDMApplication)`` that uses ``MyMainWindow``.

Currently ``Ui_MainWindow`` instantiation is hard-coded in the ``__init__`` method of ``PyDMMainWindow`` (and the same for ``PyDMMainWindow`` in ``PyDMApplication``), which means that when I subclass ``PyDMMainWindow`` I have copy its ``__init__`` and change one line while keeping 75 other lines of setup code. Since ``PyDMMainWindow`` is instantiated in the middle of ``__init__`` I can't use ``super().__init__`` to avoid duplicating the code.

If ``PyDMMainWindow.__init__()`` gets updated in the future, I will not get the benefits of those updates. 

The same problem exists with ``MyApplication``, though the ``make_main_window()`` method is shorter.

My proposed solution is to attach the ``Ui_MainWindow`` as an attribute ``PyDMMainWindow.UiClass``, and then instead of ``self.ui = Ui_MainWindow()``, use ``self.ui = self.UiClass()``.

Below is some sample code of the how the custom menu is then implemented in my application. It's still smells a little kludgy since I need to subclass 3 things from pydm, but this seemed like the best choice for now so as to avoid having the implement a full-on custom menu scheme.

Full implementation of the custom application can be found here (using the ``start_firefly`` entry point): https://github.com/spc-group/firefly
 
**launcher.py**
```python
app = MyApplication(...)
sys.exit(app.exec())
```

my_application.py
```python
from pydm.application import PyDMApplication

from .my_main_window import MyMain_Window

class MyApplication(PyDMApplication):
    MainWindowClass = MyMain_Window
```

**my_main_window.py:**
```python
from pydm.main_window import PyDMMainWindow

from .my_ui import MyUi_MainWindow

class MyMainWindow(PyDMMainWindow):
    UiClass = MyUi_MainWindow
```

**my_ui.py:**
```python
from pydm.pydm_ui import Ui_MainWindow

class MyUi_MainWindow(Ui_MainWindow):
    def setupUi(self, MainWindow):
        # Create the menu how I want it
        ....