### PR TITLE
FIX: in analong_indicator, explicitly cast to int for py310+ compat

### DIFF
--- a/pydm/widgets/analog_indicator.py
+++ b/pydm/widgets/analog_indicator.py
@@ -137,9 +137,9 @@ class QScaleAlarmed(QScale):
         pointer_width = self._pointer_width_rate * self._widget_width
         pointer_height = self._bg_size_rate * self._scale_height * 1.5
         points = [
-            QPoint(self.position + 0.5 * pointer_width, 0),
-            QPoint(self.position - 0.5 * pointer_width, 0),
-            QPoint(self.position, pointer_height),
+            QPoint(int(self.position + 0.5 * pointer_width), 0),
+            QPoint(int(self.position - 0.5 * pointer_width), 0),
+            QPoint(int(self.position), int(pointer_height)),
         ]
         self._painter.drawPolygon(QPolygon(points))
 
@@ -152,7 +152,7 @@ class QScaleAlarmed(QScale):
         pointer_height = self._bg_size_rate * self._scale_height
         bg_width = self._widget_width
         bg_height = self._bg_size_rate * self._widget_height - 2
-        self._painter.drawRect(0, pointer_height, bg_width, bg_height)
+        self._painter.drawRect(0, int(pointer_height), int(bg_width), int(bg_height))
 
     def draw_minor_alarm_region(self):
         """
@@ -176,7 +176,12 @@ class QScaleAlarmed(QScale):
         else:
             self._painter.setBrush(self._minor_alarm_region_color)
         if self._lower_minor_alarm > self._lower_limit:
-            self._painter.drawRect(0, pointer_height, lower_minor_alarm_width, minor_alarm_height)
+            self._painter.drawRect(
+                0,
+                int(pointer_height),
+                int(lower_minor_alarm_width),
+                int(minor_alarm_height),
+            )
         """
         sets the pen color to alarm if the value is in the upper minor alarm region
         """
@@ -185,7 +190,12 @@ class QScaleAlarmed(QScale):
         else:
             self._painter.setBrush(self._minor_alarm_region_color)
         if self._upper_minor_alarm < self._upper_limit:
-            self._painter.drawRect(upper_minor_alarm_start, pointer_height, upper_minor_alarm_width, minor_alarm_height)
+            self._painter.drawRect(
+                int(upper_minor_alarm_start),
+                int(pointer_height),
+                int(upper_minor_alarm_width),
+                int(minor_alarm_height),
+            )
 
     def draw_major_alarm_region(self):
         """
@@ -211,7 +221,12 @@ class QScaleAlarmed(QScale):
             self._painter.setBrush(self._major_alarm_region_color)
         # makes sure alarm value is in range
         if self._lower_major_alarm > self._lower_limit:
-            self._painter.drawRect(0, pointer_height, lower_major_alarm_width, major_alarm_height)
+            self._painter.drawRect(
+                0,
+                int(pointer_height),
+                int(lower_major_alarm_width),
+                int(major_alarm_height),
+            )
 
         """
         sets the pen color to alarm if the value is in the upper major alarm region
@@ -222,7 +237,12 @@ class QScaleAlarmed(QScale):
             self._painter.setBrush(self._major_alarm_region_color)
         # makes sure alarm value is in range
         if self._upper_major_alarm < self._upper_limit:
-            self._painter.drawRect(upper_major_alarm_start, pointer_height, upper_major_alarm_width, major_alarm_height)
+            self._painter.drawRect(
+                int(upper_major_alarm_start),
+                int(pointer_height),
+                int(upper_major_alarm_width),
+                int(major_alarm_height),
+            )
 
     def paintEvent(self, event):
         """


### PR DESCRIPTION
Starting at python 3.10, the rules for passing floats into python C extension modules like pyqt has gotten stricter.
See #951 (closes #951)

The analog indicator widgets have this issue, but they mask over it with try/except blocks to prevent the app from crashing.
This PR makes the widget render as intended by casting all variable inputs to int.
Some of these are guaranteed to always be ints, but some of them are floats. Rather than parse out which is which, I figured it was better to cover all of them.

Python 3.9 pre-PR:
![indicatorpy39](https://github.com/slaclab/pydm/assets/10647860/80da08cf-0a64-4836-aa01-ba12a2789e5f)

Python 3.12 pre-PR:
![indicatorpy312](https://github.com/slaclab/pydm/assets/10647860/4a7b1d58-767c-46fd-97d8-2c4b959beb8b)

Python 3.12 post-PR:
![indicator312_fixed](https://github.com/slaclab/pydm/assets/10647860/b2d3f7fb-d371-49d8-8cd0-0b8a8d24e3fa)
