### PR TITLE
STY: Stop overriding tooltip's disconnected-msg when channel is disconnected

### DIFF
--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -1335,7 +1335,7 @@ class PyDMWidget(PyDMPrimitiveWidget, new_properties=_positionRuleProperties):
             return false.
         """
 
-        if event.type() == QEvent.Enter:
+        if event.type() == QEvent.Enter and self._connected:
             if not self._pydm_tool_tip:
                 self.setToolTip(self.parseTip(self.toolTip()))
             else:


### PR DESCRIPTION
disconnected message was being set correctly, but was getting overridden at point when mouse hovers over widget (when it is time to actually display the tooltip).

the fix is to not write any new values to the tooltip while the widgets channel is disconnected (since tooltip will be already set to the correct disconnected msg). once reconnected, the connected msg will be set again.

to verify this works:

-launch examples/pydm-testing-ioc and then examples/label/label.ui
-open it in designer
-add _Test: $(pv_value)_ as the PyDMToolTip for the label on the left (the one connected to _ca://MTEST:Float_)]
-relaunch label.ui, and hover over the modified label, and confirm it reads _Test: \<value of MTEST:Float\>_
-kill pydm-testing-ioc, go back to the label window and hover mouse over this same label, confirm the tooltip reads: 

_Test: None
PV is disconnected.
ca://MTEST:Float_

-now start pydm-testing-ioc again and hover over label, confirm the tooltip again reads _Test: \<value of MTEST:Float\>_