### PR TITLE
Slight changes to Calc Plugin

### DIFF
--- a/pydm/data_plugins/local_plugin.py
+++ b/pydm/data_plugins/local_plugin.py
@@ -450,3 +450,4 @@ class UrlToPython:
                 raise ValueError("error in local data plugin input")
 
         return config, name, address
+    


### PR DESCRIPTION
- Added an optional reimplementation of UrlToPython class methods so that it is consistent with the local plugin's implementation. (Reimplemented code is commented out).
- Tested the issue https://github.com/slaclab/pydm/issues/1050 and it appears that the calc plugin CAN be reused after it is defined. (However, further testing and investigation into the specific edge case is needed)
