### PR TITLE
Updating PyDMSlider source code so that users can do single steps with specified step size. 

### DIFF
--- a/pydm/widgets/slider.py
+++ b/pydm/widgets/slider.py
@@ -399,20 +399,26 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget,new_properties=_step_
 
         if self._parameters_menu_flag:
             self._slider_position_to_value_map = self.create_slider_positions_map()
-            print(self._slider_position_to_value_map)
             self._parameters_menu_flag = False
-        elif is_channel_valid(self.step_size_channel):
-            pass
+
         else:
             # if no defaults. create a linear space from min to max from default num_steps = 101, this means we cant step to max, but also cant call create map without a value
             print('just opened display with only limits set')
             self._slider_position_to_value_map = np.linspace(self.minimum, self.maximum, num=self._num_steps)
-            self.
             # try to connect channel and remap. do nothing if not valid 
             # checks 
             # flag
             # emit channel
             # what happens if step size channel is init'd
+            if is_channel_valid(self.step_size_channel):
+                # need to check if we have a value!!!!!! and that step size is being set.
+                print('valid channel set')
+                self.init_step_size_channel()
+                #self._slider_position_to_value_map = self.create_slider_positions_map()
+                #print(self.value,self.step_size,self.num_steps)
+
+
+
         self.update_labels()
         self.rangeChanged.emit(self.minimum, self.maximum)
         self.set_slider_to_closest_value(self.value)
@@ -424,22 +430,26 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget,new_properties=_step_
 
 
 
-
-
-
-
     def init_step_size_channel(self):
         if  self.step_size_channel_pv is None:
             self.step_size_channel_pv = PyDMChannel(address=self.step_size_channel, value_slot=self.step_size_changed)
+
             self.step_size_channel_pv.connect()
-        elif self.step_size_channel_pv is not None and self.step_size_channel_pv.address == self.step_size_channel:
+            print(self.step_size_channel_pv.address)
+            print('case5 path1')
+        '''
+        elif self.step_size_channel_pv is not None and self.step_size_channel_pv.address != self.step_size_channel:
             self.step_size_channel_pv.disconnect()
             self.step_size_channel_pv = None
             self.step_size_channel_pv = PyDMChannel(address=self.step_size_channel, value_slot=self.step_size_changed)
             self.step_size_channel_pv.connect()
-        if self.step_size_channel_pv is not None:
-            self.step_size_channel.disconnect()
-            self.step_size_channel = None
+            print('case5 path2')
+        elif self.step_size_channel_pv is not None and self.step_size_channel_pv.address == self.step_size_channel:
+            return True
+        '''
+
+            # once channel is set the value_slot calls the step_size_change slot which call step_size setter, really want to make sure this isnt too recursive
+
     
     def create_slider_positions_map(self):
         print(self._step_size)
@@ -960,8 +970,8 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget,new_properties=_step_
         self.num_steps = ((self.maximum - self.minimum) / self._step_size) 
 
         return True
-
-    @Slot(int)
+ 
+    @Slot(str)
     @Slot(float)
     def step_size_changed(self, new_val):
         """
@@ -972,11 +982,14 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget,new_properties=_step_
         ----------
         new_val : int, float
         """
-        
-        if new_val > 0:
-            print('step size changed')
-            print(f'is this the val from channel: {new_val}')
-            self.step_size = new_val
+        print(new_val)
+        try:
+            self.step_size = float(new_val)
+        except ValueError:
+            print('cannot cast PV value as float')
+
+
+
 
     @Property(str)
     def step_size_channel(self):

--- a/pydm/widgets/slider.py
+++ b/pydm/widgets/slider.py
@@ -387,20 +387,14 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget,new_properties=_step_
             return
         logger.debug("Has both limits, proceeding.")
         self._needs_limit_info = False
-
         if self._parameters_menu_flag:
             self._slider_position_to_value_map = self.create_slider_positions_map()
             self._parameters_menu_flag = False
-
         else:
             # if no defaults. create a linear space from min to max from default num_steps = 101, this means we cant step to max, but also cant call create map without a value
-            print('just opened display with only limits set')
             self._slider_position_to_value_map = np.linspace(self.minimum, self.maximum, num=self._num_steps)
             if is_channel_valid(self.step_size_channel):
-                print('valid channel set')
                 self.init_step_size_channel(pv_address=self.step_size_channel,slot=self.step_size_changed )
-
-
 
         self.update_labels()
         self.rangeChanged.emit(self.minimum, self.maximum)
@@ -417,31 +411,23 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget,new_properties=_step_
             self.step_size_channel_pv.connect()
             print(self.step_size_channel_pv.address)
         elif self.step_size_channel_pv is not None and self.step_size_channel_pv.address != pv_address:
+            print(f'else with channel {self.step_size_channel_pv}')
             self.step_size_channel_pv.disconnect()
             self.step_size_channel_pv = None
             self.step_size_channel_pv = PyDMChannel(address=pv_address, value_slot=slot)
             self.step_size_channel_pv.connect()
-
-        '''
-        elif self.step_size_channel_pv is not None and self.step_size_channel_pv.address != self.step_size_channel:
-            self.step_size_channel_pv.disconnect()
-            self.step_size_channel_pv = None
-            self.step_size_channel_pv = PyDMChannel(address=self.step_size_channel, value_slot=self.step_size_changed)
-            self.step_size_channel_pv.connect()
-            print('case5 path2')
-        elif self.step_size_channel_pv is not None and self.step_size_channel_pv.address == self.step_size_channel:
-            return True
-        '''
-
+        #else:
             # once channel is set the value_slot calls the step_size_change slot which call step_size setter, really want to make sure this isnt too recursive
 
     def create_slider_positions_map(self):
         print(self._step_size)
         if self._step_size > 0:
             positions_map = self.step_size_to_slider_positions_map()
+            print(positions_map)
         elif self._step_size == 0:
             self.calc_step_size()
             positions_map = self.step_size_to_slider_positions_map()
+            print(positions_map)
         return positions_map
 
     def step_size_to_slider_positions_map(self):
@@ -665,7 +651,6 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget,new_properties=_step_
             try:
                 self.value = self._slider_position_to_value_map[val]
                 self.send_value_signal[float].emit(self.value)
-                print('invoking internal_slider_value_changed')
             except IndexError:
                 pass
 

--- a/pydm/widgets/slider.py
+++ b/pydm/widgets/slider.py
@@ -64,6 +64,7 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget,new_properties=_step_
         self._num_steps = 101
         self._orientation = Qt.Horizontal
         self._step_size_channel = None
+        self.allowMaxEmit = True
         # Set up all the internal widgets that make up a PyDMSlider.
         # We'll add all these things to layouts when we call setup_widgets_for_orientation
         label_size_policy = QSizePolicy(QSizePolicy.Maximum, QSizePolicy.Fixed)
@@ -216,6 +217,7 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget,new_properties=_step_
         """
         Method for the 'ok' button in the slider parameters menu.
         """
+        print('p0: In apply and close menu')
         self.apply_step_size_menu_changes()
         self.slider_parameters_menu_widget.close()
 
@@ -228,15 +230,21 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget,new_properties=_step_
         try:
             # checks if input can be converted to a float if not connect to a new channel
             new_step_size = float(self.slider_parameters_menu_input_widgets[1].text())
+            print(f'new step size = {new_step_size} and scale is {float(self.slider_parameters_menu_input_widgets[2].currentText())}')
             new_step_size_scaled = new_step_size * float(self.slider_parameters_menu_input_widgets[2].currentText())
             if new_step_size_scaled > 0:
-                self.step_size = new_step_size_scaled
+                
             # if new step_size scaled greater than zero we want to disconnect the step size channel and reset step size
 
                 if self.step_size_channel_pv is not None:
+                    self.allowMaxEmit = False
                     self.step_size_channel_pv.disconnect()
+                    print('disconnected!!')
+                    print('\n')
                     self.step_size_channel_pv = None
                     self.step_size_channel = None
+                self.step_size = new_step_size_scaled
+                print('did value change too?')
             else:
                 # calc step size and update?
                 logger.error("step input is incorrect or 0")
@@ -263,7 +271,7 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget,new_properties=_step_
             if slider_value < self.minimum or slider_value > self.maximum:
                 raise ValueError
             if slider_value != self.value:
-
+                print('inside slider_value not = self.value')
                 self.value_changed(slider_value)
                 self.send_value_signal[float].emit(self.value)
         except ValueError:
@@ -388,24 +396,44 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget,new_properties=_step_
         logger.debug("Has both limits, proceeding.")
         self._needs_limit_info = False
         if self._parameters_menu_flag:
+            print('p3.5: after parameters Flag check')
             self._slider_position_to_value_map = self.create_slider_positions_map()
             self._parameters_menu_flag = False
         else:
             # if no defaults. create a linear space from min to max from default num_steps = 101, this means we cant step to max, but also cant call create map without a value
             self._slider_position_to_value_map = np.linspace(self.minimum, self.maximum, num=self._num_steps)
             if is_channel_valid(self.step_size_channel):
+                print(f'p-1: is channel valid')
                 self.init_step_size_channel(pv_address=self.step_size_channel,slot=self.step_size_changed )
 
         self.update_labels()
         self.rangeChanged.emit(self.minimum, self.maximum)
-        self.set_slider_to_closest_value(self.value)
+        #self.set_slider_to_closest_value(self.value)
+        print(f'value:{self.value}, numsteps:{self._num_steps}')
+        print(f'right before change occurs: min:{self._slider.minimum()} max:{self._slider.maximum()}')
         self._slider.setMinimum(0)
-        self._slider.setMaximum(self._num_steps) # -1
+        print('minimum set')
+        if self.allowMaxEmit:
+            self._slider.setMaximum(self._num_steps)
+        else:
+            print(f'current slider value = {self._slider.value()}')
+            self._slider.valueChanged.disconnect(self.internal_slider_value_changed)
+            self._slider.setMaximum(self._num_steps)
+            self._slider.valueChanged.connect(self.internal_slider_value_changed)
+            print(f'current slider value = {self._slider.value()}')
+            self.allowMaxEmit = True
+            
+        print('maximum set') # -1\
+        print(f'set! min:{self._slider.minimum()} max:{self._slider.maximum()}')
+        self.set_slider_to_closest_value(self.value)
+        print('p5: after min and max reset')
+        print('\n')
         self._slider.setSingleStep(1)
         self._slider.setPageStep(1)
         self.set_enable_state()
 
     def init_step_size_channel(self,pv_address,slot):
+        print(f'inside init channel with address: {pv_address}')
         if  self.step_size_channel_pv is None:
             self.step_size_channel_pv = PyDMChannel(address=pv_address, value_slot=slot)
             self.step_size_channel_pv.connect()
@@ -420,25 +448,24 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget,new_properties=_step_
             # once channel is set the value_slot calls the step_size_change slot which call step_size setter, really want to make sure this isnt too recursive
 
     def create_slider_positions_map(self):
-        print(self._step_size)
+        print(f'inside slider positions map with step size {self._step_size}')
         if self._step_size > 0:
             positions_map = self.step_size_to_slider_positions_map()
-            print(positions_map)
+            #print(positions_map)
         elif self._step_size == 0:
             self.calc_step_size()
             positions_map = self.step_size_to_slider_positions_map()
-            print(positions_map)
+            #print(positions_map)
         return positions_map
 
     def step_size_to_slider_positions_map(self):
-            print(f'experimental with step_size = {self._step_size}')
+            print(f'inside step_size_to_slider_positions map with value: {self.value} and slider value {self._slider.value()}')
             self._num_steps = int((self.maximum-self.minimum)/self.step_size) + 1
             forward_map = []
             backward_map = []
             step_counter = 0
             forward_map_value = self.value
             backward_map_value = self.value
-            print(self.value)
 
             while forward_map_value < self.maximum:
                 step_counter += 1
@@ -496,6 +523,7 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget,new_properties=_step_
         ----------
         val : float
         """
+        print(f'p4: in set_slider_to_closest_value with value: {self.value}')
         if val is None or self._needs_limit_info:
             logger.debug("Not setting slider to closest value because we need limits.")
             return
@@ -509,6 +537,7 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget,new_properties=_step_
         # the value of the channel.
         logger.debug("Setting slider to closest value.")
         self._mute_internal_slider_changes = True
+        print(f'setting value to position {self.find_closest_slider_position_to_value(val)} on our slider with min {self._slider.minimum()} and max {self._slider.maximum()}')
         self._slider.setValue(self.find_closest_slider_position_to_value(val))
         self._mute_internal_slider_changes = False
 
@@ -605,6 +634,7 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget,new_properties=_step_
 
     @Slot(int)
     def internal_slider_action_triggered(self, action):
+        print('internal action triggered')
         self.actionTriggered.emit(action)
 
     @Slot(int)
@@ -616,6 +646,7 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget,new_properties=_step_
         ----------
         val : float
         """
+        print('slider moved')
         self.sliderMoved.emit(self.value)
 
     @Slot()
@@ -643,13 +674,14 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget,new_properties=_step_
         ----------
         val : int
         """
-
+        print(f'internal slider changed from {self.value} to value at position {val} which is {self._slider_position_to_value_map[val]}')
         # Avoid potential crash if limits are undefined
         if self._slider_position_to_value_map is None:
             return
         if not self._mute_internal_slider_changes:
             try:
                 self.value = self._slider_position_to_value_map[val]
+                
                 self.send_value_signal[float].emit(self.value)
             except IndexError:
                 pass
@@ -898,6 +930,7 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget,new_properties=_step_
         new_steps : int
         """
         #print('num step setter')
+        print(f'p3: setting num steps {int(new_steps)}')
         self._num_steps = int(new_steps)
         self.reset_slider_limits()
 
@@ -926,6 +959,7 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget,new_properties=_step_
         if self.maximum is None or self.minimum is None or new_step_size <= 0:
             print('in bad state of step size setter')
             return False
+        print('p2:setting step size')
         self._step_size = float(new_step_size)
         self._parameters_menu_flag = True
         self.num_steps = ((self.maximum - self.minimum) / self._step_size) 
@@ -944,6 +978,8 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget,new_properties=_step_
         new_val : int, float
         """
         try:
+            print('setting new step size')
+            print('p1')
             self.step_size = float(new_val)
         except ValueError:
             print('cannot cast PV value as float')
@@ -963,9 +999,11 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget,new_properties=_step_
     
     @value.setter
     def value(self,new_value):
+        print(f'value changing: to {new_value}')
         self._value = new_value
         #print('value setter')
         if self.remap_flag:
+            print('inside remap flag checker')
             #print('setting value inside remap flag call')
             self.remap_flag = False
             self._slider_position_to_value_map = self.create_slider_positions_map()


### PR DESCRIPTION
Users can now set the step size for the slider widget through designer, code, or the launched ui and the slider will step by that amount. Additionally, users can set a PV for step size through designer, code, or the launched ui.