### PR TITLE
ENH: added new pydm drawing rules for all drawing widgets that allow for p…

### DIFF
--- a/pydm/widgets/drawing.py
+++ b/pydm/widgets/drawing.py
@@ -16,6 +16,7 @@ _penRuleProperties = {
     "Set Pen Color": ["penColor", QColor],
     "Set Pen Style": ["penStyle", int],
     "Set Pen Width": ["penWidth", float],
+    "Set Brush Color": ["brush", QBrush],
 }
 
 
@@ -57,7 +58,7 @@ def qt_to_deg(deg):
     return deg / 16.0
 
 
-class PyDMDrawing(QWidget, PyDMWidget):
+class PyDMDrawing(QWidget, PyDMWidget, new_properties=_penRuleProperties):
     """
     Base class to be used for all PyDM Drawing Widgets.
     This class inherits from QWidget and PyDMWidget.
@@ -453,7 +454,7 @@ class PyDMDrawing(QWidget, PyDMWidget):
                 self.penStyle = self._original_pen_style
 
 
-class PyDMDrawingLine(PyDMDrawing, new_properties=_penRuleProperties):
+class PyDMDrawingLine(PyDMDrawing):
     """
     A widget with a line drawn in it.
     This class inherits from PyDMDrawing.

--- a/pydm/widgets/rules.py
+++ b/pydm/widgets/rules.py
@@ -5,7 +5,7 @@ import weakref
 
 from qtpy.QtCore import QThread, QMutex, Signal
 from qtpy.QtWidgets import QWidget, QApplication
-from qtpy.QtGui import QColor
+from qtpy.QtGui import QColor, QBrush
 from ..utilities import is_qt_designer
 from .channel import PyDMChannel
 
@@ -361,7 +361,7 @@ class RulesEngine(QThread):
                     pass
             calc_vals.append(v)
 
-        eval_env = {"np": np, "ch": calc_vals, "QColor": QColor}
+        eval_env = {"np": np, "ch": calc_vals, "QColor": QColor, "QBrush": QBrush}
         eval_env.update({k: v for k, v in math.__dict__.items() if k[0] != "_"})
 
         expression = rule["rule"]["expression"]


### PR DESCRIPTION
Removed the rules for adjusting the pen properties of PyDMDrawingLine and reapplied rule code in the parent class PyDMDrawing (also added an additional rule that changes brush color). This way all widgets that inherit from PyDMDrawing get rules that allow for adjustment in pen and brush properties .