### PR TITLE
ENH: Add propertry for setting Qt Standard Icons in designer

### DIFF
--- a/examples/icons/icons.ui
+++ b/examples/icons/icons.ui
@@ -1,0 +1,403 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>510</width>
+    <height>400</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>500</width>
+    <height>400</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="label_main">
+     <property name="text">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The PyDMIcon property allows for specifying icons in Designer from provided cross-platform icon sets.&lt;/p&gt;&lt;p&gt;Icons can be used from both Qt's standard icon set (https://doc.qt.io/qt-6/qstyle.html#StandardPixmap-enum) and the &amp;quot;Font Awesome&amp;quot; icon set (https://fontawesome.com/icons?d=gallery).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="textFormat">
+      <enum>Qt::RichText</enum>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="PyDMFrame" name="PyDMFrame">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="whatsThis">
+      <string>
+    QFrame with support for alarms
+    This class inherits from QFrame and PyDMWidget.
+
+    Parameters
+    ----------
+    parent : QWidget
+        The parent widget for the Label
+    init_channel : str, optional
+        The channel to be used by the widget.
+    </string>
+     </property>
+     <property name="alarmSensitiveBorder" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="channel" stdset="0">
+      <string>ca://MTEST:Run</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_4">
+      <property name="leftMargin">
+       <number>4</number>
+      </property>
+      <property name="topMargin">
+       <number>4</number>
+      </property>
+      <property name="rightMargin">
+       <number>4</number>
+      </property>
+      <property name="bottomMargin">
+       <number>4</number>
+      </property>
+      <item>
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>This button uses an icon from Qt's standard icon set.</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="PyDMPushButton" name="PyDMPushButton">
+        <property name="toolTip">
+         <string/>
+        </property>
+        <property name="whatsThis">
+         <string/>
+        </property>
+        <property name="styleSheet">
+         <string notr="true"/>
+        </property>
+        <property name="text">
+         <string>This button uses a standard icon.</string>
+        </property>
+        <property name="alarmSensitiveContent" stdset="0">
+         <bool>false</bool>
+        </property>
+        <property name="alarmSensitiveBorder" stdset="0">
+         <bool>false</bool>
+        </property>
+        <property name="PyDMToolTip" stdset="0">
+         <string/>
+        </property>
+        <property name="monitorDisp" stdset="0">
+         <bool>false</bool>
+        </property>
+        <property name="channel" stdset="0">
+         <string>ca://MTEST:Run</string>
+        </property>
+        <property name="PyDMIcon" stdset="0">
+         <string>SP_ArrowUp</string>
+        </property>
+        <property name="PyDMIconColor" stdset="0">
+         <color>
+          <red>170</red>
+          <green>0</green>
+          <blue>127</blue>
+         </color>
+        </property>
+        <property name="passwordProtected" stdset="0">
+         <bool>false</bool>
+        </property>
+        <property name="password" stdset="0">
+         <string/>
+        </property>
+        <property name="protectedPassword" stdset="0">
+         <string/>
+        </property>
+        <property name="showConfirmDialog" stdset="0">
+         <bool>false</bool>
+        </property>
+        <property name="confirmMessage" stdset="0">
+         <string/>
+        </property>
+        <property name="pressValue" stdset="0">
+         <string>1</string>
+        </property>
+        <property name="releaseValue" stdset="0">
+         <string>None</string>
+        </property>
+        <property name="relativeChange" stdset="0">
+         <bool>false</bool>
+        </property>
+        <property name="writeWhenRelease" stdset="0">
+         <bool>false</bool>
+        </property>
+        <property name="standardIcon" stdset="0">
+         <string>eye-slash</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="PyDMFrame" name="PyDMFrame_2">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="whatsThis">
+      <string>
+    QFrame with support for alarms
+    This class inherits from QFrame and PyDMWidget.
+
+    Parameters
+    ----------
+    parent : QWidget
+        The parent widget for the Label
+    init_channel : str, optional
+        The channel to be used by the widget.
+    </string>
+     </property>
+     <property name="alarmSensitiveContent" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="alarmSensitiveBorder" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="channel" stdset="0">
+      <string>ca://MTEST:Run</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_5">
+      <property name="leftMargin">
+       <number>4</number>
+      </property>
+      <property name="topMargin">
+       <number>4</number>
+      </property>
+      <property name="rightMargin">
+       <number>4</number>
+      </property>
+      <property name="bottomMargin">
+       <number>4</number>
+      </property>
+      <item>
+       <widget class="QLabel" name="label_2">
+        <property name="text">
+         <string>This button uses an icon from the &quot;Font Awesome&quot; icon set.</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="PyDMPushButton" name="PyDMPushButton_2">
+        <property name="toolTip">
+         <string/>
+        </property>
+        <property name="whatsThis">
+         <string/>
+        </property>
+        <property name="text">
+         <string>This button uses a &quot;Font Awesome&quot; icon.</string>
+        </property>
+        <property name="flat">
+         <bool>false</bool>
+        </property>
+        <property name="alarmSensitiveContent" stdset="0">
+         <bool>false</bool>
+        </property>
+        <property name="alarmSensitiveBorder" stdset="0">
+         <bool>false</bool>
+        </property>
+        <property name="PyDMToolTip" stdset="0">
+         <string/>
+        </property>
+        <property name="monitorDisp" stdset="0">
+         <bool>false</bool>
+        </property>
+        <property name="channel" stdset="0">
+         <string>ca://MTEST:Run</string>
+        </property>
+        <property name="PyDMIcon" stdset="0">
+         <string>arrow-up</string>
+        </property>
+        <property name="passwordProtected" stdset="0">
+         <bool>false</bool>
+        </property>
+        <property name="password" stdset="0">
+         <string/>
+        </property>
+        <property name="protectedPassword" stdset="0">
+         <string/>
+        </property>
+        <property name="showConfirmDialog" stdset="0">
+         <bool>false</bool>
+        </property>
+        <property name="confirmMessage" stdset="0">
+         <string/>
+        </property>
+        <property name="pressValue" stdset="0">
+         <string>0</string>
+        </property>
+        <property name="releaseValue" stdset="0">
+         <string>None</string>
+        </property>
+        <property name="relativeChange" stdset="0">
+         <bool>false</bool>
+        </property>
+        <property name="writeWhenRelease" stdset="0">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="PyDMFrame" name="PyDMFrame_3">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="whatsThis">
+      <string>
+    QFrame with support for alarms
+    This class inherits from QFrame and PyDMWidget.
+
+    Parameters
+    ----------
+    parent : QWidget
+        The parent widget for the Label
+    init_channel : str, optional
+        The channel to be used by the widget.
+    </string>
+     </property>
+     <property name="alarmSensitiveBorder" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="channel" stdset="0">
+      <string>ca://MTEST:Run</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_6">
+      <property name="leftMargin">
+       <number>4</number>
+      </property>
+      <property name="topMargin">
+       <number>4</number>
+      </property>
+      <property name="rightMargin">
+       <number>4</number>
+      </property>
+      <property name="bottomMargin">
+       <number>4</number>
+      </property>
+      <item>
+       <widget class="QLabel" name="label_3">
+        <property name="text">
+         <string>The color of icons from the &quot;Font Awesome&quot; set is configurable. (this can't be done with Qt standard icons since they are already multi-colored)</string>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="PyDMPushButton" name="PyDMPushButton_3">
+        <property name="toolTip">
+         <string/>
+        </property>
+        <property name="whatsThis">
+         <string/>
+        </property>
+        <property name="text">
+         <string>This button uses a colored &quot;Font Awesome&quot; icon.</string>
+        </property>
+        <property name="alarmSensitiveContent" stdset="0">
+         <bool>false</bool>
+        </property>
+        <property name="alarmSensitiveBorder" stdset="0">
+         <bool>false</bool>
+        </property>
+        <property name="PyDMToolTip" stdset="0">
+         <string/>
+        </property>
+        <property name="monitorDisp" stdset="0">
+         <bool>false</bool>
+        </property>
+        <property name="channel" stdset="0">
+         <string>ca://MTEST:Run</string>
+        </property>
+        <property name="PyDMIcon" stdset="0">
+         <string>arrow-up</string>
+        </property>
+        <property name="PyDMIconColor" stdset="0">
+         <color>
+          <red>255</red>
+          <green>0</green>
+          <blue>0</blue>
+         </color>
+        </property>
+        <property name="passwordProtected" stdset="0">
+         <bool>false</bool>
+        </property>
+        <property name="password" stdset="0">
+         <string/>
+        </property>
+        <property name="protectedPassword" stdset="0">
+         <string/>
+        </property>
+        <property name="showConfirmDialog" stdset="0">
+         <bool>false</bool>
+        </property>
+        <property name="confirmMessage" stdset="0">
+         <string/>
+        </property>
+        <property name="pressValue" stdset="0">
+         <string>0</string>
+        </property>
+        <property name="releaseValue" stdset="0">
+         <string>None</string>
+        </property>
+        <property name="relativeChange" stdset="0">
+         <bool>false</bool>
+        </property>
+        <property name="writeWhenRelease" stdset="0">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>PyDMFrame</class>
+   <extends>QFrame</extends>
+   <header>pydm.widgets.frame</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>PyDMPushButton</class>
+   <extends>QPushButton</extends>
+   <header>pydm.widgets.pushbutton</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/pydm/tests/widgets/test_pushbutton.py
+++ b/pydm/tests/widgets/test_pushbutton.py
@@ -107,7 +107,18 @@ def test_construct(qtbot, label, press_value, relative, init_channel, icon_font_
         test_icon = style.standardIcon(style.SP_DesktopIcon)
         test_icon_image = test_icon.pixmap(size).toImage()
 
-        pydm_pushbutton.standardIcon = "SP_DesktopIcon"
+        pydm_pushbutton.PyDMIcon = "SP_DesktopIcon"
+        push_btn_icon = pydm_pushbutton.icon()
+        push_btn_icon_image = push_btn_icon.pixmap(size).toImage()
+
+        assert test_icon_image == push_btn_icon_image
+
+        # verify that "Font Awesome" icons can be set through our custom property
+        icon_f = IconFont()
+        test_icon = icon_f.icon("eye-slash", color=None)
+        test_icon_image = test_icon.pixmap(size).toImage()
+
+        pydm_pushbutton.PyDMIcon = "eye-slash"
         push_btn_icon = pydm_pushbutton.icon()
         push_btn_icon_image = push_btn_icon.pixmap(size).toImage()
 

--- a/pydm/tests/widgets/test_pushbutton.py
+++ b/pydm/tests/widgets/test_pushbutton.py
@@ -102,6 +102,17 @@ def test_construct(qtbot, label, press_value, relative, init_channel, icon_font_
         button_icon_pixmap = pydm_pushbutton.icon().pixmap(size)
         assert icon_pixmap.toImage() == button_icon_pixmap.toImage()
 
+        # verify that qt standard icons can be set through our custom property
+        style = pydm_pushbutton.style()
+        test_icon = style.standardIcon(style.SP_DesktopIcon)
+        test_icon_image = test_icon.pixmap(size).toImage()
+
+        pydm_pushbutton.standardIcon = "SP_DesktopIcon"
+        push_btn_icon = pydm_pushbutton.icon()
+        push_btn_icon_image = push_btn_icon.pixmap(size).toImage()
+
+        assert test_icon_image == push_btn_icon_image
+
     assert pydm_pushbutton.showConfirmDialog is False
     assert pydm_pushbutton.confirmMessage == PyDMPushButton.DEFAULT_CONFIRM_MESSAGE
     assert pydm_pushbutton.passwordProtected is False

--- a/pydm/tests/widgets/test_related_display_button.py
+++ b/pydm/tests/widgets/test_related_display_button.py
@@ -66,11 +66,22 @@ def test_press_with_filename(qtbot):
     test_icon = style.standardIcon(style.SP_DesktopIcon)
     test_icon_image = test_icon.pixmap(DEFAULT_ICON_SIZE).toImage()
 
-    button.standardIcon = "SP_DesktopIcon"
+    button.PyDMIcon = "SP_DesktopIcon"
     shell_cmd_icon = button.icon()
     shell_cmd_icon_image = shell_cmd_icon.pixmap(DEFAULT_ICON_SIZE).toImage()
 
     assert test_icon_image == shell_cmd_icon_image
+
+    # verify that "Font Awesome" icons can be set through our custom property
+    icon_f = IconFont()
+    test_icon = icon_f.icon("eye-slash", color=None)
+    test_icon_image = test_icon.pixmap(DEFAULT_ICON_SIZE).toImage()
+
+    button.PyDMIcon = "eye-slash"
+    button_icon = button.icon()
+    push_btn_icon_image = button_icon.pixmap(DEFAULT_ICON_SIZE).toImage()
+
+    assert test_icon_image == push_btn_icon_image
 
     def check_title():
         assert "Form" in QApplication.instance().main_window.windowTitle()

--- a/pydm/tests/widgets/test_related_display_button.py
+++ b/pydm/tests/widgets/test_related_display_button.py
@@ -1,10 +1,11 @@
 import os
 import pytest
 import sys
-from qtpy.QtCore import Qt
+from qtpy.QtCore import Qt, QSize
 from qtpy.QtWidgets import QApplication
 from ...utilities.stylesheet import global_style
 from ...widgets.related_display_button import PyDMRelatedDisplayButton
+from ...utilities import IconFont
 
 test_ui_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "../test_data", "test.ui")
 test_ui_path_with_stylesheet = os.path.join(
@@ -47,6 +48,29 @@ def test_press_with_filename(qtbot):
     qtbot.addWidget(button)
     button._rebuild_menu()
     qtbot.mouseRelease(button, Qt.LeftButton)
+
+    # verify default icon is set as expected
+    DEFAULT_ICON_NAME = "file"
+    DEFAULT_ICON_SIZE = QSize(16, 16)
+
+    default_icon = IconFont().icon(DEFAULT_ICON_NAME)
+
+    default_icon_pixmap = default_icon.pixmap(DEFAULT_ICON_SIZE)
+    related_display_button_icon_pixmap = button.icon().pixmap(DEFAULT_ICON_SIZE)
+
+    assert related_display_button_icon_pixmap.toImage() == default_icon_pixmap.toImage()
+    assert button.cursor().pixmap().toImage() == default_icon_pixmap.toImage()
+
+    # verify that qt standard icons can be set through our custom property
+    style = button.style()
+    test_icon = style.standardIcon(style.SP_DesktopIcon)
+    test_icon_image = test_icon.pixmap(DEFAULT_ICON_SIZE).toImage()
+
+    button.standardIcon = "SP_DesktopIcon"
+    shell_cmd_icon = button.icon()
+    shell_cmd_icon_image = shell_cmd_icon.pixmap(DEFAULT_ICON_SIZE).toImage()
+
+    assert test_icon_image == shell_cmd_icon_image
 
     def check_title():
         assert "Form" in QApplication.instance().main_window.windowTitle()

--- a/pydm/tests/widgets/test_shell_command.py
+++ b/pydm/tests/widgets/test_shell_command.py
@@ -78,7 +78,18 @@ def test_construct(qtbot, command, title):
     test_icon = style.standardIcon(style.SP_DesktopIcon)
     test_icon_image = test_icon.pixmap(DEFAULT_ICON_SIZE).toImage()
 
-    pydm_shell_command.standardIcon = "SP_DesktopIcon"
+    pydm_shell_command.PyDMIcon = "SP_DesktopIcon"
+    shell_cmd_icon = pydm_shell_command.icon()
+    shell_cmd_icon_image = shell_cmd_icon.pixmap(DEFAULT_ICON_SIZE).toImage()
+
+    assert test_icon_image == shell_cmd_icon_image
+
+    # verify that "Font Awesome" icons can be set through our custom property
+    icon_f = IconFont()
+    test_icon = icon_f.icon("eye-slash", color=None)
+    test_icon_image = test_icon.pixmap(DEFAULT_ICON_SIZE).toImage()
+
+    pydm_shell_command.PyDMIcon = "eye-slash"
     shell_cmd_icon = pydm_shell_command.icon()
     shell_cmd_icon_image = shell_cmd_icon.pixmap(DEFAULT_ICON_SIZE).toImage()
 

--- a/pydm/tests/widgets/test_shell_command.py
+++ b/pydm/tests/widgets/test_shell_command.py
@@ -73,6 +73,17 @@ def test_construct(qtbot, command, title):
     assert shell_cmd_icon_pixmap.toImage() == default_icon_pixmap.toImage()
     assert pydm_shell_command.cursor().pixmap().toImage() == default_icon_pixmap.toImage()
 
+    # verify that qt standard icons can be set through our custom property
+    style = pydm_shell_command.style()
+    test_icon = style.standardIcon(style.SP_DesktopIcon)
+    test_icon_image = test_icon.pixmap(DEFAULT_ICON_SIZE).toImage()
+
+    pydm_shell_command.standardIcon = "SP_DesktopIcon"
+    shell_cmd_icon = pydm_shell_command.icon()
+    shell_cmd_icon_image = shell_cmd_icon.pixmap(DEFAULT_ICON_SIZE).toImage()
+
+    assert test_icon_image == shell_cmd_icon_image
+
 
 def test_deprecated_command_property_with_no_commands(qtbot):
     pydm_shell_command = PyDMShellCommand()

--- a/pydm/widgets/pushbutton.py
+++ b/pydm/widgets/pushbutton.py
@@ -80,7 +80,8 @@ class PyDMPushButton(QPushButton, PyDMWritableWidget):
     @Property(str)
     def standardIcon(self) -> str:
         """
-        Message to be displayed at the Confirmation dialog.
+        Name of icon to be set from Qt provided standard icons.
+        See "enum QStyle::StandardPixmap" in Qt's QStyle documentation for full list of usable icons.
 
         Returns
         -------
@@ -91,7 +92,8 @@ class PyDMPushButton(QPushButton, PyDMWritableWidget):
     @standardIcon.setter
     def standardIcon(self, value: str) -> None:
         """
-        Message to be displayed at the Confirmation dialog.
+        Name of icon to be set from Qt provided standard icons.
+        See "enum QStyle::StandardPixmap" in Qt's QStyle documentation for full list of usable icons.
 
         Parameters
         ----------

--- a/pydm/widgets/pushbutton.py
+++ b/pydm/widgets/pushbutton.py
@@ -86,7 +86,6 @@ class PyDMPushButton(QPushButton, PyDMWritableWidget):
         -------
         str
         """
-        print("standardIcon getter: ", self._standard_icon_name)
         return self._standard_icon_name
 
     @standardIcon.setter
@@ -98,12 +97,10 @@ class PyDMPushButton(QPushButton, PyDMWritableWidget):
         ----------
         value : str
         """
-        print("standardIcon setter: ", self._standard_icon_name)
         if self._standard_icon_name != value:
             self._standard_icon_name = value
             icon = getattr(QStyle, value, None)
             if icon:
-                print("setting icon")
                 self.setIcon(self.style().standardIcon(icon))
 
     @Property(bool)

--- a/pydm/widgets/pushbutton.py
+++ b/pydm/widgets/pushbutton.py
@@ -86,7 +86,7 @@ class PyDMPushButton(QPushButton, PyDMWritableWidget):
         -------
         str
         """
-        print ("standardIcon getter: ", self._standard_icon_name)
+        print("standardIcon getter: ", self._standard_icon_name)
         return self._standard_icon_name
 
     @standardIcon.setter
@@ -98,12 +98,12 @@ class PyDMPushButton(QPushButton, PyDMWritableWidget):
         ----------
         value : str
         """
-        print ("standardIcon setter: ", self._standard_icon_name)
+        print("standardIcon setter: ", self._standard_icon_name)
         if self._standard_icon_name != value:
-            self._standard_icon_name  = value
+            self._standard_icon_name = value
             icon = getattr(QStyle, value, None)
             if icon:
-                print ("setting icon")
+                print("setting icon")
                 self.setIcon(self.style().standardIcon(icon))
 
     @Property(bool)

--- a/pydm/widgets/pushbutton.py
+++ b/pydm/widgets/pushbutton.py
@@ -4,7 +4,7 @@ from qtpy.QtGui import QColor
 from qtpy.QtWidgets import QPushButton, QMessageBox, QInputDialog, QLineEdit, QStyle
 from qtpy.QtCore import Slot, Property
 from .base import PyDMWritableWidget
-from pydm.utilities import iconfont
+from ..utilities import IconFont
 import logging
 
 logger = logging.getLogger(__name__)
@@ -112,7 +112,7 @@ class PyDMPushButton(QPushButton, PyDMWritableWidget):
         # We don't know if user is trying to use a standard icon or an icon from "Font Awesome",
         # so 1st try to create a Font Awesome one, which hits exception if icon name is not valid.
         try:
-            icon_f = iconfont.IconFont()
+            icon_f = IconFont()
             i = icon_f.icon(value, color=self._pydm_icon_color)
             self.setIcon(i)
         except Exception:
@@ -144,7 +144,7 @@ class PyDMPushButton(QPushButton, PyDMWritableWidget):
             self._pydm_icon_color = state_color
             # apply the new color
             try:
-                icon_f = iconfont.IconFont()
+                icon_f = IconFont()
                 i = icon_f.icon(self._pydm_icon_name, color=self._pydm_icon_color)
                 self.setIcon(i)
             except Exception:

--- a/pydm/widgets/pushbutton.py
+++ b/pydm/widgets/pushbutton.py
@@ -1,6 +1,6 @@
 import hashlib
 
-from qtpy.QtWidgets import QPushButton, QMessageBox, QInputDialog, QLineEdit
+from qtpy.QtWidgets import QPushButton, QMessageBox, QInputDialog, QLineEdit, QStyle
 from qtpy.QtCore import Slot, Property
 from .base import PyDMWritableWidget
 
@@ -71,6 +71,40 @@ class PyDMPushButton(QPushButton, PyDMWritableWidget):
         self._write_when_release = False
         self._released = False
         self.clicked.connect(self.sendValue)
+
+        # Standard icons (which come with the qt install, and work cross-platform),
+        # can not be set with a widget's "icon" property in designer, only in python.
+        # so we provide our own propery to specify standard icons and set them with python in the prop's setter.
+        self._standard_icon_name = ""
+
+    @Property(str)
+    def standardIcon(self) -> str:
+        """
+        Message to be displayed at the Confirmation dialog.
+
+        Returns
+        -------
+        str
+        """
+        print ("standardIcon getter: ", self._standard_icon_name)
+        return self._standard_icon_name
+
+    @standardIcon.setter
+    def standardIcon(self, value: str) -> None:
+        """
+        Message to be displayed at the Confirmation dialog.
+
+        Parameters
+        ----------
+        value : str
+        """
+        print ("standardIcon setter: ", self._standard_icon_name)
+        if self._standard_icon_name != value:
+            self._standard_icon_name  = value
+            icon = getattr(QStyle, value, None)
+            if icon:
+                print ("setting icon")
+                self.setIcon(self.style().standardIcon(icon))
 
     @Property(bool)
     def passwordProtected(self):
@@ -146,7 +180,7 @@ class PyDMPushButton(QPushButton, PyDMWritableWidget):
     @Property(bool)
     def showConfirmDialog(self):
         """
-        Wether or not to display a confirmation dialog.
+        Whether or not to display a confirmation dialog.
 
         Returns
         -------
@@ -157,7 +191,7 @@ class PyDMPushButton(QPushButton, PyDMWritableWidget):
     @showConfirmDialog.setter
     def showConfirmDialog(self, value):
         """
-        Wether or not to display a confirmation dialog.
+        Whether or not to display a confirmation dialog.
 
         Parameters
         ----------
@@ -482,7 +516,7 @@ class PyDMPushButton(QPushButton, PyDMWritableWidget):
     @Property(bool)
     def writeWhenRelease(self):
         """
-        Wether or not to write releaseValue on release
+        Whether or not to write releaseValue on release
 
         Returns
         -------
@@ -493,7 +527,7 @@ class PyDMPushButton(QPushButton, PyDMWritableWidget):
     @writeWhenRelease.setter
     def writeWhenRelease(self, value):
         """
-        Wether or not to write releaseValue on release
+        Whether or not to write releaseValue on release
 
         Parameters
         ----------

--- a/pydm/widgets/pushbutton.py
+++ b/pydm/widgets/pushbutton.py
@@ -142,8 +142,13 @@ class PyDMPushButton(QPushButton, PyDMWritableWidget):
         """
         if state_color != self._pydm_icon_color:
             self._pydm_icon_color = state_color
-            # call setter to apply new color
-            self.pydmIcon = self._pydm_icon_name
+            # apply the new color
+            try:
+                icon_f = iconfont.IconFont()
+                i = icon_f.icon(self._pydm_icon_name, color=self._pydm_icon_color)
+                self.setIcon(i)
+            except Exception:
+                return
 
     @Property(bool)
     def passwordProtected(self):

--- a/pydm/widgets/related_display_button.py
+++ b/pydm/widgets/related_display_button.py
@@ -161,8 +161,13 @@ class PyDMRelatedDisplayButton(QPushButton, PyDMWidget, new_properties=_relatedD
         """
         if state_color != self._pydm_icon_color:
             self._pydm_icon_color = state_color
-            # call setter to apply new color
-            self.pydmIcon = self._pydm_icon_name
+            # apply the new color
+            try:
+                icon_f = iconfont.IconFont()
+                i = icon_f.icon(self._pydm_icon_name, color=self._pydm_icon_color)
+                self.setIcon(i)
+            except Exception:
+                return
 
     @Property("QStringList")
     def filenames(self) -> List[str]:

--- a/pydm/widgets/related_display_button.py
+++ b/pydm/widgets/related_display_button.py
@@ -13,7 +13,6 @@ from ..utilities.macro import parse_macro_string
 from ..utilities.stylesheet import merge_widget_stylesheet
 from ..display import load_file, ScreenTarget
 from typing import Optional, List
-from pydm.utilities import iconfont
 
 logger = logging.getLogger(__name__)
 
@@ -131,7 +130,7 @@ class PyDMRelatedDisplayButton(QPushButton, PyDMWidget, new_properties=_relatedD
         # We don't know if user is trying to use a standard icon or an icon from "Font Awesome",
         # so 1st try to create a Font Awesome one, which hits exception if icon name is not valid.
         try:
-            icon_f = iconfont.IconFont()
+            icon_f = IconFont()
             i = icon_f.icon(value, color=self._pydm_icon_color)
             self.setIcon(i)
         except Exception:
@@ -163,7 +162,7 @@ class PyDMRelatedDisplayButton(QPushButton, PyDMWidget, new_properties=_relatedD
             self._pydm_icon_color = state_color
             # apply the new color
             try:
-                icon_f = iconfont.IconFont()
+                icon_f = IconFont()
                 i = icon_f.icon(self._pydm_icon_name, color=self._pydm_icon_color)
                 self.setIcon(i)
             except Exception:

--- a/pydm/widgets/related_display_button.py
+++ b/pydm/widgets/related_display_button.py
@@ -99,7 +99,8 @@ class PyDMRelatedDisplayButton(QPushButton, PyDMWidget, new_properties=_relatedD
     @Property(str)
     def standardIcon(self) -> str:
         """
-        Message to be displayed at the Confirmation dialog.
+        Name of icon to be set from Qt provided standard icons.
+        See "enum QStyle::StandardPixmap" in Qt's QStyle documentation for full list of usable icons.
 
         Returns
         -------
@@ -110,7 +111,8 @@ class PyDMRelatedDisplayButton(QPushButton, PyDMWidget, new_properties=_relatedD
     @standardIcon.setter
     def standardIcon(self, value: str) -> None:
         """
-        Message to be displayed at the Confirmation dialog.
+        Name of icon to be set from Qt provided standard icons.
+        See "enum QStyle::StandardPixmap" in Qt's QStyle documentation for full list of usable icons.
 
         Parameters
         ----------

--- a/pydm/widgets/related_display_button.py
+++ b/pydm/widgets/related_display_button.py
@@ -117,7 +117,7 @@ class PyDMRelatedDisplayButton(QPushButton, PyDMWidget, new_properties=_relatedD
         value : str
         """
         if self._standard_icon_name != value:
-            self._standard_icon_name  = value
+            self._standard_icon_name = value
             icon = getattr(QStyle, value, None)
             if icon:
                 self.setIcon(self.style().standardIcon(icon))

--- a/pydm/widgets/related_display_button.py
+++ b/pydm/widgets/related_display_button.py
@@ -5,7 +5,7 @@ import warnings
 from functools import partial
 import hashlib
 from qtpy.QtWidgets import QPushButton, QMenu, QAction, QMessageBox, QInputDialog, QLineEdit, QWidget, QStyle
-from qtpy.QtGui import QCursor, QIcon, QMouseEvent
+from qtpy.QtGui import QCursor, QIcon, QMouseEvent, QColor
 from qtpy.QtCore import Slot, Property, Qt, QSize, QPoint
 from .base import PyDMWidget, only_if_channel_set
 from ..utilities import IconFont, find_file, is_pydm_app
@@ -13,6 +13,7 @@ from ..utilities.macro import parse_macro_string
 from ..utilities.stylesheet import merge_widget_stylesheet
 from ..display import load_file, ScreenTarget
 from typing import Optional, List
+from pydm.utilities import iconfont
 
 logger = logging.getLogger(__name__)
 
@@ -75,9 +76,13 @@ class PyDMRelatedDisplayButton(QPushButton, PyDMWidget, new_properties=_relatedD
         self._follow_symlinks = False
 
         # Standard icons (which come with the qt install, and work cross-platform),
+        # and icons from the "Font Awesome" icon set (https://fontawesome.com/)
         # can not be set with a widget's "icon" property in designer, only in python.
-        # so we provide our own propery to specify standard icons and set them with python in the prop's setter.
-        self._standard_icon_name = ""
+        # so we provide our own property to specify standard icons and set them with python in the prop's setter.
+        self._pydm_icon_name = ""
+        # The color of "Font Awesome" icons can be set,
+        # but standard icons are already colored and can not be set.
+        self._pydm_icon_color = QColor(90, 90, 90)
 
     @only_if_channel_set
     def check_enable_state(self) -> None:
@@ -97,32 +102,67 @@ class PyDMRelatedDisplayButton(QPushButton, PyDMWidget, new_properties=_relatedD
         self.setToolTip(tooltip)
 
     @Property(str)
-    def standardIcon(self) -> str:
+    def PyDMIcon(self) -> str:
         """
-        Name of icon to be set from Qt provided standard icons.
-        See "enum QStyle::StandardPixmap" in Qt's QStyle documentation for full list of usable icons.
+        Name of icon to be set from Qt provided standard icons or from the fontawesome icon-set.
+        See "enum QStyle::StandardPixmap" in Qt's QStyle documentation for full list of usable standard icons.
+        See https://fontawesome.com/icons?d=gallery for list of usable fontawesome icons.
 
         Returns
         -------
         str
         """
-        return self._standard_icon_name
+        return self._pydm_icon_name
 
-    @standardIcon.setter
-    def standardIcon(self, value: str) -> None:
+    @PyDMIcon.setter
+    def PyDMIcon(self, value: str) -> None:
         """
-        Name of icon to be set from Qt provided standard icons.
-        See "enum QStyle::StandardPixmap" in Qt's QStyle documentation for full list of usable icons.
+        Name of icon to be set from Qt provided standard icons or from the "Font Awesome" icon-set.
+        See "enum QStyle::StandardPixmap" in Qt's QStyle documentation for full list of usable standard icons.
+        See https://fontawesome.com/icons?d=gallery for list of usable "Font Awesome" icons.
 
         Parameters
         ----------
         value : str
         """
-        if self._standard_icon_name != value:
-            self._standard_icon_name = value
+        if self._pydm_icon_name == value:
+            return
+
+        # We don't know if user is trying to use a standard icon or an icon from "Font Awesome",
+        # so 1st try to create a Font Awesome one, which hits exception if icon name is not valid.
+        try:
+            icon_f = iconfont.IconFont()
+            i = icon_f.icon(value, color=self._pydm_icon_color)
+            self.setIcon(i)
+        except Exception:
             icon = getattr(QStyle, value, None)
             if icon:
                 self.setIcon(self.style().standardIcon(icon))
+
+        self._pydm_icon_name = value
+
+    @Property(QColor)
+    def PyDMIconColor(self) -> QColor:
+        """
+        The color of the icon (color is only applied if using icon from the "Font Awesome" set)
+        Returns
+        -------
+        QColor
+        """
+        return self._pydm_icon_color
+
+    @PyDMIconColor.setter
+    def PyDMIconColor(self, state_color: QColor) -> None:
+        """
+        The color of the icon (color is only applied if using icon from the "Font Awesome" set)
+        Parameters
+        ----------
+        new_color : QColor
+        """
+        if state_color != self._pydm_icon_color:
+            self._pydm_icon_color = state_color
+            # call setter to apply new color
+            self.pydmIcon = self._pydm_icon_name
 
     @Property("QStringList")
     def filenames(self) -> List[str]:

--- a/pydm/widgets/related_display_button.py
+++ b/pydm/widgets/related_display_button.py
@@ -4,7 +4,7 @@ import logging
 import warnings
 from functools import partial
 import hashlib
-from qtpy.QtWidgets import QPushButton, QMenu, QAction, QMessageBox, QInputDialog, QLineEdit, QWidget
+from qtpy.QtWidgets import QPushButton, QMenu, QAction, QMessageBox, QInputDialog, QLineEdit, QWidget, QStyle
 from qtpy.QtGui import QCursor, QIcon, QMouseEvent
 from qtpy.QtCore import Slot, Property, Qt, QSize, QPoint
 from .base import PyDMWidget, only_if_channel_set
@@ -74,6 +74,11 @@ class PyDMRelatedDisplayButton(QPushButton, PyDMWidget, new_properties=_relatedD
 
         self._follow_symlinks = False
 
+        # Standard icons (which come with the qt install, and work cross-platform),
+        # can not be set with a widget's "icon" property in designer, only in python.
+        # so we provide our own propery to specify standard icons and set them with python in the prop's setter.
+        self._standard_icon_name = ""
+
     @only_if_channel_set
     def check_enable_state(self) -> None:
         """
@@ -90,6 +95,32 @@ class PyDMRelatedDisplayButton(QPushButton, PyDMWidget, new_properties=_relatedD
             tooltip += self.get_address()
 
         self.setToolTip(tooltip)
+
+    @Property(str)
+    def standardIcon(self) -> str:
+        """
+        Message to be displayed at the Confirmation dialog.
+
+        Returns
+        -------
+        str
+        """
+        return self._standard_icon_name
+
+    @standardIcon.setter
+    def standardIcon(self, value: str) -> None:
+        """
+        Message to be displayed at the Confirmation dialog.
+
+        Parameters
+        ----------
+        value : str
+        """
+        if self._standard_icon_name != value:
+            self._standard_icon_name  = value
+            icon = getattr(QStyle, value, None)
+            if icon:
+                self.setIcon(self.style().standardIcon(icon))
 
     @Property("QStringList")
     def filenames(self) -> List[str]:

--- a/pydm/widgets/shell_command.py
+++ b/pydm/widgets/shell_command.py
@@ -7,7 +7,7 @@ import logging
 import warnings
 import hashlib
 from ast import literal_eval
-from qtpy.QtWidgets import QPushButton, QMenu, QMessageBox, QInputDialog, QLineEdit, QWidget
+from qtpy.QtWidgets import QPushButton, QMenu, QMessageBox, QInputDialog, QLineEdit, QWidget, QStyle
 from qtpy.QtGui import QCursor, QIcon, QMouseEvent
 from qtpy.QtCore import Property, QSize, Qt, QTimer
 from .base import PyDMWidget, only_if_channel_set
@@ -76,6 +76,11 @@ class PyDMShellCommand(QPushButton, PyDMWidget):
         self._show_confirm_dialog = False
         self._confirm_message = PyDMShellCommand.DEFAULT_CONFIRM_MESSAGE
 
+        # Standard icons (which come with the qt install, and work cross-platform),
+        # can not be set with a widget's "icon" property in designer, only in python.
+        # so we provide our own propery to specify standard icons and set them with python in the prop's setter.
+        self._standard_icon_name = ""
+
     def confirmDialog(self) -> bool:
         """
         Show the confirmation dialog with the proper message in case
@@ -102,10 +107,37 @@ class PyDMShellCommand(QPushButton, PyDMWidget):
 
         return True
 
+    @Property(str)
+    def standardIcon(self) -> str:
+        """
+        Message to be displayed at the Confirmation dialog.
+
+        Returns
+        -------
+        str
+        """
+        return self._standard_icon_name
+
+    @standardIcon.setter
+    def standardIcon(self, value: str) -> None:
+        """
+        Message to be displayed at the Confirmation dialog.
+
+        Parameters
+        ----------
+        value : str
+        """
+        if self._standard_icon_name != value:
+            self._standard_icon_name  = value
+            icon = getattr(QStyle, value, None)
+            if icon:
+                self.setIcon(self.style().standardIcon(icon))
+
+
     @Property(bool)
     def showConfirmDialog(self) -> bool:
         """
-        Wether or not to display a confirmation dialog.
+        Whether or not to display a confirmation dialog.
 
         Returns
         -------
@@ -116,7 +148,7 @@ class PyDMShellCommand(QPushButton, PyDMWidget):
     @showConfirmDialog.setter
     def showConfirmDialog(self, value: bool) -> None:
         """
-        Wether or not to display a confirmation dialog.
+        Whether or not to display a confirmation dialog.
 
         Parameters
         ----------

--- a/pydm/widgets/shell_command.py
+++ b/pydm/widgets/shell_command.py
@@ -8,11 +8,12 @@ import warnings
 import hashlib
 from ast import literal_eval
 from qtpy.QtWidgets import QPushButton, QMenu, QMessageBox, QInputDialog, QLineEdit, QWidget, QStyle
-from qtpy.QtGui import QCursor, QIcon, QMouseEvent
+from qtpy.QtGui import QCursor, QIcon, QMouseEvent, QColor
 from qtpy.QtCore import Property, QSize, Qt, QTimer
 from .base import PyDMWidget, only_if_channel_set
 from ..utilities import IconFont
 from typing import Optional, Union, List
+from pydm.utilities import iconfont
 
 logger = logging.getLogger(__name__)
 
@@ -77,9 +78,13 @@ class PyDMShellCommand(QPushButton, PyDMWidget):
         self._confirm_message = PyDMShellCommand.DEFAULT_CONFIRM_MESSAGE
 
         # Standard icons (which come with the qt install, and work cross-platform),
+        # and icons from the "Font Awesome" icon set (https://fontawesome.com/)
         # can not be set with a widget's "icon" property in designer, only in python.
-        # so we provide our own propery to specify standard icons and set them with python in the prop's setter.
-        self._standard_icon_name = ""
+        # so we provide our own property to specify standard icons and set them with python in the prop's setter.
+        self._pydm_icon_name = ""
+        # The color of "Font Awesome" icons can be set,
+        # but standard icons are already colored and can not be set.
+        self._pydm_icon_color = QColor(90, 90, 90)
 
     def confirmDialog(self) -> bool:
         """
@@ -108,32 +113,67 @@ class PyDMShellCommand(QPushButton, PyDMWidget):
         return True
 
     @Property(str)
-    def standardIcon(self) -> str:
+    def PyDMIcon(self) -> str:
         """
-        Name of icon to be set from Qt provided standard icons.
-        See "enum QStyle::StandardPixmap" in Qt's QStyle documentation for full list of usable icons.
+        Name of icon to be set from Qt provided standard icons or from the fontawesome icon-set.
+        See "enum QStyle::StandardPixmap" in Qt's QStyle documentation for full list of usable standard icons.
+        See https://fontawesome.com/icons?d=gallery for list of usable fontawesome icons.
 
         Returns
         -------
         str
         """
-        return self._standard_icon_name
+        return self._pydm_icon_name
 
-    @standardIcon.setter
-    def standardIcon(self, value: str) -> None:
+    @PyDMIcon.setter
+    def PyDMIcon(self, value: str) -> None:
         """
-        Name of icon to be set from Qt provided standard icons.
-        See "enum QStyle::StandardPixmap" in Qt's QStyle documentation for full list of usable icons.
+        Name of icon to be set from Qt provided standard icons or from the "Font Awesome" icon-set.
+        See "enum QStyle::StandardPixmap" in Qt's QStyle documentation for full list of usable standard icons.
+        See https://fontawesome.com/icons?d=gallery for list of usable "Font Awesome" icons.
 
         Parameters
         ----------
         value : str
         """
-        if self._standard_icon_name != value:
-            self._standard_icon_name = value
+        if self._pydm_icon_name == value:
+            return
+
+        # We don't know if user is trying to use a standard icon or an icon from "Font Awesome",
+        # so 1st try to create a Font Awesome one, which hits exception if icon name is not valid.
+        try:
+            icon_f = iconfont.IconFont()
+            i = icon_f.icon(value, color=self._pydm_icon_color)
+            self.setIcon(i)
+        except Exception:
             icon = getattr(QStyle, value, None)
             if icon:
                 self.setIcon(self.style().standardIcon(icon))
+
+        self._pydm_icon_name = value
+
+    @Property(QColor)
+    def PyDMIconColor(self) -> QColor:
+        """
+        The color of the icon (color is only applied if using icon from the "Font Awesome" set)
+        Returns
+        -------
+        QColor
+        """
+        return self._pydm_icon_color
+
+    @PyDMIconColor.setter
+    def PyDMIconColor(self, state_color: QColor) -> None:
+        """
+        The color of the icon (color is only applied if using icon from the "Font Awesome" set)
+        Parameters
+        ----------
+        new_color : QColor
+        """
+        if state_color != self._pydm_icon_color:
+            self._pydm_icon_color = state_color
+            # call setter to apply new color
+            self.pydmIcon = self._pydm_icon_name
 
     @Property(bool)
     def showConfirmDialog(self) -> bool:

--- a/pydm/widgets/shell_command.py
+++ b/pydm/widgets/shell_command.py
@@ -110,7 +110,8 @@ class PyDMShellCommand(QPushButton, PyDMWidget):
     @Property(str)
     def standardIcon(self) -> str:
         """
-        Message to be displayed at the Confirmation dialog.
+        Name of icon to be set from Qt provided standard icons.
+        See "enum QStyle::StandardPixmap" in Qt's QStyle documentation for full list of usable icons.
 
         Returns
         -------
@@ -121,7 +122,8 @@ class PyDMShellCommand(QPushButton, PyDMWidget):
     @standardIcon.setter
     def standardIcon(self, value: str) -> None:
         """
-        Message to be displayed at the Confirmation dialog.
+        Name of icon to be set from Qt provided standard icons.
+        See "enum QStyle::StandardPixmap" in Qt's QStyle documentation for full list of usable icons.
 
         Parameters
         ----------

--- a/pydm/widgets/shell_command.py
+++ b/pydm/widgets/shell_command.py
@@ -128,11 +128,10 @@ class PyDMShellCommand(QPushButton, PyDMWidget):
         value : str
         """
         if self._standard_icon_name != value:
-            self._standard_icon_name  = value
+            self._standard_icon_name = value
             icon = getattr(QStyle, value, None)
             if icon:
                 self.setIcon(self.style().standardIcon(icon))
-
 
     @Property(bool)
     def showConfirmDialog(self) -> bool:

--- a/pydm/widgets/shell_command.py
+++ b/pydm/widgets/shell_command.py
@@ -13,7 +13,6 @@ from qtpy.QtCore import Property, QSize, Qt, QTimer
 from .base import PyDMWidget, only_if_channel_set
 from ..utilities import IconFont
 from typing import Optional, Union, List
-from pydm.utilities import iconfont
 
 logger = logging.getLogger(__name__)
 
@@ -142,7 +141,7 @@ class PyDMShellCommand(QPushButton, PyDMWidget):
         # We don't know if user is trying to use a standard icon or an icon from "Font Awesome",
         # so 1st try to create a Font Awesome one, which hits exception if icon name is not valid.
         try:
-            icon_f = iconfont.IconFont()
+            icon_f = IconFont()
             i = icon_f.icon(value, color=self._pydm_icon_color)
             self.setIcon(i)
         except Exception:
@@ -174,7 +173,7 @@ class PyDMShellCommand(QPushButton, PyDMWidget):
             self._pydm_icon_color = state_color
             # apply the new color
             try:
-                icon_f = iconfont.IconFont()
+                icon_f = IconFont()
                 i = icon_f.icon(self._pydm_icon_name, color=self._pydm_icon_color)
                 self.setIcon(i)
             except Exception:

--- a/pydm/widgets/shell_command.py
+++ b/pydm/widgets/shell_command.py
@@ -172,8 +172,13 @@ class PyDMShellCommand(QPushButton, PyDMWidget):
         """
         if state_color != self._pydm_icon_color:
             self._pydm_icon_color = state_color
-            # call setter to apply new color
-            self.pydmIcon = self._pydm_icon_name
+            # apply the new color
+            try:
+                icon_f = iconfont.IconFont()
+                i = icon_f.icon(self._pydm_icon_name, color=self._pydm_icon_color)
+                self.setIcon(i)
+            except Exception:
+                return
 
     @Property(bool)
     def showConfirmDialog(self) -> bool:

--- a/pydm/widgets/slider.py
+++ b/pydm/widgets/slider.py
@@ -530,7 +530,7 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget):
 
     def set_enable_state(self):
         """
-        Determines wether or not the widget must be enabled or not depending
+        Determines Whether or not the widget must be enabled or not depending
         on the write access, connection state and presence of limits information
         """
         # Even though by documentation disabling parent QFrame (self), should disable internal
@@ -718,7 +718,7 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget):
     @Property(bool)
     def userDefinedLimits(self):
         """
-        Wether or not to use limits defined by the user and not from the
+        Whether or not to use limits defined by the user and not from the
         channel
 
         Returns
@@ -730,7 +730,7 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget):
     @userDefinedLimits.setter
     def userDefinedLimits(self, user_defined_limits):
         """
-        Wether or not to use limits defined by the user and not from the
+        Whether or not to use limits defined by the user and not from the
         channel
 
         Parameters


### PR DESCRIPTION
  allow qt standard icons to be set in designer by exposing a custom property that sets the icon using python inside the property's setter.

this should provide a set of default icons cross-platform, since they ship with qt.