### PR TITLE
ENH: Adding new feature in main_window.py that allows user to switch …

### DIFF
--- a/pydm/main_window.py
+++ b/pydm/main_window.py
@@ -20,6 +20,8 @@ import subprocess
 import platform
 import logging
 
+from .utilities.stylesheet import apply_stylesheet, _get_style_data
+
 logger = logging.getLogger(__name__)
 
 
@@ -33,6 +35,10 @@ class PyDMMainWindow(QMainWindow):
         self.iconFont = IconFont()
         self._display_widget = None
         self._showing_file_path_in_title_bar = False
+
+        # style sheet change flag
+        self.isSS_Changed = False
+        self.ss_path = None
 
         self._saved_menu_geometry = None
         self._saved_menu_height = None
@@ -63,6 +69,7 @@ class PyDMMainWindow(QMainWindow):
         self.ui.actionForward.setIcon(self.iconFont.icon("angle-right"))
         self.ui.actionEdit_in_Designer.triggered.connect(self.edit_in_designer)
         self.ui.actionOpen_File.triggered.connect(self.open_file_action)
+        self.ui.actionChange_Stylesheet.triggered.connect(self.change_stylesheet_action)
         self.ui.actionReload_Display.triggered.connect(self.reload_display)
         self.ui.actionIncrease_Font_Size.triggered.connect(self.increase_font_size)
         self.ui.actionDecrease_Font_Size.triggered.connect(self.decrease_font_size)
@@ -341,6 +348,24 @@ class PyDMMainWindow(QMainWindow):
 
             except (IOError, OSError, ValueError, ImportError) as e:
                 self.handle_open_file_error(filename, e)
+
+    @Slot(bool)
+    def change_stylesheet_action(self, checked):
+        try:
+            curr_file = self.current_file()
+            folder = os.path.dirname(curr_file)
+        except Exception:
+            folder = os.getcwd()
+
+        ss_filename = QFileDialog.getOpenFileName(self, 'Change Stylesheet...',
+                folder, 'PyDM Stylesheets (*.qss *.css)')
+        
+        if ss_filename:
+            ss_filename = str(ss_filename)
+            self.ss_path = ss_filename.split("'")
+            style= open(self.ss_path[1],"r")
+            style= style.read()
+            self.setStyleSheet(style)
 
     def open(self, filename, macros=None, args=None, target=None):
         if not os.path.isabs(filename):

--- a/pydm/pydm.ui
+++ b/pydm/pydm.ui
@@ -38,6 +38,7 @@
     </property>
     <addaction name="actionOpen_File"/>
     <addaction name="separator"/>
+    <addaction name="actionChange_Stylesheet"/>
     <addaction name="actionEdit_in_Designer"/>
     <addaction name="actionReload_Display"/>
     <addaction name="separator"/>
@@ -324,6 +325,11 @@
    </property>
    <property name="text">
     <string>Load</string>
+   </property>
+  </action>
+  <action name="actionChange_Stylesheet">
+   <property name="text">
+    <string>Change Stylesheet</string>
    </property>
   </action>
  </widget>

--- a/pydm/pydm_ui.py
+++ b/pydm/pydm_ui.py
@@ -7,7 +7,7 @@
 # WARNING! All changes made in this file will be lost!
 
 
-from qtpy import QtCore, QtGui, QtWidgets
+from PyQt5 import QtCore, QtGui, QtWidgets
 
 
 class Ui_MainWindow(object):
@@ -22,7 +22,7 @@ class Ui_MainWindow(object):
         self.verticalLayout.setObjectName("verticalLayout")
         MainWindow.setCentralWidget(self.centralwidget)
         self.menubar = QtWidgets.QMenuBar(MainWindow)
-        self.menubar.setGeometry(QtCore.QRect(0, 0, 677, 22))
+        self.menubar.setGeometry(QtCore.QRect(0, 0, 677, 20))
         self.menubar.setObjectName("menubar")
         self.menuFile = QtWidgets.QMenu(self.menubar)
         self.menuFile.setObjectName("menuFile")
@@ -34,7 +34,6 @@ class Ui_MainWindow(object):
         self.menuTools.setObjectName("menuTools")
         self.menuCustomActions = QtWidgets.QMenu(self.menubar)
         self.menuCustomActions.setObjectName("menuCustomActions")
-        self.menuCustomActions.setTitle('Actions')
         MainWindow.setMenuBar(self.menubar)
         self.statusbar = QtWidgets.QStatusBar(MainWindow)
         self.statusbar.setObjectName("statusbar")
@@ -101,26 +100,31 @@ class Ui_MainWindow(object):
         self.actionDefault_Font_Size = QtWidgets.QAction(MainWindow)
         self.actionDefault_Font_Size.setObjectName("actionDefault_Font_Size")
         self.actionQuit = QtWidgets.QAction(MainWindow)
+        self.actionQuit.setEnabled(True)
         self.actionQuit.setObjectName("actionQuit")
         self.actionSave = QtWidgets.QAction(MainWindow)
-        self.actionSave.setObjectName('actionSave')
-        self.actionSave.setVisible(False)
+        self.actionSave.setEnabled(False)
+        self.actionSave.setShortcutContext(QtCore.Qt.WindowShortcut)
+        self.actionSave.setObjectName("actionSave")
         self.actionSave_As = QtWidgets.QAction(MainWindow)
-        self.actionSave_As.setObjectName('actionSave_As')
-        self.actionSave_As.setVisible(False)
+        self.actionSave_As.setEnabled(False)
+        self.actionSave_As.setObjectName("actionSave_As")
         self.actionLoad = QtWidgets.QAction(MainWindow)
-        self.actionLoad.setObjectName('actionLoad')
-        self.actionLoad.setVisible(False)
+        self.actionLoad.setEnabled(False)
+        self.actionLoad.setObjectName("actionLoad")
+        self.actionChange_Stylesheet = QtWidgets.QAction(MainWindow)
+        self.actionChange_Stylesheet.setObjectName("actionChange_Stylesheet")
         self.menuFile.addAction(self.actionOpen_File)
         self.menuFile.addSeparator()
+        self.menuFile.addAction(self.actionChange_Stylesheet)
         self.menuFile.addAction(self.actionEdit_in_Designer)
         self.menuFile.addAction(self.actionReload_Display)
         self.menuFile.addSeparator()
         self.menuFile.addAction(self.actionAbout_PyDM)
+        self.menuFile.addAction(self.actionQuit)
         self.menuFile.addAction(self.actionSave)
         self.menuFile.addAction(self.actionSave_As)
         self.menuFile.addAction(self.actionLoad)
-        self.menuFile.addAction(self.actionQuit)
         self.menuView.addAction(self.actionEnter_Fullscreen)
         self.menuView.addAction(self.actionIncrease_Font_Size)
         self.menuView.addAction(self.actionDecrease_Font_Size)
@@ -157,9 +161,6 @@ class Ui_MainWindow(object):
         self.menuHistory.setTitle(_translate("MainWindow", "History"))
         self.menuTools.setTitle(_translate("MainWindow", "Tools"))
         self.menuCustomActions.setTitle(_translate("MainWindow", "Actions"))
-        self.actionSave.setText(_translate("MainWindow", "Save"))
-        self.actionSave_As.setText(_translate("MainWindow", "Save As"))
-        self.actionLoad.setText(_translate("MainWindow", "Load"))
         self.navbar.setWindowTitle(_translate("MainWindow", "toolBar"))
         self.actionEdit_in_Designer.setText(_translate("MainWindow", "Edit in Designer"))
         self.actionAbout_PyDM.setText(_translate("MainWindow", "About PyDM"))
@@ -189,3 +190,17 @@ class Ui_MainWindow(object):
         self.actionDefault_Font_Size.setText(_translate("MainWindow", "Default Font Size"))
         self.actionDefault_Font_Size.setShortcut(_translate("MainWindow", "Ctrl+0"))
         self.actionQuit.setText(_translate("MainWindow", "Quit"))
+        self.actionSave.setText(_translate("MainWindow", "Save"))
+        self.actionSave_As.setText(_translate("MainWindow", "Save As..."))
+        self.actionLoad.setText(_translate("MainWindow", "Load"))
+        self.actionChange_Stylesheet.setText(_translate("MainWindow", "Change Stylesheet"))
+
+
+if __name__ == "__main__":
+    import sys
+    app = QtWidgets.QApplication(sys.argv)
+    MainWindow = QtWidgets.QMainWindow()
+    ui = Ui_MainWindow()
+    ui.setupUi(MainWindow)
+    MainWindow.show()
+    sys.exit(app.exec_())

--- a/pydm/pydm_ui.py
+++ b/pydm/pydm_ui.py
@@ -7,7 +7,7 @@
 # WARNING! All changes made in this file will be lost!
 
 
-from PyQt5 import QtCore, QtGui, QtWidgets
+from qtpy import QtCore, QtGui, QtWidgets
 
 
 class Ui_MainWindow(object):
@@ -194,13 +194,3 @@ class Ui_MainWindow(object):
         self.actionSave_As.setText(_translate("MainWindow", "Save As..."))
         self.actionLoad.setText(_translate("MainWindow", "Load"))
         self.actionChange_Stylesheet.setText(_translate("MainWindow", "Change Stylesheet"))
-
-
-if __name__ == "__main__":
-    import sys
-    app = QtWidgets.QApplication(sys.argv)
-    MainWindow = QtWidgets.QMainWindow()
-    ui = Ui_MainWindow()
-    ui.setupUi(MainWindow)
-    MainWindow.show()
-    sys.exit(app.exec_())


### PR DESCRIPTION
…between stylesheets in an active pydm window.

Per request from scientists, I have implemented a stylesheet switcher that allows a user to change their stylesheet in an active PyDM window. They are able to change it multiple times with any qss or css file. I have done some basic testing with the UI in an active session but have not done any unit tests on this.