### PR TITLE
MAINT: Fix flake8 run in github actions

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,5 +1,5 @@
 # This workflow will run when a new release is published and upload it to PyPI using trusted publishing.
-# Done in two separate build and publish jobs per suggested best practice for limiting token usage.
+# Done in two separate build and publish jobs per suggested best practice for limiting scope of token usage.
 
 name: Publish - PyPI
 
@@ -10,6 +10,7 @@ on:
 
 jobs:
   build:
+    if: ${{ github.repository == 'slaclab/pydm' }}
     name: Build new release
     runs-on: ubuntu-latest
 
@@ -37,6 +38,7 @@ jobs:
         retention-days: 1
 
   publish:
+    if: ${{ github.repository == 'slaclab/pydm' }}
     name: Publish release to PyPI
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,6 +14,7 @@ permissions:
 
 jobs:
   build:
+    if: ${{ github.repository == 'slaclab/pydm' }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -37,12 +38,12 @@ jobs:
     - name: Install python packages
       shell: bash -el {0}
       run: |
+        # Note the pinning of zipp here is because versions 3.16.0+ do not support python 3.7. Specifying zipp can be entirely removed (will be pulled in by flake8) if pydm drops support for 3.7
         if [ "$RUNNER_OS" == "Windows" ]; then
-          mamba install flake8 pyqt=${{ matrix.pyqt-version }} 
-          mamba install --file requirements.txt 
-          mamba install --file windows-dev-requirements.txt
+          mamba install flake8 zipp=3.15.0 pyqt=${{ matrix.pyqt-version }}
+          mamba install --file requirements.txt --file windows-dev-requirements.txt
         else
-          mamba install flake8 pyqt=${{ matrix.pyqt-version }} $(cat requirements.txt dev-requirements.txt)
+          mamba install flake8 zipp=3.15.0 pyqt=${{ matrix.pyqt-version }} $(cat requirements.txt dev-requirements.txt)
         fi
     - name: Install packages for testing a pyqt app on linux
       shell: bash -el {0}


### PR DESCRIPTION
Follow up to #1009. 

Pins zipp to 3.15.0, the most recent version released two days ago no longer supports python 3.7.

Also adds checks to not run the test and pypi jobs by default on forks.
