### PR TITLE
ENH: Base Plot Axis range values

### DIFF
--- a/pydm/widgets/baseplot.py
+++ b/pydm/widgets/baseplot.py
@@ -410,6 +410,8 @@ class BasePlotAxisItem(AxisItem):
     """
 
     log_mode_updated = Signal(str, bool)
+    sigXRangeChanged = Signal(object, object)
+    sigYRangeChanged = Signal(object, object)
     axis_orientations = OrderedDict([("Left", "left"), ("Right", "right")])
 
     def __init__(
@@ -432,6 +434,7 @@ class BasePlotAxisItem(AxisItem):
         self._max_range = maxRange
         self._auto_range = autoRange
         self._log_mode = logMode
+        self.setRange(minRange, maxRange)
 
     @property
     def name(self) -> str:
@@ -497,7 +500,7 @@ class BasePlotAxisItem(AxisItem):
         -------
         float
         """
-        return self._min_range
+        return self.range[0]
 
     @min_range.setter
     def min_range(self, min_range: float) -> None:
@@ -508,7 +511,7 @@ class BasePlotAxisItem(AxisItem):
         ----------
         min_range: float
         """
-        self._min_range = min_range
+        self.linkedView().setYRange(min_range, self.range[1], padding=0)
 
     @property
     def max_range(self) -> float:
@@ -519,7 +522,7 @@ class BasePlotAxisItem(AxisItem):
         -------
         float
         """
-        return self._max_range
+        return self.range[1]
 
     @max_range.setter
     def max_range(self, max_range: float) -> None:
@@ -530,7 +533,7 @@ class BasePlotAxisItem(AxisItem):
         ----------
         max_range: float
         """
-        self._max_range = max_range
+        self.linkedView().setYRange(self.range[0], max_range, padding=0)
 
     @property
     def auto_range(self) -> bool:
@@ -592,8 +595,8 @@ class BasePlotAxisItem(AxisItem):
                 ("name", self._name),
                 ("orientation", self._orientation),
                 ("label", self._label),
-                ("minRange", self._min_range),
-                ("maxRange", self._max_range),
+                ("minRange", self.range[0]),
+                ("maxRange", self.range[1]),
                 ("autoRange", self._auto_range),
                 ("logMode", self._log_mode),
             ]

--- a/pydm/widgets/baseplot.py
+++ b/pydm/widgets/baseplot.py
@@ -430,8 +430,6 @@ class BasePlotAxisItem(AxisItem):
         self._name = name
         self._orientation = orientation
         self._label = label
-        self._min_range = minRange
-        self._max_range = maxRange
         self._auto_range = autoRange
         self._log_mode = logMode
         self.setRange(minRange, maxRange)

--- a/pydm/widgets/baseplot.py
+++ b/pydm/widgets/baseplot.py
@@ -434,6 +434,14 @@ class BasePlotAxisItem(AxisItem):
         self._log_mode = logMode
         self.setRange(minRange, maxRange)
 
+    def linkToView(self, view):
+        if oldView := self.linkedView():
+            oldView.sigXRangeChanged.disconnect(self.sigXRangeChanged.emit)
+            oldView.sigYRangeChanged.disconnect(self.sigYRangeChanged.emit)
+        view.sigXRangeChanged.connect(self.sigXRangeChanged.emit)
+        view.sigYRangeChanged.connect(self.sigYRangeChanged.emit)
+        super().linkToView(view)
+
     @property
     def name(self) -> str:
         """

--- a/pydm/widgets/baseplot.py
+++ b/pydm/widgets/baseplot.py
@@ -81,7 +81,7 @@ class BasePlotCurveItem(PlotDataItem):
         lineStyle: Optional[Qt.PenStyle] = None,
         lineWidth: Optional[int] = None,
         yAxisName: Optional[str] = None,
-        **kws
+        **kws,
     ) -> None:
         self._color = QColor("white")
         self._thresholdColor = QColor("white")
@@ -423,7 +423,7 @@ class BasePlotAxisItem(AxisItem):
         maxRange: Optional[float] = 1.0,
         autoRange: Optional[bool] = True,
         logMode: Optional[bool] = False,
-        **kws
+        **kws,
     ) -> None:
         super(BasePlotAxisItem, self).__init__(orientation, **kws)
 

--- a/pydm/widgets/baseplot.py
+++ b/pydm/widgets/baseplot.py
@@ -5,7 +5,15 @@ from qtpy.QtGui import QColor, QBrush, QMouseEvent
 from qtpy.QtCore import Signal, Slot, Property, QTimer, Qt, QEvent, QObject, QRect
 from qtpy.QtWidgets import QToolTip, QWidget
 from .. import utilities
-from pyqtgraph import AxisItem, PlotWidget, PlotDataItem, mkPen, ViewBox, InfiniteLine, SignalProxy
+from pyqtgraph import (
+    AxisItem,
+    PlotWidget,
+    PlotDataItem,
+    mkPen,
+    ViewBox,
+    InfiniteLine,
+    SignalProxy,
+)
 from collections import OrderedDict
 from typing import Dict, List, Optional, Union
 from .base import PyDMPrimitiveWidget, widget_destroyed
@@ -122,7 +130,9 @@ class BasePlotCurveItem(PlotDataItem):
         -------
         str
         """
-        return str(utilities.colors.svg_color_from_hex(self.color.name(), hex_on_fail=True))
+        return str(
+            utilities.colors.svg_color_from_hex(self.color.name(), hex_on_fail=True)
+        )
 
     @color_string.setter
     def color_string(self, new_color_string: str) -> None:
@@ -179,7 +189,11 @@ class BasePlotCurveItem(PlotDataItem):
         -------
         str
         """
-        return str(utilities.colors.svg_color_from_hex(self.threshold_color.name(), hex_on_fail=True))
+        return str(
+            utilities.colors.svg_color_from_hex(
+                self.threshold_color.name(), hex_on_fail=True
+            )
+        )
 
     @property
     def threshold_color(self) -> QColor:
@@ -639,7 +653,9 @@ class BasePlot(PlotWidget, PyDMPrimitiveWidget):
             # The pyqtgraph PlotItem.setAxisItems() will always add an an AxisItem called left whether you asked
             # it to or not. This will clear it if not specifically requested.
             plotItem.removeAxis("left")
-        super(BasePlot, self).__init__(parent=parent, background=background, plotItem=plotItem)
+        super(BasePlot, self).__init__(
+            parent=parent, background=background, plotItem=plotItem
+        )
 
         self.plotItem = plotItem
         self.plotItem.hideButtons()
@@ -708,7 +724,10 @@ class BasePlot(PlotWidget, PyDMPrimitiveWidget):
         return ret
 
     def addCurve(
-        self, plot_data_item: BasePlotCurveItem, curve_color: Optional[QColor] = None, y_axis_name: Optional[str] = None
+        self,
+        plot_data_item: BasePlotCurveItem,
+        curve_color: Optional[QColor] = None,
+        y_axis_name: Optional[str] = None,
     ):
         """
         Adds a curve to this plot.
@@ -729,7 +748,9 @@ class BasePlot(PlotWidget, PyDMPrimitiveWidget):
         """
 
         if curve_color is None:
-            curve_color = utilities.colors.default_colors[len(self._curves) % len(utilities.colors.default_colors)]
+            curve_color = utilities.colors.default_colors[
+                len(self._curves) % len(utilities.colors.default_colors)
+            ]
             plot_data_item.color_string = curve_color
 
         self._curves.append(plot_data_item)
@@ -737,10 +758,14 @@ class BasePlot(PlotWidget, PyDMPrimitiveWidget):
         if y_axis_name is None:
             if utilities.is_qt_designer():
                 # If we are just in designer, add an axis that will not conflict with the pyqtgraph default
-                self.addAxis(plot_data_item=plot_data_item, name="Axis 1", orientation="left")
+                self.addAxis(
+                    plot_data_item=plot_data_item, name="Axis 1", orientation="left"
+                )
             # If not in designer and the user did not name the axis, use the pyqtgraph default one named left
             elif "left" not in self.plotItem.axes:
-                self.addAxis(plot_data_item=plot_data_item, name="left", orientation="left")
+                self.addAxis(
+                    plot_data_item=plot_data_item, name="left", orientation="left"
+                )
             else:
                 self.plotItem.linkDataToAxis(plot_data_item, "left")
         elif y_axis_name in self.plotItem.axes:
@@ -976,6 +1001,10 @@ class BasePlot(PlotWidget, PyDMPrimitiveWidget):
             settings
         """
         return [json.dumps(axis.to_dict()) for axis in self._axes]
+
+    def getXAxis(self) -> BasePlotAxisItem:
+        """Return the plot's X-Axis item."""
+        return self.getAxis("bottom")
 
     def setYAxes(self, new_list: List[str]) -> None:
         """
@@ -1362,7 +1391,11 @@ class BasePlot(PlotWidget, PyDMPrimitiveWidget):
         self.redraw_timer.setInterval(int((1.0 / self._redraw_rate) * 1000))
 
     def pausePlotting(self) -> bool:
-        self.redraw_timer.stop() if self.redraw_timer.isActive() else self.redraw_timer.start()
+        (
+            self.redraw_timer.stop()
+            if self.redraw_timer.isActive()
+            else self.redraw_timer.start()
+        )
         return self.redraw_timer.isActive()
 
     def mouseMoved(self, evt: QMouseEvent) -> None:

--- a/pydm/widgets/baseplot.py
+++ b/pydm/widgets/baseplot.py
@@ -130,9 +130,7 @@ class BasePlotCurveItem(PlotDataItem):
         -------
         str
         """
-        return str(
-            utilities.colors.svg_color_from_hex(self.color.name(), hex_on_fail=True)
-        )
+        return str(utilities.colors.svg_color_from_hex(self.color.name(), hex_on_fail=True))
 
     @color_string.setter
     def color_string(self, new_color_string: str) -> None:
@@ -189,11 +187,7 @@ class BasePlotCurveItem(PlotDataItem):
         -------
         str
         """
-        return str(
-            utilities.colors.svg_color_from_hex(
-                self.threshold_color.name(), hex_on_fail=True
-            )
-        )
+        return str(utilities.colors.svg_color_from_hex(self.threshold_color.name(), hex_on_fail=True))
 
     @property
     def threshold_color(self) -> QColor:
@@ -653,9 +647,7 @@ class BasePlot(PlotWidget, PyDMPrimitiveWidget):
             # The pyqtgraph PlotItem.setAxisItems() will always add an an AxisItem called left whether you asked
             # it to or not. This will clear it if not specifically requested.
             plotItem.removeAxis("left")
-        super(BasePlot, self).__init__(
-            parent=parent, background=background, plotItem=plotItem
-        )
+        super(BasePlot, self).__init__(parent=parent, background=background, plotItem=plotItem)
 
         self.plotItem = plotItem
         self.plotItem.hideButtons()
@@ -748,9 +740,7 @@ class BasePlot(PlotWidget, PyDMPrimitiveWidget):
         """
 
         if curve_color is None:
-            curve_color = utilities.colors.default_colors[
-                len(self._curves) % len(utilities.colors.default_colors)
-            ]
+            curve_color = utilities.colors.default_colors[len(self._curves) % len(utilities.colors.default_colors)]
             plot_data_item.color_string = curve_color
 
         self._curves.append(plot_data_item)
@@ -758,14 +748,10 @@ class BasePlot(PlotWidget, PyDMPrimitiveWidget):
         if y_axis_name is None:
             if utilities.is_qt_designer():
                 # If we are just in designer, add an axis that will not conflict with the pyqtgraph default
-                self.addAxis(
-                    plot_data_item=plot_data_item, name="Axis 1", orientation="left"
-                )
+                self.addAxis(plot_data_item=plot_data_item, name="Axis 1", orientation="left")
             # If not in designer and the user did not name the axis, use the pyqtgraph default one named left
             elif "left" not in self.plotItem.axes:
-                self.addAxis(
-                    plot_data_item=plot_data_item, name="left", orientation="left"
-                )
+                self.addAxis(plot_data_item=plot_data_item, name="left", orientation="left")
             else:
                 self.plotItem.linkDataToAxis(plot_data_item, "left")
         elif y_axis_name in self.plotItem.axes:
@@ -1391,11 +1377,7 @@ class BasePlot(PlotWidget, PyDMPrimitiveWidget):
         self.redraw_timer.setInterval(int((1.0 / self._redraw_rate) * 1000))
 
     def pausePlotting(self) -> bool:
-        (
-            self.redraw_timer.stop()
-            if self.redraw_timer.isActive()
-            else self.redraw_timer.start()
-        )
+        (self.redraw_timer.stop() if self.redraw_timer.isActive() else self.redraw_timer.start())
         return self.redraw_timer.isActive()
 
     def mouseMoved(self, evt: QMouseEvent) -> None:

--- a/pydm/widgets/baseplot.py
+++ b/pydm/widgets/baseplot.py
@@ -34,7 +34,7 @@ class BasePlotCurveItem(PlotDataItem):
     ----------
     color : QColor, optional
         The color used to draw the curve line and the symbols.
-    lineStyle: int, optional
+    lineStyle: Qt.PenStyle, optional
         Style of the line connecting the data points.
         Must be a value from the Qt::PenStyle enum
         (see http://doc.qt.io/qt-5/qt.html#PenStyle-enum).
@@ -193,7 +193,7 @@ class BasePlotCurveItem(PlotDataItem):
         return self._thresholdColor
 
     @threshold_color.setter
-    def threshold_color(self, new_color: QColor):
+    def threshold_color(self, new_color: Union[QColor, str]):
         """
         Set the color used for bars exceeding either the upper or lower thresholds.
 
@@ -201,6 +201,8 @@ class BasePlotCurveItem(PlotDataItem):
         -------
         new_color: QColor
         """
+        if isinstance(new_color, str):
+            new_color = QColor(new_color)
         self._thresholdColor = new_color
 
     @property


### PR DESCRIPTION
Follow up to #1061 

Currently, BasePlotAxisItems have range values (_min_range & _max_range) but these are unnecessary as BasePlotAxisItem subclasses AxisItem which has range values. I changed the to_dict function, setters and getters to use these native properties instead.

Created signals for the BasePlotAxisItem that emit when the x or y ranges change. These signals are attached to the axis' linked view (rather than the range setters) because this captures all range changes in the plot's viewbox rather than just on the axis item.

Small fix in BasePlotCurveItem's threshold color setter. The setter takes both QColor objects and strings (which are converted to QColor objects).