### PR TITLE
BUG: reset _min_x in clearCurves()

### DIFF
--- a/pydm/widgets/archiver_time_plot.py
+++ b/pydm/widgets/archiver_time_plot.py
@@ -335,6 +335,9 @@ class PyDMArchiverTimePlot(PyDMTimePlot):
             # Need to clear out any bars from optimized data, then super() can handle the rest
             if not curve.error_bar_needs_set:
                 curve.getViewBox().removeItem(curve.error_bar_item)
+
+        # reset _min_x to let updateXAxis make requests anew
+        self._min_x = self._starting_timestamp 
         super().clearCurves()
 
     def getCurves(self) -> List[str]:


### PR DESCRIPTION
Resets the internal `PyDMArchiverTimePlot._min_x` when calling `.clearCurves()`.

As the widget makes requests to the archiver appliance, `._min_x` is updated to keep track of the earliest datapoint requested from the archiver.  This internal attribute is updated whenever the plot is adjusted to include earlier times.
https://github.com/slaclab/pydm/blob/72111a266cd41af7778ac19f68af986bc267f2d3/pydm/widgets/archiver_time_plot.py#L249-L251

This is never reset, so if `.clearCurves()` is called, the plot mistakenly remembers that previous setting and new data will only be requested if we navigate earlier than that number.  

This PR simply resets this to the time the widget was created.