### PR TITLE
MAINT: Use mambaforge to fix failing github action for running tests

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -32,8 +32,8 @@ jobs:
       uses: conda-incubator/setup-miniconda@v2
       with:
         python-version: ${{ matrix.python-version }}
-        mamba-version: "*"
-        channels: conda-forge
+        miniforge-variant: Mambaforge
+        miniforge-version: latest
         activate-environment: pydm-env
     - name: Install python packages
       shell: bash -el {0}


### PR DESCRIPTION
Attempting to fix the macOS test runs failing to build the environment by using Mambaforge in the setup-miniconda action