### PR TITLE
FIX: Switch usages of numpy aliases of floats to the built-in float

### DIFF
--- a/pydm/widgets/archiver_time_plot.py
+++ b/pydm/widgets/archiver_time_plot.py
@@ -159,11 +159,11 @@ class ArchivePlotCurveItem(TimePlotCurveItem):
             super(ArchivePlotCurveItem, self).redrawCurve()
         else:
             try:
-                x = np.concatenate((self.archive_data_buffer[0, -self.archive_points_accumulated:].astype(np.float),
-                                    self.data_buffer[0, -self.points_accumulated:].astype(np.float)))
+                x = np.concatenate((self.archive_data_buffer[0, -self.archive_points_accumulated:].astype(float),
+                                    self.data_buffer[0, -self.points_accumulated:].astype(float)))
 
-                y = np.concatenate((self.archive_data_buffer[1, -self.archive_points_accumulated:].astype(np.float),
-                                    self.data_buffer[1, -self.points_accumulated:].astype(np.float)))
+                y = np.concatenate((self.archive_data_buffer[1, -self.archive_points_accumulated:].astype(float),
+                                    self.data_buffer[1, -self.points_accumulated:].astype(float)))
 
                 self.setData(y=y, x=x)
             except (ZeroDivisionError, OverflowError, TypeError):

--- a/pydm/widgets/eventplot.py
+++ b/pydm/widgets/eventplot.py
@@ -196,8 +196,8 @@ class EventPlotCurveItem(BasePlotCurveItem):
         Called by the curve's parent plot whenever the curve needs to be
         re-drawn with new data.
         """
-        self.setData(x=self.data_buffer[0, -self.points_accumulated:].astype(np.float),
-                     y=self.data_buffer[1, -self.points_accumulated:].astype(np.float))
+        self.setData(x=self.data_buffer[0, -self.points_accumulated:].astype(float),
+                     y=self.data_buffer[1, -self.points_accumulated:].astype(float))
 
     def limits(self):
         """

--- a/pydm/widgets/scatterplot.py
+++ b/pydm/widgets/scatterplot.py
@@ -288,8 +288,8 @@ class ScatterPlotCurveItem(BasePlotCurveItem):
         Called by the curve's parent plot whenever the curve needs to be
         re-drawn with new data.
         """
-        self.setData(x=self.data_buffer[0, -self.points_accumulated:].astype(np.float),
-                     y=self.data_buffer[1, -self.points_accumulated:].astype(np.float))
+        self.setData(x=self.data_buffer[0, -self.points_accumulated:].astype(float),
+                     y=self.data_buffer[1, -self.points_accumulated:].astype(float))
         self.needs_new_x = True
         self.needs_new_y = True
 

--- a/pydm/widgets/timeplot.py
+++ b/pydm/widgets/timeplot.py
@@ -275,8 +275,8 @@ class TimePlotCurveItem(BasePlotCurveItem):
             The maximum timestamp to render when plotting as a bar graph.
         """
         try:
-            x = self.data_buffer[0, -self.points_accumulated:].astype(np.float)
-            y = self.data_buffer[1, -self.points_accumulated:].astype(np.float)
+            x = self.data_buffer[0, -self.points_accumulated:].astype(float)
+            y = self.data_buffer[1, -self.points_accumulated:].astype(float)
 
             if not self._plot_by_timestamps:
                 x -= time.time()

--- a/pydm/widgets/waveformplot.py
+++ b/pydm/widgets/waveformplot.py
@@ -258,9 +258,9 @@ class WaveformCurveItem(BasePlotCurveItem):
     def _setCurveData(self):
         """ Sets the most recently received waveform data for display as a line graph. """
         if self.x_waveform is None:
-            self.setData(y=self.y_waveform.astype(np.float))
+            self.setData(y=self.y_waveform.astype(float))
             return
-        self.setData(x=self.x_waveform.astype(np.float), y=self.y_waveform.astype(np.float))
+        self.setData(x=self.x_waveform.astype(float), y=self.y_waveform.astype(float))
 
     def _setBarGraphItem(self):
         """ Sets the most recently received waveform data for display as a bar graph. """


### PR DESCRIPTION
The most recent version of numpy has now removed the deprecated aliases, causing errors when trying to use them. This PR will just use the built-in `float` as that is what `np.float` is an alias for.

See here for information on the change: https://numpy.org/doc/stable/release/1.20.0-notes.html#deprecations

See here for why this cast is still needed in pydm plots (underlying issue not yet resolved): #370

Verified tests are passing again after this change, and plots still look fine.