### PR TITLE
Fix idx typing for eventplot

### DIFF
--- a/pydm/widgets/eventplot.py
+++ b/pydm/widgets/eventplot.py
@@ -19,13 +19,15 @@ class EventPlotCurveItem(BasePlotCurveItem):
     def __init__(self, addr, y_idx, x_idx, bufferSizeChannelAddress=None, **kws):
         self.channel = None
         self.address = addr
-        if not is_qt_designer():
-            self.x_idx = int(x_idx)
-            self.y_idx = int(y_idx)
-        else:
-            print('The live update is not available for this widget on QtDesigner.')
-            self.x_idx = None
-            self.y_idx = None
+        self.x_idx = x_idx
+        self.y_idx = y_idx
+        #if not is_qt_designer():
+        #    self.x_idx = int(x_idx)
+        #    self.y_idx = int(y_idx)
+        #else:
+        #    print('The live update is not available for this widget on QtDesigner.')
+        #    self.x_idx = None
+        #    self.y_idx = None
         self.connected = False
         if kws.get('name') is None:
             kws['name'] = ""
@@ -110,6 +112,11 @@ class EventPlotCurveItem(BasePlotCurveItem):
             return
         if self.x_idx is None or self.y_idx is None:
             return
+        if not isinstance(self.x_idx, int) or not isinstance(self.y_idx, int):
+            """ The x_idx and y_idx typing is made this late so that macros can
+            can be used alongside regular indexing. """
+            self.x_idx = int(self.x_idx)
+            self.y_idx = int(self.y_idx)
         if len(new_data) <= self.x_idx or len(new_data) <= self.y_idx:
             return
         self.data_buffer = np.roll(self.data_buffer, -1)
@@ -293,7 +300,7 @@ class PyDMEventPlot(BasePlot):
 
     def addChannel(self, channel=None, y_idx=None, x_idx=None, name=None,
                    color=None, lineStyle=None, lineWidth=None,
-                   symbol=None, symbolSize=None, buffer_size=None,
+                   symbol='o', symbolSize=5, buffer_size=None,
                    yAxisName=None, bufferSizeChannelAddress=None):
         """
         Add a new curve to the plot.  In addition to the arguments below,

--- a/pydm/widgets/eventplot.py
+++ b/pydm/widgets/eventplot.py
@@ -6,7 +6,7 @@ from qtpy.QtGui import QColor
 from qtpy.QtCore import Slot, Property, Qt
 from .baseplot import BasePlot, NoDataError, BasePlotCurveItem
 from .channel import PyDMChannel
-from ..utilities import remove_protocol, is_qt_designer
+from ..utilities import remove_protocol
 
 
 DEFAULT_BUFFER_SIZE = 1200
@@ -21,13 +21,6 @@ class EventPlotCurveItem(BasePlotCurveItem):
         self.address = addr
         self.x_idx = x_idx
         self.y_idx = y_idx
-        #if not is_qt_designer():
-        #    self.x_idx = int(x_idx)
-        #    self.y_idx = int(y_idx)
-        #else:
-        #    print('The live update is not available for this widget on QtDesigner.')
-        #    self.x_idx = None
-        #    self.y_idx = None
         self.connected = False
         if kws.get('name') is None:
             kws['name'] = ""

--- a/pydm/widgets/eventplot.py
+++ b/pydm/widgets/eventplot.py
@@ -6,7 +6,7 @@ from qtpy.QtGui import QColor
 from qtpy.QtCore import Slot, Property, Qt
 from .baseplot import BasePlot, NoDataError, BasePlotCurveItem
 from .channel import PyDMChannel
-from ..utilities import remove_protocol
+from ..utilities import remove_protocol, is_qt_designer
 
 
 DEFAULT_BUFFER_SIZE = 1200
@@ -19,8 +19,13 @@ class EventPlotCurveItem(BasePlotCurveItem):
     def __init__(self, addr, y_idx, x_idx, bufferSizeChannelAddress=None, **kws):
         self.channel = None
         self.address = addr
-        self.x_idx = x_idx
-        self.y_idx = y_idx
+        if not is_qt_designer():
+            self.x_idx = int(x_idx)
+            self.y_idx = int(y_idx)
+        else:
+            print('On designer the live update is not available for this widget.')
+            self.x_idx = x_idx
+            self.y_idx = y_idx
         self.connected = False
         if kws.get('name') is None:
             kws['name'] = ""
@@ -105,9 +110,6 @@ class EventPlotCurveItem(BasePlotCurveItem):
             return
         if self.x_idx is None or self.y_idx is None:
             return
-        if not isinstance(self.x_idx, int) or not isinstance(self.y_idx, int):
-            self.x_idx = int(self.x_idx)
-            self.y_idx = int(self.y_idx)
         if len(new_data) <= self.x_idx or len(new_data) <= self.y_idx:
             return
         self.data_buffer = np.roll(self.data_buffer, -1)

--- a/pydm/widgets/eventplot.py
+++ b/pydm/widgets/eventplot.py
@@ -23,9 +23,9 @@ class EventPlotCurveItem(BasePlotCurveItem):
             self.x_idx = int(x_idx)
             self.y_idx = int(y_idx)
         else:
-            print('On designer the live update is not available for this widget.')
-            self.x_idx = x_idx
-            self.y_idx = y_idx
+            print('The live update is not available for this widget on QtDesigner.')
+            self.x_idx = None
+            self.y_idx = None
         self.connected = False
         if kws.get('name') is None:
             kws['name'] = ""

--- a/pydm/widgets/eventplot.py
+++ b/pydm/widgets/eventplot.py
@@ -105,6 +105,9 @@ class EventPlotCurveItem(BasePlotCurveItem):
             return
         if self.x_idx is None or self.y_idx is None:
             return
+        if not isinstance(self.x_idx, int) or not isinstance(self.y_idx, int):
+            self.x_idx = int(self.x_idx)
+            self.y_idx = int(self.y_idx)
         if len(new_data) <= self.x_idx or len(new_data) <= self.y_idx:
             return
         self.data_buffer = np.roll(self.data_buffer, -1)

--- a/pydm/widgets/eventplot_curve_editor.py
+++ b/pydm/widgets/eventplot_curve_editor.py
@@ -38,9 +38,10 @@ class PyDMEventPlotCurvesModel(BasePlotCurvesModel):
         if column_name == "Channel":
             curve.address = str(value)
         elif column_name == "Y Index":
-            curve.y_idx = int(value)
+            print(f'yindex: {value}')
+            curve.y_idx = value
         elif column_name == "X Index":
-            curve.x_idx = int(value)
+            curve.x_idx = value
         elif column_name == "Buffer Size":
             curve.setBufferSize(int(value))
         elif column_name == "Buffer Size Channel":

--- a/pydm/widgets/eventplot_curve_editor.py
+++ b/pydm/widgets/eventplot_curve_editor.py
@@ -38,7 +38,6 @@ class PyDMEventPlotCurvesModel(BasePlotCurvesModel):
         if column_name == "Channel":
             curve.address = str(value)
         elif column_name == "Y Index":
-            print(f'yindex: {value}')
             curve.y_idx = value
         elif column_name == "X Index":
             curve.x_idx = value


### PR DESCRIPTION
The early explicit int typing on the x and y index made the use of macro impossible.
This fixes that by pushing the typing much later, at the receive value step.

This has been tested with embedded display for XPP.