### PR TITLE
Fix password

### DIFF
--- a/pydm/widgets/pushbutton.py
+++ b/pydm/widgets/pushbutton.py
@@ -2,6 +2,7 @@ import hashlib
 
 from qtpy.QtWidgets import QPushButton, QMessageBox, QInputDialog, QLineEdit
 from qtpy.QtCore import Slot, Property
+from qtpy import QtDesigner
 from .base import PyDMWritableWidget
 
 import logging
@@ -126,6 +127,11 @@ class PyDMPushButton(QPushButton, PyDMWritableWidget):
             # Use the setter as it also checks whether the existing password is the same with the
             # new one, and only updates if the new password is different
             self.protectedPassword = sha.hexdigest()
+
+            # Make sure designer knows it should save the protectedPassword field
+            formWindow = QtDesigner.QDesignerFormWindowInterface.findFormWindow(self)
+            if formWindow:
+                formWindow.cursor().setProperty("protectedPassword", self.protectedPassword)
 
     @Property(str)
     def protectedPassword(self):

--- a/pydm/widgets/related_display_button.py
+++ b/pydm/widgets/related_display_button.py
@@ -7,6 +7,7 @@ import hashlib
 from qtpy.QtWidgets import QPushButton, QMenu, QAction, QMessageBox, QInputDialog, QLineEdit, QWidget
 from qtpy.QtGui import QCursor, QIcon, QMouseEvent
 from qtpy.QtCore import Slot, Property, Qt, QSize, QPoint
+from qtpy import QtDesigner
 from .base import PyDMWidget, only_if_channel_set
 from ..utilities import IconFont, find_file, is_pydm_app
 from ..utilities.macro import parse_macro_string
@@ -317,6 +318,11 @@ class PyDMRelatedDisplayButton(QPushButton, PyDMWidget, new_properties=_relatedD
             # Use the setter as it also checks whether the existing password is the same with the
             # new one, and only updates if the new password is different
             self.protectedPassword = sha.hexdigest()
+
+            # Make sure designer knows it should save the protectedPassword field
+            formWindow = QtDesigner.QDesignerFormWindowInterface.findFormWindow(self)
+            if formWindow:
+                formWindow.cursor().setProperty("protectedPassword", self.protectedPassword)
 
     @Property(str)
     def protectedPassword(self) -> str:

--- a/pydm/widgets/shell_command.py
+++ b/pydm/widgets/shell_command.py
@@ -10,6 +10,7 @@ from ast import literal_eval
 from qtpy.QtWidgets import QPushButton, QMenu, QMessageBox, QInputDialog, QLineEdit, QWidget
 from qtpy.QtGui import QCursor, QIcon, QMouseEvent
 from qtpy.QtCore import Property, QSize, Qt, QTimer
+from qtpy import QtDesigner
 from .base import PyDMWidget, only_if_channel_set
 from ..utilities import IconFont
 from typing import Optional, Union, List
@@ -378,6 +379,11 @@ class PyDMShellCommand(QPushButton, PyDMWidget):
             # Use the setter as it also checks whether the existing password is the same with the
             # new one, and only updates if the new password is different
             self.protectedPassword = sha.hexdigest()
+
+            # Make sure designer knows it should save the protectedPassword field
+            formWindow = QtDesigner.QDesignerFormWindowInterface.findFormWindow(self)
+            if formWindow:
+                formWindow.cursor().setProperty("protectedPassword", self.protectedPassword)
 
     @Property(str)
     def protectedPassword(self) -> str:


### PR DESCRIPTION
Issue was when using designer, entering a password in "Property" window on right-side of screen would not save the encrypted password to the .ui file as expected, and password feature would not work.

This is because editing the "password" property would in-turn update the "protectedPassword" property, 
but designer would not consider the "protectedPassword" property as having been edited, and would then not save it out to the .ui file.

Fix is to update the "protectedPassword" widget property directly with "setProperty" when the "password" is set, to make sure designer knows to save the "protectedPassword" value.

Widget-update code grabbed from the "update_property_for_widget" function in "pydm/widgets/designer_settings.py":

```python
def update_property_for_widget(widget: QtWidgets.QWidget, name: str, value):
    """Update a Property for the given widget in the designer."""
    formWindow = QtDesigner.QDesignerFormWindowInterface.findFormWindow(widget)
    logger.info("Updating %s.%s = %s", widget.objectName(), name, value)
    if formWindow:
        formWindow.cursor().setProperty(name, value)
    else:
        setattr(widget, name, value)
```