### PR TITLE
DOC: Add doc page for event plot

### DIFF
--- a/docs/source/widgets/event_plot.rst
+++ b/docs/source/widgets/event_plot.rst
@@ -1,0 +1,7 @@
+#######################
+PyDMEventPlot
+#######################
+
+.. autoclass:: pydm.widgets.eventplot.PyDMEventPlot
+   :members:
+   :show-inheritance:

--- a/docs/source/widgets/index.rst
+++ b/docs/source/widgets/index.rst
@@ -44,6 +44,7 @@ Plot Widgets
    curve_editor.rst
    scatterplot.rst
    timeplot.rst
+   event_plot.rst
    archiver_timeplot.rst
    waveformplot.rst
 


### PR DESCRIPTION
Adding missing doc page for PyDMEventPlot

Now doc page should be present for all the pydm widgets we export:
_(from pydm/widgets/__init__.py)_ 
__all__ = [
    "PyDMChannel",
    "PyDMByteIndicator",
    "PyDMCheckbox",
    "PyDMDrawingLine",
    "PyDMDrawingRectangle",
    "PyDMDrawingTriangle",
    "PyDMDrawingEllipse",
    "PyDMDrawingCircle",
    "PyDMDrawingArc",
    "PyDMDrawingPie",
    "PyDMDrawingChord",
    "PyDMDrawingImage",
    "PyDMDrawingPolyline",
    "PyDMDrawingPolygon",
    "PyDMDrawingIrregularPolygon",
    "PyDMEmbeddedDisplay",
    "PyDMEnumComboBox",
    "PyDMImageView",
    "PyDMLabel",
    "PyDMLineEdit",
    "PyDMPushButton",
    "PyDMRelatedDisplayButton",
    "PyDMShellCommand",
    "PyDMSlider",
    "PyDMSpinbox",
    "PyDMSymbol",
    "PyDMWaveformTable",
    "PyDMScaleIndicator",
    "PyDMTimePlot",
    "PyDMArchiverTimePlot",
    "PyDMWaveformPlot",
    "PyDMScatterPlot",
    "PyDMEventPlot",
    "PyDMTabWidget",
    "PyDMTemplateRepeater",
    "PyDMNTTable",
]