### PR TITLE
ENH: Add an example NTTable

### DIFF
--- a/examples/pva/nt_table.ui
+++ b/examples/pva/nt_table.ui
@@ -1,0 +1,187 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>356</width>
+    <height>419</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <widget class="PyDMNTTable" name="PyDMNTTable">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>20</y>
+     <width>331</width>
+     <height>171</height>
+    </rect>
+   </property>
+   <property name="toolTip">
+    <string/>
+   </property>
+   <property name="alarmSensitiveContent" stdset="0">
+    <bool>false</bool>
+   </property>
+   <property name="alarmSensitiveBorder" stdset="0">
+    <bool>true</bool>
+   </property>
+   <property name="PyDMToolTip" stdset="0">
+    <string/>
+   </property>
+   <property name="channel" stdset="0">
+    <string>pva://PyDM:PVA:Table</string>
+   </property>
+   <property name="readOnly" stdset="0">
+    <bool>true</bool>
+   </property>
+  </widget>
+  <widget class="PyDMLabel" name="PyDMLabel">
+   <property name="geometry">
+    <rect>
+     <x>30</x>
+     <y>240</y>
+     <width>231</width>
+     <height>31</height>
+    </rect>
+   </property>
+   <property name="toolTip">
+    <string/>
+   </property>
+   <property name="precision" stdset="0">
+    <number>0</number>
+   </property>
+   <property name="showUnits" stdset="0">
+    <bool>false</bool>
+   </property>
+   <property name="precisionFromPV" stdset="0">
+    <bool>true</bool>
+   </property>
+   <property name="alarmSensitiveContent" stdset="0">
+    <bool>false</bool>
+   </property>
+   <property name="alarmSensitiveBorder" stdset="0">
+    <bool>true</bool>
+   </property>
+   <property name="PyDMToolTip" stdset="0">
+    <string/>
+   </property>
+   <property name="channel" stdset="0">
+    <string>pva://PyDM:PVA:Table/names</string>
+   </property>
+  </widget>
+  <widget class="PyDMLabel" name="PyDMLabel_2">
+   <property name="geometry">
+    <rect>
+     <x>30</x>
+     <y>290</y>
+     <width>231</width>
+     <height>31</height>
+    </rect>
+   </property>
+   <property name="toolTip">
+    <string/>
+   </property>
+   <property name="precision" stdset="0">
+    <number>0</number>
+   </property>
+   <property name="showUnits" stdset="0">
+    <bool>false</bool>
+   </property>
+   <property name="precisionFromPV" stdset="0">
+    <bool>true</bool>
+   </property>
+   <property name="alarmSensitiveContent" stdset="0">
+    <bool>false</bool>
+   </property>
+   <property name="alarmSensitiveBorder" stdset="0">
+    <bool>true</bool>
+   </property>
+   <property name="PyDMToolTip" stdset="0">
+    <string/>
+   </property>
+   <property name="channel" stdset="0">
+    <string>pva://PyDM:PVA:Table/floats</string>
+   </property>
+  </widget>
+  <widget class="PyDMLabel" name="PyDMLabel_3">
+   <property name="geometry">
+    <rect>
+     <x>40</x>
+     <y>380</y>
+     <width>231</width>
+     <height>31</height>
+    </rect>
+   </property>
+   <property name="toolTip">
+    <string/>
+   </property>
+   <property name="precision" stdset="0">
+    <number>0</number>
+   </property>
+   <property name="showUnits" stdset="0">
+    <bool>false</bool>
+   </property>
+   <property name="precisionFromPV" stdset="0">
+    <bool>true</bool>
+   </property>
+   <property name="alarmSensitiveContent" stdset="0">
+    <bool>false</bool>
+   </property>
+   <property name="alarmSensitiveBorder" stdset="0">
+    <bool>true</bool>
+   </property>
+   <property name="PyDMToolTip" stdset="0">
+    <string/>
+   </property>
+   <property name="channel" stdset="0">
+    <string>pva://PyDM:PVA:Table/booleans/2</string>
+   </property>
+  </widget>
+  <widget class="QLabel" name="label">
+   <property name="geometry">
+    <rect>
+     <x>30</x>
+     <y>200</y>
+     <width>281</width>
+     <height>21</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Retrieving individual columns of the table:</string>
+   </property>
+  </widget>
+  <widget class="QLabel" name="label_4">
+   <property name="geometry">
+    <rect>
+     <x>30</x>
+     <y>360</y>
+     <width>331</width>
+     <height>21</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Retrieiving a specific cell from the table by index:</string>
+   </property>
+  </widget>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>PyDMNTTable</class>
+   <extends>QWidget</extends>
+   <header>pydm.widgets.nt_table</header>
+  </customwidget>
+  <customwidget>
+   <class>PyDMLabel</class>
+   <extends>QLabel</extends>
+   <header>pydm.widgets.label</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/examples/testing_ioc/pva_testing_ioc.py
+++ b/examples/testing_ioc/pva_testing_ioc.py
@@ -1,5 +1,5 @@
 from p4p.client.thread import Context
-from p4p.nt import NTNDArray, NTScalar
+from p4p.nt import NTNDArray, NTScalar, NTTable
 from p4p.server import Server, ServerOperation
 from p4p.server.thread import SharedPV
 import numpy as np
@@ -55,6 +55,14 @@ class PVServer(object):
         # An NTNDArray that will be used to hold image data
         self.image_pv = SharedPV(handler=handler, nt=NTNDArray(), initial=np.zeros(1))
 
+        # An NTTable that can be displayed via the PyDMNTTable widget
+        table_structure = NTTable([('names', 's'), ('floats', 'd'), ('booleans', '?')])
+        table_strings = ['This', 'Is', 'A', 'PyDM', 'Table']
+        table_rows = []
+        for i in range(5):
+            table_rows.append({'names': table_strings[i], 'floats': 0.35 * i, 'booleans': i % 2 == 0})
+        self.nt_table_pv = SharedPV(handler=handler, nt=table_structure, initial=table_structure.wrap(table_rows))
+
     def run_server(self) -> None:
         """ Run the server that will provide the PVs until keyboard interrupt """
         Server.forever(providers=[{'PyDM:PVA:IntValue': self.int_value,
@@ -69,7 +77,8 @@ class PVServer(object):
                                    'PyDM:PVA:Waveform': self.wave_form,
                                    'PyDM:PVA:BoolArray': self.bool_array,
                                    'PyDM:PVA:StringArray': self.string_array,
-                                   'PyDM:PVA:Image': self.image_pv}])
+                                   'PyDM:PVA:Image': self.image_pv,
+                                   'PyDM:PVA:Table': self.nt_table_pv}])
 
     def gaussian_2d(self, x: float, y: float, x0: float, y0: float, xsig: float, ysig: float) -> np.ndarray:
         return np.exp(-0.5 * (((x - x0) / xsig) ** 2 + ((y - y0) / ysig) ** 2))


### PR DESCRIPTION
Makes it easier to test NTTable widget changes and gives users an example of how to display both the whole table and sub-fields. 

Requires #992 to work properly as in the screenshot

 
![table_example](https://github.com/slaclab/pydm/assets/89539359/1b2ece72-bd0d-4881-b733-6dff55631000)
