### PR TITLE
ENH: adds error messege for when file cannot be found 

### DIFF
--- a/pydm/display.py
+++ b/pydm/display.py
@@ -59,8 +59,13 @@ def load_file(file, macros=None, args=None, target=ScreenTarget.NEW_PROCESS):
 
     if target == ScreenTarget.NEW_PROCESS:
         # Invoke PyDM to open a new process here.
-        app = QApplication.instance()
-        app.new_pydm_process(file, macros=macros, command_line_args=args)
+
+        try: 
+            app = QApplication.instance()
+            app.new_pydm_process(file, macros=macros, command_line_args=args)
+        except TypeError:
+            logger.error("pydm: can't open file %s: No such file or directory", file)
+ 
         return None
 
     _, extension = os.path.splitext(file)

--- a/pydm/display.py
+++ b/pydm/display.py
@@ -63,7 +63,7 @@ def load_file(file, macros=None, args=None, target=ScreenTarget.NEW_PROCESS):
         app.new_pydm_process(file, macros=macros, command_line_args=args)
         return None
 
-    _, extension = os.path.splitext(file)    
+    _, extension = os.path.splitext(file)
     loader = _extension_to_loader.get(extension, load_py_file)
     logger.debug("Loading %s file by way of %s...", file, loader.__name__)
     w = loader(file, args=args, macros=macros)

--- a/pydm/display.py
+++ b/pydm/display.py
@@ -63,12 +63,7 @@ def load_file(file, macros=None, args=None, target=ScreenTarget.NEW_PROCESS):
         app.new_pydm_process(file, macros=macros, command_line_args=args)
         return None
 
-    try:
-        _, extension = os.path.splitext(file)
-    except TypeError:
-        logger.error("pydm: can't open file %s: No such file or directory", file)
-        raise 
-    
+    _, extension = os.path.splitext(file)    
     loader = _extension_to_loader.get(extension, load_py_file)
     logger.debug("Loading %s file by way of %s...", file, loader.__name__)
     w = loader(file, args=args, macros=macros)

--- a/pydm/display.py
+++ b/pydm/display.py
@@ -59,16 +59,16 @@ def load_file(file, macros=None, args=None, target=ScreenTarget.NEW_PROCESS):
 
     if target == ScreenTarget.NEW_PROCESS:
         # Invoke PyDM to open a new process here.
-
-        try: 
-            app = QApplication.instance()
-            app.new_pydm_process(file, macros=macros, command_line_args=args)
-        except TypeError:
-            logger.error("pydm: can't open file %s: No such file or directory", file)
- 
+        app = QApplication.instance()
+        app.new_pydm_process(file, macros=macros, command_line_args=args)
         return None
 
-    _, extension = os.path.splitext(file)
+    try:
+        _, extension = os.path.splitext(file)
+    except TypeError:
+        logger.error("pydm: can't open file %s: No such file or directory", file)
+        raise 
+    
     loader = _extension_to_loader.get(extension, load_py_file)
     logger.debug("Loading %s file by way of %s...", file, loader.__name__)
     w = loader(file, args=args, macros=macros)

--- a/pydm/main_window.py
+++ b/pydm/main_window.py
@@ -348,7 +348,7 @@ class PyDMMainWindow(QMainWindow):
             curr_display = self.display_widget()
             if curr_display:
                 base_path = os.path.dirname(curr_display.loaded_file())
-            filename = find_file(filename, base_path=base_path)
+            filename = find_file(filename, base_path=base_path, accept_bad_data=False)
         new_widget = load_file(filename,
                                macros=macros,
                                args=args,

--- a/pydm/main_window.py
+++ b/pydm/main_window.py
@@ -348,7 +348,7 @@ class PyDMMainWindow(QMainWindow):
             curr_display = self.display_widget()
             if curr_display:
                 base_path = os.path.dirname(curr_display.loaded_file())
-            filename = find_file(filename, base_path=base_path, accept_bad_data=False)
+            filename = find_file(filename, base_path=base_path, raise_if_not_found=True)
         new_widget = load_file(filename,
                                macros=macros,
                                args=args,

--- a/pydm/utilities/__init__.py
+++ b/pydm/utilities/__init__.py
@@ -9,6 +9,7 @@ import shlex
 import sys
 import types
 import uuid
+import errno
 
 from typing import List, Optional
 
@@ -178,7 +179,7 @@ def _screen_file_extensions(preferred_extension):
     return extensions
 
 
-def find_file(fname, base_path=None, mode=None, extra_path=None):
+def find_file(fname, base_path=None, mode=None, extra_path=None, accept_bad_data = True):
     """
     Look for files at the search paths common to PyDM.
 
@@ -246,6 +247,10 @@ def find_file(fname, base_path=None, mode=None, extra_path=None):
         file_path = which(str(root) + str(e), mode=mode, pathext=e, extra_path=x_path)
         if file_path is not None:
             break  # pick the first screen file found
+    
+    if not accept_bad_data:
+        if not file_path:
+            raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), fname)
 
     return file_path
 

--- a/pydm/utilities/__init__.py
+++ b/pydm/utilities/__init__.py
@@ -207,11 +207,11 @@ def find_file(fname, base_path=None, mode=None, extra_path=None, accept_bad_data
     accept_bad_data : bool 
         Flag which if False will add a check that raises a FileNotFoundError 
         instead of returning None when the file is not found. 
-        
+
     Returns
     -------
     file_path : str
-        Returns the file path or None in case the file was not found 
+        Returns the file path or None in case the file was not found
     """
     fname = os.path.expanduser(os.path.expandvars(fname))
 

--- a/pydm/utilities/__init__.py
+++ b/pydm/utilities/__init__.py
@@ -204,11 +204,14 @@ def find_file(fname, base_path=None, mode=None, extra_path=None, accept_bad_data
         Which ensure that the file exists and we can read it.
     extra_path : list
         Additional paths to look for file.
-
+    accept_bad_data : bool 
+        Flag which if False will add a check that raises a FileNotFoundError 
+        instead of returning None when the file is not found. 
+        
     Returns
     -------
     file_path : str
-        Returns the file path or None in case the file was not found
+        Returns the file path or None in case the file was not found 
     """
     fname = os.path.expanduser(os.path.expandvars(fname))
 

--- a/pydm/utilities/__init__.py
+++ b/pydm/utilities/__init__.py
@@ -179,7 +179,7 @@ def _screen_file_extensions(preferred_extension):
     return extensions
 
 
-def find_file(fname, base_path=None, mode=None, extra_path=None, accept_bad_data = True):
+def find_file(fname, base_path=None, mode=None, extra_path=None, raise_if_not_found=False):
     """
     Look for files at the search paths common to PyDM.
 
@@ -204,7 +204,7 @@ def find_file(fname, base_path=None, mode=None, extra_path=None, accept_bad_data
         Which ensure that the file exists and we can read it.
     extra_path : list
         Additional paths to look for file.
-    accept_bad_data : bool 
+    raise_if_not_found : bool 
         Flag which if False will add a check that raises a FileNotFoundError 
         instead of returning None when the file is not found. 
 
@@ -251,7 +251,7 @@ def find_file(fname, base_path=None, mode=None, extra_path=None, accept_bad_data
         if file_path is not None:
             break  # pick the first screen file found
     
-    if not accept_bad_data:
+    if raise_if_not_found:
         if not file_path:
             raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), fname)
 

--- a/pydm/widgets/embedded_display.py
+++ b/pydm/widgets/embedded_display.py
@@ -217,7 +217,7 @@ class PyDMEmbeddedDisplay(QFrame, PyDMPrimitiveWidget, new_properties=_embeddedD
             if parent_display:
                 base_path = os.path.dirname(parent_display.loaded_file())
 
-            fname = find_file(self.filename, base_path=base_path, accept_bad_data=False)
+            fname = find_file(self.filename, base_path=base_path, raise_if_not_found=True)
             w = load_file(fname, macros=self.parsed_macros(), target=None)
             self._needs_load = False
             self.clear_error_text()
@@ -381,7 +381,7 @@ class PyDMEmbeddedDisplay(QFrame, PyDMPrimitiveWidget, new_properties=_embeddedD
         """ Open the embedded display in a new window """
         if not self.filename:
             return
-        file_path = find_file(self.filename, base_path='')
+        file_path = find_file(self.filename, base_path='', raise_if_not_found=True)
         macros = self.parsed_macros()
 
         if is_pydm_app():

--- a/pydm/widgets/embedded_display.py
+++ b/pydm/widgets/embedded_display.py
@@ -217,7 +217,7 @@ class PyDMEmbeddedDisplay(QFrame, PyDMPrimitiveWidget, new_properties=_embeddedD
             if parent_display:
                 base_path = os.path.dirname(parent_display.loaded_file())
 
-            fname = find_file(self.filename, base_path=base_path)
+            fname = find_file(self.filename, base_path=base_path, accept_bad_data=False)
             w = load_file(fname, macros=self.parsed_macros(), target=None)
             self._needs_load = False
             self.clear_error_text()

--- a/pydm/widgets/related_display_button.py
+++ b/pydm/widgets/related_display_button.py
@@ -443,7 +443,7 @@ class PyDMRelatedDisplayButton(QPushButton, PyDMPrimitiveWidget, new_properties=
             base_path = os.path.dirname(parent_display.loaded_file())
             macros = copy.copy(parent_display.macros())
 
-        fname = find_file(filename, base_path=base_path)
+        fname = find_file(filename, base_path=base_path, accept_bad_data=False)
         widget_macros = parse_macro_string(macro_string)
         macros.update(widget_macros)
 

--- a/pydm/widgets/related_display_button.py
+++ b/pydm/widgets/related_display_button.py
@@ -443,7 +443,7 @@ class PyDMRelatedDisplayButton(QPushButton, PyDMPrimitiveWidget, new_properties=
             base_path = os.path.dirname(parent_display.loaded_file())
             macros = copy.copy(parent_display.macros())
 
-        fname = find_file(filename, base_path=base_path, accept_bad_data=False)
+        fname = find_file(filename, base_path=base_path, raise_if_not_found=True)
         widget_macros = parse_macro_string(macro_string)
         macros.update(widget_macros)
 

--- a/pydm/widgets/template_repeater.py
+++ b/pydm/widgets/template_repeater.py
@@ -324,7 +324,7 @@ class PyDMTemplateRepeater(QFrame, PyDMPrimitiveWidget, LayoutType):
                         if parent_display:
                             base_path = os.path.dirname(
                                 parent_display.loaded_file())
-                        fname = find_file(self._data_source, base_path=base_path, accept_bad_data=False)
+                        fname = find_file(self._data_source, base_path=base_path, raise_if_not_found=True)
 
                         if not fname:
                             if not is_qt_designer():
@@ -363,7 +363,7 @@ class PyDMTemplateRepeater(QFrame, PyDMPrimitiveWidget, LayoutType):
         if parent_display:
             base_path = os.path.dirname(
                 parent_display.loaded_file())
-        fname = find_file(self.templateFilename, base_path=base_path, accept_bad_data=False)
+        fname = find_file(self.templateFilename, base_path=base_path, raise_if_not_found=True)
 
         if self._parent_macros is None:
             self._parent_macros = {}

--- a/pydm/widgets/template_repeater.py
+++ b/pydm/widgets/template_repeater.py
@@ -324,7 +324,7 @@ class PyDMTemplateRepeater(QFrame, PyDMPrimitiveWidget, LayoutType):
                         if parent_display:
                             base_path = os.path.dirname(
                                 parent_display.loaded_file())
-                        fname = find_file(self._data_source, base_path=base_path)
+                        fname = find_file(self._data_source, base_path=base_path, accept_bad_data=False)
 
                         if not fname:
                             if not is_qt_designer():
@@ -363,7 +363,7 @@ class PyDMTemplateRepeater(QFrame, PyDMPrimitiveWidget, LayoutType):
         if parent_display:
             base_path = os.path.dirname(
                 parent_display.loaded_file())
-        fname = find_file(self.templateFilename, base_path=base_path)
+        fname = find_file(self.templateFilename, base_path=base_path, accept_bad_data=False)
 
         if self._parent_macros is None:
             self._parent_macros = {}


### PR DESCRIPTION
This adds a check to see if the filename is None in the utilities/__init__.py method 'find_file' to catch an obtuse error when file is missing and set to None then passed on to otehr methods. This change should make the error more understandable to the user. The check is only enabled with a flag set to False, that way the methods original functionality is preserved. 