### PR TITLE
ENH: PyDMNTTable Widget 

### DIFF
--- a/docs/source/data_plugins/p4p_plugin.rst
+++ b/docs/source/data_plugins/p4p_plugin.rst
@@ -55,6 +55,10 @@ multiple layers of subfields also works::
 
     pva://MTEST/sub-field/subfield_of_a_subfield
 
+Note: currenty subfields can only be used to read a subset of data from an NTTables 
+and can't be used to write to the subfield. A follow up release will add an ability to 
+write to the subfield.    
+
 Image decompression
 -------------------
 

--- a/docs/source/data_plugins/p4p_plugin.rst
+++ b/docs/source/data_plugins/p4p_plugin.rst
@@ -45,8 +45,8 @@ NTTables
 The plugin accepts NTTables. It will convert NTTables in python dictionaries which are then passed to the pydm widgets. 
 Not all widgets will accept a dictionary (or the whole NTTable) as an input. 
 A specified section of the NTTable can be passed to a those pydm widgets which do not accept dictionaries.
-If the PV is passing an NTTable and the user wants to pass only a specific subfield of the NTTable. 
-This can be achieved via appending a ``/`` followed by the key or name of the column header of the subfield of the NTTable.
+If the PV is passing an NTTable and the user wants to pass only a specific subfield of the NTTable this can be achieved via appending a ``/`` 
+followed by the key or name of the column header of the subfield of the NTTable.
 For example::
 
     pva://MTEST/subfield

--- a/docs/source/data_plugins/p4p_plugin.rst
+++ b/docs/source/data_plugins/p4p_plugin.rst
@@ -28,7 +28,7 @@ P4P is the only option (and will be chosen automatically if this variable is not
 in the future.
 
 Supported Types
----------------
+===============
 
 Currently this data plugin supports all `normative types`_. The values and control variables are pulled out of
 the data received and sent through the existing PyDM signals to be read by widgets via the channels they are
@@ -38,6 +38,25 @@ In order to support compatibility with all existing signals and widgets, full st
 currently possible in this version of the plugin. For example, defining a group PV using Q:Group will not
 result in the named fields being sent to the widgets. Full support for structured data is planned to be supported
 as part of a future release.
+
+NTTables
+--------
+
+The plugin accepts NTTables. It will convert NTTables in python dictionaries which are then passed to the pydm widgets. 
+Not all widgets will accept a dictionary (or the whole NTTable) as an input. 
+A specified section of the NTTable can be passed to a those pydm widgets which do not accept dictionaries.
+If the PV is passing an NTTable and the user wants to pass only a specific subfield of the NTTable. 
+This can be achieved via appending a ``/`` followed by the key or name of the column header of the subfield of the NTTable.
+For example::
+
+    pva://MTEST/subfield
+
+multiple layers of subfields also works::
+
+    pva://MTEST/sub-field/subfield_of_a_subfield
+
+Image decompression
+-------------------
 
 Image decompression is performed when image data is specified using an ``NTNDArray`` with the ``codec`` field set.
 The decompression algorithm to apply will be determined by what the ``codec`` field is set to. In order

--- a/docs/source/widgets/nt_table.rst
+++ b/docs/source/widgets/nt_table.rst
@@ -1,0 +1,13 @@
+#######################
+PyDMNTTable
+#######################
+
+.. autoclass:: pydm.widgets.nt_table.PythonTableModel
+   :members:
+   :inherited-members:
+   :show-inheritance:
+
+.. autoclass:: pydm.widgets.nt_table.PyDMNTTable
+   :members:
+   :inherited-members:
+   :show-inheritance:

--- a/pydm/data_plugins/__init__.py
+++ b/pydm/data_plugins/__init__.py
@@ -76,7 +76,11 @@ def plugin_for_address(address: str) -> Optional[PyDMPlugin]:
     Find the correct PyDMPlugin for a channel
     """
     # Check for a configured protocol
-    protocol = parsed_address(address).scheme 
+    try:
+        protocol = parsed_address(address).scheme
+    except AttributeError:
+        protocol = None 
+    
     # Use default protocol
     if protocol is None and config.DEFAULT_PROTOCOL is not None:
         logger.debug("Using default protocol %s for %s",
@@ -84,7 +88,8 @@ def plugin_for_address(address: str) -> Optional[PyDMPlugin]:
         # If no protocol was specified, and the default protocol
         # environment variable is specified, try to use that instead.
         protocol = config.DEFAULT_PROTOCOL
-    # Load proper plugin module
+
+    # Load proper plugin module    
     if protocol:
         initialize_plugins_if_needed()
         try:
@@ -97,6 +102,7 @@ def plugin_for_address(address: str) -> Optional[PyDMPlugin]:
                  "will receive no data. To specify a default protocol, "
                  "set the PYDM_DEFAULT_PROTOCOL environment variable."
                  "".format(addr=address))
+    
     return None
 
 

--- a/pydm/data_plugins/__init__.py
+++ b/pydm/data_plugins/__init__.py
@@ -77,7 +77,7 @@ def plugin_for_address(address: str) -> Optional[PyDMPlugin]:
     Find the correct PyDMPlugin for a channel
     """
     # Check for a configured protocol
-    protocol, addr, subfield = protocol_and_address(address)
+    protocol, addr, subfield, full_addr = protocol_and_address(address)
     # Use default protocol
     if protocol is None and config.DEFAULT_PROTOCOL is not None:
         logger.debug("Using default protocol %s for %s",

--- a/pydm/data_plugins/__init__.py
+++ b/pydm/data_plugins/__init__.py
@@ -77,7 +77,7 @@ def plugin_for_address(address: str) -> Optional[PyDMPlugin]:
     Find the correct PyDMPlugin for a channel
     """
     # Check for a configured protocol
-    protocol, addr, subfield, full_addr = protocol_and_address(address)
+    protocol, *_ = protocol_and_address(address)
     # Use default protocol
     if protocol is None and config.DEFAULT_PROTOCOL is not None:
         logger.debug("Using default protocol %s for %s",

--- a/pydm/data_plugins/__init__.py
+++ b/pydm/data_plugins/__init__.py
@@ -77,7 +77,7 @@ def plugin_for_address(address: str) -> Optional[PyDMPlugin]:
     Find the correct PyDMPlugin for a channel
     """
     # Check for a configured protocol
-    protocol, addr = protocol_and_address(address)
+    protocol, addr, subfield = protocol_and_address(address)
     # Use default protocol
     if protocol is None and config.DEFAULT_PROTOCOL is not None:
         logger.debug("Using default protocol %s for %s",

--- a/pydm/data_plugins/__init__.py
+++ b/pydm/data_plugins/__init__.py
@@ -14,8 +14,7 @@ import entrypoints
 from qtpy.QtWidgets import QApplication
 
 from .. import config
-from ..utilities import (import_module_by_filename, log_failures,
-                         protocol_and_address)
+from ..utilities import (import_module_by_filename, log_failures, parsed_address)
 from .plugin import PyDMPlugin
 
 logger = logging.getLogger(__name__)
@@ -77,7 +76,7 @@ def plugin_for_address(address: str) -> Optional[PyDMPlugin]:
     Find the correct PyDMPlugin for a channel
     """
     # Check for a configured protocol
-    protocol, *_ = protocol_and_address(address)
+    protocol = parsed_address(address).scheme 
     # Use default protocol
     if protocol is None and config.DEFAULT_PROTOCOL is not None:
         logger.debug("Using default protocol %s for %s",

--- a/pydm/data_plugins/epics_plugins/p4p_plugin_component.py
+++ b/pydm/data_plugins/epics_plugins/p4p_plugin_component.py
@@ -98,8 +98,11 @@ class Connection(PyDMConnection):
                         new_value = value.value
                     
                     if self.nttable_data_location:
+                        msg = f"Invalid channel... {self.nttable_data_location}"
+
                         for value in self.nttable_data_location:
-                            if isinstance(new_value, collections.Container) and type(new_value) != str:
+                            if isinstance(new_value, collections.Container) and not isinstance(new_value, str):
+                                
                                 if type(value) == str:
                                     try:
                                         new_value = new_value[value] 
@@ -107,20 +110,15 @@ class Connection(PyDMConnection):
                                     except TypeError:
                                         logger.debug('Type Error when attempting to use the given key, code will next attempt to convert the key to an int')
                                     except KeyError:
-                                        msg = "Invalid channel address path for NTTable given. %s"
-                                        logger.exception(msg, self.nttable_data_location)
-                                        raise KeyError("error in channel address")
+                                        logger.exception(msg)
                                     
                                     try:
                                         new_value = new_value[int(value)] 
                                     except ValueError:
-                                        msg = "Invalid channel address path for NTTable given. %s"
-                                        logger.exception(msg, self.nttable_data_location, exc_info=True)
-                                        raise ValueError("error in channel address")
+                                        logger.exception(msg, exc_info=True)
                             else:
-                                msg = "Invalid channel address path for NTTable given. %s"
-                                logger.exception(msg, self.nttable_data_location, exc_info=True)
-                                raise ValueError("error in channel address")
+                                logger.exception(msg, exc_info=True)
+                                raise ValueError(msg)
 
                     if new_value is not None:
                         if isinstance(new_value, np.ndarray):

--- a/pydm/data_plugins/epics_plugins/p4p_plugin_component.py
+++ b/pydm/data_plugins/epics_plugins/p4p_plugin_component.py
@@ -108,7 +108,7 @@ class Connection(PyDMConnection):
                                         logger.debug('Type Error when attempting to use the given key, code will next attempt to convert the key to an int')
                                     except KeyError:
                                         msg = "Invalid channel address path for NTTable given. %s"
-                                        logger.exception(msg, self.nttable_data_location, exc_info=True)
+                                        logger.exception(msg, self.nttable_data_location)
                                         raise KeyError("error in channel address")
                                     
                                     try:

--- a/pydm/data_plugins/epics_plugins/p4p_plugin_component.py
+++ b/pydm/data_plugins/epics_plugins/p4p_plugin_component.py
@@ -1,4 +1,3 @@
-
 import logging
 import numpy as np
 
@@ -192,7 +191,7 @@ class Connection(PyDMConnection):
             except KeyError:
                 pass
             try:
-                channel.value_signal[object].connect(self.put_value, Qt.QueuedConnection)
+                channel.value_signal[np.ndarray].connect(self.put_value, Qt.QueuedConnection)
             except KeyError:
                 pass
             try:

--- a/pydm/data_plugins/epics_plugins/p4p_plugin_component.py
+++ b/pydm/data_plugins/epics_plugins/p4p_plugin_component.py
@@ -107,8 +107,7 @@ class Connection(PyDMConnection):
                         elif isinstance(new_value, str):
                             self.new_value_signal[str].emit(new_value)
                         elif isinstance(new_value, dict):
-                            # for some reason, pyqt struggles to emit on a dict type signal, and wants this to be a list
-                            self.new_value_signal[dict].emit(np.array(new_value))
+                            self.new_value_signal[dict].emit(new_value)
                         else:
                             raise ValueError(f'No matching signal for value: {new_value} with type: {type(new_value)}')
                 # Sometimes unchanged control variables appear to be returned with value changes, so checking against
@@ -193,7 +192,7 @@ class Connection(PyDMConnection):
             except KeyError:
                 pass
             try:
-                channel.value_signal[np.ndarray].connect(self.put_value, Qt.QueuedConnection)
+                channel.value_signal[object].connect(self.put_value, Qt.QueuedConnection)
             except KeyError:
                 pass
             try:

--- a/pydm/data_plugins/plugin.py
+++ b/pydm/data_plugins/plugin.py
@@ -267,6 +267,7 @@ class PyDMPlugin(object):
         with self.lock:
             connection_id = self.get_connection_id(channel)
             address = self.get_address(channel)
+
             # If this channel is already connected to this plugin lets ignore
             if channel in self.channels:
                 return
@@ -276,7 +277,7 @@ class PyDMPlugin(object):
                 return
 
             self.channels.add(channel)
-            if connection_id in self.connections:
+            if connection_id in self.connections and not PyDMPlugin.get_subfield(channel):
                 self.connections[connection_id].add_listener(channel)
             else:
                 self.connections[connection_id] = self.connection_class(

--- a/pydm/data_plugins/plugin.py
+++ b/pydm/data_plugins/plugin.py
@@ -12,7 +12,7 @@ from .. import config
 import re
 
 class PyDMConnection(QObject):
-    new_value_signal = Signal([float], [int], [str], [object], [bool])
+    new_value_signal = Signal([float], [int], [str], [bool], [object])
     connection_state_signal = Signal(bool)
     new_severity_signal = Signal(int)
     write_access_signal = Signal(bool)
@@ -55,15 +55,11 @@ class PyDMConnection(QObject):
             except TypeError:
                 pass
             try:
-                self.new_value_signal[ndarray].connect(channel.value_slot, Qt.QueuedConnection)
-            except TypeError:
-                pass
-            try:
                 self.new_value_signal[bool].connect(channel.value_slot, Qt.QueuedConnection)
             except TypeError:
                 pass
             try:
-                self.new_value_signal[dict].connect(channel.value_slot, Qt.QueuedConnection)
+                self.new_value_signal[object].connect(channel.value_slot, Qt.QueuedConnection)
             except TypeError:
                 pass
         
@@ -138,15 +134,11 @@ class PyDMConnection(QObject):
             except TypeError:
                 pass
             try:
-                self.new_value_signal[ndarray].disconnect(channel.value_slot)
-            except TypeError:
-                pass
-            try:
                 self.new_value_signal[bool].disconnect(channel.value_slot)
             except TypeError:
                 pass
             try:
-                self.new_value_signal[dict].disconnect(channel.value_slot)
+                self.new_value_signal[object].disconnect(channel.value_slot)
             except TypeError:
                 pass
         

--- a/pydm/data_plugins/plugin.py
+++ b/pydm/data_plugins/plugin.py
@@ -5,7 +5,7 @@ import threading
 from numpy import ndarray
 from typing import Optional, Callable
 
-from ..utilities.remove_protocol import protocol_and_address
+from ..utilities.remove_protocol import protocol_and_address, parsed_address
 from qtpy.QtCore import Signal, QObject, Qt
 from qtpy.QtWidgets import QApplication
 from .. import config
@@ -252,10 +252,10 @@ class PyDMPlugin(object):
 
     @staticmethod
     def get_full_address(channel):
-        parsed_address = protocol_and_address(channel.address)[2]
+        parsed_addr = parsed_address(channel.address)
 
-        if parsed_address:
-            full_addr = parsed_address.netloc + parsed_address.path
+        if parsed_addr:
+            full_addr = parsed_addr.netloc + parsed_addr.path
         else: 
             full_addr = None
 
@@ -263,15 +263,22 @@ class PyDMPlugin(object):
 
     @staticmethod
     def get_address(channel):
-        return protocol_and_address(channel.address)[1]
+        parsed_addr = parsed_address(channel.address)
+        addr = parsed_addr.netloc
+        protocol = parsed_addr.scheme
+
+        if protocol == 'calc' or protocol == 'loc':
+            addr = parsed_addr.netloc + '?' + parsed_addr.query
+        
+        return addr
     
     @staticmethod
     def get_subfield(channel):
         
-        parsed_address = protocol_and_address(channel.address)[2]
+        parsed_addr = parsed_address(channel.address)
 
-        if parsed_address:
-            subfield = parsed_address.path
+        if parsed_addr:
+            subfield = parsed_addr.path
 
             if subfield != '':
                 subfield = subfield[1:].split('/')

--- a/pydm/data_plugins/plugin.py
+++ b/pydm/data_plugins/plugin.py
@@ -9,10 +9,10 @@ from ..utilities.remove_protocol import protocol_and_address
 from qtpy.QtCore import Signal, QObject, Qt
 from qtpy.QtWidgets import QApplication
 from .. import config
-
+import re
 
 class PyDMConnection(QObject):
-    new_value_signal = Signal([float], [int], [str], [ndarray], [bool])
+    new_value_signal = Signal([float], [int], [str], [object], [bool])
     connection_state_signal = Signal(bool)
     new_severity_signal = Signal(int)
     write_access_signal = Signal(bool)
@@ -62,7 +62,11 @@ class PyDMConnection(QObject):
                 self.new_value_signal[bool].connect(channel.value_slot, Qt.QueuedConnection)
             except TypeError:
                 pass
-
+            try:
+                self.new_value_signal[dict].connect(channel.value_slot, Qt.QueuedConnection)
+            except TypeError:
+                pass
+        
         if channel.severity_slot is not None:
             self.new_severity_signal.connect(channel.severity_slot, Qt.QueuedConnection)
 
@@ -141,7 +145,11 @@ class PyDMConnection(QObject):
                 self.new_value_signal[bool].disconnect(channel.value_slot)
             except TypeError:
                 pass
-
+            try:
+                self.new_value_signal[dict].disconnect(channel.value_slot)
+            except TypeError:
+                pass
+        
         if self._should_disconnect(channel.severity_slot, destroying):
             try:
                 self.new_severity_signal.disconnect(channel.severity_slot)

--- a/pydm/data_plugins/plugin.py
+++ b/pydm/data_plugins/plugin.py
@@ -5,7 +5,7 @@ import threading
 from numpy import ndarray
 from typing import Optional, Callable
 
-from ..utilities.remove_protocol import protocol_and_address, parsed_address
+from ..utilities.remove_protocol import parsed_address
 from qtpy.QtCore import Signal, QObject, Qt
 from qtpy.QtWidgets import QApplication
 from .. import config
@@ -274,7 +274,6 @@ class PyDMPlugin(object):
     
     @staticmethod
     def get_subfield(channel):
-        
         parsed_addr = parsed_address(channel.address)
 
         if parsed_addr:

--- a/pydm/data_plugins/plugin.py
+++ b/pydm/data_plugins/plugin.py
@@ -252,7 +252,14 @@ class PyDMPlugin(object):
 
     @staticmethod
     def get_full_address(channel):
-        return protocol_and_address(channel.address)[3]
+        parsed_address = protocol_and_address(channel.address)[2]
+
+        if parsed_address:
+            full_addr = parsed_address.netloc + parsed_address.path
+        else: 
+            full_addr = None
+
+        return full_addr
 
     @staticmethod
     def get_address(channel):
@@ -260,7 +267,18 @@ class PyDMPlugin(object):
     
     @staticmethod
     def get_subfield(channel):
-        return protocol_and_address(channel.address)[2]
+        
+        parsed_address = protocol_and_address(channel.address)[2]
+
+        if parsed_address:
+            subfield = parsed_address.path
+
+            if subfield != '':
+                subfield = subfield[1:].split('/')
+        else:
+            subfield = None
+        
+        return subfield
 
     @staticmethod
     def get_connection_id(channel):

--- a/pydm/data_plugins/plugin.py
+++ b/pydm/data_plugins/plugin.py
@@ -251,6 +251,10 @@ class PyDMPlugin(object):
         self.lock = threading.Lock()
 
     @staticmethod
+    def get_full_address(channel):
+        return protocol_and_address(channel.address)[3]
+
+    @staticmethod
     def get_address(channel):
         return protocol_and_address(channel.address)[1]
     
@@ -260,7 +264,7 @@ class PyDMPlugin(object):
 
     @staticmethod
     def get_connection_id(channel):
-        return PyDMPlugin.get_address(channel)
+        return PyDMPlugin.get_full_address(channel)
 
     def add_connection(self, channel):
         from pydm.utilities import is_qt_designer
@@ -277,7 +281,7 @@ class PyDMPlugin(object):
                 return
 
             self.channels.add(channel)
-            if connection_id in self.connections and not PyDMPlugin.get_subfield(channel):
+            if connection_id in self.connections:
                 self.connections[connection_id].add_listener(channel)
             else:
                 self.connections[connection_id] = self.connection_class(

--- a/pydm/data_plugins/plugin.py
+++ b/pydm/data_plugins/plugin.py
@@ -253,6 +253,10 @@ class PyDMPlugin(object):
     @staticmethod
     def get_address(channel):
         return protocol_and_address(channel.address)[1]
+    
+    @staticmethod
+    def get_subfield(channel):
+        return protocol_and_address(channel.address)[2]
 
     @staticmethod
     def get_connection_id(channel):

--- a/pydm/tests/test_data_plugins_import.py
+++ b/pydm/tests/test_data_plugins_import.py
@@ -39,13 +39,13 @@ def test_plugin_directory_loading(qapp, caplog):
         os.remove(os.path.join(cur_dir, 'plugin_foo.py'))
 
 
-def test_plugin_for_address(test_plugin):
+def test_plugin_for_address(test_plugin, monkeypatch):
     # Get by protocol
     assert isinstance(plugin_for_address('tst://tst:this'),
                       test_plugin)
     assert plugin_for_address('tst:this') is None
     # Default protocol
-    config.DEFAULT_PROTOCOL = 'tst'
+    monkeypatch.setattr(config, 'DEFAULT_PROTOCOL', 'tst')
     assert isinstance(plugin_for_address('tst:this'),
                       test_plugin)
 

--- a/pydm/tests/utilities/test_remove_protocol.py
+++ b/pydm/tests/utilities/test_remove_protocol.py
@@ -24,7 +24,7 @@ def test_parsed_address():
     assert (out == None)
 
     out = parsed_address('foo:/bar')
-    assert (out == ('foo', '/bar', '', '', '', ''))
+    assert (out == None)
 
     out = parsed_address('foo://bar')
     assert (out == ('foo', 'bar', '', '', '', ''))

--- a/pydm/tests/utilities/test_remove_protocol.py
+++ b/pydm/tests/utilities/test_remove_protocol.py
@@ -1,5 +1,6 @@
 from ...utilities.remove_protocol import remove_protocol
-
+from ...utilities.remove_protocol import protocol_and_address
+from ...utilities.remove_protocol import parsed_address
 
 def test_remove_protocol():
     out = remove_protocol('foo://bar')
@@ -10,3 +11,22 @@ def test_remove_protocol():
 
     out = remove_protocol('foo://bar://foo2')
     assert (out == 'bar://foo2')
+
+def test_protocol_and_address():
+    out = protocol_and_address('foo://bar')
+    assert (out == ('foo', 'bar'))
+
+    out = protocol_and_address('foo:/bar')
+    assert (out == (None, 'foo:/bar'))
+
+def test_parsed_address():
+    out = parsed_address(1)
+    assert (out == None)
+
+    out = parsed_address('foo:/bar')
+    assert (out == None)
+
+    out = parsed_address('foo://bar')
+    assert (out == ('foo', 'bar', '', '', '', ''))
+
+

--- a/pydm/tests/utilities/test_remove_protocol.py
+++ b/pydm/tests/utilities/test_remove_protocol.py
@@ -24,7 +24,7 @@ def test_parsed_address():
     assert (out == None)
 
     out = parsed_address('foo:/bar')
-    assert (out == None)
+    assert (out == ('foo', '/bar', '', '', '', ''))
 
     out = parsed_address('foo://bar')
     assert (out == ('foo', 'bar', '', '', '', ''))

--- a/pydm/utilities/__init__.py
+++ b/pydm/utilities/__init__.py
@@ -17,7 +17,7 @@ from qtpy import QtCore, QtGui, QtWidgets
 from . import colors, macro, shortcuts
 from .connection import close_widget_connections, establish_widget_connections
 from .iconfont import IconFont
-from .remove_protocol import protocol_and_address, remove_protocol
+from .remove_protocol import protocol_and_address, remove_protocol, parsed_address
 from .units import convert, find_unit_options, find_unittype
 
 logger = logging.getLogger(__name__)

--- a/pydm/utilities/remove_protocol.py
+++ b/pydm/utilities/remove_protocol.py
@@ -14,13 +14,13 @@ def remove_protocol(addr):
     -------
     str
     """
-    _, addr,  *_ = protocol_and_address(addr)
+    _, addr, _ = protocol_and_address(addr)
     return addr
 
 
 def protocol_and_address(address):
     """
-    Returns the Protocol, Address and optional subfield pieces of a Channel Address
+    Returns the protocol, address and parsed address 
 
     Parameters
     ----------
@@ -38,17 +38,10 @@ def protocol_and_address(address):
     match = re.match('.*?://', address)
     protocol = None 
     addr = address
-    subfield = None 
-    full_addr = None 
-    
+    parsed_address = None
     if match:
         parsed_address = urllib.parse.urlparse(address)
         protocol = parsed_address.scheme 
         addr = parsed_address.netloc
-        subfield = parsed_address.path 
-        full_addr = parsed_address.netloc + parsed_address.path
-
-        if subfield != '':
-            subfield = subfield[1:].split('/')
     
-    return protocol, addr, subfield, full_addr
+    return protocol, addr, parsed_address

--- a/pydm/utilities/remove_protocol.py
+++ b/pydm/utilities/remove_protocol.py
@@ -39,7 +39,8 @@ def protocol_and_address(address):
     protocol = None 
     addr = address
     subfield = None 
-
+    full_addr = None 
+    
     if match:
         parsed_address = urllib.parse.urlparse(address)
         protocol = parsed_address.scheme 

--- a/pydm/utilities/remove_protocol.py
+++ b/pydm/utilities/remove_protocol.py
@@ -21,10 +21,12 @@ def remove_protocol(addr):
 def protocol_and_address(address):
     """
     Returns the Protocol and Address pieces of a Channel Address
+
     Parameters
     ----------
     address : str
         The address from which to remove the address prefix.
+
     Returns
     -------
     protocol : str
@@ -54,6 +56,9 @@ def parsed_address(address):
     -------
     parsed_address : tuple 
     """
+    if type(address) != str:
+        return None
+
     match = re.match('.*?://', address)
     parsed_address = None
     

--- a/pydm/utilities/remove_protocol.py
+++ b/pydm/utilities/remove_protocol.py
@@ -45,8 +45,9 @@ def protocol_and_address(address):
         protocol = parsed_address.scheme 
         addr = parsed_address.netloc
         subfield = parsed_address.path 
+        full_addr = parsed_address.netloc + parsed_address.path
 
         if subfield != '':
             subfield = subfield[1:].split('/')
     
-    return protocol, addr, subfield
+    return protocol, addr, subfield, full_addr

--- a/pydm/utilities/remove_protocol.py
+++ b/pydm/utilities/remove_protocol.py
@@ -14,13 +14,36 @@ def remove_protocol(addr):
     -------
     str
     """
-    _, addr, _ = protocol_and_address(addr)
+    _, addr = protocol_and_address(addr)
     return addr
 
 
 def protocol_and_address(address):
     """
-    Returns the protocol, address and parsed address 
+    Returns the Protocol and Address pieces of a Channel Address
+    Parameters
+    ----------
+    address : str
+        The address from which to remove the address prefix.
+    Returns
+    -------
+    protocol : str
+        The protocol used. None in case the protocol is not specified.
+    addr : str
+        The piece of the address without the protocol.
+    """
+    match = re.match('.*?://', address)
+    protocol = None
+    addr = address
+    if match:
+        protocol = match.group(0)[:-3]
+        addr = address.replace(match.group(0), '')
+
+    return protocol, addr
+
+def parsed_address(address):
+    """
+    Returns the given address parsed into a 6-tuple. The parsing is done by urllib.parse.urlparse
 
     Parameters
     ----------
@@ -29,25 +52,12 @@ def protocol_and_address(address):
 
     Returns
     -------
-    protocol : str
-        The protocol used. None in case the protocol is not specified.
-    addr : str
-        The piece of the address without the protocol.
-    subfield : list, str
+    parsed_address : tuple 
     """
     match = re.match('.*?://', address)
-    protocol = None 
-    addr = address
     parsed_address = None
     
     if match:
         parsed_address = urllib.parse.urlparse(address)
-        protocol = parsed_address.scheme 
-        
-        if protocol == 'calc' or protocol == 'loc':
-            addr = parsed_address.netloc + '?' + parsed_address.query
-        else:
-            addr = parsed_address.netloc
 
-    
-    return protocol, addr, parsed_address
+    return parsed_address

--- a/pydm/utilities/remove_protocol.py
+++ b/pydm/utilities/remove_protocol.py
@@ -39,9 +39,15 @@ def protocol_and_address(address):
     protocol = None 
     addr = address
     parsed_address = None
+    
     if match:
         parsed_address = urllib.parse.urlparse(address)
         protocol = parsed_address.scheme 
-        addr = parsed_address.netloc
+        
+        if protocol == 'calc' or protocol == 'loc':
+            addr = parsed_address.netloc + parsed_address.query
+        else:
+            addr = parsed_address.netloc
+
     
     return protocol, addr, parsed_address

--- a/pydm/utilities/remove_protocol.py
+++ b/pydm/utilities/remove_protocol.py
@@ -37,8 +37,19 @@ def protocol_and_address(address):
     match = re.match('.*?://', address)
     protocol = None
     addr = address
+    subfield = None 
+
     if match:
         protocol = match.group(0)[:-3]
         addr = address.replace(match.group(0), '')
+        resulting_string = addr.split('/', 1)
+        
+        if len(resulting_string) < 2:
+            resulting_string.append(None)
+        
+        addr, subfield = resulting_string
 
-    return protocol, addr
+        if subfield:
+            subfield = subfield.split('/')
+
+    return protocol, addr, subfield

--- a/pydm/utilities/remove_protocol.py
+++ b/pydm/utilities/remove_protocol.py
@@ -1,5 +1,6 @@
 import re
 import urllib
+from .. import config 
 
 def remove_protocol(addr):
     """
@@ -64,5 +65,8 @@ def parsed_address(address):
     
     if match:
         parsed_address = urllib.parse.urlparse(address)
+    else:
+        parsed_address = urllib.parse.urlparse(config.DEFAULT_PROTOCOL + '://' + address)
+    
 
     return parsed_address

--- a/pydm/utilities/remove_protocol.py
+++ b/pydm/utilities/remove_protocol.py
@@ -62,11 +62,10 @@ def parsed_address(address):
 
     match = re.match('.*?://', address)
     parsed_address = None
-    
+
     if match:
         parsed_address = urllib.parse.urlparse(address)
-    else:
+    elif config.DEFAULT_PROTOCOL:
         parsed_address = urllib.parse.urlparse(config.DEFAULT_PROTOCOL + '://' + address)
-    
 
     return parsed_address

--- a/pydm/utilities/remove_protocol.py
+++ b/pydm/utilities/remove_protocol.py
@@ -45,7 +45,7 @@ def protocol_and_address(address):
         protocol = parsed_address.scheme 
         
         if protocol == 'calc' or protocol == 'loc':
-            addr = parsed_address.netloc + parsed_address.query
+            addr = parsed_address.netloc + '?' + parsed_address.query
         else:
             addr = parsed_address.netloc
 

--- a/pydm/utilities/remove_protocol.py
+++ b/pydm/utilities/remove_protocol.py
@@ -1,5 +1,5 @@
 import re
-
+import urllib
 
 def remove_protocol(addr):
     """
@@ -20,7 +20,7 @@ def remove_protocol(addr):
 
 def protocol_and_address(address):
     """
-    Returns the Protocol and Address pieces of a Channel Address
+    Returns the Protocol, Address and optional subfield pieces of a Channel Address
 
     Parameters
     ----------
@@ -33,23 +33,20 @@ def protocol_and_address(address):
         The protocol used. None in case the protocol is not specified.
     addr : str
         The piece of the address without the protocol.
+    subfield : list, str
     """
     match = re.match('.*?://', address)
-    protocol = None
+    protocol = None 
     addr = address
     subfield = None 
 
     if match:
-        protocol = match.group(0)[:-3]
-        addr = address.replace(match.group(0), '')
-        resulting_string = addr.split('/', 1)
-        
-        if len(resulting_string) < 2:
-            resulting_string.append(None)
-        
-        addr, subfield = resulting_string
+        parsed_address = urllib.parse.urlparse(address)
+        protocol = parsed_address.scheme 
+        addr = parsed_address.netloc
+        subfield = parsed_address.path 
 
-        if subfield:
-            subfield = subfield.split('/')
-
+        if subfield != '':
+            subfield = subfield[1:].split('/')
+    
     return protocol, addr, subfield

--- a/pydm/utilities/remove_protocol.py
+++ b/pydm/utilities/remove_protocol.py
@@ -14,7 +14,7 @@ def remove_protocol(addr):
     -------
     str
     """
-    _, addr = protocol_and_address(addr)
+    _, addr,  *_ = protocol_and_address(addr)
     return addr
 
 

--- a/pydm/widgets/__init__.py
+++ b/pydm/widgets/__init__.py
@@ -27,3 +27,4 @@ from .scatterplot import PyDMScatterPlot
 from .eventplot import PyDMEventPlot
 from .tab_bar import PyDMTabWidget
 from .template_repeater import PyDMTemplateRepeater
+from .nt_table import PyDMNTTable

--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -873,7 +873,8 @@ class PyDMWidget(PyDMPrimitiveWidget, new_properties=_positionRuleProperties):
     @Slot(float)
     @Slot(str)
     @Slot(bool)
-    @Slot(np.ndarray)
+    #@Slot(np.ndarray)
+    @Slot(object)
     def channelValueChanged(self, new_val):
         """
         PyQT Slot for changes on the Value of the Channel
@@ -1348,10 +1349,11 @@ class PyDMWritableWidget(PyDMWidget):
         Emitted when the user changes the value
     """
 
-    __Signals__ = ("send_value_signal([int], [float], [str], [bool], [np.ndarray])")
+    __Signals__ = ("send_value_signal([int], [float], [str], [bool], [object])")
 
     # Emitted when the user changes the value.
-    send_value_signal = Signal([int], [float], [str], [bool], [np.ndarray])
+
+    send_value_signal = Signal([int], [float], [str], [bool], [object])
 
     def __init__(self, init_channel=None):
         self._write_access = False

--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -741,7 +741,6 @@ class PyDMWidget(PyDMPrimitiveWidget, new_properties=_positionRuleProperties):
         self.value = new_val
         self.channeltype = type(self.value)
         if self.channeltype == np.ndarray:
-            print("cold")
             self.subtype = self.value.dtype.type
         else:
             try:
@@ -874,7 +873,7 @@ class PyDMWidget(PyDMPrimitiveWidget, new_properties=_positionRuleProperties):
     @Slot(float)
     @Slot(str)
     @Slot(bool)
-    #@Slot(np.ndarray)
+    @Slot(np.ndarray)
     @Slot(object)
     def channelValueChanged(self, new_val):
         """
@@ -1350,11 +1349,11 @@ class PyDMWritableWidget(PyDMWidget):
         Emitted when the user changes the value
     """
 
-    __Signals__ = ("send_value_signal([int], [float], [str], [bool], [object])")
+    __Signals__ = ("send_value_signal([int], [float], [str], [bool], [np.ndarray])")
 
     # Emitted when the user changes the value.
 
-    send_value_signal = Signal([int], [float], [str], [bool], [object])
+    send_value_signal = Signal([int], [float], [str], [bool], [np.ndarray])
 
     def __init__(self, init_channel=None):
         self._write_access = False

--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -1348,10 +1348,10 @@ class PyDMWritableWidget(PyDMWidget):
         Emitted when the user changes the value
     """
 
-    __Signals__ = ("send_value_signal([int], [float], [str], [bool], [np.ndarray])")
+    __Signals__ = ("send_value_signal([int], [float], [str], [bool], [object])")
 
     # Emitted when the user changes the value.
-    send_value_signal = Signal([int], [float], [str], [bool], [np.ndarray])
+    send_value_signal = Signal([int], [float], [str], [bool], [object])
 
     def __init__(self, init_channel=None):
         self._write_access = False

--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -741,6 +741,7 @@ class PyDMWidget(PyDMPrimitiveWidget, new_properties=_positionRuleProperties):
         self.value = new_val
         self.channeltype = type(self.value)
         if self.channeltype == np.ndarray:
+            print("cold")
             self.subtype = self.value.dtype.type
         else:
             try:

--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -874,7 +874,6 @@ class PyDMWidget(PyDMPrimitiveWidget, new_properties=_positionRuleProperties):
     @Slot(str)
     @Slot(bool)
     @Slot(np.ndarray)
-    @Slot(object)
     def channelValueChanged(self, new_val):
         """
         PyQT Slot for changes on the Value of the Channel
@@ -1352,7 +1351,6 @@ class PyDMWritableWidget(PyDMWidget):
     __Signals__ = ("send_value_signal([int], [float], [str], [bool], [np.ndarray])")
 
     # Emitted when the user changes the value.
-
     send_value_signal = Signal([int], [float], [str], [bool], [np.ndarray])
 
     def __init__(self, init_channel=None):

--- a/pydm/widgets/nt_table.py
+++ b/pydm/widgets/nt_table.py
@@ -168,6 +168,7 @@ class PythonTableModel(QtCore.QAbstractTableModel):
 class PyDMNTTable(QtWidgets.QWidget, PyDMWidget):
     def __init__(self, parent=None, init_channel=None):
         super(PyDMNTTable, self).__init__(parent=parent, init_channel=init_channel)
+        PyDMWidget.__init__(self, init_channel=init_channel)
         self.setLayout(QtWidgets.QVBoxLayout())
         self._table = QtWidgets.QTableView(self)
         self.layout().addWidget(self._table)
@@ -175,24 +176,27 @@ class PyDMNTTable(QtWidgets.QWidget, PyDMWidget):
         self._table_labels = None
         self._table_values = []
 
-    def _receive_data(self, data=None, introspection=None, *args, **kwargs):
-        super(PyDMNTTable, self)._receive_data(data, introspection, *args,
-                                           **kwargs)
+    def value_changed(self, data=None):
         if data is None:
             return
-        labels = data.get('labels', None)
-        values = data.get('value', {})
-
+        print(data, type(data), "test")        
+        super(PyDMNTTable, self).value_changed(data)
+        
+        labels = data.dtype.names
+        values = data.tolist()
+        
+        print(values, type(values), "test")
+        
         if labels is None or len(labels) == 0:
             labels = values.keys()
-
+       
         try:
             values = list(zip(*[v for k, v in values.items()]))
         except TypeError:
             logger.exception("NTTable value items must be iterables.")
 
         self._table_values = values
-
+      
         if labels != self._table_labels:
             self._table_labels = labels
             self._model = PythonTableModel(labels, initial_list=values)

--- a/pydm/widgets/nt_table.py
+++ b/pydm/widgets/nt_table.py
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 class PythonTableModel(QtCore.QAbstractTableModel):
     def __init__(self, column_names, initial_list=[], parent=None,
                  edit_method=None, can_edit_method=None):
-        super(PythonTableModel, self).__init__(parent=parent)
+        super().__init__(parent=parent)
         self._list = []
         self._column_names = column_names
         self.edit_method = edit_method

--- a/pydm/widgets/nt_table.py
+++ b/pydm/widgets/nt_table.py
@@ -196,17 +196,25 @@ class PyDMNTTable(QtWidgets.QWidget, PyDMWritableWidget):
         self._model = None
         self._table_labels = None
         self._table_values = []
-        self._can_edit = False 
+        self._read_only = True 
         self.edit_method = None
 
     @QtCore.Property(bool)
     def readOnly(self):
-        return self._can_edit
+        return self._read_only
 
     @readOnly.setter
     def readOnly(self, value):
-        if self._can_edit != value:
-            self._can_edit = value
+        if self._read_only != value:
+            self._read_only = value
+        
+    def check_enable_state(self):
+        """
+        Checks whether or not the widget should be disable.
+
+        """
+        PyDMWritableWidget.check_enable_state(self)
+        self.setEnabled(True)
 
     def value_changed(self, data=None):
         """
@@ -241,7 +249,7 @@ class PyDMNTTable(QtWidgets.QWidget, PyDMWritableWidget):
 
         if labels != self._table_labels:
             
-            if self.readOnly:
+            if not self.readOnly:
                 self.edit_method = PyDMNTTable.send_table
             else:
                 self.edit_method = None
@@ -270,7 +278,6 @@ class PyDMNTTable(QtWidgets.QWidget, PyDMWritableWidget):
         """
         if isinstance(self.value[self._table_labels[column]], np.ndarray):
             self.value[self._table_labels[column]] = self.value[self._table_labels[column]].copy()
-            self.value[self._table_labels[column]].setflags(write=True)
         
         self.value[self._table_labels[column]][row] = value
         

--- a/pydm/widgets/nt_table.py
+++ b/pydm/widgets/nt_table.py
@@ -166,6 +166,9 @@ class PythonTableModel(QtCore.QAbstractTableModel):
 
 
 class PyDMNTTable(QtWidgets.QWidget, PyDMWidget):
+    """
+    PyDMNTTable 
+    """
     def __init__(self, parent=None, init_channel=None):
         super(PyDMNTTable, self).__init__(parent=parent, init_channel=init_channel)
         PyDMWidget.__init__(self, init_channel=init_channel)
@@ -177,26 +180,36 @@ class PyDMNTTable(QtWidgets.QWidget, PyDMWidget):
         self._table_values = []
 
     def value_changed(self, data=None):
+        """
+        Callback invoked when the Channel value is changed.
+
+        Parameters
+        ----------
+        data : dict
+            The new value from the channel. 
+        """
         if data is None:
             return
-        print(data, type(data), "test")        
+        
         super(PyDMNTTable, self).value_changed(data)
         
-        labels = data.dtype.names
-        values = data.tolist()
-        
-        print(values, type(values), "test")
+        labels = data.get('labels', None)
+        values = data.get('value', {})
+
+        if not values: 
+            values = data.values()
         
         if labels is None or len(labels) == 0:
-            labels = values.keys()
-       
+            labels = data.keys()
+            labels = list(labels)
+        
         try:
-            values = list(zip(*[v for k, v in values.items()]))
+            values = list(zip(*[v for k, v in data.items()]))
         except TypeError:
             logger.exception("NTTable value items must be iterables.")
 
         self._table_values = values
-      
+
         if labels != self._table_labels:
             self._table_labels = labels
             self._model = PythonTableModel(labels, initial_list=values)

--- a/pydm/widgets/nt_table.py
+++ b/pydm/widgets/nt_table.py
@@ -188,6 +188,8 @@ class PyDMNTTable(QtWidgets.QWidget, PyDMWritableWidget):
             The channel to be used by the widget. 
     """
     def __init__(self, parent=None, init_channel=None):
+        self._read_only = True 
+
         super().__init__(parent=parent)
         PyDMWidget.__init__(self, init_channel=init_channel)
         self.setLayout(QtWidgets.QVBoxLayout())
@@ -196,7 +198,6 @@ class PyDMNTTable(QtWidgets.QWidget, PyDMWritableWidget):
         self._model = None
         self._table_labels = None
         self._table_values = []
-        self._read_only = True 
         self.edit_method = None
 
     @QtCore.Property(bool)
@@ -215,6 +216,14 @@ class PyDMNTTable(QtWidgets.QWidget, PyDMWritableWidget):
         """
         PyDMWritableWidget.check_enable_state(self)
         self.setEnabled(True)
+        tooltip = self.toolTip()
+
+        if self.readOnly: 
+            if tooltip != '':
+                tooltip += '\n'
+            tooltip += "Running PyDMNTTable on Read-Only mode."
+        
+        self.setToolTip(tooltip)
 
     def value_changed(self, data=None):
         """
@@ -278,7 +287,7 @@ class PyDMNTTable(QtWidgets.QWidget, PyDMWritableWidget):
         """
         if isinstance(self.value[self._table_labels[column]], np.ndarray):
             self.value[self._table_labels[column]] = self.value[self._table_labels[column]].copy()
-        
+
         self.value[self._table_labels[column]][row] = value
         
         # dictionary needs to be wrapped in another dictionary with a key 'value'

--- a/pydm/widgets/nt_table.py
+++ b/pydm/widgets/nt_table.py
@@ -23,7 +23,7 @@ class PythonTableModel(QtCore.QAbstractTableModel):
     @list.setter
     def list(self, new_list):
         self.beginResetModel()
-        self._list = new_list
+        self._list = list(new_list)
         self.endResetModel()
 
     # QAbstractItemModel Implementation

--- a/pydm/widgets/nt_table.py
+++ b/pydm/widgets/nt_table.py
@@ -1,4 +1,5 @@
 import logging
+import numpy as np
 from operator import itemgetter
 from pydm.widgets.base import PyDMWidget, PyDMWritableWidget
 from qtpy import QtCore, QtWidgets
@@ -199,11 +200,11 @@ class PyDMNTTable(QtWidgets.QWidget, PyDMWritableWidget):
         self.edit_method = None
 
     @QtCore.Property(bool)
-    def set_edit(self):
+    def readOnly(self):
         return self._can_edit
 
-    @set_edit.setter
-    def set_edit(self, value):
+    @readOnly.setter
+    def readOnly(self, value):
         if self._can_edit != value:
             self._can_edit = value
 
@@ -240,7 +241,7 @@ class PyDMNTTable(QtWidgets.QWidget, PyDMWritableWidget):
 
         if labels != self._table_labels:
             
-            if self.set_edit:
+            if self.readOnly:
                 self.edit_method = PyDMNTTable.send_table
             else:
                 self.edit_method = None
@@ -267,6 +268,10 @@ class PyDMNTTable(QtWidgets.QWidget, PyDMWritableWidget):
         value : str
             new value of cell
         """
+        if isinstance(self.value[self._table_labels[column]], np.ndarray):
+            self.value[self._table_labels[column]] = self.value[self._table_labels[column]].copy()
+            self.value[self._table_labels[column]].setflags(write=True)
+        
         self.value[self._table_labels[column]][row] = value
         
         # dictionary needs to be wrapped in another dictionary with a key 'value'

--- a/pydm/widgets/nt_table.py
+++ b/pydm/widgets/nt_table.py
@@ -1,7 +1,5 @@
 import logging
-
 from operator import itemgetter
-
 from pydm.widgets.base import PyDMWidget
 from qtpy import QtCore, QtWidgets
 
@@ -167,7 +165,22 @@ class PythonTableModel(QtCore.QAbstractTableModel):
 
 class PyDMNTTable(QtWidgets.QWidget, PyDMWidget):
     """
-    PyDMNTTable 
+    The PyDMNTTable is a table widget used to display PVA NTTable data. 
+
+    The PyDMNTTable has two ways of filling the table from the data. 
+    If the incoming data dictionary has a 'labels' and/or a 'value' key. 
+    Then the list of labels will be set with the data from the 'labels' key. 
+    While the data from the 'value' key will be used to set the values in the table. 
+    if neither 'labels' or 'value' key are present in the incoming 'data' dictionary,
+    then the keys of the data dictionary are set as the labels 
+    and all the values stored by the keys will make up the values of the table. 
+    
+    Parameters
+        ----------
+        parent : QWidget, optional
+            The parent widget for the PyDMNTTable
+        init_channel : str, optional
+            The channel to be used by the widget. 
     """
     def __init__(self, parent=None, init_channel=None):
         super(PyDMNTTable, self).__init__(parent=parent, init_channel=init_channel)

--- a/pydm/widgets/nt_table.py
+++ b/pydm/widgets/nt_table.py
@@ -185,7 +185,7 @@ class PyDMNTTable(QtWidgets.QWidget, PyDMWidget):
             The channel to be used by the widget. 
     """
     def __init__(self, parent=None, init_channel=None):
-        super().__init__(parent=parent, init_channel=init_channel)
+        super().__init__(parent=parent)
         PyDMWidget.__init__(self, init_channel=init_channel)
         self.setLayout(QtWidgets.QVBoxLayout())
         self._table = QtWidgets.QTableView(self)

--- a/pydm/widgets/nt_table.py
+++ b/pydm/widgets/nt_table.py
@@ -183,7 +183,7 @@ class PyDMNTTable(QtWidgets.QWidget, PyDMWidget):
             The channel to be used by the widget. 
     """
     def __init__(self, parent=None, init_channel=None):
-        super(PyDMNTTable, self).__init__(parent=parent, init_channel=init_channel)
+        super().__init__(parent=parent, init_channel=init_channel)
         PyDMWidget.__init__(self, init_channel=init_channel)
         self.setLayout(QtWidgets.QVBoxLayout())
         self._table = QtWidgets.QTableView(self)

--- a/pydm/widgets/nt_table.py
+++ b/pydm/widgets/nt_table.py
@@ -7,10 +7,10 @@ logger = logging.getLogger(__name__)
 
 
 class PythonTableModel(QtCore.QAbstractTableModel):
-    def __init__(self, column_names, initial_list=[], parent=None,
+    def __init__(self, column_names, initial_list=None, parent=None,
                  edit_method=None, can_edit_method=None):
         super().__init__(parent=parent)
-        self._list = []
+        self._list = None
         self._column_names = column_names
         self.edit_method = edit_method
         self.can_edit_method = can_edit_method
@@ -22,6 +22,8 @@ class PythonTableModel(QtCore.QAbstractTableModel):
 
     @list.setter
     def list(self, new_list):
+        if new_list is None:
+            new_list = []
         self.beginResetModel()
         self._list = list(new_list)
         self.endResetModel()

--- a/pydm/widgets/nt_table.py
+++ b/pydm/widgets/nt_table.py
@@ -278,5 +278,5 @@ class PyDMNTTable(QtWidgets.QWidget, PyDMWritableWidget):
         # to be passed back to the p4p plugin. 
         emit_dict = {'value': self.value}  
         
-        self.send_value_signal[object].emit(emit_dict)
+        self.send_value_signal[dict].emit(emit_dict)
         return True

--- a/pydm/widgets/nt_table.py
+++ b/pydm/widgets/nt_table.py
@@ -1,0 +1,201 @@
+import logging
+
+from operator import itemgetter
+
+from pydm.widgets.base import PyDMWidget
+from qtpy import QtCore, QtWidgets
+
+logger = logging.getLogger(__name__)
+
+
+class PythonTableModel(QtCore.QAbstractTableModel):
+    def __init__(self, column_names, initial_list=[], parent=None,
+                 edit_method=None, can_edit_method=None):
+        super(PythonTableModel, self).__init__(parent=parent)
+        self._list = []
+        self._column_names = column_names
+        self.edit_method = edit_method
+        self.can_edit_method = can_edit_method
+        self.list = initial_list
+
+    @property
+    def list(self):
+        return self._list
+
+    @list.setter
+    def list(self, new_list):
+        self.beginResetModel()
+        self._list = new_list
+        self.endResetModel()
+
+    # QAbstractItemModel Implementation
+    def clear(self):
+        self.list = []
+
+    def flags(self, index):
+        f = QtCore.Qt.ItemIsSelectable | QtCore.Qt.ItemIsEnabled
+        if self.edit_method is not None:
+            editable = True
+            if self.can_edit_method is not None:
+                editable = self.can_edit_method(
+                    self._list[index.row()][index.column()])
+            if editable:
+                f = f | QtCore.Qt.ItemIsEditable
+        return f
+
+    def rowCount(self, parent=None):
+        if parent is not None and parent.isValid():
+            return 0
+        return len(self._list)
+
+    def columnCount(self, parent=None):
+        return len(self._column_names)
+
+    def data(self, index, role=QtCore.Qt.DisplayRole):
+        if not index.isValid():
+            return QtCore.QVariant()
+        if index.row() >= self.rowCount():
+            return QtCore.QVariant()
+        if index.column() >= self.columnCount():
+            return QtCore.QVariant()
+        if role == QtCore.Qt.DisplayRole:
+            try:
+                item = str(self._list[index.row()][index.column()])
+            except IndexError:
+                item = ""
+            return item
+        else:
+            return QtCore.QVariant()
+
+    def setData(self, index, value, role=QtCore.Qt.EditRole):
+        if self.edit_method is None:
+            return False
+        if role != QtCore.Qt.EditRole:
+            return False
+        if not index.isValid():
+            return False
+        if index.row() >= self.rowCount():
+            return False
+        if index.column() >= self.columnCount():
+            return False
+        success = self.edit_method(self._list[index.row()][index.column()],
+                                   value.toPyObject())
+        if success:
+            self.dataChanged.emit(index, index)
+        return success
+
+    def headerData(self, section, orientation, role=QtCore.Qt.DisplayRole):
+        if role != QtCore.Qt.DisplayRole:
+            return super(PythonTableModel, self).headerData(section,
+                                                            orientation, role)
+        if orientation == QtCore.Qt.Horizontal \
+                and section < self.columnCount():
+            return str(self._column_names[section])
+        elif orientation == QtCore.Qt.Vertical and section < self.rowCount():
+            return section
+
+    def sort(self, col, order=QtCore.Qt.AscendingOrder):
+        self.layoutAboutToBeChanged.emit()
+        sort_reversed = (order == QtCore.Qt.AscendingOrder)
+        self._list.sort(key=itemgetter(col), reverse=sort_reversed)
+        self.layoutChanged.emit()
+
+    # End QAbstractItemModel implementation.
+
+    # Python collection implementation.
+    def __len__(self):
+        return len(self._list)
+
+    def __iter__(self):
+        return iter(self._list)
+
+    def __contains__(self, value):
+        return value in self._list
+
+    def __getitem__(self, index):
+        return self._list[index]
+
+    def __setitem__(self, index, value):
+        if len(value) != self.columnCount():
+            msg = "Items must have the same length as the column count ({})"
+            raise ValueError(msg.format(self.columnCount()))
+        self._list[index] = value
+        self.dataChanged.emit(index, index)
+
+    def __delitem__(self, index):
+        if (index + 1) > len(self):
+            raise IndexError("list assignment index out of range")
+        self.beginRemoveRows(QtCore.QModelIndex(), index, index)
+        del self._list[index]
+        self.endRemoveRows()
+
+    def append(self, value):
+        self.beginInsertRows(QtCore.QModelIndex(), len(self._list),
+                             len(self._list))
+        self._list.append(value)
+        self.endInsertRows()
+
+    def extend(self, values):
+        self.beginInsertRows(QtCore.QModelIndex(), len(self._list),
+                             len(self._list) + len(values) - 1)
+        self._list.extend(values)
+        self.endInsertRows()
+
+    def remove(self, item):
+        index = None
+        try:
+            index = self._list.index(item)
+        except ValueError:
+            raise ValueError("list.remove(x): x not in list")
+        del self[index]
+
+    def pop(self, index=None):
+        if len(self._list) < 1:
+            raise IndexError("pop from empty list")
+        if index is None:
+            index = len(self._list) - 1
+        del self[index]
+
+    def count(self, item):
+        return self._list.count(item)
+
+    def reverse(self):
+        self.layoutAboutToBeChanged.emit()
+        self._list.reverse()
+        self.layoutChanged.emit()
+
+
+class PyDMNTTable(QtWidgets.QWidget, PyDMWidget):
+    def __init__(self, parent=None, init_channel=None):
+        super(PyDMNTTable, self).__init__(parent=parent, init_channel=init_channel)
+        self.setLayout(QtWidgets.QVBoxLayout())
+        self._table = QtWidgets.QTableView(self)
+        self.layout().addWidget(self._table)
+        self._model = None
+        self._table_labels = None
+        self._table_values = []
+
+    def _receive_data(self, data=None, introspection=None, *args, **kwargs):
+        super(PyDMNTTable, self)._receive_data(data, introspection, *args,
+                                           **kwargs)
+        if data is None:
+            return
+        labels = data.get('labels', None)
+        values = data.get('value', {})
+
+        if labels is None or len(labels) == 0:
+            labels = values.keys()
+
+        try:
+            values = list(zip(*[v for k, v in values.items()]))
+        except TypeError:
+            logger.exception("NTTable value items must be iterables.")
+
+        self._table_values = values
+
+        if labels != self._table_labels:
+            self._table_labels = labels
+            self._model = PythonTableModel(labels, initial_list=values)
+            self._table.setModel(self._model)
+        else:
+            self._model.list = values

--- a/pydm/widgets/qtplugins.py
+++ b/pydm/widgets/qtplugins.py
@@ -50,6 +50,7 @@ from .terminator import PyDMTerminator
 from .timeplot import PyDMTimePlot
 from .waveformplot import PyDMWaveformPlot
 from .waveformtable import PyDMWaveformTable
+from .nt_table import PyDMNTTable
 
 logger = logging.getLogger(__name__)
 
@@ -272,6 +273,11 @@ PyDMWaveformTablePlugin = qtplugin_factory(PyDMWaveformTable,
                                            group=WidgetCategory.INPUT,
                                            extensions=BASE_EXTENSIONS,
                                            icon=ifont.icon("table"))
+# NTTable plugin 
+PyDMNTTable = qtplugin_factory(PyDMNTTable,
+                               group=WidgetCategory.INPUT,
+                               extensions=BASE_EXTENSIONS,
+                               icon=ifont.icon("table"))
 
 # Tab Widget plugin
 PyDMTabWidgetPlugin = TabWidgetPlugin(extensions=BASE_EXTENSIONS)


### PR DESCRIPTION
## Description
This PR adds a way to use p4p to pass NTTable data through pydm as a dictionary and to be accessed and displayed with a PyDMNTTable Widget. 

Adapts Hugo Slepicka's NTTable widget for the current version of PyDM:
https://github.com/slaclab/pydm_pva_widgets/blob/master/pydm_pva_widgets/widgets/pva_table.py

and adapts Jake Rudolph's PR https://github.com/slaclab/pydm/pull/979

also implements this idea from @mattgibbs
https://github.com/slaclab/pydm/pull/979#issuecomment-1451152201

A follow up PR will change the calc and loc plugin to work with the changes to hoe the address is parsed. I will aslo add more test coverage and the ability to write with sub-fields in a follow up PR. - YY

## How Has This Been Tested?
Tested on an example Gui

## Where Has This Been Documented?
Auto documentation will add documentation for the NTTable Widget and for any new methods. 
Added to the p4p documentation

## Tests
one test added. more tests will be added in a follow up PR. 

## Screenshots:
![Screen Shot 2023-03-16 at 11 57 08 AM](https://user-images.githubusercontent.com/2607613/225725570-71489f07-50e0-4439-bae3-aaa11f8335c9.png)

three widgets with PV_Name, PV_Name/Key and PV_Name/key/index given for the channel addresses:
![Screen Shot 2023-03-21 at 3 40 07 PM](https://user-images.githubusercontent.com/2607613/226757739-bea75ae0-4dc0-4ed9-9963-c56139e572b0.png)

