### PR TITLE
Fix connection inspector with local plugins

### DIFF
--- a/pydm/connection_inspector/connection_inspector.py
+++ b/pydm/connection_inspector/connection_inspector.py
@@ -53,7 +53,8 @@ class ConnectionInspector(QWidget):
             for p in plugins.values()
             for connection in p.connections.values()
             # DISP field is connected to separately for writable channels, including it on this list is redundant
-            if not connection.address.endswith(".DISP")
+            # Local plugins have a ParseResult address, not a string, so they may not have a 'endswith' attribute
+            if (not connection.address.endswith(".DISP") if hasattr(connection.address, "endswith") else True)
         ]
 
     @Slot()


### PR DESCRIPTION
Local plugin's `self.address` is not a string, but rather a parsed URL. As such, it does not have a `.endswith` attribute, which would make it fail with an exception when trying to open the connection inspector.

This has been an issue since commit 709a144, in release 1.20.0.