### PR TITLE
Fix event plot curve creation

### DIFF
--- a/examples/eventplot/eventplot.ui
+++ b/examples/eventplot/eventplot.ui
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <widget class="PyDMEventPlot" name="PyDMEventPlot">
+   <property name="geometry">
+    <rect>
+     <x>20</x>
+     <y>10</y>
+     <width>341</width>
+     <height>271</height>
+    </rect>
+   </property>
+   <property name="toolTip">
+    <string/>
+   </property>
+   <property name="yAxes">
+    <stringlist>
+     <string>{&quot;name&quot;: &quot;Axis 1&quot;, &quot;orientation&quot;: &quot;left&quot;, &quot;label&quot;: null, &quot;minRange&quot;: -1.0, &quot;maxRange&quot;: 1.0, &quot;autoRange&quot;: true, &quot;logMode&quot;: false}</string>
+    </stringlist>
+   </property>
+   <property name="curves">
+    <stringlist>
+     <string>{&quot;channel&quot;: &quot;ca://MTEST:Waveform&quot;, &quot;y_idx&quot;: &quot;1&quot;, &quot;x_idx&quot;: &quot;2&quot;, &quot;name&quot;: &quot;&quot;, &quot;color&quot;: &quot;white&quot;, &quot;lineStyle&quot;: 2, &quot;lineWidth&quot;: 1, &quot;symbol&quot;: &quot;o&quot;, &quot;symbolSize&quot;: 15, &quot;yAxisName&quot;: &quot;Axis 1&quot;, &quot;barWidth&quot;: null, &quot;upperThreshold&quot;: null, &quot;lowerThreshold&quot;: null, &quot;thresholdColor&quot;: &quot;white&quot;, &quot;buffer_size&quot;: 2, &quot;bufferSizeChannelAddress&quot;: null}</string>
+     <string>{&quot;channel&quot;: &quot;ca://MTEST:Waveform&quot;, &quot;y_idx&quot;: &quot;3&quot;, &quot;x_idx&quot;: &quot;3&quot;, &quot;name&quot;: &quot;&quot;, &quot;color&quot;: &quot;red&quot;, &quot;lineStyle&quot;: 2, &quot;lineWidth&quot;: 1, &quot;symbol&quot;: &quot;star&quot;, &quot;symbolSize&quot;: 15, &quot;yAxisName&quot;: &quot;Axis 1&quot;, &quot;barWidth&quot;: null, &quot;upperThreshold&quot;: null, &quot;lowerThreshold&quot;: null, &quot;thresholdColor&quot;: &quot;white&quot;, &quot;buffer_size&quot;: 2, &quot;bufferSizeChannelAddress&quot;: null}</string>
+    </stringlist>
+   </property>
+  </widget>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>PyDMEventPlot</class>
+   <extends>QGraphicsView</extends>
+   <header>pydm.widgets.eventplot</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/pydm/tests/conftest.py
+++ b/pydm/tests/conftest.py
@@ -126,6 +126,10 @@ def qapp(qapp_args):
     -------
     An instance of PyDMApplication.
     """
+    # Don't pass along the default app name we get from pytest-qt otherwise PyDM will misinterpret it as a ui file name
+    if "pytest-qt-qapp" == qapp_args[0]:
+        qapp_args.remove("pytest-qt-qapp")
+
     yield PyDMApplication(use_main_window=False, *qapp_args)
 
 

--- a/pydm/tests/widgets/test_eventplot.py
+++ b/pydm/tests/widgets/test_eventplot.py
@@ -2,7 +2,7 @@ from ...widgets.eventplot import PyDMEventPlot
 
 
 def test_add_channel(qtbot):
-    """ A quick check to ensure adding a channel to an event plot works as expected """
+    """A quick check to ensure adding a channel to an event plot works as expected"""
     event_plot = PyDMEventPlot()
     qtbot.addWidget(event_plot)
 

--- a/pydm/tests/widgets/test_eventplot.py
+++ b/pydm/tests/widgets/test_eventplot.py
@@ -1,0 +1,12 @@
+from ...widgets.eventplot import PyDMEventPlot
+
+
+def test_add_channel(qtbot):
+    """ A quick check to ensure adding a channel to an event plot works as expected """
+    event_plot = PyDMEventPlot()
+    qtbot.addWidget(event_plot)
+
+    curve = "TEST:EVENT:PLOT"
+    event_plot.addChannel(curve)
+
+    assert event_plot.curveAtIndex(0).channel.address == "TEST:EVENT:PLOT"

--- a/pydm/tests/widgets/test_related_display_button.py
+++ b/pydm/tests/widgets/test_related_display_button.py
@@ -1,6 +1,7 @@
 import os
 import pytest
 import sys
+import warnings
 from qtpy.QtCore import Qt, QSize
 from qtpy.QtWidgets import QApplication
 from ...utilities.stylesheet import global_style
@@ -24,7 +25,7 @@ def test_old_display_filename_property(qtbot):
     main_window.setWindowTitle("Related Display Button Test")
     qtbot.addWidget(main_window)
     button = PyDMRelatedDisplayButton(parent=main_window)
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
         button.displayFilename = test_ui_path
     assert len(record) >= 1
     assert button.filenames[0] == test_ui_path

--- a/pydm/widgets/eventplot.py
+++ b/pydm/widgets/eventplot.py
@@ -378,7 +378,6 @@ class PyDMEventPlot(BasePlot):
         Remove a curve from the plot, given an index
         for a curve.
 
-
         Parameters
         ----------
         index: int

--- a/pydm/widgets/eventplot.py
+++ b/pydm/widgets/eventplot.py
@@ -360,7 +360,7 @@ class PyDMEventPlot(BasePlot):
         curve.data_changed.connect(self.set_needs_redraw)
 
     def createCurveItem(self, *args, **kwargs):
-        return EventPlotCurveItem(*args, *kwargs)
+        return EventPlotCurveItem(*args, **kwargs)
 
     def removeChannel(self, curve):
         """
@@ -377,6 +377,7 @@ class PyDMEventPlot(BasePlot):
         """
         Remove a curve from the plot, given an index
         for a curve.
+
 
         Parameters
         ----------


### PR DESCRIPTION
Just adds the second '*' to the keyword arguments so they are handled properly. Added simple test case to cover this, as well as an example event plot that can be run.

Also includes a couple minor test updates to make the test suite compatible with pytest 8.0 and pytest-qt 4.3+

To reproduce can run the new test or example without the change to `eventplot.py` and see it fail