### PR TITLE
ENH: Archived Data Mode for the Archiver Time Plot Widget

### DIFF
--- a/examples/archiver_time_plot/archiver_time_plot_example.py
+++ b/examples/archiver_time_plot/archiver_time_plot_example.py
@@ -1,0 +1,45 @@
+from pydm import Display
+
+from qtpy import QtCore
+from qtpy.QtWidgets import QHBoxLayout, QApplication
+from pydm.widgets import PyDMArchiverTimePlot
+
+
+class archiver_time_plot_example(Display):
+    def __init__(self, parent=None, args=None, macros=None):
+        super(archiver_time_plot_example, self).__init__(parent=parent, args=args, macros=None)
+        self.app = QApplication.instance()
+        self.setup_ui()
+
+    def minimumSizeHint(self):
+        return QtCore.QSize(100, 100)
+
+    def ui_filepath(self):
+        return None
+
+    def setup_ui(self):
+        self.main_layout = QHBoxLayout()
+        self.setLayout(self.main_layout)
+        self.plot_live = PyDMArchiverTimePlot(background=[255, 255, 255, 255])
+        self.plot_archived = PyDMArchiverTimePlot(background=[255, 255, 255, 255])
+        self.main_layout.addWidget(self.plot_live)
+        self.main_layout.addWidget(self.plot_archived)
+
+        self.plot_live.addYChannel(
+            y_channel="CA://XCOR:LI29:302:IACT",
+            name="name",
+            color="red",
+            yAxisName="Axis",
+            useArchiveData=True,
+            liveData=True
+        )
+        
+        self.plot_archived.addYChannel(
+            y_channel="CA://XCOR:LI29:302:IACT",
+            name="name",
+            color="blue",
+            yAxisName="Axis",
+            useArchiveData=True,
+            liveData=False
+        )
+        

--- a/examples/archiver_time_plot/archiver_time_plot_example.py
+++ b/examples/archiver_time_plot/archiver_time_plot_example.py
@@ -31,15 +31,14 @@ class archiver_time_plot_example(Display):
             color="red",
             yAxisName="Axis",
             useArchiveData=True,
-            liveData=True
+            liveData=True,
         )
-        
+
         self.plot_archived.addYChannel(
             y_channel="CA://XCOR:LI29:302:IACT",
             name="name",
             color="blue",
             yAxisName="Axis",
             useArchiveData=True,
-            liveData=False
+            liveData=False,
         )
-        

--- a/pydm/widgets/archiver_time_plot.py
+++ b/pydm/widgets/archiver_time_plot.py
@@ -106,7 +106,7 @@ class ArchivePlotCurveItem(TimePlotCurveItem):
         # Avoids noisy requests when first rendering the plot
         if max_x - min_x > 5:
             self.archive_data_request_signal.emit(min_x, max_x - 1, "")
-        
+
         self._liveData = True
 
     @Slot(np.ndarray)

--- a/pydm/widgets/archiver_time_plot.py
+++ b/pydm/widgets/archiver_time_plot.py
@@ -43,7 +43,7 @@ class ArchivePlotCurveItem(TimePlotCurveItem):
     def __init__(
         self, channel_address: Optional[str] = None, use_archive_data: bool = True, liveData: bool = True, **kws
     ):
-        super(ArchivePlotCurveItem, self).__init__(channel_address, **kws)
+        super(ArchivePlotCurveItem, self).__init__(**kws)
         self.use_archive_data = use_archive_data
         self.archive_channel = None
         self.archive_points_accumulated = 0

--- a/pydm/widgets/archiver_time_plot.py
+++ b/pydm/widgets/archiver_time_plot.py
@@ -60,12 +60,7 @@ class ArchivePlotCurveItem(TimePlotCurveItem):
 
     def to_dict(self) -> OrderedDict:
         """Returns an OrderedDict representation with values for all properties needed to recreate this curve."""
-        dic_ = OrderedDict(
-            [
-                ("useArchiveData", self.use_archive_data),
-                ("liveData", self.liveData)
-            ]
-        )
+        dic_ = OrderedDict([("useArchiveData", self.use_archive_data), ("liveData", self.liveData)])
         dic_.update(super(ArchivePlotCurveItem, self).to_dict())
         return dic_
 
@@ -85,7 +80,6 @@ class ArchivePlotCurveItem(TimePlotCurveItem):
         # Avoids noisy requests when first rendering the plot
         if max_x - min_x > 5:
             self.archive_data_request_signal.emit(min_x, max_x - 1, "")
-
 
     def setArchiveChannel(self, address: str) -> None:
         """Creates the channel for the input address for communicating with the archiver appliance plugin."""

--- a/pydm/widgets/archiver_time_plot.py
+++ b/pydm/widgets/archiver_time_plot.py
@@ -107,27 +107,6 @@ class ArchivePlotCurveItem(TimePlotCurveItem):
         if max_x - min_x > 5:
             self.archive_data_request_signal.emit(min_x, max_x - 1, "")
 
-    def setArchiveChannel(self, new_address: str) -> None:
-        """Creates the channel for the input address for communicating with the archiver appliance plugin."""
-        TimePlotCurveItem.address.__set__(self, new_address)
-
-        if not new_address:
-            self.archive_channel = None
-            return
-        elif self.archive_channel and new_address == self.archive_channel.address:
-            return
-
-        # Prepare new address to use the archiver plugin and create the new channel
-        archive_address = "archiver://pv=" + remove_protocol(new_address)
-        self.archive_channel = PyDMChannel(
-            address=archive_address, value_slot=self.receiveArchiveData, value_signal=self.archive_data_request_signal
-        )
-
-        # Clear the archive data of the previous channel and redraw the curve
-        if self.archive_points_accumulated:
-            self.initializeArchiveBuffer()
-            self.redrawCurve()
-
     @Slot(np.ndarray)
     def receiveArchiveData(self, data: np.ndarray) -> None:
         """Receive data from archiver appliance and place it into the archive data buffer.

--- a/pydm/widgets/archiver_time_plot.py
+++ b/pydm/widgets/archiver_time_plot.py
@@ -73,7 +73,7 @@ class ArchivePlotCurveItem(TimePlotCurveItem):
         if not get_live:
             self._liveData = False
             return
-
+                
         min_x = self.data_buffer[0, self._bufferSize - 1]
         max_x = time.time()
 
@@ -428,7 +428,8 @@ class PyDMArchiverTimePlot(PyDMTimePlot):
                 symbol=d.get("symbol"),
                 symbolSize=d.get("symbolSize"),
                 yAxisName=d.get("yAxisName"),
-                useArchiveData=d.get("useArchiveData"),
+                useArchiveData=d.get("useArchiveData")
+                liveData=d.get("liveData"),
             )
 
     curves = Property("QStringList", getCurves, setCurves, designable=False)

--- a/pydm/widgets/archiver_time_plot.py
+++ b/pydm/widgets/archiver_time_plot.py
@@ -39,13 +39,14 @@ class ArchivePlotCurveItem(TimePlotCurveItem):
     archive_data_request_signal = Signal(float, float, str)
     archive_data_received_signal = Signal()
 
-    def __init__(self, channel_address: Optional[str] = None, use_archive_data: bool = True, **kws):
+    def __init__(self, channel_address: Optional[str] = None, use_archive_data: bool = True, liveData: bool = True, **kws):
         super(ArchivePlotCurveItem, self).__init__(channel_address, **kws)
         self.use_archive_data = use_archive_data
         self.archive_channel = None
         self.archive_points_accumulated = 0
         self._archiveBufferSize = DEFAULT_ARCHIVE_BUFFER_SIZE
         self.archive_data_buffer = np.zeros((2, self._archiveBufferSize), order="f", dtype=float)
+        self.liveData = liveData
 
         # When optimized or mean value data is requested, we can display error bars representing
         # the full range of values retrieved
@@ -213,7 +214,11 @@ class ArchivePlotCurveItem(TimePlotCurveItem):
         """Return the list of channels this curve is connected to"""
         return [self.channel, self.archive_channel]
 
-
+    def receiveNewValue(self, new_value):
+        """ """
+        if self.liveData:
+            super().receiveNewValue(new_value)
+            
 class PyDMArchiverTimePlot(PyDMTimePlot):
     """
     PyDMArchiverTimePlot is a PyDMTimePlot with support for receiving data from
@@ -403,3 +408,41 @@ class PyDMArchiverTimePlot(PyDMTimePlot):
             )
 
     curves = Property("QStringList", getCurves, setCurves, designable=False)
+
+    def addYChannel(
+        self,
+        y_channel=None,
+        plot_style=None,
+        name=None,
+        color=None,
+        lineStyle=None,
+        lineWidth=None,
+        symbol=None,
+        symbolSize=None,
+        barWidth=None,
+        upperThreshold=None,
+        lowerThreshold=None,
+        thresholdColor=None,
+        yAxisName=None,
+        useArchiveData=False,
+        liveData=True
+    ):
+        """
+        Overrides timeplot addYChannel method to be able to pass the liveData flag.
+        """
+        super().addYChannel(
+            y_channel=y_channel,
+            plot_style=plot_style,
+            name=name,
+            color=color,
+            lineStyle=lineStyle,
+            lineWidth=lineWidth,
+            symbol=symbol,
+            symbolSize=symbolSize,
+            barWidth=barWidth,
+            upperThreshold=upperThreshold,
+            lowerThreshold=lowerThreshold,
+            thresholdColor=thresholdColor,
+            yAxisName=yAxisName,
+            useArchiveData=useArchiveData,
+            liveData=liveData)

--- a/pydm/widgets/archiver_time_plot.py
+++ b/pydm/widgets/archiver_time_plot.py
@@ -107,7 +107,7 @@ class ArchivePlotCurveItem(TimePlotCurveItem):
         if max_x - min_x > 5:
             self.archive_data_request_signal.emit(min_x, max_x - 1, "")
 
-    def setArchiveChannel(self, address: str) -> None:
+    def setArchiveChannel(self, new_address: str) -> None:
         """Creates the channel for the input address for communicating with the archiver appliance plugin."""
         TimePlotCurveItem.address.__set__(self, new_address)
 

--- a/pydm/widgets/archiver_time_plot.py
+++ b/pydm/widgets/archiver_time_plot.py
@@ -428,8 +428,8 @@ class PyDMArchiverTimePlot(PyDMTimePlot):
                 symbol=d.get("symbol"),
                 symbolSize=d.get("symbolSize"),
                 yAxisName=d.get("yAxisName"),
-                useArchiveData=d.get("useArchiveData")
-                liveData=d.get("liveData"),
+                useArchiveData=d.get("useArchiveData"),
+                liveData=d.get("liveData")
             )
 
     curves = Property("QStringList", getCurves, setCurves, designable=False)

--- a/pydm/widgets/archiver_time_plot.py
+++ b/pydm/widgets/archiver_time_plot.py
@@ -39,7 +39,9 @@ class ArchivePlotCurveItem(TimePlotCurveItem):
     archive_data_request_signal = Signal(float, float, str)
     archive_data_received_signal = Signal()
 
-    def __init__(self, channel_address: Optional[str] = None, use_archive_data: bool = True, liveData: bool = True, **kws):
+    def __init__(
+        self, channel_address: Optional[str] = None, use_archive_data: bool = True, liveData: bool = True, **kws
+    ):
         super(ArchivePlotCurveItem, self).__init__(channel_address, **kws)
         self.use_archive_data = use_archive_data
         self.archive_channel = None
@@ -218,7 +220,8 @@ class ArchivePlotCurveItem(TimePlotCurveItem):
         """ """
         if self.liveData:
             super().receiveNewValue(new_value)
-            
+
+
 class PyDMArchiverTimePlot(PyDMTimePlot):
     """
     PyDMArchiverTimePlot is a PyDMTimePlot with support for receiving data from
@@ -425,7 +428,7 @@ class PyDMArchiverTimePlot(PyDMTimePlot):
         thresholdColor=None,
         yAxisName=None,
         useArchiveData=False,
-        liveData=True
+        liveData=True,
     ):
         """
         Overrides timeplot addYChannel method to be able to pass the liveData flag.
@@ -445,4 +448,5 @@ class PyDMArchiverTimePlot(PyDMTimePlot):
             thresholdColor=thresholdColor,
             yAxisName=yAxisName,
             useArchiveData=useArchiveData,
-            liveData=liveData)
+            liveData=liveData,
+        )

--- a/pydm/widgets/archiver_time_plot.py
+++ b/pydm/widgets/archiver_time_plot.py
@@ -106,6 +106,8 @@ class ArchivePlotCurveItem(TimePlotCurveItem):
         # Avoids noisy requests when first rendering the plot
         if max_x - min_x > 5:
             self.archive_data_request_signal.emit(min_x, max_x - 1, "")
+        
+        self._liveData = True
 
     @Slot(np.ndarray)
     def receiveArchiveData(self, data: np.ndarray) -> None:
@@ -127,7 +129,6 @@ class ArchivePlotCurveItem(TimePlotCurveItem):
         last_ts = self.archive_data_buffer[0][-1]
         if self.archive_data_buffer.any() and (int(last_ts) <= data[0][0]):
             self.insert_live_data(data)
-            self._liveData = True
             self.data_changed.emit()
             return
 

--- a/pydm/widgets/timeplot.py
+++ b/pydm/widgets/timeplot.py
@@ -509,7 +509,7 @@ class PyDMTimePlot(BasePlot, updateMode):
         new_curve : TimePlotCurveItem
             The newly created curve.
         """
-        plot_opts = dict()        
+        plot_opts = dict()
         plot_opts["symbol"] = symbol
         if symbolSize is not None:
             plot_opts["symbolSize"] = symbolSize
@@ -519,7 +519,7 @@ class PyDMTimePlot(BasePlot, updateMode):
             plot_opts["lineWidth"] = lineWidth
         if kwargs:
             plot_opts.update(kwargs)
-            
+
         # Add curve
         new_curve = self.createCurveItem(
             channel_address=y_channel,

--- a/pydm/widgets/timeplot.py
+++ b/pydm/widgets/timeplot.py
@@ -277,9 +277,7 @@ class TimePlotCurveItem(BasePlotCurveItem):
         min_insertion_index = np.searchsorted(self.data_buffer[0], min_x)
         max_insertion_index = np.searchsorted(self.data_buffer[0], max_x)
         # Delete any non-raw data between the indices so we don't have multiple data points for the same timestamp
-        self.data_buffer = np.delete(
-            self.data_buffer, slice(min_insertion_index, max_insertion_index), axis=1
-        )
+        self.data_buffer = np.delete(self.data_buffer, slice(min_insertion_index, max_insertion_index), axis=1)
         num_points_deleted = max_insertion_index - min_insertion_index
         delta_points = live_data_length - num_points_deleted
         if live_data_length > num_points_deleted:

--- a/pydm/widgets/timeplot.py
+++ b/pydm/widgets/timeplot.py
@@ -468,6 +468,7 @@ class PyDMTimePlot(BasePlot, updateMode):
         thresholdColor=None,
         yAxisName=None,
         useArchiveData=False,
+        **kwargs
     ):
         """
         Adds a new curve to the current plot
@@ -508,7 +509,7 @@ class PyDMTimePlot(BasePlot, updateMode):
         new_curve : TimePlotCurveItem
             The newly created curve.
         """
-        plot_opts = dict()
+        plot_opts = dict()        
         plot_opts["symbol"] = symbol
         if symbolSize is not None:
             plot_opts["symbolSize"] = symbolSize
@@ -516,7 +517,9 @@ class PyDMTimePlot(BasePlot, updateMode):
             plot_opts["lineStyle"] = lineStyle
         if lineWidth is not None:
             plot_opts["lineWidth"] = lineWidth
-
+        if kwargs:
+            plot_opts.update(kwargs)
+            
         # Add curve
         new_curve = self.createCurveItem(
             channel_address=y_channel,
@@ -544,7 +547,6 @@ class PyDMTimePlot(BasePlot, updateMode):
 
         new_curve.data_changed.connect(self.set_needs_redraw)
         self.redraw_timer.start()
-
         return new_curve
 
     def createCurveItem(self, *args, **kwargs):


### PR DESCRIPTION
## Description
Archived Data Only Mode

The Archived Time Plot Widget currently only supports a live+archived data, this pull requests looks to add a mode where the widget would only pull and display archived data from the given data source.   

## Motivation and Context
At SLAC we are developing a new Archive Viewer, which we wish to also double with displaying live data--which is the current functionally of the PYDM Archiver Time Plot Widget. We also need it to be able to display only archived data without fetching live data. We think this functionality would be useful to the greater PYDM community.     

## How Has This Been Tested?
Will be tested on an example GUI and unit tests will be included in the PR. 

## Where Has This Been Documented?
documentation is still being worked on. 