### PR TITLE
ENH: Allow following symlinks when opening embedded / related files using relative paths

### DIFF
--- a/pydm/tests/test_data/subfolder/test_relative_filename_child.ui
+++ b/pydm/tests/test_data/subfolder/test_relative_filename_child.ui
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="RelativeImportTestChild">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>285</width>
+    <height>141</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Child</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QFormLayout" name="formLayout">
+     <item row="0" column="0">
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>Number of Blobs:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QLabel" name="numBlobsLabel">
+       <property name="text">
+        <string>TextLabel</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/pydm/tests/test_data/test_relative_filename_parent.ui
+++ b/pydm/tests/test_data/test_relative_filename_parent.ui
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>RelativeImportTest</class>
+ <widget class="QWidget" name="RelativeImportTestParent">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>1280</width>
+    <height>720</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="leftMargin">
+    <number>4</number>
+   </property>
+   <property name="topMargin">
+    <number>4</number>
+   </property>
+   <property name="rightMargin">
+    <number>4</number>
+   </property>
+   <property name="bottomMargin">
+    <number>4</number>
+   </property>
+   <item>
+    <widget class="PyDMEmbeddedDisplay" name="embeddedDisplay">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="filename" stdset="0">
+      <string>subfolder/test_relative_filename_child.ui</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="Line" name="line">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="PyDMRelatedDisplayButton" name="relatedDisplayButton">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Related Display Button</string>
+     </property>
+     <property name="filenames" stdset="0">
+      <stringlist>
+       <string>subfolder/test_relative_filename_child.ui</string>
+      </stringlist>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>PyDMEmbeddedDisplay</class>
+   <extends>QFrame</extends>
+   <header>pydm.widgets.embedded_display</header>
+  </customwidget>
+  <customwidget>
+   <class>PyDMRelatedDisplayButton</class>
+   <extends>QPushButton</extends>
+   <header>pydm.widgets.related_display_button</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/pydm/tests/widgets/test_embedded_display.py
+++ b/pydm/tests/widgets/test_embedded_display.py
@@ -1,5 +1,6 @@
 import os
 import pytest
+import sys
 from qtpy.QtWidgets import QApplication
 
 test_ui_path_with_relative_path = os.path.join(
@@ -19,6 +20,7 @@ def test_show_with_relative_filename(qtbot):
         assert display.embedded_widget is not None
     qtbot.waitUntil(check_embed)
 
+@pytest.mark.skipif(sys.platform == "win32" and sys.version_info < (3, 8), reason="os.path.realpath on Python 3.7 and prior does not resolve symlinks on Windows")
 def test_show_with_relative_filename_and_symlink(qtbot, tmp_path):
     symlinked_ui_file = tmp_path / "test_ui_with_relative_path.ui"
     try:

--- a/pydm/tests/widgets/test_embedded_display.py
+++ b/pydm/tests/widgets/test_embedded_display.py
@@ -1,0 +1,38 @@
+import os
+import pytest
+from qtpy.QtWidgets import QApplication
+
+test_ui_path_with_relative_path = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)),
+    "../test_data", "test_relative_filename_parent.ui")
+
+def test_show_with_relative_filename(qtbot):
+    QApplication.instance().make_main_window()
+    main_window = QApplication.instance().main_window
+    main_window.open(test_ui_path_with_relative_path)
+    main_window.setWindowTitle("Embedded Display Test")
+    qtbot.addWidget(main_window)
+    display = main_window.home_widget.embeddedDisplay
+    # Default behavior should be to not follow symlinks (for backwards compat.).
+    # Same effect as: display.followSymlinks = False
+    def check_embed():
+        assert display.embedded_widget is not None
+    qtbot.waitUntil(check_embed)
+
+def test_show_with_relative_filename_and_symlink(qtbot, tmp_path):
+    symlinked_ui_file = tmp_path / "test_ui_with_relative_path.ui"
+    try:
+        os.symlink(test_ui_path_with_relative_path, symlinked_ui_file)
+    except:
+        pytest.skip("Unable to create a symlink for testing purposes.")
+
+    QApplication.instance().make_main_window()
+    main_window = QApplication.instance().main_window
+    main_window.open(symlinked_ui_file)
+    main_window.setWindowTitle("Embedded Display Test")
+    qtbot.addWidget(main_window)
+    display = main_window.home_widget.embeddedDisplay
+    display.followSymlinks = True
+    def check_embed():
+        assert display.embedded_widget is not None
+    qtbot.waitUntil(check_embed)

--- a/pydm/tests/widgets/test_related_display_button.py
+++ b/pydm/tests/widgets/test_related_display_button.py
@@ -1,5 +1,6 @@
 import os
 import pytest
+import sys
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QApplication, QVBoxLayout
 from ...utilities.stylesheet import global_style
@@ -134,6 +135,7 @@ def test_press_with_relative_filename(qtbot):
         assert "Child" in QApplication.instance().main_window.windowTitle()
     qtbot.waitUntil(check_title)
 
+@pytest.mark.skipif(sys.platform == "win32" and sys.version_info < (3, 8), reason="os.path.realpath on Python 3.7 and prior does not resolve symlinks on Windows")
 def test_press_with_relative_filename_and_symlink(qtbot, tmp_path):
     symlinked_ui_file = tmp_path / "test_ui_with_relative_path.ui"
     try:

--- a/pydm/widgets/embedded_display.py
+++ b/pydm/widgets/embedded_display.py
@@ -355,6 +355,8 @@ class PyDMEmbeddedDisplay(QFrame, PyDMPrimitiveWidget, new_properties=_embeddedD
         If True, any symlinks in the path to filename (including the base path of the parent display) will be followed, so that it
         will always use the canonical path. If False (default), the file will be searched without canonicalizing the path beforehand.
 
+        Note that it will not work on Windows if you're using a Python version prior to 3.8.
+
         Returns
         -------
         bool
@@ -366,6 +368,8 @@ class PyDMEmbeddedDisplay(QFrame, PyDMPrimitiveWidget, new_properties=_embeddedD
         """
         If True, any symlinks in the path to filename (including the base path of the parent display) will be followed, so that it
         will always use the canonical path. If False (default), the file will be searched using the non-canonical path.
+
+        Note that it will not work on Windows if you're using a Python version prior to 3.8.
 
         Parameters
         ----------

--- a/pydm/widgets/related_display_button.py
+++ b/pydm/widgets/related_display_button.py
@@ -339,6 +339,8 @@ class PyDMRelatedDisplayButton(QPushButton, PyDMWidget, new_properties=_relatedD
         If True, any symlinks in the path to filename (including the base path of the parent display) will be followed, so that it
         will always use the canonical path. If False (default), the file will be searched without canonicalizing the path beforehand.
 
+        Note that it will not work on Windows if you're using a Python version prior to 3.8.
+
         Returns
         -------
         bool
@@ -350,6 +352,8 @@ class PyDMRelatedDisplayButton(QPushButton, PyDMWidget, new_properties=_relatedD
         """
         If True, any symlinks in the path to filename (including the base path of the parent display) will be followed, so that it
         will always use the canonical path. If False (default), the file will be searched using the non-canonical path.
+
+        Note that it will not work on Windows if you're using a Python version prior to 3.8.
 
         Parameters
         ----------

--- a/pydm/widgets/related_display_button.py
+++ b/pydm/widgets/related_display_button.py
@@ -73,6 +73,8 @@ class PyDMRelatedDisplayButton(QPushButton, PyDMWidget, new_properties=_relatedD
         self._password = ""
         self._protected_password = ""
 
+        self._follow_symlinks = False
+
     @only_if_channel_set
     def check_enable_state(self) -> None:
         """
@@ -331,6 +333,30 @@ class PyDMRelatedDisplayButton(QPushButton, PyDMWidget, new_properties=_relatedD
         if self._protected_password != value:
             self._protected_password = value
 
+    @Property(bool)
+    def followSymlinks(self) -> bool:
+        """
+        If True, any symlinks in the path to filename (including the base path of the parent display) will be followed, so that it
+        will always use the canonical path. If False (default), the file will be searched without canonicalizing the path beforehand.
+
+        Returns
+        -------
+        bool
+        """
+        return self._follow_symlinks
+
+    @followSymlinks.setter
+    def followSymlinks(self, follow_symlinks: bool) -> None:
+        """
+        If True, any symlinks in the path to filename (including the base path of the parent display) will be followed, so that it
+        will always use the canonical path. If False (default), the file will be searched using the non-canonical path.
+
+        Parameters
+        ----------
+        follow_symlinks : bool
+        """
+        self._follow_symlinks = follow_symlinks
+
     def mousePressEvent(self, event: QMouseEvent) -> None:
         if self._menu_needs_rebuild:
             self._rebuild_menu()
@@ -457,7 +483,10 @@ class PyDMRelatedDisplayButton(QPushButton, PyDMWidget, new_properties=_relatedD
         base_path = ""
         macros = {}
         if parent_display:
-            base_path = os.path.dirname(parent_display.loaded_file())
+            parent_file_path = parent_display.loaded_file()
+            if self._follow_symlinks:
+                parent_file_path = os.path.realpath(parent_file_path)
+            base_path = os.path.dirname(parent_file_path)
             macros = copy.copy(parent_display.macros())
 
         fname = find_file(filename, base_path=base_path, raise_if_not_found=True)


### PR DESCRIPTION
This PR adds a new property to both `PyDMEmbeddedDisplay` and `PyDMRelatedDisplayButton`, called `followSymlinks`. 

This is rather useful for some situations, in which we have the main display file for an interface mapped with a symbolic link to somewhere else (some people are _a bit_ overly enthusiastic with symlinks, and that's a bit outside our control :P), in which case the previous behavior would be to not follow the link on that file, so when you tried to open a child display via a relative path, it would not find the file.

With this new property, you can switch that behavior so that the path is canonized before trying to search the relative path, so even in that case the correct file is found.

Aside from the very particular issue I mentioned, that kick-started this PR, I think this is a good change from a general usability perspective as well, considering that most interfaces (at least, that I know of) are treated more or less like python packages, in the sense that you rely on the folder structure being preserved in installation for things to work out. For that, I think it is more common to have the situation where you want to open a display file relative to your current (real, canonical) path, inside the package, than to reference something outside your package via a symlink.

All that is to say, I think this is more useful than our particular use case, so I figured it would be best to try to contribute it upstream! :slightly_smiling_face: