### PR TITLE
BUG: prevent PyDMDrawingLine from dividing by a length of 0

### DIFF
--- a/pydm/widgets/drawing.py
+++ b/pydm/widgets/drawing.py
@@ -478,7 +478,7 @@ class PyDMDrawingLine(PyDMDrawing):
         diff_x = startpoint.x() - endpoint.x()
         diff_y = startpoint.y() - endpoint.y()
 
-        length = math.sqrt(diff_x**2 + diff_y**2)
+        length = max(math.sqrt(diff_x**2 + diff_y**2), 1.0)
 
         norm_x = diff_x / length
         norm_y = diff_y / length


### PR DESCRIPTION
## Description
Modifies `pydm.widgets.drawing.PyDMDrawingLine._arrow_points` to avoid divide by 0 errors.  

## Context
https://github.com/pcdshub/atef/issues/210

I ran into this, but had difficulty consistently reproducing it.  I think in most cases when the length is 0, the widget is hidden and this method would never get called.  But in some cases (if you slowly contract a container or expand a container with the hidden line), this method can be called with arguments that make the `length=0`.  

This modification did not prevent the widget from being hidden when squeezed out of existence, which maintains the existing functionality.

## Testing?
Tested this interactively with no issues