### PR TITLE
FIX: Clear out the bars set on the archiver plot when clearCurves() is called

### DIFF
--- a/pydm/widgets/archiver_time_plot.py
+++ b/pydm/widgets/archiver_time_plot.py
@@ -329,6 +329,14 @@ class PyDMArchiverTimePlot(PyDMTimePlot):
             return
         self._time_span = value
 
+    def clearCurves(self) -> None:
+        """ Clear all curves from the plot """
+        for curve in self._curves:
+            # Need to clear out any bars from optimized data, then super() can handle the rest
+            if not curve.error_bar_needs_set:
+                curve.getViewBox().removeItem(curve.error_bar_item)
+        super().clearCurves()
+
     def getCurves(self) -> List[str]:
         """
         Dump and return the current list of curves and each curve's settings into a list


### PR DESCRIPTION
When optimized data is used on the archiver time plot and bars are set to represent the min/max values, these bars will persist on the plot even when `clearCurves()` is called. This will clean them up.