### PR TITLE
FIX: Escape double quotes during macro substitution

### DIFF
--- a/pydm/tests/test_data/macro_test.ui
+++ b/pydm/tests/test_data/macro_test.ui
@@ -24,6 +24,13 @@
       </widget>
      </item>
      <item row="0" column="1">
+      <widget class="QLabel" name="doubleQuotedLabel">
+       <property name="text">
+        <string>${channel_with_dec_option}</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="2">
       <widget class="QLabel" name="shellCommand">
        <property name="commands">
         <stringlist>

--- a/pydm/tests/test_display.py
+++ b/pydm/tests/test_display.py
@@ -139,7 +139,8 @@ def test_load_file_with_macros(qtbot):
         # Compile the ui file into python code
         macros = {"test_label": "magnet_list",
                   "test_command": "grep -i 'string with spaces'",
-                  "test_command_2": "echo hello"}
+                  "test_command_2": "echo hello",
+                  "channel_with_dec_option": '.{"dec":{"n": 25}}'}
         code_string, class_name = _compile_ui_file(test_ui_with_macros_path)
         assert class_name == 'Ui_Form'
 
@@ -149,6 +150,7 @@ def test_load_file_with_macros(qtbot):
 
         # Verify that the macros were replaced correctly
         assert test_display.ui.myLabel.text() == "magnet_list"
+        assert test_display.ui.doubleQuotedLabel.text() == '.{"dec":{"n": 25}}'
         assert commands_from_macro == ["grep -i 'string with spaces'", "echo hello"]
 
     finally:

--- a/pydm/utilities/macro.py
+++ b/pydm/utilities/macro.py
@@ -34,8 +34,10 @@ def replace_macros_in_template(template, macros):
     curr_template = template
     prev_template = Template("")
     expanded_text = ""
-    # Escape any single quotes to ensure macros such result in valid python code when replaced (e.g. xterm -e 'echo hi')
-    macros = {key: re.sub(r"(?<!\\)'", "\\'", value) if isinstance(value, str) else value for key, value in macros.items()}
+    # Escape any single or double quotes to ensure macro substitution results in valid python code
+    # when replaced (e.g. xterm -e 'echo hi')
+    macros = {key: re.sub(r'(?<!\\)"', '\\"', re.sub(r"(?<!\\)'", "\\'", value)) if isinstance(value, str) else value
+              for key, value in macros.items()}
 
     for i in range(100):
         expanded_text = curr_template.safe_substitute(macros)


### PR DESCRIPTION
I made an incorrect assumption in #991 where I had thought that double quotes were already handled properly during macro substitution. This just applies the same strategy of escaping double quote as well. 

The context for the problem is a display that had a macro like:

`FIELD='.{"dec":{"n":25}}'`

And then when the substitution into the channel address happened it resulted in invalid python code with multiple sets of double quotes:

`self.Val.setProperty("channel", _translate("Form", "ca://PvName.{"dec":{"n":25}}"))`
