### PR TITLE
ENH: Let the x-axis of time plots autorange until the buffer is filled

### DIFF
--- a/pydm/widgets/timeplot.py
+++ b/pydm/widgets/timeplot.py
@@ -603,7 +603,12 @@ class PyDMTimePlot(BasePlot,updateMode):
             else:
                 maxrange = time.time()
             minrange = maxrange - self._time_span
-            self.plotItem.setXRange(minrange, maxrange, padding=0.0, update=update_immediately)
+            current_min_x = self.plotItem.getAxis('bottom').range[0]  # Minimum x value currently displayed on the plot
+            if not self.plotItem.isAnyXAutoRange() or (self.plotItem.isAnyXAutoRange() and
+                                                       maxrange - current_min_x >= self._time_span):
+                # Keep the rolling window of data moving, unless the user asked for autorange and we've
+                # not yet hit the maximum amount of data to display based on the time span
+                self.plotItem.setXRange(minrange, maxrange, padding=0.0, update=update_immediately)
         else:
             diff_time = self.starting_epoch_time - max([curve.max_x() for curve in self._curves])
             if diff_time > DEFAULT_X_MIN:


### PR DESCRIPTION
Implements the request in #223 

Currently if you open a time plot, set the timespan to something high like 500, right click on it, and choose "View All" or set the x-axis to autorange, it will not do anything useful since it is set to always display the amount of data specified by the time span.

After applying this, it will auto range properly until it reaches the time span.