### PR TITLE
BUG: clear buffer queue requested flag during initial renders

### DIFF
--- a/pydm/widgets/archiver_time_plot.py
+++ b/pydm/widgets/archiver_time_plot.py
@@ -293,6 +293,7 @@ class PyDMArchiverTimePlot(PyDMTimePlot):
                         max_x = self._starting_timestamp
                 requested_seconds = max_x - min_x
                 if requested_seconds <= 5:
+                    self._archive_request_queued = False
                     continue  # Avoids noisy requests when first rendering the plot
                 # Max amount of raw data to return before using optimized data
                 max_data_request = int(0.80 * self.getArchiveBufferSize())


### PR DESCRIPTION
Previously on startup, the `PyDMArchiverTimePlot` would mark an archive request as queued, and run `requestDataFromArchiver`.  
https://github.com/slaclab/pydm/blob/9225c7bd8a5fe8907586212d02f80e7a2885f0fb/pydm/widgets/archiver_time_plot.py#L243-L247
If the time range was not large enough, this method would return without emitting the `archive_data_request_signal` https://github.com/slaclab/pydm/blob/9225c7bd8a5fe8907586212d02f80e7a2885f0fb/pydm/widgets/archiver_time_plot.py#L295-L296

which clears the flag.

This simply clears the flag when those initial requests are veto'd