### PR TITLE
ENH: Make deferring connections the default for main window again for better performance

### DIFF
--- a/pydm/data_plugins/__init__.py
+++ b/pydm/data_plugins/__init__.py
@@ -29,7 +29,19 @@ __plugins_initialized = False
 
 
 @contextmanager
-def connection_queue(defer_connections=False):
+def connection_queue(defer_connections: bool = False) -> None:
+    """
+    Creates a queue for holding channel connections and potentially processing them at a later time. When
+    defer_connections is set to True, the exit from the context manager will not result in any connections being made.
+    This allows for a more responsive end user experience on displays with many connections as it will load without
+    needing to establish all connections first.
+    Parameters
+    ----------
+    defer_connections : bool
+        Whether or not to defer making the actual connections to channels at a later time. Note that if this
+        is set to true, a call to establish_queued_connections() must be made at some point later as the queue
+        will not be automatically be processed by the context manager in this case.
+    """
     global __CONNECTION_QUEUE__
     global __DEFER_CONNECTIONS__
     if __CONNECTION_QUEUE__ is None:
@@ -41,7 +53,11 @@ def connection_queue(defer_connections=False):
     establish_queued_connections()
 
 
-def establish_queued_connections():
+def establish_queued_connections() -> None:
+    """
+    Processes all channels in the deferred connection queue establishing the actual connection for each. Upon
+    completion, will reset the global connection queue to None.
+    """
     global __DEFER_CONNECTIONS__
     global __CONNECTION_QUEUE__
     if __CONNECTION_QUEUE__ is None:

--- a/pydm/display.py
+++ b/pydm/display.py
@@ -33,7 +33,7 @@ def load_file(file: str,
               macros: Optional[Dict[str, str]] = None,
               args: Optional[List[str]] = None,
               target: ScreenTarget = ScreenTarget.NEW_PROCESS,
-              defer_connections: bool = False):
+              defer_connections: bool = False) -> None:
     """
     Load .ui, .py, or .adl screen file, perform macro substitution, then return
     the resulting QWidget.

--- a/pydm/display.py
+++ b/pydm/display.py
@@ -33,7 +33,7 @@ def load_file(file: str,
               macros: Optional[Dict[str, str]] = None,
               args: Optional[List[str]] = None,
               target: ScreenTarget = ScreenTarget.NEW_PROCESS,
-              defer_connections: bool = False) -> None:
+              defer_connections: bool = False):
     """
     Load .ui, .py, or .adl screen file, perform macro substitution, then return
     the resulting QWidget.

--- a/pydm/main_window.py
+++ b/pydm/main_window.py
@@ -17,6 +17,7 @@ from . import tools
 from .widgets.rules import register_widget_rules, unregister_widget_rules
 from . import config
 import subprocess
+import threading
 import platform
 import logging
 
@@ -352,7 +353,8 @@ class PyDMMainWindow(QMainWindow):
         new_widget = load_file(filename,
                                macros=macros,
                                args=args,
-                               target=target)
+                               target=target,
+                               defer_connections=True)
         if new_widget:
             if self.home_widget is None:
                 self.home_widget = new_widget
@@ -370,6 +372,10 @@ class PyDMMainWindow(QMainWindow):
             self.ui.actionEdit_in_Designer.setText(edit_in_text)
             if (self.designer_path and ui_file) or (py_file and not ui_file):
                 self.ui.actionEdit_in_Designer.setEnabled(True)
+
+        # Create and run the thread for establishing the channel connections which have been queued above
+        establish_connections_thread = threading.Thread(target=data_plugins.establish_queued_connections, daemon=True)
+        establish_connections_thread.start()
         return new_widget
 
     def load_tool(self, checked):

--- a/pydm/tests/test_display.py
+++ b/pydm/tests/test_display.py
@@ -1,7 +1,7 @@
 import os
 import pytest
-from pydm import Display
-from pydm.display import load_py_file, _compile_ui_file
+from pydm import Display, data_plugins
+from pydm.display import load_file, load_py_file, _compile_ui_file, ScreenTarget
 from qtpy.QtWidgets import QWidget
 import pydm.utilities.stylesheet
 
@@ -114,3 +114,16 @@ def test_compile_ui_file():
     assert class_name == 'Ui_Form'
     assert 'setupUi(self' in code_string
     assert 'retranslateUi(self' in code_string
+
+
+def test_defer_connections(qtbot):
+    """
+    Verify that when the defer_connections parameter is set to true, connections are held up in a queue
+    until it is time to process them
+    """
+    load_file(valid_display_test_py_path, target=ScreenTarget.HOME, defer_connections=True)
+
+    # The test file loaded has one connection to TST:Val1. Since defer_connections is True, verify
+    # that this address has been placed in the queue.
+    assert 'TST:Val1' == data_plugins.__CONNECTION_QUEUE__[0].address
+    data_plugins.__CONNECTION_QUEUE__ = None

--- a/pydm/tests/test_display.py
+++ b/pydm/tests/test_display.py
@@ -2,8 +2,6 @@ import os
 import pytest
 from pydm import Display, data_plugins
 from pydm.display import load_file, load_py_file, _compile_ui_file, ScreenTarget
-from qtpy.QtWidgets import QWidget
-import pydm.utilities.stylesheet
 
 # The path to the .ui file used in these tests
 test_ui_path = os.path.join(

--- a/pydm/widgets/template_repeater.py
+++ b/pydm/widgets/template_repeater.py
@@ -395,26 +395,20 @@ class PyDMTemplateRepeater(QFrame, PyDMPrimitiveWidget, LayoutType):
             self.setLayout(l)
             self.layout().setSpacing(self._temp_layout_spacing)
         try:
-            with pydm.data_plugins.connection_queue(defer_connections=True):
-                for i, variables in enumerate(self.data):
-                    if is_qt_designer() and i > self.countShownInDesigner - 1:
-                        break
-                    w = self.open_template_file(variables)
-                    if w is None:
-                        w = QLabel()
-                        w.setText("No Template Loaded.  Data: {}".format(variables))
-                    w.setParent(self)
-                    self.layout().addWidget(w)
+            for i, variables in enumerate(self.data):
+                if is_qt_designer() and i > self.countShownInDesigner - 1:
+                    break
+                w = self.open_template_file(variables)
+                if w is None:
+                    w = QLabel()
+                    w.setText("No Template Loaded.  Data: {}".format(variables))
+                w.setParent(self)
+                self.layout().addWidget(w)
         except:
             logger.exception('Template repeater failed to rebuild.')
         finally:
-            # If issues happen during the rebuild we should still enable
-            # updates and establish connection for the widgets added.
-            # Moreover, if we dont call establish_queued_connections
-            # the queue will never be emptied and new connections will be
-            # staled.
+            # If issues happen during the rebuild we should still enable updates for the widgets added.
             self.setUpdatesEnabled(True)
-            pydm.data_plugins.establish_queued_connections()
     
     def clear(self):
         """ Clear out any existing instances of the template inside

--- a/pydm/widgets/template_repeater.py
+++ b/pydm/widgets/template_repeater.py
@@ -3,13 +3,13 @@ import json
 import copy
 import logging
 from qtpy.QtWidgets import (QFrame, QApplication, QLabel, QVBoxLayout,
-                           QHBoxLayout, QWidget, QStyle, QSizePolicy,
-                           QLayout)
+                            QHBoxLayout, QWidget, QStyle, QSizePolicy,
+                            QLayout)
 from qtpy.QtCore import Qt, QSize, QRect, Property, QPoint, Q_ENUMS
 from .base import PyDMPrimitiveWidget
 from pydm.utilities import is_qt_designer
 import pydm.data_plugins
-from ..utilities import macro, find_file
+from ..utilities import find_file
 from ..display import load_file
 logger = logging.getLogger(__name__)
 
@@ -21,53 +21,53 @@ class FlowLayout(QLayout):
         self.m_h_space = h_spacing
         self.m_v_space = v_spacing
         self.item_list = []
-    
+
     def addItem(self, item):
         self.item_list.append(item)
-    
+
     def horizontalSpacing(self):
         if self.m_h_space >= 0:
             return self.m_h_space
         else:
             return self.smart_spacing(QStyle.PM_LayoutHorizontalSpacing)
-    
+
     def verticalSpacing(self):
         if self.m_v_space >= 0:
             return self.m_v_space
         else:
             return self.smart_spacing(QStyle.PM_LayoutVerticalSpacing)
-    
+
     def count(self):
         return len(self.item_list)
-    
+
     def itemAt(self, index):
         if index >= 0 and index < len(self.item_list):
             return self.item_list[index]
         else:
             return None
-    
+
     def takeAt(self, index):
         if index >= 0 and index < len(self.item_list):
             return self.item_list.pop(index)
         else:
             return None
-    
+
     def expandingDirections(self):
         return Qt.Orientations(0)
-    
+
     def hasHeightForWidth(self):
         return True
-    
+
     def heightForWidth(self, width):
-        return self.do_layout(QRect(0,0, width, 0), True)
-    
+        return self.do_layout(QRect(0, 0, width, 0), True)
+
     def setGeometry(self, rect):
         super(FlowLayout, self).setGeometry(rect)
         self.do_layout(rect, False)
-    
+
     def sizeHint(self):
         return self.minimumSize()
-    
+
     def minimumSize(self):
         size = QSize()
         for item in self.item_list:
@@ -75,7 +75,7 @@ class FlowLayout(QLayout):
         #size += QSize(2*self.margin(), 2*self.margin())
         size += QSize(2*8, 2*8)
         return size
-    
+
     def do_layout(self, rect, test_only):
         (left, top, right, bottom) = self.getContentsMargins()
         effective_rect = rect.adjusted(left, top, -right, -bottom)
@@ -101,7 +101,7 @@ class FlowLayout(QLayout):
             x = next_x
             line_height = max(line_height, item.sizeHint().height())
         return y + line_height - rect.y() + bottom
-    
+
     def smart_spacing(self, pm):
         parent = self.parent()
         if not parent:
@@ -157,7 +157,7 @@ class PyDMTemplateRepeater(QFrame, PyDMPrimitiveWidget, LayoutType):
         self._temp_layout_spacing = 4
         self.app = QApplication.instance()
         self.rebuild()
-    
+
     @Property(LayoutType)
     def layoutType(self):
         """
@@ -191,31 +191,31 @@ class PyDMTemplateRepeater(QFrame, PyDMPrimitiveWidget, LayoutType):
         if self.layout():
             return self.layout().spacing()
         return self._temp_layout_spacing
-    
+
     @layoutSpacing.setter
     def layoutSpacing(self, new_spacing):
         self._temp_layout_spacing = new_spacing
         if self.layout():
             self.layout().setSpacing(new_spacing)
-    
+
     @Property(int)
     def countShownInDesigner(self):
         """
         The number of instances to show in Qt Designer.  This property has no
         effect outside of Designer.
-        
+
         Returns
         -------
         int
         """
         return self._count_shown_in_designer
-    
+
     @countShownInDesigner.setter
     def countShownInDesigner(self, new_count):
         """
         The number of instances to show in Qt Designer.  This property has no
         effect outside of Designer.
-        
+
         Parameters
         ----------
         new_count : int
@@ -231,23 +231,23 @@ class PyDMTemplateRepeater(QFrame, PyDMPrimitiveWidget, LayoutType):
         if new_count != self._count_shown_in_designer:
             self._count_shown_in_designer = new_count
             self.rebuild()
-    
+
     @Property(str)
     def templateFilename(self):
         """
         The path to the .ui file to use as a template.
-        
+
         Returns
         -------
         str
         """
         return self._template_filename
-    
+
     @templateFilename.setter
     def templateFilename(self, new_filename):
         """
         The path to the .ui file to use as a template.
-        
+
         Parameters
         ----------
         new_filename : str
@@ -286,25 +286,25 @@ class PyDMTemplateRepeater(QFrame, PyDMPrimitiveWidget, LayoutType):
         """
         The path to the JSON file or a valid JSON string to fill in each
         instance of the template.
-        
+
         Returns
         -------
         str
         """
         return self._data_source
-    
+
     @dataSource.setter
     def dataSource(self, data_source):
         """
         Sets the path to the JSON file or a valid JSON string to fill in each
         instance of the template.
-        
+
         For example, if you build a template that contains two macro variables,
         ${NAME} and ${UNIT}, your JSON file should be a list of dictionaries,
         each with keys for NAME and UNIT, like this:
-        
+
         [{"NAME": "First Device", "UNIT": 1}, {"NAME": "Second Device", "UNIT": 2}]
-        
+
         Parameters
         -------
         data_source : str
@@ -345,7 +345,7 @@ class PyDMTemplateRepeater(QFrame, PyDMPrimitiveWidget, LayoutType):
     def open_template_file(self, variables=None):
         """
         Opens the widget specified in the templateFilename property.
-        
+
         Parameters
         ----------
         variables : dict
@@ -385,7 +385,7 @@ class PyDMTemplateRepeater(QFrame, PyDMPrimitiveWidget, LayoutType):
         if (not self.templateFilename) or (not self.data):
             return
         self.setUpdatesEnabled(False)
-        
+
         layout_class = layout_class_for_type[self.layoutType]
         if type(self.layout()) != layout_class:
             if self.layout() is not None:
@@ -409,7 +409,7 @@ class PyDMTemplateRepeater(QFrame, PyDMPrimitiveWidget, LayoutType):
         finally:
             # If issues happen during the rebuild we should still enable updates for the widgets added.
             self.setUpdatesEnabled(True)
-    
+
     def clear(self):
         """ Clear out any existing instances of the template inside
         the widget."""
@@ -419,13 +419,13 @@ class PyDMTemplateRepeater(QFrame, PyDMPrimitiveWidget, LayoutType):
             item = self.layout().takeAt(0)
             item.widget().deleteLater()
             del item
-    
+
     def count(self):
         if not self.layout():
             return 0
         return self.layout().count()
-    
-    @property    
+
+    @property
     def data(self):
         """
         The dictionary used by the widget to fill in each instance of the template.
@@ -433,13 +433,13 @@ class PyDMTemplateRepeater(QFrame, PyDMPrimitiveWidget, LayoutType):
         property.
         """
         return self._data
-    
+
     @data.setter
     def data(self, new_data):
         """
-        Sets the dictionary used by the widget to fill in each instance of 
+        Sets the dictionary used by the widget to fill in each instance of
         the template.  This property will be overwritten if the user changes
-        the dataSource property.  After setting this property, `rebuild` 
+        the dataSource property.  After setting this property, `rebuild`
         is automatically called to refresh the widget.
         """
         self._data = new_data


### PR DESCRIPTION
### Context

As mentioned in the previous performance PR, load time of establishing connections was what I wanted to take a look at next as a lot of time is spent making connections to channels upon starting up a display. While looking through the relevant code, I found that there is already a mechanism for making this better, a connection queue that can be appended to and then processed at a later time. I did some digging to find out why this wasn't being used much just in case there was an issue with it, but I think its use may have been removed inadvertently?:

It was added here: #467 
Deferring connections was made the default here: #489 
And then its use was removed here, maybe just accidentally dropped among all the changes as there's no mention of why it was removed: #590

### What's Changing

This makes using the connection queue/deferring the default again for the main window. By doing it this way, displays with hundreds or thousands of connections appear to be much more responsive as the display will appear sooner and be responsive to user input faster as it is no longer required to establish every single connection prior to becoming responsive.

I've also removed the use of deferring connections from the template repeater, this appeared to be slowing down performance in most test cases as the resulting call to establish the connections was not being delayed enough to make any big difference.

This seems to speed up response times in a couple large displays I tested by anywhere from ~15% - 40% depending on number of connections made at startup.

Before
```

Total time: 10.2724 s

   352         2      11413.0   5706.5     88.8          new_widget = load_file(filename,
   353         1          0.0      0.0      0.0                                 macros=macros,
   354         1          0.0      0.0      0.0                                 args=args,
   355         1          0.0      0.0      0.0                                 target=target)
```

After
```
Total time: 6.87503 s

   353         2       5365.4   2682.7     79.2          new_widget = load_file(filename,
   354         1          0.0      0.0      0.0                                 macros=macros,
   355         1          0.0      0.0      0.0                                 args=args,
   356         1          0.0      0.0      0.0                                 target=target,
   357         1          0.0      0.0      0.0                                 defer_connections=True)
```

I also compared this defer strategy to just making connections in background threads, but the threaded approach did not help nearly as much as it is just taking time from the main thread during display initialization.

### Testing

Verified performance increases on several large displays on the accelerator side including lclshome. Tried pmps and saw speedups although again without any actual connections.

Added a simple test case for verifying setting of the parameter.