### PR TITLE
FIX: MultiAxisViewBox resizing breaks in certain cases

### DIFF
--- a/pydm/widgets/multi_axis_viewbox.py
+++ b/pydm/widgets/multi_axis_viewbox.py
@@ -1,5 +1,5 @@
-from pyqtgraph import ViewBox
-from qtpy.QtCore import Qt, Signal
+from pyqtgraph import GraphicsWidget, ViewBox
+from qtpy.QtCore import Qt, QRectF, Signal
 
 
 class MultiAxisViewBox(ViewBox):
@@ -16,6 +16,14 @@ class MultiAxisViewBox(ViewBox):
     sigMouseDraggedDone = Signal()
     sigMouseWheelZoomed = Signal(object, object, object)
     sigHistoryChanged = Signal(object)
+
+    def boundingRect(self) -> QRectF:
+        """Bypass the ViewBox implementation of boundingRect which gives us extra padding we don't want in pydm"""
+        return GraphicsWidget.boundingRect(self)
+
+    def sceneBoundingRect(self) -> QRectF:
+        """Bypass the ViewBox implementation of sceneBoundingRect which gives us extra padding we don't want in pydm"""
+        return GraphicsWidget.sceneBoundingRect(self)
 
     def wheelEvent(self, ev, axis=None, fromSignal=False):
         """


### PR DESCRIPTION
### Context

As a follow up to #1069 there are cases in which depending on how the user initializes their plot the main view box on it can get stuck in a loop in which it will continue increasing in size. As a fun example try running `pydm/examples/scatterplot/scatterplot.ui ` using pyqtgraph 0.13.4 without this fix

This is due to https://github.com/pyqtgraph/pyqtgraph/pull/2762

The bounding rect of a ViewBox now adjusts itself before returning, so connecting the `sigResized` signal of a ViewBox to a function which changes its own size results in an endless loop of it resizing itself.

There are more robust ways to solve this on our end, but this is the most fragile area of our code base which I hope to eventually replace with a built-in pyqtgraph solution to multi-axis plots if one of the PRs there gets merged. So for now the simplest seems best.

### Testing

Verified that all example plots work correctly with both pyqtgraph 0.13.3 and 0.13.4.
