### PR TITLE
ENH: Set resize policy for the QFormLayout of the basic settings widget

### DIFF
--- a/pydm/widgets/designer_settings.py
+++ b/pydm/widgets/designer_settings.py
@@ -347,7 +347,7 @@ class BasicSettingsEditor(QtWidgets.QDialog):
         self.setLayout(vlayout)
 
         settings_form = QtWidgets.QFormLayout()
-        settings_form.setFieldGrowthPolicy(QtWidgets.QFormLayout.AllNonFixedFieldsGrow)
+        settings_form.setFieldGrowthPolicy(QtWidgets.QFormLayout.ExpandingFieldsGrow)
         vlayout.addLayout(settings_form)
 
         for helper_widget in self._create_helper_widgets(settings_form):

--- a/pydm/widgets/designer_settings.py
+++ b/pydm/widgets/designer_settings.py
@@ -347,6 +347,7 @@ class BasicSettingsEditor(QtWidgets.QDialog):
         self.setLayout(vlayout)
 
         settings_form = QtWidgets.QFormLayout()
+        settings_form.setFieldGrowthPolicy(QtWidgets.QFormLayout.AllNonFixedFieldsGrow)
         vlayout.addLayout(settings_form)
 
         for helper_widget in self._create_helper_widgets(settings_form):

--- a/pydm/widgets/designer_settings.py
+++ b/pydm/widgets/designer_settings.py
@@ -287,7 +287,7 @@ def get_qt_properties(cls):
 
 
 def get_helper_label_text(attr: str) -> str:
-    spaced = re.sub("(.)([A-Z])", r"\1 \2", attr)
+    spaced = re.sub("(PyDM|.)([A-Z])", r"\1 \2", attr)
     return spaced.strip().capitalize()
 
 


### PR DESCRIPTION
## Description

The issue reported in #943 was only reproducible on a mac, as Qt on a mac will default to using `QFormLayout::FieldsStayAtSizeHint` while other platforms do not.

(https://doc.qt.io/qt-6/qformlayout.html#details)

This changes the resize policy to specifically use `QFormLayout::ExpandingFieldsGrow` for all platforms as it will resize the fields that need to expand correctly while leaving fixed size items like the rules button alone.

Also includes a small tweak to the regex so that pydm will parse as a single word when at the start of an attribute name (PyDMToolTip in this case).

## Testing

Works as expected on all of mac/linux/windows now (screenshot from mac):

<img width="444" alt="basic_settings" src="https://user-images.githubusercontent.com/89539359/200957090-fd600609-4fe8-4ce2-a5ca-43f5734abad3.png">
