### PR TITLE
Allow nptypes for the result of a calc.

### DIFF
--- a/pydm/data_plugins/calc_plugin.py
+++ b/pydm/data_plugins/calc_plugin.py
@@ -241,6 +241,13 @@ class Connection(PyDMConnection):
             logger.debug('Connection was not available yet for calc.')
         try:
             val = data.get('value')
+            if isinstance(val, np.generic):
+                if np.issubdtype(type(val), np.floating):
+                    val = float(val)
+                elif np.issubdtype(type(val), np.integer):
+                    val = int(val)
+                elif np.issubdtype(type(val), np.bool_):
+                    val = bool(val)
             self.value = val
             if val is not None:
                 self.new_value_signal[type(val)].emit(val)


### PR DESCRIPTION
It would often be convenient to use np.take() in a calc expression to pull a single element out of an event-built array.  However, the type of the result is an nptype, not a basic python type.  This patch simply checks if the calc result is an nptype, and if so casts it to the appropriate base type so new_value_signal will work correctly.
