### PR TITLE
FIX: Send the labels value for the NTTable to widgets

### DIFF
--- a/pydm/data_plugins/epics_plugins/p4p_plugin_component.py
+++ b/pydm/data_plugins/epics_plugins/p4p_plugin_component.py
@@ -94,6 +94,9 @@ class Connection(PyDMConnection):
                     
                     if 'NTTable' in value.getID():
                         new_value = value.value.todict()
+                        if hasattr(value, 'labels') and 'labels' not in new_value:
+                            # Labels are the column headers for the table
+                            new_value['labels'] = value.labels
                     else:
                         new_value = value.value
                     


### PR DESCRIPTION
A table I was displaying had column headers that were different from the value names, and this is valid as noted here: https://github.com/epics-base/normativeTypesCPP/wiki/Normative+Types+Specification

`Agents SHOULD use the elements of labels as the column headings. There is no normative requirement that the field names of value match the strings in labels.`

So just a minor change to send along the labels as well to cover the case where they are different than the field names of value.