### PR TITLE
FIX: PyDMSlider out of bounds bug

### DIFF
--- a/pydm/tests/widgets/test_slider.py
+++ b/pydm/tests/widgets/test_slider.py
@@ -377,28 +377,6 @@ def test_reset_slider_limits(qtbot, signals, minimum, maximum, write_access, con
             pydm_slider._write_access and pydm_slider._connected and not pydm_slider._needs_limit_info
         )
 
-@pytest.mark.parametrize(
-    "new_value, minimum, maximum",
-    [
-        (10, 0, 0),
-        (-10, 10, 10)
-    ],
-)
-def test_slider_step_size_value_error(qtbot,new_value,minimum,maximum):
-    pydm_slider = PyDMSlider()
-    qtbot.addWidget(pydm_slider)
-
-    pydm_slider.userDefinedLimits = True
-    pydm_slider.userMinimum = minimum
-    pydm_slider.userMaximum = maximum
-    try:
-        pydm_slider.value = new_value
-    except:
-        ValueError
-    
-
-
-
 
 @pytest.mark.parametrize(
     "new_value, minimum, maximum",

--- a/pydm/tests/widgets/test_slider.py
+++ b/pydm/tests/widgets/test_slider.py
@@ -377,6 +377,28 @@ def test_reset_slider_limits(qtbot, signals, minimum, maximum, write_access, con
             pydm_slider._write_access and pydm_slider._connected and not pydm_slider._needs_limit_info
         )
 
+@pytest.mark.parametrize(
+    "new_value, minimum, maximum",
+    [
+        (10, 0, 0),
+        (-10, 10, 10)
+    ],
+)
+def test_slider_step_size_value_error(qtbot,new_value,minimum,maximum):
+    pydm_slider = PyDMSlider()
+    qtbot.addWidget(pydm_slider)
+
+    pydm_slider.userDefinedLimits = True
+    pydm_slider.userMinimum = minimum
+    pydm_slider.userMaximum = maximum
+    try:
+        pydm_slider.value = new_value
+    except:
+        ValueError
+    
+
+
+
 
 @pytest.mark.parametrize(
     "new_value, minimum, maximum",

--- a/pydm/widgets/slider.py
+++ b/pydm/widgets/slider.py
@@ -1018,6 +1018,8 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget, new_properties=_step
         self._step_size = float(new_step_size)
         self._parameters_menu_flag = True
         self.num_steps = (self.maximum - self.minimum) / self._step_size
+        if self.num_steps == 0:
+            raise ValueError("Num steps is set to zero")
 
         return True
 

--- a/pydm/widgets/slider.py
+++ b/pydm/widgets/slider.py
@@ -499,6 +499,7 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget, new_properties=_step
         """
         if self.value is not None and (self.value > self.maximum or self.value < self.minimum):
             logger.debug("Slider out of bounds.")
+            self._slider.setEnabled(False)
             raise ValueError('Slider is out of bounds either greater than max or less than min')
         
         forward_map = []
@@ -543,6 +544,7 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget, new_properties=_step
         """
         self.step_size = (self.maximum - self.minimum) / self.num_steps
         if self.step_size == 0:
+            self._slider.setEnabled(False)
             raise  ValueError('step size is zero afte calc step step size')
 
     def find_closest_slider_position_to_value(self, val):
@@ -1057,5 +1059,6 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget, new_properties=_step
     @value.setter
     def value(self, new_value):
         self._value = new_value
+        print('setting value')
         if self.remap_flag:
             self._slider_position_to_value_map = self.create_slider_positions_to_value_map()

--- a/pydm/widgets/slider.py
+++ b/pydm/widgets/slider.py
@@ -1059,6 +1059,5 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget, new_properties=_step
     @value.setter
     def value(self, new_value):
         self._value = new_value
-        print("setting value")
         if self.remap_flag:
             self._slider_position_to_value_map = self.create_slider_positions_to_value_map()

--- a/pydm/widgets/slider.py
+++ b/pydm/widgets/slider.py
@@ -500,8 +500,8 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget, new_properties=_step
         if self.value is not None and (self.value > self.maximum or self.value < self.minimum):
             logger.debug("Slider out of bounds.")
             self._slider.setEnabled(False)
-            raise ValueError('Slider is out of bounds either greater than max or less than min')
-        
+            raise ValueError("Slider is out of bounds either greater than max or less than min")
+
         forward_map = []
         backward_map = []
         forward_map_value = self.value
@@ -545,7 +545,7 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget, new_properties=_step
         self.step_size = (self.maximum - self.minimum) / self.num_steps
         if self.step_size == 0:
             self._slider.setEnabled(False)
-            raise  ValueError('step size is zero afte calc step step size')
+            raise ValueError("step size is zero afte calc step step size")
 
     def find_closest_slider_position_to_value(self, val):
         """
@@ -1059,6 +1059,6 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget, new_properties=_step
     @value.setter
     def value(self, new_value):
         self._value = new_value
-        print('setting value')
+        print("setting value")
         if self.remap_flag:
             self._slider_position_to_value_map = self.create_slider_positions_to_value_map()

--- a/pydm/widgets/slider.py
+++ b/pydm/widgets/slider.py
@@ -497,6 +497,10 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget, new_properties=_step
         array of allowed values where the length of the array is the number of slider positions.
         and the slider position i has value array[i].
         """
+        if self.value is not None and (self.value > self.maximum or self.value < self.minimum):
+            logger.debug("Slider out of bounds.")
+            raise ValueError('Slider is out of bounds either greater than max or less than min')
+        
         forward_map = []
         backward_map = []
         forward_map_value = self.value
@@ -538,7 +542,8 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget, new_properties=_step
         Given max, min, and num steps calculate step size
         """
         self.step_size = (self.maximum - self.minimum) / self.num_steps
-        # maybe do callback to stepsize line edit  here?
+        if self.step_size == 0:
+            raise  ValueError('step size is zero afte calc step step size')
 
     def find_closest_slider_position_to_value(self, val):
         """


### PR DESCRIPTION
The PyDMSlider has a bug(s) when the channel it is connected to is a certain type of PV (epics record).  If the record is an analog out (ao), and it does not have the record fields DRVH and DRVL set, then the slider is not forced to be within the bounds of the minimum and maximum properties. Since the default values of DRVH and DRVL are both zero, the slider wouldn't have a range of allowed values outside of "0".

This can cause two bugs. The first was calculated step size becomes 0,  which would essentially form a never ending while loop of allowed positions when the slider value was out of bounds. The second bug is PV values could be out of the slider bounds.

These bugs only occur when both DRVH and DRVL were at default values. If either was set it would not occur. This PR has code to catch these edges and then raise value errors since we neither want a unending loop or a slider with values existing out of bounds.