### PR TITLE
FIX: Error with shell command when environment variable set to empty string

### DIFF
--- a/pydm/tests/widgets/test_shell_command.py
+++ b/pydm/tests/widgets/test_shell_command.py
@@ -95,6 +95,17 @@ def test_no_crash_with_none_command(qtbot):
      pydm_shell_command.command = None
      qtbot.mouseClick(pydm_shell_command, QtCore.Qt.LeftButton)
 
+
+def test_no_error_without_env_variable(qtbot, caplog):
+    """ Verify that the shell command works when the environment variable property is saved as an empty string """
+    pydm_shell_command = PyDMShellCommand()
+    qtbot.addWidget(pydm_shell_command)
+    pydm_shell_command.command = "echo hello"
+    pydm_shell_command.environmentVariables = ""
+    qtbot.mouseClick(pydm_shell_command, QtCore.Qt.LeftButton)
+    assert 'error' not in caplog.text.lower()
+
+
 @pytest.mark.parametrize("cmd, retcode, stdout", [
     (["choice /c yn /d n /t 0"] if platform.system() == "Windows" else ["sleep 0"],
         [2] if platform.system() == "Windows" else [0], ["[Y,N]?N"] if platform.system() == "Windows" else [""]),

--- a/pydm/widgets/shell_command.py
+++ b/pydm/widgets/shell_command.py
@@ -400,7 +400,7 @@ class PyDMShellCommand(QPushButton, PyDMPrimitiveWidget):
                 logger.debug("Launching process: %s", repr(args))
                 stdout = subprocess.PIPE
 
-                if self.env_var is not None:
+                if self.env_var:
                     env_var = literal_eval(self.env_var)
                 else:
                     env_var = None

--- a/pydm/widgets/shell_command.py
+++ b/pydm/widgets/shell_command.py
@@ -7,20 +7,34 @@ import logging
 import warnings
 import hashlib
 from ast import literal_eval
-from qtpy.QtWidgets import QPushButton, QMenu, QMessageBox, QInputDialog, QLineEdit
-from qtpy.QtGui import QCursor, QIcon, QColor
+from typing import Optional, Union, List
+from qtpy.QtWidgets import QPushButton, QMenu, QMessageBox, QInputDialog, QLineEdit, QWidget
+from qtpy.QtGui import QCursor, QIcon, QMouseEvent
 from qtpy.QtCore import Property, QSize, Qt, QTimer
 from .base import PyDMPrimitiveWidget
 from ..utilities import IconFont
 
 logger = logging.getLogger(__name__)
 
+
 class PyDMShellCommand(QPushButton, PyDMPrimitiveWidget):
     """
     A QPushButton capable of execute shell commands.
+
+    Parameters
+    ----------
+    parent : QWidget, optional
+        The parent widget for the shell command
+    command : str or list, optional
+        A string for a single command to run, or a list of strings for multiple commands
+    title : str or list, optional
+        Title of the command to run, shown in the display. If a list, number of elements must match that of command
     """
 
-    def __init__(self, parent=None, command=None, title=None):
+    def __init__(self,
+                 parent: Optional[QWidget] = None,
+                 command: Optional[Union[str, List[str]]] = None,
+                 title: Optional[Union[str, List[str]]] = None) -> None:
         QPushButton.__init__(self, parent)
         PyDMPrimitiveWidget.__init__(self)
         self.iconFont = IconFont()
@@ -54,7 +68,7 @@ class PyDMShellCommand(QPushButton, PyDMPrimitiveWidget):
         self.env_var = None
 
     @Property(str)
-    def environmentVariables(self):
+    def environmentVariables(self) -> str:
         """
         Return the environment variables which would be set along with the shell command.
 
@@ -65,7 +79,7 @@ class PyDMShellCommand(QPushButton, PyDMPrimitiveWidget):
         return self.env_var
 
     @environmentVariables.setter
-    def environmentVariables(self, new_dict):
+    def environmentVariables(self, new_dict: str) -> None:
         """
         Set environment variables which would be set along with the shell command.
 
@@ -77,7 +91,7 @@ class PyDMShellCommand(QPushButton, PyDMPrimitiveWidget):
             self.env_var = new_dict
 
     @Property(bool)
-    def showIcon(self):
+    def showIcon(self) -> bool:
         """
         Whether or not we should show the selected Icon.
 
@@ -88,7 +102,7 @@ class PyDMShellCommand(QPushButton, PyDMPrimitiveWidget):
         return self._show_icon
 
     @showIcon.setter
-    def showIcon(self, value):
+    def showIcon(self, value: bool) -> None:
         """
         Whether or not we should show the selected Icon.
 
@@ -106,7 +120,7 @@ class PyDMShellCommand(QPushButton, PyDMPrimitiveWidget):
                 self.setIcon(QIcon())
 
     @Property(bool)
-    def redirectCommandOutput(self):
+    def redirectCommandOutput(self) -> bool:
         """
         Whether or not we should redirect the output of command to the shell.
 
@@ -117,7 +131,7 @@ class PyDMShellCommand(QPushButton, PyDMPrimitiveWidget):
         return self._redirect_output
 
     @redirectCommandOutput.setter
-    def redirectCommandOutput(self, value):
+    def redirectCommandOutput(self, value: bool) -> None:
         """
         Whether or not we should redirect the output of command to the shell.
 
@@ -133,7 +147,7 @@ class PyDMShellCommand(QPushButton, PyDMPrimitiveWidget):
             self._redirect_output = value
 
     @Property(bool)
-    def allowMultipleExecutions(self):
+    def allowMultipleExecutions(self) -> bool:
         """
         Whether or not we should allow the same command
         to be executed even if it is still running.
@@ -145,7 +159,7 @@ class PyDMShellCommand(QPushButton, PyDMPrimitiveWidget):
         return self._allow_multiple
 
     @allowMultipleExecutions.setter
-    def allowMultipleExecutions(self, value):
+    def allowMultipleExecutions(self, value: bool) -> None:
         """
         Whether or not we should allow the same command
         to be executed even if it is still running.
@@ -158,20 +172,20 @@ class PyDMShellCommand(QPushButton, PyDMPrimitiveWidget):
             self._allow_multiple = value
 
     @Property('QStringList')
-    def titles(self):
+    def titles(self) -> List[str]:
         return self._titles
 
     @titles.setter
-    def titles(self, val):
+    def titles(self, val: List[str]) -> None:
         self._titles = val
         self._menu_needs_rebuild = True
 
     @Property('QStringList')
-    def commands(self):
+    def commands(self) -> List[str]:
         return self._commands
 
     @commands.setter
-    def commands(self, val):
+    def commands(self, val: List[str]) -> None:
         if not val:
             self._commands = []
         else:
@@ -179,7 +193,7 @@ class PyDMShellCommand(QPushButton, PyDMPrimitiveWidget):
         self._menu_needs_rebuild = True
 
     @Property(str, designable=False)
-    def command(self):
+    def command(self) -> str:
         """
         DEPRECATED: use the 'commands' property.
         This property simply returns the first command from the 'commands'
@@ -195,7 +209,7 @@ class PyDMShellCommand(QPushButton, PyDMPrimitiveWidget):
         return self.commands[0]
 
     @command.setter
-    def command(self, value):
+    def command(self, value: str) -> None:
         """
         DEPRECATED: Use the 'commands' property instead.
         This property only has an effect if the 'commands' property is empty.
@@ -214,9 +228,8 @@ class PyDMShellCommand(QPushButton, PyDMPrimitiveWidget):
             else:
                 self.commands = []
 
-
     @Property(bool)
-    def passwordProtected(self):
+    def passwordProtected(self) -> bool:
         """
         Whether or not this button is password protected.
         Returns
@@ -227,7 +240,7 @@ class PyDMShellCommand(QPushButton, PyDMPrimitiveWidget):
         return self._password_protected
 
     @passwordProtected.setter
-    def passwordProtected(self, value):
+    def passwordProtected(self, value: bool) -> None:
         """
         Whether or not this button is password protected.
         Parameters
@@ -238,30 +251,30 @@ class PyDMShellCommand(QPushButton, PyDMPrimitiveWidget):
             self._password_protected = value
 
     @Property(str)
-    def password(self):
+    def password(self) -> str:
         """
-    	Password to be encrypted using SHA256.
+        Password to be encrypted using SHA256.
 
-    	.. warning::
-    		To avoid issues exposing the password this method
-    		always returns an empty string.
+        .. warning::
+            To avoid issues exposing the password this method
+            always returns an empty string.
 
-    	Returns
-    	-------
-    	str
-    	"""
+        Returns
+        -------
+        str
+        """
         return ""
 
     @password.setter
-    def password(self, value):
+    def password(self, value: str) -> None:
         """
-    	Password to be encrypted using SHA256.
+        Password to be encrypted using SHA256.
 
-    	Parameters
-    	----------
-    	value : str
-    		The password to be encrypted
-    	"""
+        Parameters
+        ----------
+        value : str
+            The password to be encrypted
+        """
         if value is not None and value != "":
             sha = hashlib.sha256()
             sha.update(value.encode())
@@ -270,23 +283,22 @@ class PyDMShellCommand(QPushButton, PyDMPrimitiveWidget):
             self.protectedPassword = sha.hexdigest()
 
     @Property(str)
-    def protectedPassword(self):
+    def protectedPassword(self) -> str:
         """
-    	The encrypted password.
+        The encrypted password.
 
-    	Returns
-    	-------
-    	str
-    	"""
+        Returns
+        -------
+        str
+        """
         return self._protected_password
 
     @protectedPassword.setter
-    def protectedPassword(self, value):
+    def protectedPassword(self, value: str) -> None:
         if self._protected_password != value:
             self._protected_password = value
 
-
-    def _rebuild_menu(self):
+    def _rebuild_menu(self) -> None:
         if not any(self._commands):
             self._commands = []
         if not any(self._titles):
@@ -308,12 +320,12 @@ class PyDMShellCommand(QPushButton, PyDMPrimitiveWidget):
         self.setMenu(menu)
         self._menu_needs_rebuild = False
 
-    def mousePressEvent(self, event):
+    def mousePressEvent(self, event: QMouseEvent) -> None:
         if self._menu_needs_rebuild:
             self._rebuild_menu()
         super(PyDMShellCommand, self).mousePressEvent(event)
 
-    def mouseReleaseEvent(self, mouse_event):
+    def mouseReleaseEvent(self, mouse_event: QMouseEvent) -> None:
         """
         mouseReleaseEvent is called when a mouse button is released.
         This means that if the user presses the mouse inside your widget,
@@ -332,13 +344,13 @@ class PyDMShellCommand(QPushButton, PyDMPrimitiveWidget):
         self.execute_command(self.commands[0])
         super(PyDMShellCommand, self).mouseReleaseEvent(mouse_event)
 
-    def show_warning_icon(self):
+    def show_warning_icon(self) -> None:
         """ Show the warning icon.  This is called when a shell command fails
         (i.e. exits with nonzero status) """
         self.setIcon(self._warning_icon)
         QTimer.singleShot(5000, self.hide_warning_icon)
 
-    def hide_warning_icon(self):
+    def hide_warning_icon(self) -> None:
         """ Hide the warning icon.  This is called on a timer after the warning
         icon is shown."""
         if self._show_icon:
@@ -346,7 +358,7 @@ class PyDMShellCommand(QPushButton, PyDMPrimitiveWidget):
         else:
             self.setIcon(QIcon())
 
-    def validate_password(self):
+    def validate_password(self) -> None:
         """
         If the widget is ```passwordProtected```, this method will propmt
         the user for the correct password.
@@ -381,7 +393,7 @@ class PyDMShellCommand(QPushButton, PyDMPrimitiveWidget):
             return False
         return True
 
-    def execute_command(self, command):
+    def execute_command(self, command: str) -> None:
         """
         Execute the shell command given by ```command```.
         The process is available through the ```process``` member.


### PR DESCRIPTION
Fixes #968

If the `enviornmentVariables` property of a `PyDMShellCommand` is saved as an empty string, it will cause an error. This fixes it by not using it if it is empty, same as is done for `None`.

Also includes flake8 fixes, type hints, a bit more documentation, and a unit test covering this case which will fail prior to applying this PR.

Verified existing shell commands still work fine, verified this fixes the issue.