### PR TITLE
FIX: Take precision into account for the line edit widget

### DIFF
--- a/pydm/tests/widgets/test_lineedit.py
+++ b/pydm/tests/widgets/test_lineedit.py
@@ -85,7 +85,9 @@ def test_change_display_format_type(qtbot, display_format):
 
 @pytest.mark.parametrize("value, display_format, precision, scale, unit, show_unit, expected_display", [
     (123, DisplayFormat.Default, 3, 1, "s", True, "123.000 s"),
-    (123.47, DisplayFormat.Decimal, 3, 2, "seconds", False, "246.94"),
+    (123.47, DisplayFormat.Decimal, 3, 2, "seconds", False, "246.940"),
+    (123.4567, DisplayFormat.String, 2, 1, "", False, "123.46"),
+    (123.4567, DisplayFormat.Decimal, 1, 1, "", False, "123.5"),
     (1e2, DisplayFormat.Exponential, 2, 2, "light years", True, "2.00e+02 light years"),
     (0x1FF, DisplayFormat.Hex, 0, 1, "Me", True, "0x1ff Me"),
     (0b100, DisplayFormat.Binary, 0, 1, "KB", True, "0b100 KB"),

--- a/pydm/widgets/line_edit.py
+++ b/pydm/widgets/line_edit.py
@@ -127,7 +127,7 @@ class PyDMLineEdit(QLineEdit, TextFormatter, PyDMWritableWidget, DisplayFormat):
                 self.send_value_signal[str].emit(send_value)
         except ValueError:
             logger.exception("Error trying to set data '{0}' with type '{1}' and format '{2}' at widget '{3}'."
-                         .format(self.text(), self.channeltype, self._display_format_type, self.objectName()))
+                             .format(self.text(), self.channeltype, self._display_format_type, self.objectName()))
 
         self.clearFocus()
         self.set_display()
@@ -260,11 +260,10 @@ class PyDMLineEdit(QLineEdit, TextFormatter, PyDMWritableWidget, DisplayFormat):
         else:
             self._display = str(new_value)
 
-        if self._display_format_type == DisplayFormat.Default:
-            if isinstance(new_value, (int, float)):
-                self._display = str(self.format_string.format(new_value))
-                self.setText(self._display)
-                return
+        if isinstance(new_value, (int, float)):
+            self._display = str(self.format_string.format(new_value))
+            self.setText(self._display)
+            return
 
         if self._show_units:
             self._display = "{} {}".format(self._display, self._unit)
@@ -292,4 +291,3 @@ class PyDMLineEdit(QLineEdit, TextFormatter, PyDMWritableWidget, DisplayFormat):
             return 0
         else:
             raise ValueError("invalid boolean input")
-


### PR DESCRIPTION
Fixes #940 

To reproduce the issue - create a pydm display with a `PyDMLineEdit` widget. Set the precision (manually or from PV are both fine) and set the `displayFormat` to Decimal or String. It will ignore the value of precision. 

This PR removes the unnecessary check for the display format type. The text formatter will do the right thing no matter what it is set to, this is what the `PyDMLabel` already does.

Verified it works as expected with test displays. Corrected the test case already in place, and added a couple more cases.