### PR TITLE
PERF: create unit menu on-demand for QLineEdit

### DIFF
--- a/pydm/tests/widgets/test_lineedit.py
+++ b/pydm/tests/widgets/test_lineedit.py
@@ -49,6 +49,10 @@ def test_construct(qtbot, init_channel):
     assert pydm_lineedit._scale == 1
     assert pydm_lineedit._prec == 0
     assert pydm_lineedit.showUnits == False
+
+    assert pydm_lineedit.unitMenu is None
+    pydm_lineedit.widget_ctx_menu()
+
     assert isinstance(pydm_lineedit.unitMenu, QMenu) and pydm_lineedit.unitMenu.title() == "Convert Units"
     assert pydm_lineedit.displayFormat == pydm_lineedit.DisplayFormat.Default
     assert (pydm_lineedit._string_encoding == pydm_lineedit.app.get_string_encoding()

--- a/pydm/widgets/line_edit.py
+++ b/pydm/widgets/line_edit.py
@@ -40,8 +40,7 @@ class PyDMLineEdit(QLineEdit, TextFormatter, PyDMWritableWidget, DisplayFormat):
         self._scale = 1
 
         self.returnPressed.connect(self.send_value)
-        self.unitMenu = QMenu('Convert Units', self)
-        self.create_unit_options()
+        self.unitMenu = None
         self._display_format_type = self.DisplayFormat.Default
         self._string_encoding = "utf_8"
         self._user_set_read_only = False  # Are we *really* read only?
@@ -157,7 +156,6 @@ class PyDMLineEdit(QLineEdit, TextFormatter, PyDMWritableWidget, DisplayFormat):
         """
         super(PyDMLineEdit, self).unit_changed(new_unit)
         self._scale = 1
-        self.create_unit_options()
 
     def create_unit_options(self):
         """
@@ -169,7 +167,11 @@ class PyDMLineEdit(QLineEdit, TextFormatter, PyDMWritableWidget, DisplayFormat):
         :attr:`.showUnits` attribute is set to False, the menu will tell
         the user that there are no available conversions
         """
-        self.unitMenu.clear()
+        if self.unitMenu is None:
+            self.unitMenu = QMenu('Convert Units', self)
+        else:
+            self.unitMenu.clear()
+
         units = utilities.find_unit_options(self._unit)
         if units and self._show_units:
             for choice in units:
@@ -219,6 +221,8 @@ class PyDMLineEdit(QLineEdit, TextFormatter, PyDMWritableWidget, DisplayFormat):
         QMenu or None
             If the return of this method is None a new QMenu will be created by `assemble_tools_menu`.
         """
+        self.create_unit_options()
+
         menu = self.createStandardContextMenu()
         menu.addSeparator()
         menu.addMenu(self.unitMenu)


### PR DESCRIPTION
## Background

We noticed that a bunch of `QMenu` instances were in our typhos test suite at the top-level (`QApplication.instance().topLevelWidgets()`).
While tangential to the issue we were investigating in that repository, it seems unnecessary for PyDM to create these at `__init__` time.

## This PR
This PR creates the unit conversion menu on-demand.

## Testing

* Test suite was updated
* Quickly checked the example to see if it still works:

<img width="457" alt="image" src="https://github.com/slaclab/pydm/assets/5139267/76005914-20ed-4d9b-9a2e-7295bb812da0">
