### PR TITLE
DOC: added example transforming a waveform using calc_plugin

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -30,9 +30,11 @@ After having the dependency installed run the command:
 ./testing_ioc/pydm-testing-ioc
 ```
 
-On 2/9/23, we needed a different procedure to run the testing ioc:
-* use "env | grep EPICS_CA" to identify the EPICA_CA_SERVER_PORT
-* enter "export EPICS_CA_ADDR_LIST="${EPICS_CA_ADDR_LIST} (your local host):(EPICS_CA_SERVER_PORT)""
-* run "./testing_ioc/pydm-testing-ioc" in the background
-* enter "caput MTEST:Run 1"
-* do your tests!
+You may need to check the EPICS address and server port to ensure your local system can find the simulated PVs. Use the following procedure from the command line to identify the EPICS_CA_SERVER_PORT and add to your EPICS_CA_ADDR_LIST:
+
+```sh
+env | grep EPICS_CA
+export EPICS_CA_ADDR_LIST="${EPICS_CA_ADDR_LIST} (your local host):(EPICS_CA_SERVER_PORT)"
+```
+
+Then run the testing_ioc as above.

--- a/examples/README.md
+++ b/examples/README.md
@@ -29,3 +29,10 @@ After having the dependency installed run the command:
 ```sh
 ./testing_ioc/pydm-testing-ioc
 ```
+
+On 2/9/23, we needed a different procedure to run the testing ioc:
+* use "env | grep EPICS_CA" to identify the EPICA_CA_SERVER_PORT
+* enter "export EPICS_CA_ADDR_LIST="${EPICS_CA_ADDR_LIST} (your local host):(EPICS_CA_SERVER_PORT)""
+* run "./testing_ioc/pydm-testing-ioc" in the background
+* enter "caput MTEST:Run 1"
+* do your tests!

--- a/examples/waveformplot/waveform_with_transform.ui
+++ b/examples/waveformplot/waveform_with_transform.ui
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>700</width>
+    <height>600</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="PyDMWaveformPlot" name="PyDMWaveformPlot">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="yAxes">
+      <stringlist>
+       <string>{&quot;name&quot;: &quot;&quot;, &quot;orientation&quot;: &quot;left&quot;, &quot;label&quot;: null, &quot;minRange&quot;: -1.0, &quot;maxRange&quot;: 1.0, &quot;autoRange&quot;: true, &quot;logMode&quot;: false}</string>
+      </stringlist>
+     </property>
+     <property name="title" stdset="0">
+      <string>Waveform with Transform</string>
+     </property>
+     <property name="xLabels">
+      <stringlist>
+       <string>Point #</string>
+      </stringlist>
+     </property>
+     <property name="showLegend">
+      <bool>true</bool>
+     </property>
+     <property name="curves">
+      <stringlist>
+       <string>{&quot;y_channel&quot;: &quot;calc://outvar?waveform=ca://MTEST:Waveform&amp;expr=3*waveform+4&quot;, &quot;x_channel&quot;: &quot;ca://MTEST:TimeBase&quot;, &quot;plot_style&quot;: null, &quot;name&quot;: &quot;3*Cosine + 4&quot;, &quot;color&quot;: &quot;white&quot;, &quot;lineStyle&quot;: 1, &quot;lineWidth&quot;: 1, &quot;symbol&quot;: null, &quot;symbolSize&quot;: 10, &quot;yAxisName&quot;: &quot;&quot;, &quot;barWidth&quot;: null, &quot;upperThreshold&quot;: null, &quot;lowerThreshold&quot;: null, &quot;thresholdColor&quot;: &quot;white&quot;, &quot;redraw_mode&quot;: 2}</string>
+       <string>{&quot;y_channel&quot;: &quot;ca://MTEST:Waveform&quot;, &quot;x_channel&quot;: &quot;ca://MTEST:TimeBase&quot;, &quot;plot_style&quot;: null, &quot;name&quot;: &quot;Cosine&quot;, &quot;color&quot;: &quot;red&quot;, &quot;lineStyle&quot;: 1, &quot;lineWidth&quot;: 1, &quot;symbol&quot;: null, &quot;symbolSize&quot;: 10, &quot;yAxisName&quot;: &quot;&quot;, &quot;barWidth&quot;: null, &quot;upperThreshold&quot;: null, &quot;lowerThreshold&quot;: null, &quot;thresholdColor&quot;: &quot;white&quot;, &quot;redraw_mode&quot;: 2}</string>
+      </stringlist>
+     </property>
+     <property name="maxXRange">
+      <double>1.000000000000000</double>
+     </property>
+     <property name="autoRangeY">
+      <bool>false</bool>
+     </property>
+     <property name="maxYRange">
+      <double>45.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>PyDMWaveformPlot</class>
+   <extends>QGraphicsView</extends>
+   <header>pydm.widgets.waveformplot</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
In addition, added to the examples README to reflect an EPICS configuration step we needed to take before we could run the testing_ioc.