### PR TITLE
ENH: Improve load time of displays that re-use the same UI file repeatedly

### DIFF
--- a/pydm/display.py
+++ b/pydm/display.py
@@ -124,8 +124,6 @@ def _load_compiled_ui_into_display(code_string: str, class_name: str, display) -
     # Create and grab the class described by the compiled ui file
     ui_globals = {}
     exec(code_string, ui_globals)
-
-    class_name = re.search(r'class\s*(\S*)\(', code_string).group(1)
     klass = ui_globals[class_name]
 
     # Add retranslateUi to Display class

--- a/pydm/display.py
+++ b/pydm/display.py
@@ -72,7 +72,7 @@ def load_file(file, macros=None, args=None, target=ScreenTarget.NEW_PROCESS):
     return w
 
 
-@lru_cache
+@lru_cache()
 def _compile_ui_file(uifile: str) -> Tuple[str, str]:
     """
     Compile the ui file using uic and return the result as a string along with the associated class name.

--- a/pydm/display.py
+++ b/pydm/display.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import functools
 import inspect
 import logging
@@ -108,7 +109,7 @@ def _load_ui_into_display(uifile, display):
     display.ui = display
 
 
-def _load_compiled_ui_into_display(code_string: str, class_name: str, display) -> None:
+def _load_compiled_ui_into_display(code_string: str, class_name: str, display: Display) -> None:
     """
     Takes a ui file which has already been compiled by uic and loads it into the input display
 

--- a/pydm/display.py
+++ b/pydm/display.py
@@ -90,7 +90,7 @@ def _compile_ui_file(uifile: str) -> Tuple[str, str]:
     code_string = StringIO()
     uic.compileUi(uifile, code_string)
     # Grabs non-whitespace characters between class and the opening parenthesis
-    class_name = re.search(r'class\s*(\S*)\(', code_string.getvalue()).group(1)
+    class_name = re.search(r'^class\s*(\S*)\(', code_string.getvalue()).group(1)
     return code_string.getvalue(), class_name
 
 

--- a/pydm/display.py
+++ b/pydm/display.py
@@ -90,7 +90,7 @@ def _compile_ui_file(uifile: str) -> Tuple[str, str]:
     code_string = StringIO()
     uic.compileUi(uifile, code_string)
     # Grabs non-whitespace characters between class and the opening parenthesis
-    class_name = re.search(r'^class\s*(\S*)\(', code_string.getvalue()).group(1)
+    class_name = re.search(r'^class\s*(\S*)\(', code_string.getvalue(), re.MULTILINE).group(1)
     return code_string.getvalue(), class_name
 
 

--- a/pydm/tests/test_display.py
+++ b/pydm/tests/test_display.py
@@ -1,7 +1,7 @@
 import os
 import pytest
 from pydm import Display
-from pydm.display import load_py_file
+from pydm.display import load_py_file, _compile_ui_file
 from qtpy.QtWidgets import QWidget
 import pydm.utilities.stylesheet
 
@@ -103,3 +103,14 @@ def test_stylesheet_property_without_path(qtbot):
     css = "PyDMLabel { font-weight: bold; }"
     my_display.setStyleSheet(css)
     assert my_display.styleSheet() == css
+
+
+def test_compile_ui_file():
+    """
+    Does a compile of our test ui file with uic and verifies the correct class is created,
+    and the expected methods are added
+    """
+    code_string, class_name = _compile_ui_file(test_ui_path)
+    assert class_name == 'Ui_Form'
+    assert 'setupUi(self' in code_string
+    assert 'retranslateUi(self' in code_string


### PR DESCRIPTION
### Motivation

This is a continuation of the work done in #859 

When doing some profiling on the pyqt side of things, a lot of time was spent in the compilation of ui files when calling `loadUiType`. For example:

```
Total time: 5.24095 s
File: /afs/slac/g/lcls/package/anaconda/envs/python3_devel/lib/python3.8/site-packages/PyQt5/uic/__init__.py
Function: loadUiType at line 171

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   171                                           def loadUiType(uifile, from_imports=False, resource_suffix='_rc', import_from='.'):
   <snip>
   199       107       4868.2     45.5     92.9      winfo = compiler.UICompiler().compileUi(uifile, code_string, from_imports, 
   <snip>
```

This PR applies a similar strategy to #859, but with the focus on caching the result of that compilation, rather than altering the way macros are loaded. This should capture much of the gain, without the loss seen in calling channel setters twice.

### What Changed
As explained in 859 currently we do this:

1. Read the file from disc
2. Substitute macros into the file text
3. Invoke the pyqt uic loader to create a widget class
4. Graft the widgets defined by the widget class onto an empty Display object

This PR changes it to be:

1. Load the code for the compiled ui class from cache if it exists, otherwise read the file
2. If we needed to read the file, then use uic to do compilation only
3. Now do the macro substitution
4. `exec()` and call `retranslateUi() ` and `setupUi()`
5. Graft the widget class onto an empty Display object

So the big time saving is in not having to redo the compilation of a ui file a whole bunch of times if it is re-used a lot in the same display (for example in template repeaters).

### Testing

I tested some displays on the accelerator side, they still function well and those using template repeaters show speed ups in load times. 

For a more concrete example I tried the pmps_ui, albeit not actually connected to any channels. Load time for me dropped from ~28 seconds to ~22.5 seconds. The function in particular that was targeted:

Before this PR:

```
Total time: 13.2016 s
File: /home/jesseb/Documents/pydm/pydm/display.py
Function: load_ui_file at line 85

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
    85                                           def load_ui_file(uifile, macros=None, args=None):
    86                                               """
    87                                               Load a .ui file, perform macro substitution, then return the resulting QWidget.
    88                                           
    89                                               This is an internal method, users will usually want to use `open_file` instead.
    90                                           
    91                                               Parameters
    92                                               ----------
    93                                               uifile : str
    94                                                   The path to a .ui file to load.
    95                                               macros : dict, optional
    96                                                   A dictionary of macro variables to supply to the file
    97                                                   to be opened.
    98                                               args : list, optional
    99                                                   This is ignored for UI files.
   100                                           
   101                                               Returns
   102                                               -------
   103                                               QWidget
   104                                               """
   105                                           
   106       372         15.8      0.0      0.1      d = Display(macros=macros)
   107       372          0.3      0.0      0.0      if macros:
   108       372         95.8      0.3      0.7          f = macro.substitute_in_file(uifile, macros)
   109                                               else:
   110                                                   f = uifile
   111                                           
   112       372          0.3      0.0      0.0      d._loaded_file = uifile
   113       372      13089.2     35.2     99.1      _load_ui_into_display(f, d)
   114       372          0.2      0.0      0.0      return d

```


After this PR:

```
Total time: 7.66983 s
File: /home/jesseb/Documents/pydm/pydm/display.py
Function: load_ui_file at line 127

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   127                                           def load_ui_file(uifile, macros=None, args=None):
   128                                               """
   129                                               Load a .ui file, perform macro substitution, then return the resulting QWidget.
   130                                           
   131                                               This is an internal method, users will usually want to use `open_file` instead.
   132                                           
   133                                               Parameters
   134                                               ----------
   135                                               uifile : str
   136                                                   The path to a .ui file to load.
   137                                               macros : dict, optional
   138                                                   A dictionary of macro variables to supply to the file
   139                                                   to be opened.
   140                                               args : list, optional
   141                                                   This is ignored for UI files.
   142                                           
   143                                               Returns
   144                                               -------
   145                                               QWidget
   146                                               """
   147                                           
   148       372         16.3      0.0      0.2      d = Display(macros=macros)
   149       372          0.3      0.0      0.0      d._loaded_file = uifile
   150       372         66.5      0.2      0.9      code_string, class_name = _compile_ui_file(uifile)
   151       372          0.2      0.0      0.0      if macros:
   152       372         53.0      0.1      0.7          code_string = macro.replace_macros_in_template(Template(code_string), macros).getvalue()
   153       372       7533.2     20.3     98.2      _load_compiled_ui_into_display(code_string, class_name, d)
   154       372          0.3      0.0      0.0      return d
```

I would think these results should hold when run in an actual production setup as I was only targeting ui file disk loading and compilation and not any of the actually EPICS connections yet, but would be interested to hear if that is the case. I don't see any slowdown anywhere else as part of this.