### PR TITLE
Allow for Read-Only PyDMLineEdit

### DIFF
--- a/pydm/widgets/line_edit.py
+++ b/pydm/widgets/line_edit.py
@@ -41,7 +41,7 @@ class PyDMLineEdit(QLineEdit, TextFormatter, PyDMWritableWidget, DisplayFormat):
         self.create_unit_options()
         self._display_format_type = self.DisplayFormat.Default
         self._string_encoding = "utf_8"
-        self._allow_rw = True
+        self._real_read_only = False  # Are we *really* read only?
         if utilities.is_pydm_app():
             self._string_encoding = self.app.get_string_encoding()
 
@@ -132,16 +132,16 @@ class PyDMLineEdit(QLineEdit, TextFormatter, PyDMWritableWidget, DisplayFormat):
         self.clearFocus()
         self.set_display()
 
-    def setReadOnly(self, noaccess):
-        self._allow_rw = not noaccess
-        super(PyDMLineEdit, self).setReadOnly(noaccess)
+    def setReadOnly(self, readOnly):
+        self._real_read_only = readOnly
+        super(PyDMLineEdit, self).setReadOnly(True if self._real_read_only else not self._write_access)
 
     def write_access_changed(self, new_write_access):
         """
         Change the PyDMLineEdit to read only if write access is denied
         """
         super(PyDMLineEdit, self).write_access_changed(new_write_access)
-        if self._allow_rw:
+        if not self._real_read_only:
             super(PyDMLineEdit, self).setReadOnly(not new_write_access)
 
     def unit_changed(self, new_unit):

--- a/pydm/widgets/line_edit.py
+++ b/pydm/widgets/line_edit.py
@@ -41,6 +41,7 @@ class PyDMLineEdit(QLineEdit, TextFormatter, PyDMWritableWidget, DisplayFormat):
         self.create_unit_options()
         self._display_format_type = self.DisplayFormat.Default
         self._string_encoding = "utf_8"
+        self._allow_rw = True
         if utilities.is_pydm_app():
             self._string_encoding = self.app.get_string_encoding()
 
@@ -131,12 +132,17 @@ class PyDMLineEdit(QLineEdit, TextFormatter, PyDMWritableWidget, DisplayFormat):
         self.clearFocus()
         self.set_display()
 
+    def setReadOnly(self, noaccess):
+        self._allow_rw = not noaccess
+        super(PyDMLineEdit, self).setReadOnly(noaccess)
+
     def write_access_changed(self, new_write_access):
         """
         Change the PyDMLineEdit to read only if write access is denied
         """
         super(PyDMLineEdit, self).write_access_changed(new_write_access)
-        self.setReadOnly(not new_write_access)
+        if self._allow_rw:
+            super(PyDMLineEdit, self).setReadOnly(not new_write_access)
 
     def unit_changed(self, new_unit):
         """


### PR DESCRIPTION
Currently, PyDMLineEdit's readOnly property tracks the write access of the channel.  I've always found it useful to have read only QLineEdits though, so I am suggesting this tweak.  If the readOnly property is *set* True, it remains True regardless of the write acces, but if it is *set* False, then the property will track the write access status.
