### PR TITLE
TST: Fix issues with inconsistent tests

### DIFF
--- a/pydm/tests/utilities/test_stylesheet.py
+++ b/pydm/tests/utilities/test_stylesheet.py
@@ -16,7 +16,7 @@ test_stylesheet_path = os.path.join(
 def save_and_restore_pydm_stylesheet():
     """
     A fixture for ensuring that modifications to the PYDM_STYLESHEET environment variable are restored
-    even if the test fails to prevent any impact to future tests in the run.
+    even if the test fails. This will prevent any impact to the user's environment, as wel as future tests in the run.
     """
     # Back up the stylesheet related variables so they can be restored after the test
     env_backup = os.getenv("PYDM_STYLESHEET", None)

--- a/pydm/tests/utilities/test_stylesheet.py
+++ b/pydm/tests/utilities/test_stylesheet.py
@@ -1,7 +1,8 @@
 import os
+import pytest
 import logging
 
-
+from ... import config
 from ...utilities import stylesheet
 from qtpy.QtWidgets import QApplication
 
@@ -11,14 +12,26 @@ test_stylesheet_path = os.path.join(
     "..", "test_data", "global_stylesheet.css")
 
 
-def test_stylesheet_apply(qtbot):
-    # Backup of the variable
+@pytest.fixture(scope='function')
+def save_and_restore_pydm_stylesheet():
+    """
+    A fixture for ensuring that modifications to the PYDM_STYLESHEET environment variable are restored
+    even if the test fails to prevent any impact to future tests in the run.
+    """
+    # Back up the stylesheet related variables so they can be restored after the test
     env_backup = os.getenv("PYDM_STYLESHEET", None)
-
-    # Backup of the GLOBAL_STYLESHEET path
-    backup_global = stylesheet.GLOBAL_STYLESHEET
-
+    backup_global_style_path = stylesheet.GLOBAL_STYLESHEET
     os.environ["PYDM_STYLESHEET"] = ""
+
+    yield
+
+    # Restore the user's original stylesheet
+    if env_backup:
+        os.environ["PYDM_STYLESHEET"] = env_backup
+    stylesheet.GLOBAL_STYLESHEET = backup_global_style_path
+
+
+def test_stylesheet_apply(qtbot, save_and_restore_pydm_stylesheet):
     assert os.getenv("PYDM_STYLESHEET", None) == ""
 
     # Retrieve instance of the application so we can test with it
@@ -33,9 +46,6 @@ def test_stylesheet_apply(qtbot):
 
     assert app.styleSheet() is not None
 
-    # Backup of the GLOBAL_STYLESHEET path
-    backup_global = stylesheet.GLOBAL_STYLESHEET
-
     stylesheet.clear_cache()
     # Exercise when there is no stylesheet available
     stylesheet.GLOBAL_STYLESHEET = "invalid_file.none"
@@ -47,20 +57,8 @@ def test_stylesheet_apply(qtbot):
 
     assert not app.styleSheet()
 
-    # Restore the variable
-    if env_backup:
-        os.environ["PYDM_STYLESHEET"] = env_backup
-    stylesheet.GLOBAL_STYLESHEET = backup_global
 
-
-def test_stylesheet_get_style_data(caplog):
-    # Backup of the variable
-    env_backup = os.getenv("PYDM_STYLESHEET", None)
-
-    # Backup of the GLOBAL_STYLESHEET path
-    backup_global = stylesheet.GLOBAL_STYLESHEET
-
-    os.environ["PYDM_STYLESHEET"] = ""
+def test_stylesheet_get_style_data(caplog, save_and_restore_pydm_stylesheet):
     assert os.getenv("PYDM_STYLESHEET", None) == ""
 
     with caplog.at_level(logging.DEBUG):
@@ -127,10 +125,8 @@ def test_stylesheet_get_style_data(caplog):
         ret = stylesheet._get_style_data()
 
         # Make sure logging capture the error, and have the correct error message
-        assert len(caplog.records) == 1
+        if not config.STYLESHEET:
+            assert len(caplog.records) == 1
+        else:
+            assert len(caplog.records) == 2  # Extra message about existing stylesheet
         assert "Cannot find the default stylesheet" in caplog.text
-
-    # Restore the variable
-    if env_backup:
-        os.environ["PYDM_STYLESHEET"] = env_backup
-    stylesheet.GLOBAL_STYLESHEET = backup_global

--- a/pydm/tests/widgets/test_lineedit.py
+++ b/pydm/tests/widgets/test_lineedit.py
@@ -549,6 +549,7 @@ def test_set_display(qtbot, qapp, value, has_focus, channel_type, display_format
     else:
         pydm_lineedit.clearFocus()
         def wait_nofocus():
+            pydm_lineedit.clearFocus()
             return not pydm_lineedit.hasFocus()
 
         qtbot.waitUntil(wait_nofocus, timeout=5000)
@@ -589,10 +590,12 @@ def test_focus_in_event(qtbot, qapp, displayed_value, focus_reason, expected_foc
     with qtbot.waitExposed(pydm_lineedit):
         pydm_lineedit.show()
 
-    def wait_focus(focus_state):
+    def wait_focus(focus_state, wait_on_clear):
         """ Verify the current focus state of the line edit """
         if focus_state:
             pydm_lineedit.setFocus(Qt.OtherFocusReason)
+        elif wait_on_clear:
+            pydm_lineedit.clearFocus()
         qapp.processEvents()
         return pydm_lineedit.hasFocus() == focus_state
 
@@ -600,10 +603,10 @@ def test_focus_in_event(qtbot, qapp, displayed_value, focus_reason, expected_foc
     # measuring the correct end state
     if expected_focus:
         pydm_lineedit.clearFocus()
-        qtbot.waitUntil(functools.partial(wait_focus, False), timeout=5000)
+        qtbot.waitUntil(functools.partial(wait_focus, False, True), timeout=5000)
     else:
         pydm_lineedit.setFocus(Qt.OtherFocusReason)
-        qtbot.waitUntil(functools.partial(wait_focus, True), timeout=5000)
+        qtbot.waitUntil(functools.partial(wait_focus, True, False), timeout=5000)
 
     # Set the focus, verify the result is what we are expecting
     if expected_focus:
@@ -611,7 +614,7 @@ def test_focus_in_event(qtbot, qapp, displayed_value, focus_reason, expected_foc
     else:
         event_to_send = QFocusEvent(QEvent.FocusIn, reason=focus_reason)
         pydm_lineedit.focusInEvent(event_to_send)
-    qtbot.waitUntil(functools.partial(wait_focus, expected_focus), timeout=5000)
+    qtbot.waitUntil(functools.partial(wait_focus, expected_focus, False), timeout=5000)
 
 
 @pytest.mark.parametrize("display_value", [
@@ -655,9 +658,9 @@ def test_focus_out_event(qtbot, qapp, display_value):
     qtbot.waitUntil(wait_focus, timeout=5000)
 
     pydm_lineedit.setText("Canceled after the focusOut event")
-    pydm_lineedit.clearFocus()
 
     def wait_nofocus():
+        pydm_lineedit.clearFocus()
         qapp.processEvents()
         return not pydm_lineedit.hasFocus()
 


### PR DESCRIPTION
### Context

This is an attempt to fix #1012. 

For the first half of that issue (`test_line_edit.py`), this adds retries to the change in focus of the line edit while waiting for qtbot to confirm that the change actually took place. This appears to have made these stable for the tests I already changed in this way, and this doesn't affect what they are actually testing.

For the stylesheet test failues in the issue, the only test that fails in isolation when a custom stylesheet is set is this one: 

`FAILED pydm/tests/utilities/test_stylesheet.py::test_stylesheet_get_style_data - assert 2 == 1`.

The others are fine when run by themselves even with a stylesheet set.

But `test_stylesheet_get_style_data` makes changes to the `PYDM_STYLESHEET` environment variable, as well as the locally stored stylesheet, and does not clean up after itself if it fails. Then those left over modifications cause the other tests later in the run to fail too.

So the first fix is just to get that test to pass when a custom stylesheet is set. Then I also added a fixture to make sure it always cleans up after even if it fails, and set both tests in that file to use it since the other one has the same problem too.

### Testing

Ran the tests with `PYDM_STYLESHEET` set to  https://github.com/pcdshub/vacuumscreens/blob/master/styleSheet/masterStyleSheet.qss 


