### PR TITLE
BLD: Update ubuntu version used in pipelines

### DIFF
--- a/azure-build-template.yml
+++ b/azure-build-template.yml
@@ -2,7 +2,7 @@
 jobs:
 - job: 'Build'
   pool:
-    vmImage: 'Ubuntu 22.04'
+    vmImage: 'ubuntu-22.04'
   variables:
     PYTHON: 3.7.3
     BUILD_DOCS: 1

--- a/azure-build-template.yml
+++ b/azure-build-template.yml
@@ -2,7 +2,7 @@
 jobs:
 - job: 'Build'
   pool:
-    vmImage: 'Ubuntu 18.04'
+    vmImage: 'Ubuntu 22.04'
   variables:
     PYTHON: 3.7.3
     BUILD_DOCS: 1

--- a/azure-pipelines-linux.yml
+++ b/azure-pipelines-linux.yml
@@ -3,21 +3,21 @@ jobs:
   - template: azure-test-template.yml
     parameters:
       name: Linux_3_7
-      vmImage: 'Ubuntu 18.04'
+      vmImage: 'Ubuntu 20.04'
       build_docs: 1
       python: '3.7'
       allowFailure: false
   - template: azure-test-template.yml
     parameters:
       name: Linux_3_8
-      vmImage: 'Ubuntu 18.04'
+      vmImage: 'Ubuntu 20.04'
       build_docs: 1
       python: '3.8'
       allowFailure: false
   - template: azure-test-template.yml
     parameters:
       name: Linux_3_9
-      vmImage: 'Ubuntu 18.04'
+      vmImage: 'Ubuntu 20.04'
       build_docs: 1
       python: '3.9'
       allowFailure: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -49,7 +49,7 @@ stages:
         continueOnError: true
         displayName: 'Linter - Flake8'
         pool:
-          vmImage: 'ubuntu-18.04'
+          vmImage: 'ubuntu-latest'
         steps:
         - task: UsePythonVersion@0
           inputs:
@@ -80,7 +80,7 @@ stages:
       - job: 'Control'
         displayName: Build Control
         pool:
-          vmImage: 'ubuntu-18.04'
+          vmImage: 'ubuntu-latest'
         steps:
           - bash: echo "##vso[task.setvariable variable=build_ok;isOutput=true]true"
             name: var
@@ -95,7 +95,7 @@ stages:
         dependsOn: Control
         displayName: Publish - Documentation
         pool:
-          vmImage: 'ubuntu-18.04'
+          vmImage: 'ubuntu-latest'
         condition: |
             and (
               eq( dependencies.Control.outputs['var.build_ok'], true),
@@ -135,7 +135,7 @@ stages:
           )
 
         pool:
-          vmImage: 'ubuntu-18.04'
+          vmImage: 'ubuntu-latest'
 
         steps:
         - task: UsePythonVersion@0
@@ -186,7 +186,7 @@ stages:
             )
           )
         pool:
-          vmImage: 'ubuntu-18.04'
+          vmImage: 'ubuntu-latest'
         steps:
         # Download Anaconda packages
         - task: DownloadBuildArtifacts@0


### PR DESCRIPTION
Version 18.04 is deprecated per https://github.com/actions/runner-images/issues/6002

Moved to 20.04 for our tests, and switched to just using latest for build pipelines.