### PR TITLE
ENH: apply pydm stylesheet to related display if not pydm app

### DIFF
--- a/pydm/tests/test_data/test_emb_style.ui
+++ b/pydm/tests/test_data/test_emb_style.ui
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>285</width>
+    <height>141</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <property name="styleSheet">
+   <string notr="true">QLabel { font-weight: bold; }</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QFormLayout" name="formLayout">
+     <item row="0" column="0">
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>Number of Blobs:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QLabel" name="numBlobsLabel">
+       <property name="text">
+        <string>TextLabel</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/pydm/widgets/related_display_button.py
+++ b/pydm/widgets/related_display_button.py
@@ -11,7 +11,7 @@ from qtpy.QtCore import Slot, Property, Qt, QSize, QPoint
 from .base import PyDMPrimitiveWidget
 from ..utilities import IconFont, find_file, is_pydm_app
 from ..utilities.macro import parse_macro_string
-from ..utilities.stylesheet import apply_stylesheet
+from ..utilities.stylesheet import merge_widget_stylesheet
 from ..display import (load_file, ScreenTarget)
 
 
@@ -462,8 +462,10 @@ class PyDMRelatedDisplayButton(QPushButton, PyDMPrimitiveWidget, new_properties=
             else:
                 self.window().open(fname, macros=macros)
         else:
-            w = load_file(fname, macros=macros, target=ScreenTarget.DIALOG)
-            apply_stylesheet(widget=w)
+            display = load_file(fname, macros=macros, target=ScreenTarget.DIALOG)
+            # Not a pydm app: need to give our new display proper pydm styling
+            # Usually done in PyDMApplication
+            merge_widget_stylesheet(widget=display)
 
     def context_menu(self):
         try:

--- a/pydm/widgets/related_display_button.py
+++ b/pydm/widgets/related_display_button.py
@@ -11,6 +11,7 @@ from qtpy.QtCore import Slot, Property, Qt, QSize, QPoint
 from .base import PyDMPrimitiveWidget
 from ..utilities import IconFont, find_file, is_pydm_app
 from ..utilities.macro import parse_macro_string
+from ..utilities.stylesheet import apply_stylesheet
 from ..display import (load_file, ScreenTarget)
 
 
@@ -462,6 +463,7 @@ class PyDMRelatedDisplayButton(QPushButton, PyDMPrimitiveWidget, new_properties=
                 self.window().open(fname, macros=macros)
         else:
             w = load_file(fname, macros=macros, target=ScreenTarget.DIALOG)
+            apply_stylesheet(widget=w)
 
     def context_menu(self):
         try:

--- a/pydm/widgets/related_display_button.py
+++ b/pydm/widgets/related_display_button.py
@@ -427,6 +427,11 @@ class PyDMRelatedDisplayButton(QPushButton, PyDMPrimitiveWidget, new_properties=
             PyDMRelatedDisplayButton.EXISTING_WINDOW or 0 will open the
             file on the same window. PyDMRelatedDisplayButton.NEW_WINDOW
             or 1 will result on a new process.
+
+        Returns
+        -------
+        display : Display
+            The widget that was opened. Useful for testing and debug.
         """
         if not self.validate_password():
             return None
@@ -458,14 +463,15 @@ class PyDMRelatedDisplayButton(QPushButton, PyDMPrimitiveWidget, new_properties=
 
         if is_pydm_app():
             if target == self.NEW_WINDOW:
-                load_file(fname, macros=macros, target=screen_target)
+                return load_file(fname, macros=macros, target=screen_target)
             else:
-                self.window().open(fname, macros=macros)
+                return self.window().open(fname, macros=macros)
         else:
             display = load_file(fname, macros=macros, target=ScreenTarget.DIALOG)
             # Not a pydm app: need to give our new display proper pydm styling
             # Usually done in PyDMApplication
             merge_widget_stylesheet(widget=display)
+            return display
 
     def context_menu(self):
         try:


### PR DESCRIPTION
This isn't quite ready yet (see questions at the bottom) but I think it is in the right direction

In the `PyDMRelatedDisplayButton` widget, load the pydm stylesheet onto the widget that gets created if we're not in a pydm app.

If we are in a pydm app, we already have the stylesheet as set in https://github.com/slaclab/pydm/blob/68150968259ea190c521768e275dfc4fbc6fff26/pydm/application.py#L225 which applies the pydm stylesheet at the pydm application level. We can't do this the same way in a non-pydm app without restyling everything in the application, including the non-pydm things, and potentially overwriting application stylesheets.

If we're not in a pydm application and we want to include a pydm screen, one convenient way to do this is to use the `PyDMRelatedDisplay` button, but then the screen doesn't look quite as it should because the pydm stylesheet never gets loaded.

This adjustment makes the screen look more like it would inside a standard pydm application.

Questions: 
- How should this interact with display-level stylesheets as set in designer? I see a bunch of code in Display for loading stylesheets from filenames. I suppose the Display's stylesheet should take precedence over these? But it's not obvious to me how that should be done. I think this works in the pydm applications because the application-level stylesheet is a parent to the Display's, but I have no such thing here, so it looks like I need to combine them into one blob? Or maybe there's some way to introduce a related display parent QObject that holds the pydm application stylesheet?
- I think embedded displays have the same problem. Does pydm need to support embedded displays in non-pydm apps? My guess is probably not.

This is affecting one of our applications so I'm interested in figuring out and implementing the right way to handle it.