### PR TITLE
Simplify using CurveItem subclasses in Plot subclasses

### DIFF
--- a/pydm/tests/widgets/test_timeplot.py
+++ b/pydm/tests/widgets/test_timeplot.py
@@ -221,6 +221,16 @@ def test_pydmtimeplot_construct(qtbot):
     assert pydm_timeplot._bottom_axis.orientation == "bottom"
 
 
+def test_pydmtimeplot_add_curve(qtbot):
+    pydm_timeplot = PyDMTimePlot()
+    qtbot.addWidget(pydm_timeplot)
+
+    curve_pv = "loc://test:timeplot:pv"
+    pydm_timeplot.addYChannel(curve_pv)
+
+    assert pydm_timeplot.findCurve(curve_pv) is not None
+
+
 @mock.patch("pydm.widgets.timeplot.TimePlotCurveItem.setData")
 @mock.patch("pyqtgraph.BarGraphItem.setOpts")
 def test_redraw_plot(mocked_set_opts, mocked_set_data, qtbot, monkeypatch):

--- a/pydm/widgets/archiver_time_plot.py
+++ b/pydm/widgets/archiver_time_plot.py
@@ -2,7 +2,7 @@ import json
 import time
 import numpy as np
 from collections import OrderedDict
-from typing import List, Optional, Union
+from typing import List, Optional
 from pyqtgraph import DateAxisItem, ErrorBarItem
 from pydm.widgets.channel import PyDMChannel
 from pydm.widgets.timeplot import TimePlotCurveItem
@@ -332,26 +332,9 @@ class PyDMArchiverTimePlot(PyDMTimePlot):
             return DEFAULT_ARCHIVE_BUFFER_SIZE
         return self._curves[0].getArchiveBufferSize()
 
-    def createCurveItem(
-        self,
-        y_channel: str,
-        plot_by_timestamps: bool,
-        name: str,
-        color: Union[QColor, str],
-        yAxisName: str,
-        useArchiveData: bool,
-        **plot_opts
-    ) -> ArchivePlotCurveItem:
+    def createCurveItem(self, *args, **kwargs) -> ArchivePlotCurveItem:
         """Create and return a curve item to be plotted"""
-        curve_item = ArchivePlotCurveItem(
-            y_channel,
-            use_archive_data=useArchiveData,
-            plot_by_timestamps=plot_by_timestamps,
-            name=name,
-            color=color,
-            yAxisName=yAxisName,
-            **plot_opts
-        )
+        curve_item = ArchivePlotCurveItem(*args, **kwargs)
         curve_item.archive_data_received_signal.connect(self.archive_data_received)
         return curve_item
 

--- a/pydm/widgets/eventplot.py
+++ b/pydm/widgets/eventplot.py
@@ -343,7 +343,7 @@ class PyDMEventPlot(BasePlot):
             plot_opts["lineStyle"] = lineStyle
         if lineWidth is not None:
             plot_opts["lineWidth"] = lineWidth
-        curve = EventPlotCurveItem(
+        curve = self.createCurveItem(
             addr=channel,
             y_idx=y_idx,
             x_idx=x_idx,
@@ -358,6 +358,18 @@ class PyDMEventPlot(BasePlot):
         self.index_pairs[(x_idx, y_idx)] = curve
         self.addCurve(curve, curve_color=color, y_axis_name=yAxisName)
         curve.data_changed.connect(self.set_needs_redraw)
+
+    def createCurveItem(self, channel, y_idx, x_idx, name, color, yAxisName, bufferSizeChannelAddress, **plot_opts):
+        return EventPlotCurveItem(
+            addr=channel,
+            y_idx=y_idx,
+            x_idx=x_idx,
+            name=name,
+            color=color,
+            yAxisName=yAxisName,
+            bufferSizeChannelAddress=bufferSizeChannelAddress,
+            **plot_opts
+        )
 
     def removeChannel(self, curve):
         """

--- a/pydm/widgets/eventplot.py
+++ b/pydm/widgets/eventplot.py
@@ -359,17 +359,8 @@ class PyDMEventPlot(BasePlot):
         self.addCurve(curve, curve_color=color, y_axis_name=yAxisName)
         curve.data_changed.connect(self.set_needs_redraw)
 
-    def createCurveItem(self, channel, y_idx, x_idx, name, color, yAxisName, bufferSizeChannelAddress, **plot_opts):
-        return EventPlotCurveItem(
-            addr=channel,
-            y_idx=y_idx,
-            x_idx=x_idx,
-            name=name,
-            color=color,
-            yAxisName=yAxisName,
-            bufferSizeChannelAddress=bufferSizeChannelAddress,
-            **plot_opts
-        )
+    def createCurveItem(self, *args, **kwargs):
+        return EventPlotCurveItem(*args, *kwargs)
 
     def removeChannel(self, curve):
         """

--- a/pydm/widgets/scatterplot.py
+++ b/pydm/widgets/scatterplot.py
@@ -448,16 +448,8 @@ class PyDMScatterPlot(BasePlot):
         self.addCurve(curve, curve_color=color, y_axis_name=yAxisName)
         curve.data_changed.connect(self.set_needs_redraw)
 
-    def createCurveItem(self, y_addr, x_addr, name, color, yAxisName, bufferSizeChannelAddress, **plot_opts):
-        return ScatterPlotCurveItem(
-            y_addr,
-            x_addr,
-            name=name,
-            color=color,
-            yAxisName=yAxisName,
-            bufferSizeChannelAddress=bufferSizeChannelAddress,
-            **plot_opts
-        )
+    def createCurveItem(self, *args, **kwargs):
+        return ScatterPlotCurveItem(*args, **kwargs)
 
     def removeChannel(self, curve):
         """

--- a/pydm/widgets/scatterplot.py
+++ b/pydm/widgets/scatterplot.py
@@ -433,7 +433,7 @@ class PyDMScatterPlot(BasePlot):
             plot_opts["lineWidth"] = lineWidth
         if redraw_mode is not None:
             plot_opts["redraw_mode"] = redraw_mode
-        curve = ScatterPlotCurveItem(
+        curve = self.createCurveItem(
             y_addr=y_channel,
             x_addr=x_channel,
             name=name,
@@ -447,6 +447,17 @@ class PyDMScatterPlot(BasePlot):
         self.channel_pairs[(x_channel, y_channel)] = curve
         self.addCurve(curve, curve_color=color, y_axis_name=yAxisName)
         curve.data_changed.connect(self.set_needs_redraw)
+
+    def createCurveItem(self, y_addr, x_addr, name, color, yAxisName, bufferSizeChannelAddress, **plot_opts):
+        return ScatterPlotCurveItem(
+            y_addr,
+            x_addr,
+            name=name,
+            color=color,
+            yAxisName=yAxisName,
+            bufferSizeChannelAddress=bufferSizeChannelAddress,
+            **plot_opts
+        )
 
     def removeChannel(self, curve):
         """

--- a/pydm/widgets/timeplot.py
+++ b/pydm/widgets/timeplot.py
@@ -519,7 +519,7 @@ class PyDMTimePlot(BasePlot, updateMode):
 
         # Add curve
         new_curve = self.createCurveItem(
-            y_channel=y_channel,
+            channel_address=y_channel,
             plot_by_timestamps=self._plot_by_timestamps,
             plot_style=plot_style,
             name=name,

--- a/pydm/widgets/timeplot.py
+++ b/pydm/widgets/timeplot.py
@@ -547,18 +547,8 @@ class PyDMTimePlot(BasePlot, updateMode):
 
         return new_curve
 
-    def createCurveItem(
-        self, y_channel, plot_by_timestamps, plot_style, name, color, yAxisName, useArchiveData, **plot_opts
-    ):
-        return TimePlotCurveItem(
-            y_channel,
-            plot_by_timestamps=plot_by_timestamps,
-            plot_style=plot_style,
-            name=name,
-            color=color,
-            yAxisName=yAxisName,
-            **plot_opts
-        )
+    def createCurveItem(self, *args, **kwargs):
+        return TimePlotCurveItem(*args, **kwargs)
 
     def removeYChannel(self, curve):
         """

--- a/pydm/widgets/waveformplot.py
+++ b/pydm/widgets/waveformplot.py
@@ -457,10 +457,8 @@ class PyDMWaveformPlot(BasePlot):
             curve.getViewBox().addItem(curve.bar_graph_item)
         curve.data_changed.connect(self.set_needs_redraw)
 
-    def createCurveItem(self, y_addr, x_addr, plot_style, name, color, yAxisName, **plot_opts):
-        return WaveformCurveItem(
-            y_addr, x_addr, plot_style=plot_style, name=name, color=color, yAxisName=yAxisName, **plot_opts
-        )
+    def createCurveItem(self, *args, **kwargs):
+        return WaveformCurveItem(*args, **kwargs)
 
     def removeChannel(self, curve):
         """

--- a/pydm/widgets/waveformplot.py
+++ b/pydm/widgets/waveformplot.py
@@ -436,7 +436,7 @@ class PyDMWaveformPlot(BasePlot):
         if redraw_mode is not None:
             plot_opts["redraw_mode"] = redraw_mode
         self._needs_redraw = False
-        curve = WaveformCurveItem(
+        curve = self.createCurveItem(
             y_addr=y_channel,
             x_addr=x_channel,
             plot_style=plot_style,
@@ -456,6 +456,11 @@ class PyDMWaveformPlot(BasePlot):
             # Must happen after addCurve() so that the view box has been created
             curve.getViewBox().addItem(curve.bar_graph_item)
         curve.data_changed.connect(self.set_needs_redraw)
+
+    def createCurveItem(self, y_addr, x_addr, plot_style, name, color, yAxisName, **plot_opts):
+        return WaveformCurveItem(
+            y_addr, x_addr, plot_style=plot_style, name=name, color=color, yAxisName=yAxisName, **plot_opts
+        )
 
     def removeChannel(self, curve):
         """


### PR DESCRIPTION
While making subclasses for TimePlot and WaveformPlot for my application, I noticed this little inconvenience with non-TimePlot plots. I think it's a good thing to have a factory method such as this in every plot! :slightly_smiling_face:

I kept it as close as possible to the one in TimePlot, so as to not change more stuff than needed, though I figured it may be even better to pass a generic `*args, **kwargs` to the `createCurveItem` functions, so as to not constrain the signature of the CurveItem custom implementations. What do you think?