### PR TITLE
STY: Enable rich text for PyDMLabels

### DIFF
--- a/examples/label/label.ui
+++ b/examples/label/label.ui
@@ -18,8 +18,8 @@
     <rect>
      <x>60</x>
      <y>80</y>
-     <width>69</width>
-     <height>16</height>
+     <width>71</width>
+     <height>41</height>
     </rect>
    </property>
    <property name="focusPolicy">
@@ -36,6 +36,58 @@
    </property>
    <property name="channel" stdset="0">
     <string>ca://MTEST:Float</string>
+   </property>
+   <property name="displayFormat" stdset="0">
+    <enum>PyDMLabel::String</enum>
+   </property>
+  </widget>
+  <widget class="PyDMLabel" name="PyDMLabel_2">
+   <property name="geometry">
+    <rect>
+     <x>230</x>
+     <y>80</y>
+     <width>71</width>
+     <height>41</height>
+    </rect>
+   </property>
+   <property name="focusPolicy">
+    <enum>Qt::StrongFocus</enum>
+   </property>
+   <property name="toolTip">
+    <string/>
+   </property>
+   <property name="whatsThis">
+    <string/>
+   </property>
+   <property name="text">
+    <string>&lt;b&gt;Rich&lt;b&gt; &lt;i&gt;text!&lt;i&gt;</string>
+   </property>
+   <property name="rules" stdset="0">
+    <string>[]</string>
+   </property>
+   <property name="precision" stdset="0">
+    <number>0</number>
+   </property>
+   <property name="showUnits" stdset="0">
+    <bool>false</bool>
+   </property>
+   <property name="precisionFromPV" stdset="0">
+    <bool>true</bool>
+   </property>
+   <property name="alarmSensitiveContent" stdset="0">
+    <bool>true</bool>
+   </property>
+   <property name="alarmSensitiveBorder" stdset="0">
+    <bool>true</bool>
+   </property>
+   <property name="PyDMToolTip" stdset="0">
+    <string/>
+   </property>
+   <property name="channel" stdset="0">
+    <string/>
+   </property>
+   <property name="enableRichText" stdset="0">
+    <bool>true</bool>
    </property>
    <property name="displayFormat" stdset="0">
     <enum>PyDMLabel::String</enum>

--- a/pydm/tests/widgets/test_label.py
+++ b/pydm/tests/widgets/test_label.py
@@ -11,6 +11,7 @@ from ...widgets.base import PyDMWidget
 from ...widgets.display_format import parse_value_for_display, DisplayFormat
 
 from qtpy.QtWidgets import QApplication, QStyleOption
+from qtpy.QtCore import Qt
 
 # --------------------
 # POSITIVE TEST CASES
@@ -37,6 +38,25 @@ def test_construct(qtbot):
     assert display_format_type == pydm_label.DisplayFormat.Default
     assert pydm_label._string_encoding == pydm_label.app.get_string_encoding() if is_pydm_app() else "utf_8"
 
+def test_enable_rich_text(qtbot):
+    """
+    Test the widget's option for enabling rich text.
+
+    Expectations:
+    1. The label has plain text as default text format
+    2. The label allows rich text to be enabled using its "enableRichText" setters
+
+    Parameters
+    ----------
+    qtbot : fixture
+        Window for widget testing
+    """
+    pydm_label = PyDMLabel()
+    assert pydm_label.textFormat() == Qt.PlainText
+
+    pydm_label.enableRichText = True #invoke setter
+    qtbot.addWidget(pydm_label)
+    assert pydm_label.textFormat() == Qt.RichText
 
 @pytest.mark.parametrize("value, display_format", [
     ("abc", DisplayFormat.Default),

--- a/pydm/widgets/label.py
+++ b/pydm/widgets/label.py
@@ -36,8 +36,24 @@ class PyDMLabel(QLabel, TextFormatter, PyDMWidget, DisplayFormat, new_properties
         self.setText("######")
         self._display_format_type = self.DisplayFormat.Default
         self._string_encoding = "utf_8"
+        self._enable_rich_text = False
         if is_pydm_app():
             self._string_encoding = self.app.get_string_encoding()
+
+    @Property(bool)
+    def enableRichText(self):
+        return self._enable_rich_text
+
+    @enableRichText.setter
+    def enableRichText(self, new_value):
+        if self._enable_rich_text == new_value:
+            return
+        self._enable_rich_text = new_value
+
+        if self._enable_rich_text:
+            self.setTextFormat(Qt.RichText)
+        else:
+            self.setTextFormat(Qt.PlainText)
 
     @Property(DisplayFormat)
     def displayFormat(self):


### PR DESCRIPTION
Fixes https://github.com/slaclab/pydm/issues/1013

Fix is simply to set the text format of the PyDMLabel class to from PlainText to RichText.

 Added small test case to ensure stays set.
Also tested by using newly added rich text example:

_-pydm examples/label/label.ui
-in another terminal: caput MTEST:Float 3.2
-label with rich text is shown in Qt window
-caput MTEST:Float 0.007
-label with rich text is hidden_