### PR TITLE
FIX: Ensure placeholders for macro substitutions are always double quoted

### DIFF
--- a/pydm/display.py
+++ b/pydm/display.py
@@ -75,10 +75,10 @@ def load_file(file, macros=None, args=None, target=ScreenTarget.NEW_PROCESS):
 
 def _replace_macro_format(match: re.Match, macro_keys: FrozenSet[str]):
     """ Takes in a match of form '${MACRO_KEY}' and returns double quoted "${MACRO_KEY}" if it is a valid macro key """
-    group = match.group(1)
-    macro_key = re.search(r'\$\{([^}]+)}', group).group(1)
+    matched_text = match.group(1)
+    macro_key = re.search(r'\$\{([^}]+)}', matched_text).group(1)
     if macro_key in macro_keys:
-        return '"' + group + '"'
+        return '"' + matched_text + '"'
     else:
         return match.group(0)  # If not found then just leave it as is
 

--- a/pydm/display.py
+++ b/pydm/display.py
@@ -73,18 +73,8 @@ def load_file(file, macros=None, args=None, target=ScreenTarget.NEW_PROCESS):
     return w
 
 
-def _replace_macro_format(match: re.Match, macro_keys: FrozenSet[str]):
-    """ Takes in a match of form '${MACRO_KEY}' and returns double quoted "${MACRO_KEY}" if it is a valid macro key """
-    matched_text = match.group(1)
-    macro_key = re.search(r'\$\{([^}]+)}', matched_text).group(1)
-    if macro_key in macro_keys:
-        return '"' + matched_text + '"'
-    else:
-        return match.group(0)  # If not found then just leave it as is
-
-
 @lru_cache()
-def _compile_ui_file(uifile: str, macro_keys: Optional[FrozenSet[str]] = None) -> Tuple[str, str]:
+def _compile_ui_file(uifile: str) -> Tuple[str, str]:
     """
     Compile the ui file using uic and return the result as a string along with the associated class name.
     Caches the result to improve performance when the same ui file is re-used many times within a display.
@@ -93,8 +83,6 @@ def _compile_ui_file(uifile: str, macro_keys: Optional[FrozenSet[str]] = None) -
     ----------
     uifile : str
         The path to a .ui file to compile
-    macro_keys : FrozenSet, optional
-        Only the keys of any macros associated with the display. FrozenSet so that it hashes for the lru_cache
 
     Returns
     -------
@@ -102,15 +90,9 @@ def _compile_ui_file(uifile: str, macro_keys: Optional[FrozenSet[str]] = None) -
     """
     code_string = StringIO()
     uic.compileUi(uifile, code_string)
-    compiled_code = code_string.getvalue()
-    if macro_keys is not None and len(macro_keys) > 0:
-        # Replaces any single quoted macro definitions with double quoted ones
-        compiled_code = re.sub(r"'(\$\{[^\n}]+\})'",
-                               lambda match: _replace_macro_format(match, macro_keys),
-                               compiled_code)
     # Grabs non-whitespace characters between class and the opening parenthesis
-    class_name = re.search(r'^class\s*(\S*)\(', compiled_code, re.MULTILINE).group(1)
-    return compiled_code, class_name
+    class_name = re.search(r'^class\s*(\S*)\(', code_string.getvalue(), re.MULTILINE).group(1)
+    return code_string.getvalue(), class_name
 
 
 def _load_ui_into_display(uifile, display):
@@ -416,8 +398,7 @@ class Display(QWidget):
     def load_ui_from_file(self, ui_file_path: str, macros: Optional[Dict[str, str]] = None):
         """ Load the ui file from the input path, and make the file's widgets available in self.ui """
         self._loaded_file = ui_file_path
-        macro_keys = frozenset(macros.keys()) if macros else None
-        code_string, class_name = _compile_ui_file(ui_file_path, macro_keys)
+        code_string, class_name = _compile_ui_file(ui_file_path)
         _load_compiled_ui_into_display(code_string, class_name, self, macros)
 
     def setStyleSheet(self, new_stylesheet):

--- a/pydm/display.py
+++ b/pydm/display.py
@@ -9,7 +9,7 @@ from functools import lru_cache
 from io import StringIO
 from os import path
 from string import Template
-from typing import Dict, FrozenSet, Optional, Tuple
+from typing import Dict, Optional, Tuple
 
 import re
 import six

--- a/pydm/tests/test_data/macro_test.ui
+++ b/pydm/tests/test_data/macro_test.ui
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>285</width>
+    <height>141</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QFormLayout" name="formLayout">
+     <item row="0" column="0">
+      <widget class="QLabel" name="myLabel">
+       <property name="text">
+        <string>${test_label}</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QLabel" name="shellCommand">
+       <property name="commands">
+        <stringlist>
+         <string>${test_command}</string>
+         <string>${test_command_2}</string>
+        </stringlist>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/pydm/tests/test_display.py
+++ b/pydm/tests/test_display.py
@@ -2,7 +2,7 @@ import os
 import pytest
 import re
 from pydm import Display
-from pydm.display import load_py_file, _compile_ui_file, _load_compiled_ui_into_display, _replace_macro_format
+from pydm.display import load_py_file, _compile_ui_file, _load_compiled_ui_into_display
 from qtpy.QtWidgets import QLabel
 
 # The path to the .ui file used in these tests
@@ -141,7 +141,7 @@ def test_load_file_with_macros(qtbot):
         macros = {"test_label": "magnet_list",
                   "test_command": "grep -i 'string with spaces'",
                   "test_command_2": "echo hello"}
-        code_string, class_name = _compile_ui_file(test_ui_with_macros_path, frozenset(macros.keys()))
+        code_string, class_name = _compile_ui_file(test_ui_with_macros_path)
         assert class_name == 'Ui_Form'
 
         # Parse and replace macros, then load into the display
@@ -154,17 +154,3 @@ def test_load_file_with_macros(qtbot):
 
     finally:
         del QLabel.setCommands
-
-
-@pytest.mark.parametrize("test_string, expected_result",
-                         [("A test string with '${test macro}' in it", '"${test macro}"'),
-                          ("A test string with '${not_a_real_macro}' in it", "'${not_a_real_macro}'")])
-def test_replace_macro_format(test_string, expected_result):
-    """
-    Tests the replace macro format function to verify it works as expected. The first test case is a valid macro and
-    is replaced, the second one isn't and is left alone
-    """
-    match = re.search(r"'(\$\{[^\n}]+\})'", test_string)
-
-    macro_keys = {'test macro', 'test macro 2'}
-    assert _replace_macro_format(match, macro_keys) == expected_result

--- a/pydm/tests/test_display.py
+++ b/pydm/tests/test_display.py
@@ -1,6 +1,5 @@
 import os
 import pytest
-import re
 from pydm import Display
 from pydm.display import load_py_file, _compile_ui_file, _load_compiled_ui_into_display
 from qtpy.QtWidgets import QLabel

--- a/pydm/utilities/macro.py
+++ b/pydm/utilities/macro.py
@@ -1,4 +1,5 @@
 import io
+import re
 import six
 from string import Template
 import json
@@ -33,6 +34,9 @@ def replace_macros_in_template(template, macros):
     curr_template = template
     prev_template = Template("")
     expanded_text = ""
+    # Escape any single quotes to ensure macros such result in valid python code when replaced (e.g. xterm -e 'echo hi')
+    macros = {key: re.sub(r"(?<!\\)'", "\\'", value) if isinstance(value, str) else value for key, value in macros.items()}
+
     for i in range(100):
         expanded_text = curr_template.safe_substitute(macros)
         if curr_template.template == prev_template.template:


### PR DESCRIPTION
A follow up fix from #965 

Errors were seen in shell commands like the following where the compilation process was not generating valid python code due to use of single vs double quoted strings like so:

`self.PyDMShellCommand.setProperty("commands", ['xterm -e 'command to run''])`

The reason is that the uic compiler was returning the macros in single quotes like:

`self.PyDMShellCommand.setProperty("commands", ['${button_4_command}'])`

This replaces all instances of single quoted placeholders with double quotes. It double checks that it is actually a macro key before replacing on the off change anyone uses the same format for something else and is expecting single quotes to stay that way.

Also adds a unit test for the new code, as well as one for macro replacing in general to catch this or anything similar in the future