### PR TITLE
FIX: Line edit value setting on Python 3.10+

### DIFF
--- a/pydm/tests/widgets/test_lineedit.py
+++ b/pydm/tests/widgets/test_lineedit.py
@@ -150,6 +150,7 @@ def test_value_change(qtbot, signals, value, display_format, precision, scale, u
     (np.array(["A", "B"]), "[C D]", DisplayFormat.String, 0, 10, "ms", True, "[C D]", "[C D] ms"),
     (np.array(["A", "B"]), np.array(["C", "D"]), DisplayFormat.String, 0, 10, "ms", True, "C   D    ", "C   D    ms"),
     (np.array(["A", "B"]), np.array(["C", "D"]), DisplayFormat.Default, 0, 10, "ms", True, "['C' 'D']", "['C' 'D'] ms"),
+    (0, 10, DisplayFormat.Default, 0, 1.0, "V", True, 10, "10 V"),
 ])
 def test_send_value(qtbot, signals, init_value, user_typed_value, display_format, precision, scale, unit,
                     show_units, expected_received_value, expected_display_value):

--- a/pydm/widgets/line_edit.py
+++ b/pydm/widgets/line_edit.py
@@ -106,7 +106,7 @@ class PyDMLineEdit(QLineEdit, TextFormatter, PyDMWritableWidget, DisplayFormat):
                 elif self._display_format_type in [DisplayFormat.Exponential, DisplayFormat.Decimal]:
                     num_value = locale.atof(send_value)
 
-                num_value = num_value / scale
+                num_value = self.channeltype(num_value / scale)
                 self.send_value_signal[self.channeltype].emit(num_value)
             elif self.channeltype == np.ndarray:
                 # Arrays will be in the [1.2 3.4 22.214] format


### PR DESCRIPTION
This is probably another instance of #951, though it seems like the only one caught in the test coverage, since resolving it also removes the deprecation warning for that issue (or I misunderstood something about those warnings, which is highly possible :P).