### PR TITLE
ENH: add midpoint arrows to PyDMDrawingLine

### DIFF
--- a/pydm/widgets/drawing.py
+++ b/pydm/widgets/drawing.py
@@ -464,6 +464,8 @@ class PyDMDrawingLine(PyDMDrawing):
         super(PyDMDrawingLine, self).__init__(parent, init_channel)
         self._arrow_end_point_selection = False
         self._arrow_start_point_selection = False
+        self._arrow_mid_point_selection = False
+        self._mid_point_arrow_direction = False
         self.rotation = 0
         self.penStyle = Qt.SolidLine
         self.penWidth = 1
@@ -538,6 +540,7 @@ class PyDMDrawingLine(PyDMDrawing):
         midpoint = x + w/2
         start_point = QPointF(midpoint - length/2, 0)
         end_point = QPointF(midpoint + length/2, 0)
+        mid_point = QPointF(midpoint, 0)
 
         # Draw the line
         painter.drawLine(start_point, end_point)
@@ -549,6 +552,13 @@ class PyDMDrawingLine(PyDMDrawing):
 
         if self._arrow_start_point_selection:
             points = self._arrow_points(end_point, start_point, 6, 6)
+            painter.drawPolygon(points)
+
+        if self._arrow_mid_point_selection:
+            if self._mid_point_arrow_direction:
+                points = self._arrow_points(start_point, mid_point, 6, 6)
+            else:
+                points = self._arrow_points(end_point, mid_point, 6, 6)
             painter.drawPolygon(points)
 
     @Property(bool)
@@ -597,6 +607,50 @@ class PyDMDrawingLine(PyDMDrawing):
         """
         if self._arrow_start_point_selection != new_selection:
             self._arrow_start_point_selection = new_selection
+            self.update()
+
+    @Property(bool)
+    def arrowMidPoint(self):
+        """
+        If True, an arrow will be drawn at the midpoiint of the line.
+        Returns
+        -------
+        bool
+        """
+        return self._arrow_mid_point_selection
+
+    @arrowMidPoint.setter
+    def arrowMidPoint(self, new_selection):
+        """
+        If True, an arrow will be drawn at the midpoiint of the line.
+        Parameters
+        -------
+        new_selection : bool
+        """
+        if self._arrow_mid_point_selection != new_selection:
+            self._arrow_mid_point_selection = new_selection
+            self.update()
+
+    @Property(bool)
+    def arrowMidPointDirection(self):
+        """
+        If True, an arrow will be drawn at the midpoiint of the line.
+        Returns
+        -------
+        bool
+        """
+        return self._mid_point_arrow_direction
+
+    @arrowMidPointDirection.setter
+    def arrowMidPointDirection(self, new_selection):
+        """
+        If True, an arrow will be drawn at the midpoiint of the line.
+        Parameters
+        -------
+        new_selection : bool
+        """
+        if self._mid_point_arrow_direction != new_selection:
+            self._mid_point_arrow_direction = new_selection
             self.update()
 
 class PyDMDrawingImage(PyDMDrawing):

--- a/pydm/widgets/drawing.py
+++ b/pydm/widgets/drawing.py
@@ -465,7 +465,7 @@ class PyDMDrawingLine(PyDMDrawing):
         self._arrow_end_point_selection = False
         self._arrow_start_point_selection = False
         self._arrow_mid_point_selection = False
-        self._mid_point_arrow_direction = False
+        self._mid_point_arrow_flipped = False
         self.rotation = 0
         self.penStyle = Qt.SolidLine
         self.penWidth = 1
@@ -555,7 +555,7 @@ class PyDMDrawingLine(PyDMDrawing):
             painter.drawPolygon(points)
 
         if self._arrow_mid_point_selection:
-            if self._mid_point_arrow_direction:
+            if self._mid_point_arrow_flipped:
                 points = self._arrow_points(start_point, mid_point, 6, 6)
             else:
                 points = self._arrow_points(end_point, mid_point, 6, 6)
@@ -612,7 +612,7 @@ class PyDMDrawingLine(PyDMDrawing):
     @Property(bool)
     def arrowMidPoint(self):
         """
-        If True, an arrow will be drawn at the midpoiint of the line.
+        If True, an arrow will be drawn at the midpoint of the line.
         Returns
         -------
         bool
@@ -622,7 +622,7 @@ class PyDMDrawingLine(PyDMDrawing):
     @arrowMidPoint.setter
     def arrowMidPoint(self, new_selection):
         """
-        If True, an arrow will be drawn at the midpoiint of the line.
+        If True, an arrow will be drawn at the midpoint of the line.
         Parameters
         -------
         new_selection : bool
@@ -632,25 +632,27 @@ class PyDMDrawingLine(PyDMDrawing):
             self.update()
 
     @Property(bool)
-    def arrowMidPointDirection(self):
+    def flipMidPointArrow(self):
         """
-        If True, an arrow will be drawn at the midpoiint of the line.
+        Flips the direction of the midpoint arrow.
+
         Returns
         -------
         bool
         """
-        return self._mid_point_arrow_direction
+        return self._mid_point_arrow_flipped
 
-    @arrowMidPointDirection.setter
-    def arrowMidPointDirection(self, new_selection):
+    @flipMidPointArrow.setter
+    def flipMidPointArrow(self, new_selection):
         """
-        If True, an arrow will be drawn at the midpoiint of the line.
+        Flips the direction of the midpoint arrow.
+        
         Parameters
         -------
         new_selection : bool
         """
-        if self._mid_point_arrow_direction != new_selection:
-            self._mid_point_arrow_direction = new_selection
+        if self._mid_point_arrow_flipped != new_selection:
+            self._mid_point_arrow_flipped = new_selection
             self.update()
 
 class PyDMDrawingImage(PyDMDrawing):


### PR DESCRIPTION
## Description
This PR adds midpoint arrows to PyDMDrawingLine.
Added to address #963
 
## How Has This Been Tested?
Tested on an example Gui.

## Where Has This Been Documented?
auto documentation will add the documentation for the new properties. 

## Screenshots:

<img width="150" alt="Screen Shot 2023-02-24 at 10 34 22 AM" src="https://user-images.githubusercontent.com/2607613/221263726-5d5a9d96-ae89-448b-9d6b-8232b4d48453.png">
<img width="155" alt="Screen Shot 2023-02-24 at 10 34 13 AM" src="https://user-images.githubusercontent.com/2607613/221263732-2b00e3a4-8f72-4507-915d-8d97350d0c47.png">