### PR TITLE
ENH: Monitor the DISP field of records connected to by PyDMWritableWidget

### DIFF
--- a/pydm/connection_inspector/connection_inspector.py
+++ b/pydm/connection_inspector/connection_inspector.py
@@ -41,6 +41,7 @@ class ConnectionInspector(QWidget):
         return [connection
                 for p in plugins.values()
                 for connection in p.connections.values()
+                # DISP field is connected to separately for writable channels, including it on this list is redundant
                 if not connection.address.endswith('.DISP')
                 ]
 

--- a/pydm/connection_inspector/connection_inspector.py
+++ b/pydm/connection_inspector/connection_inspector.py
@@ -41,6 +41,7 @@ class ConnectionInspector(QWidget):
         return [connection
                 for p in plugins.values()
                 for connection in p.connections.values()
+                if not connection.address.endswith('.DISP')
                 ]
 
     @Slot()

--- a/pydm/tests/widgets/test_base.py
+++ b/pydm/tests/widgets/test_base.py
@@ -526,7 +526,8 @@ def test_pydmwidget_tooltip(qtbot):
     assert tool_tip == str(pydm_label.value)
 
 
-def test_pydmwritablewidget_channels(qtbot):
+@pytest.mark.parametrize('channel_address', ['tst://this', 'tst://this.VAL', 'tst://this.[1:2]'])
+def test_pydmwritablewidget_channels(qtbot, channel_address):
     """
     Test the channels population for the widget whose base class PyDMWritableWidget
 
@@ -547,7 +548,7 @@ def test_pydmwritablewidget_channels(qtbot):
     assert pydm_lineedit._channel is None
     assert pydm_lineedit.channels() is None
 
-    pydm_lineedit.channel = 'tst://this'
+    pydm_lineedit.channel = channel_address
     pydm_channels = pydm_lineedit.channels()[0]
 
     default_pydm_channels = PyDMChannel(address=pydm_lineedit.channel,

--- a/pydm/tests/widgets/test_base.py
+++ b/pydm/tests/widgets/test_base.py
@@ -575,7 +575,7 @@ def test_pydmwritablewidget_channels(qtbot, channel_address, monitor_disp):
                                         timestamp_slot=pydm_lineedit.timestamp_changed)
     assert pydm_channels == default_pydm_channels
     if monitor_disp:
-        assert pydm_lineedit._disp_channel == 'tst://this.DISP'
+        assert pydm_lineedit._disp_channel.address == 'tst://this.DISP'
     else:
         assert pydm_lineedit._disp_channel is None
 

--- a/pydm/tests/widgets/test_base.py
+++ b/pydm/tests/widgets/test_base.py
@@ -567,34 +567,38 @@ def test_pydmwritablewidget_channels(qtbot):
                                         write_access_slot=pydm_lineedit.writeAccessChanged,
                                         timestamp_slot=pydm_lineedit.timestamp_changed)
     assert pydm_channels == default_pydm_channels
-
+    assert pydm_lineedit._disp_channel == 'tst://this.DISP'
 
 @pytest.mark.parametrize(
-    "channel_address, connected, write_access, is_app_read_only", [
-        ("CA://MA_TEST", True, True, True),
-        ("CA://MA_TEST", True, False, True),
-        ("CA://MA_TEST", True, True, False),
-        ("CA://MA_TEST", True, False, False),
-        ("CA://MA_TEST", False, True, True),
-        ("CA://MA_TEST", False, False, True),
-        ("CA://MA_TEST", False, True, False),
-        ("CA://MA_TEST", False, False, False),
-        ("", False, False, False),
-        (None, False, False, False),
+    "channel_address, connected, write_access, is_app_read_only, disable_put", [
+        ("CA://MA_TEST", True, True, True, 0),
+        ("CA://MA_TEST", True, False, True, 0),
+        ("CA://MA_TEST", True, True, False, 0),
+        ("CA://MA_TEST", True, False, False, 0),
+        ("CA://MA_TEST", False, True, True, 0),
+        ("CA://MA_TEST", False, False, True, 0),
+        ("CA://MA_TEST", False, True, False, 0),
+        ("CA://MA_TEST", False, False, False, 0),
+        ("CA://MA_TEST", False, False, False, 1),
+        ("CA://MA_TEST", True, False, False, 1),
+        ("CA://MA_TEST", True, True, False, 1),
+        ("", False, False, False, 0),
+        (None, False, False, False, 0),
     ])
 def test_pydmwritable_check_enable_state(qtbot, channel_address,
                                          connected, write_access,
-                                         is_app_read_only):
+                                         is_app_read_only, disable_put):
     """
-    Test the tooltip generated depending on the channel address validation, connection, write access, and whether the
-    app is read-only. This test is for a widget whose base class is PyDMWritableWidget.
+    Test the tooltip generated depending on the channel address validation, connection, write access,
+    DISP field, and whether the app is read-only. This test is for a widget whose base class is PyDMWritableWidget.
 
     Expectations:
     1. The widget's tooltip will update only if the channel address is valid.
     2. If the data channel is disconnected, the widget's tooltip will  "PV is disconnected"
     3. If the data channel is connected, but it has no write access:
         a. If the app is read-only, the tooltip will read  "Running PyDM on Read-Only mode."
-        b. If the app is not read-only, the tooltip will read "Access denied by Channel Access Security."
+        b. If the app is not read-only, the tooltip will read "Access denied by Channel Access Security." or
+           "Access denied by DISP field" depending on which is preventing it. Access Security takes precedence.
 
     Parameters
     ----------
@@ -608,6 +612,8 @@ def test_pydmwritable_check_enable_state(qtbot, channel_address,
         True if the widget has write access to the channel; False otherwise
     is_app_read_only : bool
         True if the PyDM app is read-only; False otherwise
+    disable_put : int
+        1 if puts should be disabled based on the DISP field, 0 otherwise
     """
     pydm_lineedit = PyDMLineEdit()
     qtbot.addWidget(pydm_lineedit)
@@ -615,6 +621,7 @@ def test_pydmwritable_check_enable_state(qtbot, channel_address,
     pydm_lineedit.channel = channel_address
     pydm_lineedit._connected = connected
     pydm_lineedit._write_access = write_access
+    pydm_lineedit._disable_put = disable_put
 
     data_plugins.set_read_only(is_app_read_only)
 
@@ -626,11 +633,13 @@ def test_pydmwritable_check_enable_state(qtbot, channel_address,
     if is_channel_valid(channel_address):
         if not pydm_lineedit._connected:
             assert "PV is disconnected." in actual_tooltip
-        elif not write_access:
+        elif not write_access or disable_put:
             if data_plugins.is_read_only():
                 assert "Running PyDM on Read-Only mode." in actual_tooltip
-            else:
+            elif not pydm_lineedit._write_access:
                 assert "Access denied by Channel Access Security." in actual_tooltip
+            else:
+                assert "Access denied by DISP field" in actual_tooltip
     else:
         assert actual_tooltip == original_tooltip
 

--- a/pydm/tests/widgets/test_base.py
+++ b/pydm/tests/widgets/test_base.py
@@ -526,8 +526,13 @@ def test_pydmwidget_tooltip(qtbot):
     assert tool_tip == str(pydm_label.value)
 
 
-@pytest.mark.parametrize('channel_address', ['tst://this', 'tst://this.VAL', 'tst://this.[1:2]'])
-def test_pydmwritablewidget_channels(qtbot, channel_address):
+@pytest.mark.parametrize('channel_address, monitor_disp',  [
+                             ('tst://this', True),
+                             ('tst://this.VAL', True),
+                             ('tst://this.[1:2]', True),
+                             ('tst://this', False)
+                        ])
+def test_pydmwritablewidget_channels(qtbot, channel_address, monitor_disp):
     """
     Test the channels population for the widget whose base class PyDMWritableWidget
 
@@ -548,6 +553,7 @@ def test_pydmwritablewidget_channels(qtbot, channel_address):
     assert pydm_lineedit._channel is None
     assert pydm_lineedit.channels() is None
 
+    pydm_lineedit.monitorDisp = monitor_disp
     pydm_lineedit.channel = channel_address
     pydm_channels = pydm_lineedit.channels()[0]
 
@@ -568,7 +574,10 @@ def test_pydmwritablewidget_channels(qtbot, channel_address):
                                         write_access_slot=pydm_lineedit.writeAccessChanged,
                                         timestamp_slot=pydm_lineedit.timestamp_changed)
     assert pydm_channels == default_pydm_channels
-    assert pydm_lineedit._disp_channel == 'tst://this.DISP'
+    if monitor_disp:
+        assert pydm_lineedit._disp_channel == 'tst://this.DISP'
+    else:
+        assert pydm_lineedit._disp_channel is None
 
 @pytest.mark.parametrize(
     "channel_address, connected, write_access, is_app_read_only, disable_put", [

--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -1370,6 +1370,7 @@ class PyDMWritableWidget(PyDMWidget):
         self._write_access = False
         self._disp_channel = None
         self._disable_put = False
+        self._monitor_disp = False
         super(PyDMWritableWidget, self).__init__(init_channel=init_channel)
 
     def init_for_designer(self):
@@ -1410,6 +1411,26 @@ class PyDMWritableWidget(PyDMWidget):
 
         return PyDMWidget.eventFilter(self, obj, event)
 
+    @Property(bool)
+    def monitorDisp(self) -> bool:
+        """
+        Whether to monitor the DISP field for this widget's channel
+        """
+        return self._monitor_disp
+
+    @monitorDisp.setter
+    def monitorDisp(self, monitor_disp: bool) -> None:
+        """
+        Whether to monitor the DISP field for this widget's channel
+        """
+        if self._monitor_disp != monitor_disp:
+            self._monitor_disp = monitor_disp
+            if self._disp_channel is not None:
+                if monitor_disp:
+                    self._disp_channel.connect()
+                else:
+                    self._disp_channel.disconnect()
+
     @Property(str)
     def channel(self) -> Optional[str]:
         """
@@ -1431,7 +1452,7 @@ class PyDMWritableWidget(PyDMWidget):
         """
         if self._channel != value:
             self.set_channel(value)
-            if self._channel is None:
+            if not self._monitor_disp or self._channel is None:
                 return
 
             base_channel = self._channel.split(".", 1)[0] if "." in self._channel else self._channel

--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -1456,12 +1456,11 @@ class PyDMWritableWidget(PyDMWidget):
                 return
 
             base_channel = self._channel.split(".", 1)[0] if "." in self._channel else self._channel
-            if self._disp_channel != f'{base_channel}.DISP':
+            if self._disp_channel is None or self._disp_channel.address != f'{base_channel}.DISP':
                 if self._disp_channel is not None:
                     self._disp_channel.disconnect()
-                self._disp_channel = f'{base_channel}.DISP'
-                channel = PyDMChannel(address=self._disp_channel, value_slot=self.disp_value_changed)
-                channel.connect()
+                self._disp_channel = PyDMChannel(address=f'{base_channel}.DISP', value_slot=self.disp_value_changed)
+                self._disp_channel.connect()
 
     def disp_value_changed(self, new_disp_value: int) -> None:
         """ Callback function to receive changes to the DISP field of the monitored channel """

--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -1431,10 +1431,14 @@ class PyDMWritableWidget(PyDMWidget):
         """
         if self._channel != value:
             self.set_channel(value)
-            if value is not None and self._disp_channel != f'{value}.DISP':
+            if self._channel is None:
+                return
+
+            base_channel = self._channel.split(".", 1)[0] if "." in self._channel else self._channel
+            if self._disp_channel != f'{base_channel}.DISP':
                 if self._disp_channel is not None:
                     self._disp_channel.disconnect()
-                self._disp_channel = f'{value}.DISP'
+                self._disp_channel = f'{base_channel}.DISP'
                 channel = PyDMChannel(address=self._disp_channel, value_slot=self.disp_value_changed)
                 channel.connect()
 


### PR DESCRIPTION
This fixes #932.

I still need to add docstrings and a new test case, but just want to get a quick check that this solutions looks reasonable before proceeding.

This sets up an additional monitor on `channel_name.DISP` for any writable widget so that the widget can be disabled with an appropriate tooltip, similar to the way access security is currently handled.

If `DISP` is not set, it will timeout in a thread without performance impact, I checked with several displays with write widgets and did not see adverse performance issues.