### PR TITLE
Add additional information to error message when rule evaluation fails

### DIFF
--- a/pydm/widgets/rules.py
+++ b/pydm/widgets/rules.py
@@ -369,7 +369,8 @@ class RulesEngine(QThread):
             val = eval(expression, eval_env)
             self.emit_value(widget_ref, name, prop, val)
         except Exception as e:
-            logger.exception(f"Error while evaluating Rule with name: {name} and type: {prop}")
+            logger.exception(f"Error while evaluating Rule with name: {name} and type: {prop} "
+                             f"and expression: {expression}")
 
     def emit_value(self, widget_ref, name, prop, val):
         """

--- a/pydm/widgets/rules.py
+++ b/pydm/widgets/rules.py
@@ -369,7 +369,7 @@ class RulesEngine(QThread):
             val = eval(expression, eval_env)
             self.emit_value(widget_ref, name, prop, val)
         except Exception as e:
-            logger.exception("Error while evaluating Rule.")
+            logger.exception(f"Error while evaluating Rule with name: {name} and type: {prop}")
 
     def emit_value(self, widget_ref, name, prop, val):
         """

--- a/pydm/widgets/rules.py
+++ b/pydm/widgets/rules.py
@@ -362,10 +362,10 @@ class RulesEngine(QThread):
                          for k, v in math.__dict__.items()
                          if k[0] != '_'})
 
+        expression = rule['rule']['expression']
+        name = rule['rule']['name']
+        prop = rule['rule']['property']
         try:
-            expression = rule['rule']['expression']
-            name = rule['rule']['name']
-            prop = rule['rule']['property']
             val = eval(expression, eval_env)
             self.emit_value(widget_ref, name, prop, val)
         except Exception as e:


### PR DESCRIPTION
Implements #983

Will log output like the following:

`
[2023-04-03 14:59:33,028] [ERROR   ] - Error while evaluating Rule with name: Show Widget and type: Visible and expression: True if ch[0] == 40 else False`

Narrowed the scope of the try/except to only include the evaluation of the rule, if the rule was not created properly then it will correctly fail with a `KeyError` prior to evaluation.