### PR TITLE
ENH: NTTables readable using label and byte indicator

### DIFF
--- a/pydm/data_plugins/epics_plugins/p4p_plugin_component.py
+++ b/pydm/data_plugins/epics_plugins/p4p_plugin_component.py
@@ -11,6 +11,7 @@ from pydm.widgets.channel import PyDMChannel
 from qtpy.QtCore import QObject, Qt
 from typing import Optional
 import pdb
+from collections import OrderedDict
 
 logger = logging.getLogger(__name__)
 
@@ -110,8 +111,8 @@ class Connection(PyDMConnection):
                             self.new_value_signal[int].emit(new_value)
                         elif isinstance(new_value, str):
                             self.new_value_signal[str].emit(new_value)
-                        elif isinstance(new_value, dict):
-                            self.new_value_signal[dict].emit(new_value)
+                        elif isinstance(new_value, OrderedDict):
+                            self.new_value_signal[OrderedDict].emit(np.array(new_value))
                         else:
                             raise ValueError(f'No matching signal for value: {new_value} with type: {type(new_value)}')
                 # Sometimes unchanged control variables appear to be returned with value changes, so checking against
@@ -201,7 +202,7 @@ class Connection(PyDMConnection):
             except KeyError:
                 pass
             try:
-                channel.value_signal[dict].connect(self.put_value, Qt.QueuedConnection)
+                channel.value_signal[OrderedDict].connect(self.put_value, Qt.QueuedConnection)
             except KeyError:
                 pass
 

--- a/pydm/data_plugins/epics_plugins/p4p_plugin_component.py
+++ b/pydm/data_plugins/epics_plugins/p4p_plugin_component.py
@@ -9,7 +9,7 @@ from pydm.data_plugins.plugin import PyDMPlugin, PyDMConnection
 from pydm.widgets.channel import PyDMChannel
 from qtpy.QtCore import QObject, Qt
 from typing import Optional
-import time
+
 logger = logging.getLogger(__name__)
 
 
@@ -81,11 +81,14 @@ class Connection(PyDMConnection):
             self._value = value
             has_value_changed_yet = False
             for changed_value in value.changedSet():
-                if 'value' in changed_value and not has_value_changed_yet:
+                if changed_value == 'value' or changed_value.split('.')[0] == 'value':
                     # NTTable has a changedSet item for each column that has changed
                     # Since we want to send an update on any table change, let's track
                     # if the value item has been updated yet
-                    has_value_changed_yet = True
+                    if has_value_changed_yet:
+                        continue
+                    else:
+                        has_value_changed_yet = True
                     if 'NTTable' in value.getID():
                         new_value = value.value.todict()
                     else:

--- a/pydm/data_plugins/epics_plugins/p4p_plugin_component.py
+++ b/pydm/data_plugins/epics_plugins/p4p_plugin_component.py
@@ -95,7 +95,7 @@ class Connection(PyDMConnection):
             for changed_value in changedSet:
                 if changed_value == 'value':
                     if 'NTTable' in value.getID():
-                        new_value = NTTable.unwrap(value)[0]
+                        new_value = NTTable.unwrap(value)
                     else:
                         new_value = value.value
                     if new_value is not None:
@@ -112,6 +112,7 @@ class Connection(PyDMConnection):
                         elif isinstance(new_value, str):
                             self.new_value_signal[str].emit(new_value)
                         elif isinstance(new_value, OrderedDict):
+                            # for some reason, pyqt struggles to emit on a dict type signal, and wants this to be a list
                             self.new_value_signal[OrderedDict].emit(np.array(new_value))
                         else:
                             raise ValueError(f'No matching signal for value: {new_value} with type: {type(new_value)}')

--- a/pydm/data_plugins/epics_plugins/p4p_plugin_component.py
+++ b/pydm/data_plugins/epics_plugins/p4p_plugin_component.py
@@ -95,7 +95,7 @@ class Connection(PyDMConnection):
             for changed_value in changedSet:
                 if changed_value == 'value':
                     if 'NTTable' in value.getID():
-                        new_value = NTTable.unwrap(value)
+                        new_value = value.value.todict()
                     else:
                         new_value = value.value
                     if new_value is not None:
@@ -111,7 +111,7 @@ class Connection(PyDMConnection):
                             self.new_value_signal[int].emit(new_value)
                         elif isinstance(new_value, str):
                             self.new_value_signal[str].emit(new_value)
-                        elif isinstance(new_value, OrderedDict):
+                        elif isinstance(new_value, dict):
                             # for some reason, pyqt struggles to emit on a dict type signal, and wants this to be a list
                             self.new_value_signal[OrderedDict].emit(np.array(new_value))
                         else:

--- a/pydm/data_plugins/epics_plugins/p4p_plugin_component.py
+++ b/pydm/data_plugins/epics_plugins/p4p_plugin_component.py
@@ -9,7 +9,7 @@ from pydm.data_plugins.plugin import PyDMPlugin, PyDMConnection
 from pydm.widgets.channel import PyDMChannel
 from qtpy.QtCore import QObject, Qt
 from typing import Optional
-
+import time
 logger = logging.getLogger(__name__)
 
 

--- a/pydm/data_plugins/plugin.py
+++ b/pydm/data_plugins/plugin.py
@@ -11,6 +11,7 @@ from qtpy.QtCore import Signal, QObject, Qt
 from qtpy.QtWidgets import QApplication
 from .. import config
 from collections import OrderedDict
+import pdb
 
 
 class PyDMConnection(QObject):
@@ -275,9 +276,25 @@ class PyDMPlugin(object):
         # this method is not robust to PVs that have a . index to some attribute
         if init_channel is None:
             channel = None
+
         else:
-            row = re.findall('\[.*?\]', init_channel)
-            col_parts = re.split('\.', init_channel)
+
+            index_args = re.findall('\(.*?\)', init_channel)
+            if len(index_args) == 0:
+                return init_channel
+
+            channel = re.split('\(', init_channel)[0]
+            index_args = re.split('\,', index_args[0][1:-1])
+
+            for arg in index_args:
+                arg_parts = re.split('=', arg.strip())
+                if len(arg_parts) == 0:
+                    row = arg
+                elif arg_parts[0] == 'label':
+                    col = arg_parts[1]
+                else:
+                    row = arg_parts
+            '''
             if len(col_parts) == 1:
                 if len(row) == 0:
                     channel = init_channel
@@ -288,6 +305,7 @@ class PyDMPlugin(object):
             else:
                 print('sadness')
                 # raise error
+            '''
         return channel
 
     def add_connection(self, channel):

--- a/pydm/data_plugins/plugin.py
+++ b/pydm/data_plugins/plugin.py
@@ -270,13 +270,17 @@ class PyDMPlugin(object):
 
     @staticmethod
     def parse_channel(init_channel):
+    '''
+    Identify if channel has a column or row index for an NTTable
+    Column and row indices are entered in parantheses next to the PV name
+    Column index is noted with the keyword "label"
+    Row index is identified using a column name in which to match an element
+    '''
         channel = None
         row = None
         col = None
 
         if init_channel is not None:
-            if init_channel.startswith('calc'):
-                channel = init_channel
             index_args = re.findall('\(.*?\)', init_channel)
             if len(index_args) == 0 or init_channel.startswith('calc'):
                 channel = init_channel

--- a/pydm/data_plugins/plugin.py
+++ b/pydm/data_plugins/plugin.py
@@ -12,7 +12,7 @@ from .. import config
 
 
 class PyDMConnection(QObject):
-    new_value_signal = Signal([float], [int], [str], [ndarray], [bool])
+    new_value_signal = Signal([float], [int], [str], [ndarray], [bool], [dict])
     connection_state_signal = Signal(bool)
     new_severity_signal = Signal(int)
     write_access_signal = Signal(bool)
@@ -60,6 +60,10 @@ class PyDMConnection(QObject):
                 pass
             try:
                 self.new_value_signal[bool].connect(channel.value_slot, Qt.QueuedConnection)
+            except TypeError:
+                pass
+            try:
+                self.new_value_signal[dict].connect(channel.value_slot, Qt.QueuedConnection)
             except TypeError:
                 pass
 
@@ -139,6 +143,10 @@ class PyDMConnection(QObject):
                 pass
             try:
                 self.new_value_signal[bool].disconnect(channel.value_slot)
+            except TypeError:
+                pass
+            try:
+                self.new_value_signal[dict].disconnect(channel.value_slot)
             except TypeError:
                 pass
 

--- a/pydm/data_plugins/plugin.py
+++ b/pydm/data_plugins/plugin.py
@@ -275,8 +275,10 @@ class PyDMPlugin(object):
         col = None
 
         if init_channel is not None:
+            if init_channel.startswith('calc'):
+                channel = init_channel
             index_args = re.findall('\(.*?\)', init_channel)
-            if len(index_args) == 0:
+            if len(index_args) == 0 or init_channel.startswith('calc'):
                 channel = init_channel
             else:
                 channel = re.split('\(', init_channel)[0]

--- a/pydm/display.py
+++ b/pydm/display.py
@@ -47,6 +47,7 @@ def load_file(file, macros=None, args=None, target=ScreenTarget.NEW_PROCESS):
     -------
     pydm.Display
     """
+    print('things are even better')
     if not is_pydm_app() and target == ScreenTarget.NEW_PROCESS:
         logger.warning('New Process is only valid with PyDM Application. ' +
                        'Falling back to ScreenTarget.DIALOG.')

--- a/pydm/display.py
+++ b/pydm/display.py
@@ -47,7 +47,6 @@ def load_file(file, macros=None, args=None, target=ScreenTarget.NEW_PROCESS):
     -------
     pydm.Display
     """
-    print('things are even better')
     if not is_pydm_app() and target == ScreenTarget.NEW_PROCESS:
         logger.warning('New Process is only valid with PyDM Application. ' +
                        'Falling back to ScreenTarget.DIALOG.')

--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -682,7 +682,7 @@ class PyDMWidget(PyDMPrimitiveWidget, new_properties=_positionRuleProperties):
                 if len(row) == 0:
                     channel = init_channel
                 elif len(row):
-                    self._row = row[1][1:-1]
+                    self._row = row[0][1:-1]
                     row_parts = re.split('\[', init_channel)
                     channel = row_parts[0]
             elif len(col_parts) == 2:
@@ -690,6 +690,7 @@ class PyDMWidget(PyDMPrimitiveWidget, new_properties=_positionRuleProperties):
                 if len(row) == 0:
                     self._col = str(col_parts[1])
                 elif len(row) == 1:
+                    self._row = int(row[0][1:-1])
                     self._col = str(re.split('\[',col_parts[1])[0])
             else:
                 print('sadness')
@@ -772,11 +773,19 @@ class PyDMWidget(PyDMPrimitiveWidget, new_properties=_positionRuleProperties):
         new_val : str, int, float, bool or np.ndarray
             The new value from the channel. The type depends on the channel.
         """
-        
         self.value = new_val
         self.channeltype = type(self.value)
         if self.channeltype == np.ndarray:
-            self.subtype = self.value.dtype.type
+            if isinstance(self.value[0], dict):
+                if self._col is not None and self._row is not None:
+                    self.value = self.value[self._row][self._col]
+                elif self._col is not None:
+                    self.value = [val[self._col] for val in self.value]
+                elif self._row is not None:
+                    self.value = self.value[self._row]
+                self.channeltype = type(self.value)
+            else:
+                self.subtype = self.value.dtype.type
         else:
             try:
                 if self.channeltype == unicode:

--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -874,6 +874,7 @@ class PyDMWidget(PyDMPrimitiveWidget, new_properties=_positionRuleProperties):
     @Slot(str)
     @Slot(bool)
     @Slot(np.ndarray)
+    @Slot(dict)
     def channelValueChanged(self, new_val):
         """
         PyQT Slot for changes on the Value of the Channel
@@ -1348,10 +1349,10 @@ class PyDMWritableWidget(PyDMWidget):
         Emitted when the user changes the value
     """
 
-    __Signals__ = ("send_value_signal([int], [float], [str], [bool], [np.ndarray])")
+    __Signals__ = ("send_value_signal([int], [float], [str], [bool], [np.ndarray], [dict])")
 
     # Emitted when the user changes the value.
-    send_value_signal = Signal([int], [float], [str], [bool], [np.ndarray])
+    send_value_signal = Signal([int], [float], [str], [bool], [np.ndarray], [dict])
 
     def __init__(self, init_channel=None):
         self._write_access = False

--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -746,9 +746,10 @@ class PyDMWidget(PyDMPrimitiveWidget, new_properties=_positionRuleProperties):
         self.value = new_val
         self.channeltype = type(self.value)
         if self.channeltype == np.ndarray:
-            if isinstance(new_val.item(), dict):
-                self.value, self.channeltype = self.extract_NTTable_value(new_val.item())
-            else:
+            try:
+                if isinstance(new_val.item(), dict):
+                    self.value, self.channeltype = self.extract_NTTable_value(new_val.item())
+            except:
                 self.subtype = self.value.dtype.type
         else:
             try:

--- a/pydm/widgets/byte.py
+++ b/pydm/widgets/byte.py
@@ -551,4 +551,3 @@ class PyDMByteIndicator(QWidget, PyDMWidget):
             # before the object constructor is complete
             if hasattr(self, '_shift'):
                 self.update_indicators()
-

--- a/pydm/widgets/byte.py
+++ b/pydm/widgets/byte.py
@@ -199,7 +199,6 @@ class PyDMByteIndicator(QWidget, PyDMWidget):
             value = int(self.value) >> self._shift
         if value < 0:
             value = 0
-
         bits = [(value >> i) & 1
                 for i in range(self._num_bits)]
         for bit, indicator in zip(bits, self._indicators):
@@ -507,7 +506,7 @@ class PyDMByteIndicator(QWidget, PyDMWidget):
         """
         super(PyDMByteIndicator, self).value_changed(new_val)
         try:
-            int(new_val)
+            int(self.value)
             self.update_indicators()
         except:
             pass

--- a/pydm/widgets/label.py
+++ b/pydm/widgets/label.py
@@ -5,7 +5,8 @@ from .display_format import DisplayFormat, parse_value_for_display
 from pydm.utilities import is_pydm_app, is_qt_designer
 from pydm import config
 from pydm.widgets.base import only_if_channel_set
-
+import pdb
+import numpy as np
 _labelRuleProperties = {'Text': ['value_changed', str]}
 
 class PyDMLabel(QLabel, TextFormatter, PyDMWidget, DisplayFormat, new_properties=_labelRuleProperties):
@@ -62,6 +63,20 @@ class PyDMLabel(QLabel, TextFormatter, PyDMWidget, DisplayFormat, new_properties
         new_value : str, int, float, bool or np.ndarray
             The new value from the channel. The type depends on the channel.
         """
+        channel_type = type(new_value)
+        # unpack dict from np.array if necessary
+        if channel_type == np.ndarray:
+            if new_value.ndim == 0:
+                new_value = new_value.item()
+                # index into value if necessary
+                if self._col is not None:
+                    if self._row is not None:
+                        new_value = new_value[self._col][self._row]
+                    else:
+                        new_value = new_value[self._col]
+                elif self._row is not None:
+                    new_value = new_value[self._row]
+
         super(PyDMLabel, self).value_changed(new_value)
         new_value = parse_value_for_display(value=new_value, precision=self.precision,
                                             display_format_type=self._display_format_type,

--- a/pydm/widgets/label.py
+++ b/pydm/widgets/label.py
@@ -5,9 +5,9 @@ from .display_format import DisplayFormat, parse_value_for_display
 from pydm.utilities import is_pydm_app, is_qt_designer
 from pydm import config
 from pydm.widgets.base import only_if_channel_set
-import pdb
-import numpy as np
+
 _labelRuleProperties = {'Text': ['value_changed', str]}
+
 
 class PyDMLabel(QLabel, TextFormatter, PyDMWidget, DisplayFormat, new_properties=_labelRuleProperties):
     Q_ENUMS(DisplayFormat)
@@ -15,7 +15,7 @@ class PyDMLabel(QLabel, TextFormatter, PyDMWidget, DisplayFormat, new_properties
     """
     A QLabel with support for setting the text via a PyDM Channel, or
     through the PyDM Rules system.
-    
+
     Note: If a PyDMLabel is configured to use a Channel, and also with a rule
     which changes the 'Text' property, the behavior is undefined.  Use either
     the Channel *or* a text rule, but not both.
@@ -63,21 +63,6 @@ class PyDMLabel(QLabel, TextFormatter, PyDMWidget, DisplayFormat, new_properties
         new_value : str, int, float, bool or np.ndarray
             The new value from the channel. The type depends on the channel.
         """
-        # channel_type = type(new_value)
-        # # unpack dict from np.array if necessary
-        # if channel_type == np.ndarray:
-        #     if new_value.ndim == 0:
-        #         new_value = new_value.item()
-        #         # index into value if necessary
-        #         if self._col is not None:
-        #             if self._row is not None:
-        #                 new_value = new_value[self._col][self._row]
-        #             else:
-        #                 new_value = new_value[self._col]
-        #         elif self._row is not None:
-        #             new_value = new_value[self._row]
-
-
         super(PyDMLabel, self).value_changed(new_value)
         new_value = self.value
         new_value = parse_value_for_display(value=new_value, precision=self.precision,

--- a/pydm/widgets/label.py
+++ b/pydm/widgets/label.py
@@ -63,21 +63,23 @@ class PyDMLabel(QLabel, TextFormatter, PyDMWidget, DisplayFormat, new_properties
         new_value : str, int, float, bool or np.ndarray
             The new value from the channel. The type depends on the channel.
         """
-        channel_type = type(new_value)
-        # unpack dict from np.array if necessary
-        if channel_type == np.ndarray:
-            if new_value.ndim == 0:
-                new_value = new_value.item()
-                # index into value if necessary
-                if self._col is not None:
-                    if self._row is not None:
-                        new_value = new_value[self._col][self._row]
-                    else:
-                        new_value = new_value[self._col]
-                elif self._row is not None:
-                    new_value = new_value[self._row]
+        # channel_type = type(new_value)
+        # # unpack dict from np.array if necessary
+        # if channel_type == np.ndarray:
+        #     if new_value.ndim == 0:
+        #         new_value = new_value.item()
+        #         # index into value if necessary
+        #         if self._col is not None:
+        #             if self._row is not None:
+        #                 new_value = new_value[self._col][self._row]
+        #             else:
+        #                 new_value = new_value[self._col]
+        #         elif self._row is not None:
+        #             new_value = new_value[self._row]
+
 
         super(PyDMLabel, self).value_changed(new_value)
+        new_value = self.value
         new_value = parse_value_for_display(value=new_value, precision=self.precision,
                                             display_format_type=self._display_format_type,
                                             string_encoding=self._string_encoding,


### PR DESCRIPTION
Check out this branch implementing reading of NTTables, and let me know what you think. A couple of notes:

- column/row indices are appended to the PV name with parentheses, with format (label=column_name, column_with_element=element_to_match)
- While an arbitrary table can now be emitted by a signal, only PyDMLabel and PyDMByteIndicator widgets have been edited to be able to ingest and display values in an NTTable
- I understand if you would rather wait until a more holistic NTTable implementation is completed. Let me know, as this is useful for an application I'm working on, so I want to get a sense of when I'll be able to use it in production (on the scale of weeks, months, years).

Thanks!