### PR TITLE
FIX: Prevent race condition between PyDMLineEdit connecting and being given default focus

### DIFF
--- a/pydm/tests/widgets/test_lineedit.py
+++ b/pydm/tests/widgets/test_lineedit.py
@@ -569,22 +569,21 @@ def test_set_display(qtbot, qapp, value, has_focus, channel_type, display_format
         assert pydm_lineedit._display == expected_display
 
 
-@pytest.mark.parametrize("connected, focus_reason, expected_focus", [
+@pytest.mark.parametrize("displayed_value, focus_reason, expected_focus", [
     (True, Qt.TabFocusReason, True),
     (True, Qt.ActiveWindowFocusReason, True),
     (False, Qt.TabFocusReason, False),
     (False, Qt.ActiveWindowFocusReason, False),
     (False, Qt.MouseFocusReason, True)])
-def test_focus_in_event(qtbot, qapp, connected, focus_reason, expected_focus):
+def test_focus_in_event(qtbot, qapp, displayed_value, focus_reason, expected_focus):
     """
-    Ensure that the line edit's focusInEvent() override works as expected. When the widget is connected, it should
-    accept each FocusInEvent it receives. When it is not connected, it should specifically reject tab focus and active
-    window focus events.
+    Ensure that the line edit's focusInEvent() override works as expected. When the widget has not yet been connected
+    long enough to have received a value, it should specifically reject tab focus and active window focus events.
     """
     # Create a PyDMLineEdit and show it
     pydm_lineedit = PyDMLineEdit()
     qtbot.addWidget(pydm_lineedit)
-    pydm_lineedit._connected = connected
+    pydm_lineedit._has_displayed_value_yet = displayed_value
     with qtbot.waitExposed(pydm_lineedit):
         pydm_lineedit.show()
 

--- a/pydm/widgets/line_edit.py
+++ b/pydm/widgets/line_edit.py
@@ -275,12 +275,12 @@ class PyDMLineEdit(QLineEdit, TextFormatter, PyDMWritableWidget, DisplayFormat):
 
     def focusInEvent(self, event: QFocusEvent) -> None:
         """
-        Checks to see if the line edit has actually connected before assigning active window or tab focus to it. PyQt
-        will automatically give tab focus to the first tab-enabled widget it can on display load. But for this widget,
-        this behavior can lead to a race condition where if the widget is given focus before the PV connects, then
-        the widget never loads the initial text from the PV.
+        Checks to see if the line edit has actually received a value before assigning active window or tab focus to it.
+        PyQt will automatically give tab focus to the first tab-enabled widget it can on display load. But for this
+        widget this behavior can lead to a race condition where if the widget is given focus before the PV has been
+        connected long enough to receive a value, then the widget never loads the initial text from the PV.
         """
-        if self._has_displayed_value_yet and (event.reason() == Qt.ActiveWindowFocusReason or event.reason() == Qt.TabFocusReason):
+        if not self._has_displayed_value_yet and (event.reason() == Qt.ActiveWindowFocusReason or event.reason() == Qt.TabFocusReason):
             # Clearing focus ensures that the widget will display the value for the PV
             self.clearFocus()
             return

--- a/pydm/widgets/line_edit.py
+++ b/pydm/widgets/line_edit.py
@@ -4,8 +4,8 @@ import ast
 import logging
 from functools import partial
 from qtpy.QtWidgets import QLineEdit, QMenu, QApplication
-from qtpy.QtCore import Property, Q_ENUMS, Qt, QEvent
-from qtpy.QtGui import QFocusEvent, QKeyEvent
+from qtpy.QtCore import Property, Q_ENUMS, Qt
+from qtpy.QtGui import QFocusEvent
 from .. import utilities
 from .base import PyDMWritableWidget, TextFormatter, str_types
 from .display_format import DisplayFormat, parse_value_for_display
@@ -45,7 +45,6 @@ class PyDMLineEdit(QLineEdit, TextFormatter, PyDMWritableWidget, DisplayFormat):
         self._user_set_read_only = False  # Are we *really* read only?
         if utilities.is_pydm_app():
             self._string_encoding = self.app.get_string_encoding()
-
 
     @Property(DisplayFormat)
     def displayFormat(self):

--- a/pydm/widgets/line_edit.py
+++ b/pydm/widgets/line_edit.py
@@ -35,6 +35,7 @@ class PyDMLineEdit(QLineEdit, TextFormatter, PyDMWritableWidget, DisplayFormat):
         PyDMWritableWidget.__init__(self, init_channel=init_channel)
         self.app = QApplication.instance()
         self._display = None
+        self._has_displayed_value_yet = False
         self._scale = 1
 
         self.returnPressed.connect(self.send_value)
@@ -256,6 +257,7 @@ class PyDMLineEdit(QLineEdit, TextFormatter, PyDMWritableWidget, DisplayFormat):
                                             string_encoding=self._string_encoding,
                                             widget=self)
 
+        self._has_displayed_value_yet = True
         if type(new_value) in str_types:
             self._display = new_value
         else:
@@ -278,7 +280,7 @@ class PyDMLineEdit(QLineEdit, TextFormatter, PyDMWritableWidget, DisplayFormat):
         this behavior can lead to a race condition where if the widget is given focus before the PV connects, then
         the widget never loads the initial text from the PV.
         """
-        if not self._connected and (event.reason() == Qt.ActiveWindowFocusReason or event.reason() == Qt.TabFocusReason):
+        if self._has_displayed_value_yet and (event.reason() == Qt.ActiveWindowFocusReason or event.reason() == Qt.TabFocusReason):
             # Clearing focus ensures that the widget will display the value for the PV
             self.clearFocus()
             return


### PR DESCRIPTION
### Context

Fixes #993. As described in that issue, when a display first loads a `PyDMLineEdit` can appear with focus and missing the value of the PV it is connected to despite actually being connected. And this behavior is due to PyQT auto focusing it, no user input actually happened. 

This PR should fix that problem by checking to ensure the widget has finished connecting before accepting any `QFocusEvent` where the reason is `TabFocusReason` or `ActiveWindowFocusReason` (these both could cause the issue in my testing).

I think this is a clean way to go about it, the default behavior for a `PyDMLineEdit` which is not connected is to just disable the widget entirely, so no default user functionality is lost this way. And in case there is custom behavior out there around disconnected line edits, it remains user selectable via all other options.

### Testing

I manually forced a delay in the channel sending its first value when connecting to reproduce the issue, looks fine after applying this PR. Added test case for the new code.