### PR TITLE
BLD: pin pyqt to 5.x

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -17,7 +17,7 @@ requirements:
     - python
     - pip
     - setuptools
-    - pyqt >=5,<5.15
+    - pyqt >=5,<6
     - qtpy
   run:
     - python

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -17,7 +17,7 @@ requirements:
     - python
     - pip
     - setuptools
-    - pyqt >=5,<6
+    - pyqt =5
     - qtpy
   run:
     - python
@@ -26,7 +26,7 @@ requirements:
     - scipy
     - pyepics
     - requests
-    - pyqt >=5,<6
+    - pyqt =5
     - pyqtgraph
     - qtpy
     - entrypoints

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -26,7 +26,7 @@ requirements:
     - scipy
     - pyepics
     - requests
-    - pyqt >=5,<5.15
+    - pyqt >=5,<6
     - pyqtgraph
     - qtpy
     - entrypoints

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -15,7 +15,7 @@ Installing PyDM and Prerequisites with Anaconda
 After installing Anaconda (see https://www.anaconda.com/download/), create a new
 environment for PyDM::
   
-  $ conda create -n pydm-environment python=3.8 "pyqt >=5,<5.15" pip numpy scipy six psutil pyqtgraph pydm -c conda-forge
+  $ conda create -n pydm-environment python=3.8 "pyqt >=5,<6" pip numpy scipy six psutil pyqtgraph pydm -c conda-forge
   $ source activate pydm-environment
   
 Once you've installed and activated the environment, you should be able to run 'pydm' to launch PyDM, or run 'designer' to launch Qt Designer.  If you are on Windows, run these commands from the Anaconda Prompt.

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -15,7 +15,7 @@ Installing PyDM and Prerequisites with Anaconda
 After installing Anaconda (see https://www.anaconda.com/download/), create a new
 environment for PyDM::
   
-  $ conda create -n pydm-environment python=3.8 "pyqt >=5,<6" pip numpy scipy six psutil pyqtgraph pydm -c conda-forge
+  $ conda create -n pydm-environment python=3.8 pyqt=5 pip numpy scipy six psutil pyqtgraph pydm -c conda-forge
   $ source activate pydm-environment
   
 Once you've installed and activated the environment, you should be able to run 'pydm' to launch PyDM, or run 'designer' to launch Qt Designer.  If you are on Windows, run these commands from the Anaconda Prompt.


### PR DESCRIPTION
Remove the `<5.15` pin and just ensure we're on PyQt 5.x.

This is just a test and may fail miserably. Let's see what happens on CI.