### PR TITLE
Fix style sheet overwriting specific rules with global ones

### DIFF
--- a/pydm/display.py
+++ b/pydm/display.py
@@ -12,7 +12,6 @@ from qtpy import uic
 from qtpy.QtWidgets import QApplication, QWidget
 
 from .utilities import import_module_by_filename, is_pydm_app, macro
-from .utilities.stylesheet import merge_widget_stylesheet, global_style
 
 
 class ScreenTarget:
@@ -310,10 +309,10 @@ class Display(QWidget):
         logger.debug("Calling Display.setStyleSheet, new_stylesheet is %s", possible_stylesheet_filename)
         stylesheet_filename = None
         try:
-            #First, check if the file is already an absolute path.
+            # First, check if the file is already an absolute path.
             if os.path.isfile(possible_stylesheet_filename):
                 stylesheet_filename = possible_stylesheet_filename
-            #Second, check if the css file is specified relative to the display file.
+            # Second, check if the css file is specified relative to the display file.
             else:
                 rel_path = os.path.join(os.path.dirname(os.path.abspath(self._loaded_file)), possible_stylesheet_filename)
                 if os.path.isfile(rel_path):
@@ -326,11 +325,5 @@ class Display(QWidget):
             logger.debug("styleSheet property contains a filename, loading %s", stylesheet_filename)
             with open(stylesheet_filename) as f:
                 self._local_style = f.read()
-        style = global_style() + self._local_style
-        logger.debug("Setting stylesheet to: %s", style)
-        super(Display, self).setStyleSheet(style)
-
-    def styleSheet(self):
-        logger.debug("local styleSheet is: %s", self._local_style)
-        logger.debug("real styleSheet is: %s", super(Display, self).styleSheet())
-        return self._local_style
+        logger.debug("Setting stylesheet to: %s", self._local_style)
+        super(Display, self).setStyleSheet(self._local_style)

--- a/pydm/tests/test_display.py
+++ b/pydm/tests/test_display.py
@@ -83,6 +83,7 @@ def test_load_python_file_with_macros(qtbot):
     assert display.ui_filename() == 'test.ui'
     assert display.macros() == {'MACRO_1': 7, 'MACRO_2': 'test_string'}
 
+
 def test_file_path_in_stylesheet_property(qtbot):
     """If you supply a valid filename argument, you shouldn't get any exceptions."""
     my_display = Display(parent=None, ui_filename=test_ui_path)
@@ -93,15 +94,12 @@ def test_file_path_in_stylesheet_property(qtbot):
         css = css_file.read()
         # Assert that the stylesheet property is populated with the contents of the file.
         assert my_display.styleSheet() == css
-        # Assert that the stylesheet property "hides" the global stylesheet info.
-        assert QWidget.styleSheet(my_display) == pydm.utilities.stylesheet.global_style() + css
+
 
 def test_stylesheet_property_without_path(qtbot):
-        """If you supply a valid filename argument, you shouldn't get any exceptions."""
-        my_display = Display(parent=None, ui_filename=test_ui_path)
-        qtbot.addWidget(my_display)
-        css = "PyDMLabel { font-weight: bold; }"
-        my_display.setStyleSheet(css)
-        assert my_display.styleSheet() == css
-        # Assert that the stylesheet property "hides" the global stylesheet info.
-        assert QWidget.styleSheet(my_display) == pydm.utilities.stylesheet.global_style() + css
+    """If you supply a valid filename argument, you shouldn't get any exceptions."""
+    my_display = Display(parent=None, ui_filename=test_ui_path)
+    qtbot.addWidget(my_display)
+    css = "PyDMLabel { font-weight: bold; }"
+    my_display.setStyleSheet(css)
+    assert my_display.styleSheet() == css

--- a/pydm/utilities/stylesheet.py
+++ b/pydm/utilities/stylesheet.py
@@ -28,6 +28,12 @@ def clear_cache():
     __style_data = None
 
 
+def merge_widget_stylesheet(widget, stylesheet_file_path=None):
+    curr_style = widget.styleSheet() or ""
+    env_style = _get_style_data(stylesheet_file_path) or ""
+    widget.setStyleSheet(env_style + curr_style)
+
+
 def apply_stylesheet(stylesheet_file_path=None, widget=None):
     """
     Apply a stylesheet to the current Qt Designer form (a .ui file) or to a

--- a/pydm/utilities/stylesheet.py
+++ b/pydm/utilities/stylesheet.py
@@ -28,12 +28,6 @@ def clear_cache():
     __style_data = None
 
 
-def merge_widget_stylesheet(widget, stylesheet_file_path=None):
-    curr_style = widget.styleSheet() or ""
-    env_style = _get_style_data(stylesheet_file_path) or ""
-    widget.setStyleSheet(env_style + curr_style)
-
-
 def apply_stylesheet(stylesheet_file_path=None, widget=None):
     """
     Apply a stylesheet to the current Qt Designer form (a .ui file) or to a
@@ -58,6 +52,7 @@ def apply_stylesheet(stylesheet_file_path=None, widget=None):
         widget = QApplication.instance()
 
     widget.setStyleSheet(style)
+
 
 def _get_style_data(stylesheet_file_path=None):
     """
@@ -115,6 +110,7 @@ def _get_style_data(stylesheet_file_path=None):
                     GLOBAL_STYLESHEET,
                     str(ex)))
     return __style_data
+
 
 def global_style():
     return _get_style_data()


### PR DESCRIPTION
### Context

Currently when setting a style sheet on a display, the code will merge the local and global style sheets together before calling the actual setter. This causes an issue where the global style sheet rules are interpreted as more specific than those of the widget's parent, and thus take precedent over them when they shouldn't. In particular, widgets like embedded displays or template repeaters are not having their styles set correctly on their children.

### Fix/Testing

This just stops merging the global and the local together when setting the stylesheet of a display. The global stylesheet should already be set as part of display creation, so the additional merge should not be necessary. Tested on displays containing embedded widgets/template repeaters. Updated style sheet tests. Has the potential to change the look of displays that use (perhaps unintentionally) the current behavior.