### PR TITLE
ENH: Add a method for pausing/resuming the drawing of an image

### DIFF
--- a/pydm/widgets/image.py
+++ b/pydm/widgets/image.py
@@ -402,6 +402,19 @@ class PyDMImageView(ImageView, PyDMWidget, PyDMColorMap, ReadingOrder):
         logging.debug("ImageView RedrawImage Thread Launched")
         self.thread.start()
 
+    def toggleRedraw(self) -> bool:
+        """
+        Start or stop the thread responsible for drawing the image. Can be called by the user to
+        pause redrawing the image, and resume later if needed.
+
+        Returns
+        -------
+        bool
+            True if the image is being redrawn on a timer, false otherwise
+        """
+        self.redraw_timer.stop() if self.redraw_timer.isActive() else self.redraw_timer.start()
+        return self.redraw_timer.isActive()
+
     @Slot(list)
     def __updateDisplay(self, data):
         logging.debug("ImageView Update Display with new image")


### PR DESCRIPTION
### Context

A request from slack that it would be nice to have a way to pause drawing updates to the image in the `PyDMImageView` widget. This PR adds a simple method for doing that, same as is done for pausing plotting updates in `BasePlot`.

### Testing

Verified functionality with an example like this

```
from os import path
from pydm import Display
from qtpy.QtWidgets import QVBoxLayout, QPushButton

class ImageExample(Display):

  def __init__(self):
    super().__init__()

    self.my_layout = QVBoxLayout(self)

    self.button = QPushButton()
    self.button.clicked.connect(self.ui.PyDMImageView.toggleRedraw)

    self.my_layout.addWidget(self.button)

  def ui_filename(self):
    return 'image.ui'

  def ui_filepath(self):
    return path.join(path.dirname(path.realpath(__file__)), self.ui_filename())
```