### PR TITLE
TST: Fix mac os test run

### DIFF
--- a/azure-test-template.yml
+++ b/azure-test-template.yml
@@ -86,6 +86,13 @@ jobs:
         conda install python=$(python) pytest-azurepipelines pydm --file dev-requirements.txt
       displayName: 'Anaconda - Install Dependencies'
 
+    # mac os with python 3.7 was not solving the environment correctly (using a too old version of pyqt).
+    # This will force it to use a working version
+    - bash: |
+        conda install pyqt==5.12.3
+      displayName: 'Anaconda - mac os python 3.7 pyqt update'
+      condition: eq(variables.name, 'MacOS_3_7')
+
     - bash: |
         source activate test-environment-$(python)
         # debug of conda environment

--- a/azure-test-template.yml
+++ b/azure-test-template.yml
@@ -91,7 +91,7 @@ jobs:
     - bash: |
         conda install pyqt==5.12.3
       displayName: 'Anaconda - mac os python 3.7 pyqt update'
-      condition: eq(variables.name, 'MacOS_3_7')
+      condition: eq('${{ parameters.name }}', 'MacOS_3_7')
 
     - bash: |
         source activate test-environment-$(python)

--- a/azure-test-template.yml
+++ b/azure-test-template.yml
@@ -89,6 +89,7 @@ jobs:
     # mac os with python 3.7 was not solving the environment correctly (using a too old version of pyqt).
     # This will force it to use a working version
     - bash: |
+        source activate test-environment-$(python)
         conda install pyqt==5.12.3
       displayName: 'Anaconda - mac os python 3.7 pyqt update'
       condition: eq('${{ parameters.name }}', 'MacOS_3_7')

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,4 +5,3 @@ pytest-cov
 pytest-timeout
 p4p
 pyca
-pyqt==5.12.3

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,3 +5,4 @@ pytest-cov
 pytest-timeout
 p4p
 pyca
+pyqt==5.12.3


### PR DESCRIPTION
mac os python 3.7 tests started failing because it started solving the environment with a version of pyqt that doesn't work with pytest-qt for some reason. This will add an extra step for that specific test run only to install a version of pyqt that will definitely work with pytest-qt. 