### PR TITLE
FIX: call middleclick event filter instead of dropping middle click events

### DIFF
--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -1329,7 +1329,7 @@ class PyDMWidget(PyDMPrimitiveWidget, new_properties=_positionRuleProperties):
                 self.setToolTip(self.parseTip(self._pydm_tool_tip))
             return True
 
-        return False
+        return super().eventFilter(obj, event)
 
 
 class PyDMWritableWidget(PyDMWidget):


### PR DESCRIPTION
Not sure if you got to this already or if you have a more complete fix in the works- this seems to fix my middle-click copy that doesn't work in master