### PR TITLE
ENH: Timeplot auto scrolling

### DIFF
--- a/pydm/widgets/archiver_time_plot.py
+++ b/pydm/widgets/archiver_time_plot.py
@@ -16,7 +16,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 DEFAULT_ARCHIVE_BUFFER_SIZE = 18000
-DEFAULT_TIME_SPAN = 5.0
+DEFAULT_TIME_SPAN = 3600.0
 MIN_TIME_SPAN = 5.0
 
 

--- a/pydm/widgets/archiver_time_plot.py
+++ b/pydm/widgets/archiver_time_plot.py
@@ -8,7 +8,7 @@ from pydm.utilities import remove_protocol
 from pydm.widgets.channel import PyDMChannel
 from pydm.widgets.timeplot import TimePlotCurveItem
 from pydm.widgets import PyDMTimePlot
-from qtpy.QtCore import QObject, QTimer, Property, Signal, Slot, Qt, QEvent
+from qtpy.QtCore import QObject, QTimer, Property, Signal, Slot
 from qtpy.QtGui import QColor
 
 import logging
@@ -316,7 +316,7 @@ class PyDMArchiverTimePlot(PyDMTimePlot):
             init_y_channels=init_y_channels,
             plot_by_timestamps=True,
             background=background,
-            bottom_axis=PyDMDateAxisItem(),
+            bottom_axis=DateAxisItem("bottom"),
         )
         self.optimized_data_bins = optimized_data_bins
         self._min_x = None
@@ -548,19 +548,3 @@ class PyDMArchiverTimePlot(PyDMTimePlot):
             useArchiveData=useArchiveData,
             liveData=liveData,
         )
-
-
-class PyDMDateAxisItem(DateAxisItem):
-    sigMouseInteraction = Signal()
-
-    def __init__(self, orientation="bottom", utcOffset=None, **kwargs):
-        super().__init__(orientation, utcOffset, **kwargs)
-
-    def mouseDragEvent(self, event: QEvent):
-        if event.button() == Qt.LeftButton and event.isStart():
-            self.sigMouseInteraction.emit()
-        return super().mouseDragEvent(event)
-
-    def wheelEvent(self, event: QEvent):
-        self.sigMouseInteraction.emit()
-        return super().wheelEvent(event)

--- a/pydm/widgets/archiver_time_plot.py
+++ b/pydm/widgets/archiver_time_plot.py
@@ -342,7 +342,9 @@ class PyDMArchiverTimePlot(PyDMTimePlot):
                 self._min_x = self._min_x - self.getTimeSpan()
                 self._archive_request_queued = True
                 self.requestDataFromArchiver()
-            self.plotItem.setXRange(time.time() - DEFAULT_TIME_SPAN, time.time(), padding=0.0, update=update_immediately)
+            self.plotItem.setXRange(
+                time.time() - DEFAULT_TIME_SPAN, time.time(), padding=0.0, update=update_immediately
+            )
         elif min_x < self._min_x and not self.plotItem.isAnyXAutoRange():
             # This means the user has manually scrolled to the left, so request archived data
             self._min_x = min_x
@@ -361,7 +363,9 @@ class PyDMArchiverTimePlot(PyDMTimePlot):
                 self.setTimeSpan(max_point - min_x)
             else:
                 # Keep the plot moving with a rolling window based on the current timestamp
-                self.plotItem.setXRange(max_point - self.getTimeSpan(), max_point, padding=0.0, update=update_immediately)
+                self.plotItem.setXRange(
+                    max_point - self.getTimeSpan(), max_point, padding=0.0, update=update_immediately
+                )
         self._prev_x = min_x
 
     def requestDataFromArchiver(self, min_x: Optional[float] = None, max_x: Optional[float] = None) -> None:
@@ -549,7 +553,7 @@ class PyDMArchiverTimePlot(PyDMTimePlot):
 class PyDMDateAxisItem(DateAxisItem):
     sigMouseInteraction = Signal()
 
-    def __init__(self, orientation='bottom', utcOffset=None, **kwargs):
+    def __init__(self, orientation="bottom", utcOffset=None, **kwargs):
         super().__init__(orientation, utcOffset, **kwargs)
 
     def mouseDragEvent(self, event: QEvent):

--- a/pydm/widgets/timeplot.py
+++ b/pydm/widgets/timeplot.py
@@ -489,6 +489,9 @@ class PyDMTimePlot(BasePlot, updateMode):
         for channel in init_y_channels:
             self.addYChannel(channel)
 
+        self.auto_scroll_timer = QTimer()
+        self.auto_scroll_timer.timeout.connect(self.auto_scroll)
+
     def initialize_for_designer(self):
         # If we are in Qt Designer, don't update the plot continuously.
         # This function gets called by PyDMTimePlot's designer plugin.
@@ -653,7 +656,7 @@ class PyDMTimePlot(BasePlot, updateMode):
             Update the axis range(s) immediately if True, or defer until the
             next rendering.
         """
-        if len(self._curves) == 0:
+        if len(self._curves) == 0 or self.auto_scroll_timer.isActive():
             return
 
         if self._plot_by_timestamps:
@@ -782,6 +785,41 @@ class PyDMTimePlot(BasePlot, updateMode):
                 thresholdColor=curve.threshold_color,
                 yAxisName=curve.y_axis_name,
             )
+
+    def setAutoScroll(self, enable: bool = False, timespan: float = 60, padding: float = 0.1, refresh_rate: int = 5000):
+        """Enable/Disable autoscrolling along the x-axis. This will (un)pause
+        the autoscrolling QTimer, which calls the auto_scroll slot when time is up.
+
+        Parameters
+        ----------
+        enable : bool, optional
+            Whether or not to start the autoscroll QTimer, by default False
+        timespan : float, optional
+            The timespan to set for autoscrolling along the x-axis in seconds, by default 60
+        padding : float, optional
+            The size of the empty space between the data and the sides of the plot, by default 0.1
+        refresh_rate : int, optional
+            How often the scroll should occur in milliseconds, by default 5000
+        """
+        if not enable:
+            self.auto_scroll_timer.stop()
+            return
+
+        self.setAutoRangeX(False)
+        if timespan <= 0:
+            min_x, max_x = self.getViewBox().viewRange()[0]
+            timespan = max_x - min_x
+        self.scroll_timespan = timespan
+        self.scroll_padding = max(padding * timespan, refresh_rate / 1000)
+
+        self.auto_scroll_timer.start(refresh_rate)
+        self.auto_scroll()
+
+    def auto_scroll(self):
+        """Autoscrolling slot to be called by the autoscroll QTimer."""
+        curr = time.time()
+        # Only include padding on the right
+        self.plotItem.setXRange(curr - self.scroll_timespan, curr + self.scroll_padding)
 
     def addLegendItem(self, item, pv_name, force_show_legend=False):
         """


### PR DESCRIPTION
Follow up to #1601

Add an autoscroll feature to PyDMTimePlot and PyDMArchiverTimePlot. 

When enabling autoscroll a refresh rate, timespan, and padding are provided. A QTimer is created that will call a function to shift the plot along the X-axis, always showing the given timespan. The QTimer calls this function after <refresh_rate> seconds. The padding will show that much space to the right of the rightmost datapoint.

By default the padding is 10% of the timespan. If the padding value is less than the refresh_rate, then the padding size is the refresh_rate value. This prevents getting newer data than the X-axis shows, which would cause the plot to "jump" to the right frequently.