### PR TITLE
ENH: Add support for NTEnum to the p4p data plugin

### DIFF
--- a/examples/pva/nt_enum.ui
+++ b/examples/pva/nt_enum.ui
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <widget class="PyDMEnumComboBox" name="PyDMEnumComboBox">
+   <property name="geometry">
+    <rect>
+     <x>240</x>
+     <y>160</y>
+     <width>79</width>
+     <height>23</height>
+    </rect>
+   </property>
+   <property name="toolTip">
+    <string/>
+   </property>
+   <property name="channel" stdset="0">
+    <string>pva://PyDM:PVA:Enum</string>
+   </property>
+  </widget>
+  <widget class="PyDMEnumButton" name="PyDMEnumButton">
+   <property name="geometry">
+    <rect>
+     <x>90</x>
+     <y>130</y>
+     <width>98</width>
+     <height>100</height>
+    </rect>
+   </property>
+   <property name="toolTip">
+    <string/>
+   </property>
+   <property name="channel" stdset="0">
+    <string>pva://PyDM:PVA:Enum</string>
+   </property>
+  </widget>
+  <widget class="PyDMLabel" name="PyDMLabel">
+   <property name="geometry">
+    <rect>
+     <x>160</x>
+     <y>70</y>
+     <width>61</width>
+     <height>15</height>
+    </rect>
+   </property>
+   <property name="toolTip">
+    <string/>
+   </property>
+   <property name="channel" stdset="0">
+    <string>pva://PyDM:PVA:Enum</string>
+   </property>
+  </widget>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>PyDMLabel</class>
+   <extends>QLabel</extends>
+   <header>pydm.widgets.label</header>
+  </customwidget>
+  <customwidget>
+   <class>PyDMEnumButton</class>
+   <extends>QWidget</extends>
+   <header>pydm.widgets.enum_button</header>
+  </customwidget>
+  <customwidget>
+   <class>PyDMEnumComboBox</class>
+   <extends>QComboBox</extends>
+   <header>pydm.widgets.enum_combo_box</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/examples/testing_ioc/pva_testing_ioc.py
+++ b/examples/testing_ioc/pva_testing_ioc.py
@@ -1,5 +1,5 @@
 from p4p.client.thread import Context
-from p4p.nt import NTNDArray, NTScalar, NTTable
+from p4p.nt import NTEnum, NTNDArray, NTScalar, NTTable
 from p4p.server import Server, ServerOperation
 from p4p.server.thread import SharedPV
 import numpy as np
@@ -55,6 +55,9 @@ class PVServer(object):
         # An NTNDArray that will be used to hold image data
         self.image_pv = SharedPV(handler=handler, nt=NTNDArray(), initial=np.zeros(1))
 
+        # An NTEnum that supports read/write from PyDM widgets
+        self.enum_pv = SharedPV(handler=handler, nt=NTEnum(), initial={'index': 0, 'choices': ['YES', 'NO', 'MAYBE']})
+
         # An NTTable that can be displayed via the PyDMNTTable widget
         table_structure = NTTable([('names', 's'), ('floats', 'd'), ('booleans', '?')])
         table_strings = ['This', 'Is', 'A', 'PyDM', 'Table']
@@ -78,6 +81,7 @@ class PVServer(object):
                                    'PyDM:PVA:BoolArray': self.bool_array,
                                    'PyDM:PVA:StringArray': self.string_array,
                                    'PyDM:PVA:Image': self.image_pv,
+                                   'PyDM:PVA:Enum': self.enum_pv,
                                    'PyDM:PVA:Table': self.nt_table_pv}])
 
     def gaussian_2d(self, x: float, y: float, x0: float, y0: float, xsig: float, ysig: float) -> np.ndarray:

--- a/pydm/data_plugins/epics_plugins/p4p_plugin_component.py
+++ b/pydm/data_plugins/epics_plugins/p4p_plugin_component.py
@@ -96,6 +96,9 @@ class Connection(PyDMConnection):
                         if hasattr(value, 'labels') and 'labels' not in new_value:
                             # Labels are the column headers for the table
                             new_value['labels'] = value.labels
+                    elif 'NTEnum' in value.getID():
+                        new_value = value.value.index
+                        self.enum_strings_signal.emit(tuple(value.value.choices))
                     else:
                         new_value = value.value
                     

--- a/pydm/tests/data_plugins/test_p4p_plugin_component.py
+++ b/pydm/tests/data_plugins/test_p4p_plugin_component.py
@@ -1,13 +1,14 @@
 import functools
 import numpy as np
 import pytest
-from p4p.nt import NTScalar
+from p4p.nt import NTEnum, NTScalar
 from pydm.data_plugins.epics_plugins.p4p_plugin_component import Connection, P4PPlugin
 from pydm.tests.conftest import ConnectionSignals
 from pydm.widgets.channel import PyDMChannel
 from pytest import MonkeyPatch
 from p4p.wrapper import Value 
 from p4p import Type
+
 
 class MockContext:
     """ A do-nothing mock of a p4p context object """
@@ -25,20 +26,25 @@ def generate_control_variables(value):
             }
 
 
-@pytest.mark.parametrize('value_to_send, has_ctrl_vars, expected_value_to_receive', [
-    (NTScalar("i", display=True, control=True, valueAlarm=True).wrap(generate_control_variables(5)), True, 5),
-    (NTScalar("b", display=True, control=True, valueAlarm=True).wrap(generate_control_variables(1)), True, 1),
-    (NTScalar("h", display=True, control=True, valueAlarm=True).wrap(generate_control_variables(2)), True, 2),
-    (NTScalar("f", display=True, control=True, valueAlarm=True).wrap(generate_control_variables(7.0)), True, 7.0),
-    (NTScalar("s").wrap({'value': 'PyDM:TEST'}), False, 'PyDM:TEST'),
-    (NTScalar("ai").wrap({'value': [1, 2, 4]}), False, [1, 2, 4]),
-    (NTScalar("ab").wrap({'value': [6, 7, 8]}), False, [6, 7, 8]),
-    (NTScalar("ah").wrap({'value': [10, 11, 12]}), False, [10, 11, 12]),
-    (NTScalar("af").wrap({'value': [5.0, 6.0, 7.0, 8.0]}), False, [5.0, 6.0, 7.0, 8.0]),
-    (NTScalar("as").wrap({'value': ['PyDM', 'PVA', 'Test', 'Strings']}), False, ['PyDM', 'PVA', 'Test', 'Strings'])
+@pytest.mark.parametrize('value_to_send, has_ctrl_vars, expected_value_to_receive, expected_signal_count', [
+    (NTScalar("i", display=True, control=True, valueAlarm=True).wrap(generate_control_variables(5)), True, 5, 9),
+    (NTScalar("b", display=True, control=True, valueAlarm=True).wrap(generate_control_variables(1)), True, 1, 9),
+    (NTScalar("h", display=True, control=True, valueAlarm=True).wrap(generate_control_variables(2)), True, 2, 9),
+    (NTScalar("f", display=True, control=True, valueAlarm=True).wrap(generate_control_variables(7.0)), True, 7.0, 9),
+    (NTScalar("s").wrap({'value': 'PyDM:TEST'}), False, 'PyDM:TEST', 1),
+    (NTScalar("ai").wrap({'value': [1, 2, 4]}), False, [1, 2, 4], 1),
+    (NTScalar("ab").wrap({'value': [6, 7, 8]}), False, [6, 7, 8], 1),
+    (NTScalar("ah").wrap({'value': [10, 11, 12]}), False, [10, 11, 12], 1),
+    (NTScalar("af").wrap({'value': [5.0, 6.0, 7.0, 8.0]}), False, [5.0, 6.0, 7.0, 8.0], 1),
+    (NTScalar("as").wrap({'value': ['PyDM', 'PVA', 'Test', 'Strings']}), False, ['PyDM', 'PVA', 'Test', 'Strings'], 1),
+    (NTEnum().wrap({'index': 0, 'choices': ['YES', 'NO', 'MAYBE']}), False, 0, 2)
 ])
-def test_send_new_value(monkeypatch: MonkeyPatch, signals: ConnectionSignals,
-                        value_to_send: object, has_ctrl_vars: bool, expected_value_to_receive: object):
+def test_send_new_value(monkeypatch: MonkeyPatch,
+                        signals: ConnectionSignals,
+                        value_to_send: Value,
+                        has_ctrl_vars: bool,
+                        expected_value_to_receive: object,
+                        expected_signal_count: int):
     """ Ensure that all our signals are emitted as expected based on the structured data we received from p4p """
 
     # Set up a mock p4p client
@@ -59,6 +65,9 @@ def test_send_new_value(monkeypatch: MonkeyPatch, signals: ConnectionSignals,
     expected_value_type = type(value_to_send.value)
     if type(value_to_send.value) == list:
         expected_value_type = np.ndarray
+    elif 'NTEnum' in value_to_send.getID():
+        expected_value_type = int
+
     p4p_connection.new_value_signal[expected_value_type].connect(functools.partial(receive_signal, 'value'))
     p4p_connection.lower_alarm_limit_signal.connect(functools.partial(receive_signal, 'low_alarm_limit'))
     p4p_connection.lower_warning_limit_signal.connect(functools.partial(receive_signal, 'low_warning_limit'))
@@ -68,6 +77,7 @@ def test_send_new_value(monkeypatch: MonkeyPatch, signals: ConnectionSignals,
     p4p_connection.unit_signal.connect(functools.partial(receive_signal, 'units'))
     p4p_connection.lower_ctrl_limit_signal.connect(functools.partial(receive_signal, 'lower_ctrl_limit'))
     p4p_connection.upper_ctrl_limit_signal.connect(functools.partial(receive_signal, 'upper_ctrl_limit'))
+    p4p_connection.enum_strings_signal.connect(functools.partial(receive_signal, 'enum_strings'))
 
     # Send out the initial value for our test PV
     p4p_connection.send_new_value(value_to_send)
@@ -83,9 +93,9 @@ def test_send_new_value(monkeypatch: MonkeyPatch, signals: ConnectionSignals,
         assert received_values['units'] == 'mV'
         assert received_values['lower_ctrl_limit'] == 1
         assert received_values['upper_ctrl_limit'] == 11
-        assert signals_received == 9
+        assert signals_received == expected_signal_count
     else:
-        assert signals_received == 1
+        assert signals_received == expected_signal_count
 
     # Now make just a couple changes to our value, and send it again
     if has_ctrl_vars:


### PR DESCRIPTION
### Context

Implementation for #1016. The data plugin will now send data from `NTEnum` using the signals that the corresponding PyDM widgets expect to receive (`new_value` and `enum_strings`)

### Testing

Tested on a local record using `softIocPVA`.  Also tested on the added example in the gif below. Added a test case for sending and receiving the enum data with the p4p data plugin test.

### Screenshot

The top widget is a `PyDMLabel` connected to the new example enum channel from the pva test ioc, and the bottom two are `PyDMEnumButton` and  `PyDMEnumComboBox`. (This is the added .ui file under examples)

![enum](https://github.com/slaclab/pydm/assets/89539359/88640662-9af9-4be2-b488-46370d36f528)

