### PR TITLE
ENH: Archiver Timeplot address setters

### DIFF
--- a/pydm/widgets/archiver_time_plot.py
+++ b/pydm/widgets/archiver_time_plot.py
@@ -65,7 +65,11 @@ class ArchivePlotCurveItem(TimePlotCurveItem):
         dic_.update(super(ArchivePlotCurveItem, self).to_dict())
         return dic_
 
-    @TimePlotCurveItem.address.setter
+    @property
+    def address(self):
+        return super().address
+        
+    @address.setter
     def address(self, new_address: str) -> None:
         """Creates the channel for the input address for communicating with the archiver appliance plugin."""
         TimePlotCurveItem.address.__set__(self, new_address)

--- a/pydm/widgets/archiver_time_plot.py
+++ b/pydm/widgets/archiver_time_plot.py
@@ -4,6 +4,7 @@ import numpy as np
 from collections import OrderedDict
 from typing import List, Optional
 from pyqtgraph import DateAxisItem, ErrorBarItem
+from pydm.utilities import remove_protocol
 from pydm.widgets.channel import PyDMChannel
 from pydm.widgets.timeplot import TimePlotCurveItem
 from pydm.widgets import PyDMTimePlot
@@ -73,14 +74,8 @@ class ArchivePlotCurveItem(TimePlotCurveItem):
         elif self.archive_channel and new_address == self.archive_channel.address:
             return
 
-        archiver_prefix = "archiver://pv="
-        if new_address.startswith("ca://"):
-            archive_address = new_address.replace("ca://", archiver_prefix, 1)
-        elif new_address.startswith("pva://"):
-            archive_address = new_address.replace("pva://", archiver_prefix, 1)
-        else:
-            archive_address = archiver_prefix + new_address
-
+        # Prepare new address to use the archiver plugin and create the new channel
+        archive_address = "archiver://pv=" + remove_protocol(new_address)
         self.archive_channel = PyDMChannel(
             address=archive_address, value_slot=self.receiveArchiveData, value_signal=self.archive_data_request_signal
         )

--- a/pydm/widgets/archiver_time_plot.py
+++ b/pydm/widgets/archiver_time_plot.py
@@ -41,7 +41,7 @@ class ArchivePlotCurveItem(TimePlotCurveItem):
     archive_data_received_signal = Signal()
 
     def __init__(self, channel_address: Optional[str] = None, use_archive_data: bool = True, **kws):
-        super(ArchivePlotCurveItem, self).__init__(channel_address, **kws)
+        super(ArchivePlotCurveItem, self).__init__(**kws)
         self.use_archive_data = use_archive_data
         self.archive_channel = None
         self.archive_points_accumulated = 0
@@ -52,6 +52,8 @@ class ArchivePlotCurveItem(TimePlotCurveItem):
         # the full range of values retrieved
         self.error_bar_item = ErrorBarItem()
         self.error_bar_needs_set = True
+
+        self.address = channel_address
 
     def to_dict(self) -> OrderedDict:
         """Returns an OrderedDict representation with values for all properties needed to recreate this curve."""
@@ -81,8 +83,9 @@ class ArchivePlotCurveItem(TimePlotCurveItem):
         )
 
         # Clear the archive data of the previous channel and redraw the curve
-        self.initializeArchiveBuffer()
-        self.redrawCurve()
+        if self.archive_points_accumulated:
+            self.initializeArchiveBuffer()
+            self.redrawCurve()
 
     @Slot(np.ndarray)
     def receiveArchiveData(self, data: np.ndarray) -> None:

--- a/pydm/widgets/archiver_time_plot.py
+++ b/pydm/widgets/archiver_time_plot.py
@@ -85,6 +85,10 @@ class ArchivePlotCurveItem(TimePlotCurveItem):
             address=archive_address, value_slot=self.receiveArchiveData, value_signal=self.archive_data_request_signal
         )
 
+        # Clear the archive data of the previous channel and redraw the curve
+        self.initializeArchiveBuffer()
+        self.redrawCurve()
+
     @Slot(np.ndarray)
     def receiveArchiveData(self, data: np.ndarray) -> None:
         """Receive data from archiver appliance and place it into the archive data buffer.

--- a/pydm/widgets/archiver_time_plot.py
+++ b/pydm/widgets/archiver_time_plot.py
@@ -68,7 +68,7 @@ class ArchivePlotCurveItem(TimePlotCurveItem):
     @property
     def address(self):
         return super().address
-        
+
     @address.setter
     def address(self, new_address: str) -> None:
         """Creates the channel for the input address for communicating with the archiver appliance plugin."""

--- a/pydm/widgets/timeplot.py
+++ b/pydm/widgets/timeplot.py
@@ -115,10 +115,14 @@ class TimePlotCurveItem(BasePlotCurveItem):
         return self.channel.address
 
     @address.setter
-    def address(self, new_address):
-        if new_address is None or len(str(new_address)) < 1:
+    def address(self, new_address: str):
+        """Creates the channel for the input address for communicating with the address' plugin."""
+        if not new_address:
             self.channel = None
             return
+        elif self.channel and new_address == self.channel.address:
+            return
+
         self.channel = PyDMChannel(
             address=new_address, connection_slot=self.connectionStateChanged, value_slot=self.receiveNewValue
         )

--- a/pydm/widgets/timeplot.py
+++ b/pydm/widgets/timeplot.py
@@ -128,8 +128,9 @@ class TimePlotCurveItem(BasePlotCurveItem):
         )
 
         # Clear the data from the previous channel and redraw the curve
-        self.initialize_buffer()
-        self.redrawCurve()
+        if self.points_accumulated:
+            self.initialize_buffer()
+            self.redrawCurve()
 
     @property
     def plotByTimeStamps(self):

--- a/pydm/widgets/timeplot.py
+++ b/pydm/widgets/timeplot.py
@@ -127,6 +127,10 @@ class TimePlotCurveItem(BasePlotCurveItem):
             address=new_address, connection_slot=self.connectionStateChanged, value_slot=self.receiveNewValue
         )
 
+        # Clear the data from the previous channel and redraw the curve
+        self.initialize_buffer()
+        self.redrawCurve()
+
     @property
     def plotByTimeStamps(self):
         return self._plot_by_timestamps


### PR DESCRIPTION
Made changes to the address setters for ArchivePlotCurveItem and TimePlotCurveItem classes:

1. Archive curve object now has an address setter that replaces the function setArchiveChannel. The setter calls the TimePlotCurveItem address setter, then sets the new address as the archive channel. This results in the live and archive channels always being tied to the same address.
2. Both address setters now also check that the new address is different from the current address. If they're the same, the function returns.
3. Changed the way the ArchivePlotCurveItem address setter replaces the address's protocol. Now the pydm utility is used.
4. The TimePlotCurveItem address setter clears all live data tied to the previous channel. Similarly, the ArchivePlotCurveItem removes all archived data for the previous channel.