### PR TITLE
Fix: Issue with boolean inputs into PyDMNTTable and Issue with passing np.ndarray with a PyDMLineEdit 

### DIFF
--- a/pydm/widgets/line_edit.py
+++ b/pydm/widgets/line_edit.py
@@ -1,6 +1,7 @@
 import locale
 import numpy as np
 import ast
+import shlex
 import logging
 from functools import partial
 from qtpy.QtWidgets import QLineEdit, QMenu, QApplication
@@ -113,7 +114,7 @@ class PyDMLineEdit(QLineEdit, TextFormatter, PyDMWritableWidget, DisplayFormat):
                     self.send_value_signal[str].emit(send_value)
                 else:
                     arr_value = list(
-                        filter(None, ast.literal_eval(str(send_value.replace("[", "").replace("]", "").split()))))
+                        filter(None, ast.literal_eval(str(shlex.split(send_value.replace("[", "").replace("]", ""))))))
                     arr_value = np.array(arr_value, dtype=self.subtype)
                     self.send_value_signal[np.ndarray].emit(arr_value)
             elif self.channeltype == bool:

--- a/pydm/widgets/nt_table.py
+++ b/pydm/widgets/nt_table.py
@@ -288,8 +288,14 @@ class PyDMNTTable(QtWidgets.QWidget, PyDMWritableWidget):
         if isinstance(self.value[self._table_labels[column]], np.ndarray):
             self.value[self._table_labels[column]] = self.value[self._table_labels[column]].copy()
 
-        self.value[self._table_labels[column]][row] = value
-        
+        if isinstance(self.value[self._table_labels[column]][row], np.bool_):
+            if value == "True":
+                self.value[self._table_labels[column]][row] = True
+            elif value == "False":
+                self.value[self._table_labels[column]][row] = False
+        else:
+            self.value[self._table_labels[column]][row] = value
+
         # dictionary needs to be wrapped in another dictionary with a key 'value'
         # to be passed back to the p4p plugin. 
         emit_dict = {'value': self.value}  


### PR DESCRIPTION
This PR is for two fixes. 

First, 
Addresses issue with imputing boolean values into PyDMNTTable.

Second, 
Addresses issue with passing an np.ndarray with a PyDMLineEdit, where by the line edit is adding extra quotes every time it is passed. 
