### PR TITLE
ENH: pva image dim order option

### DIFF
--- a/pydm/widgets/image.py
+++ b/pydm/widgets/image.py
@@ -19,7 +19,22 @@ class ReadingOrder(object):
     Clike = 1
 
 class DimensionOrder(object):
-    """Class to build ReadingOrder ENUM property."""
+    """
+    Class to build DimensionOrder ENUM property.
+    
+    This relates to how the pva image data is being sent. Included in this data are the dimensions of the 
+    image (width and height) as part of the array 'dimension_t[] dimension'.
+    (https://github.com/epics-base/normativeTypesCPP/wiki/Normative+Types+Specification#ntndarray)
+    But if the array should be ordered [height, width] or [width, height] does not seem to be specified.
+    This option lets the user set which ordering PyDM should interpret the 'dimension' array as having.
+
+    HeightFirst = [height, width]
+    WidthFirst = [width, height]
+    (PyDM uses HeightFirst as default)
+
+    If you are wondering what ordering a certain pva address using, you can 'pvget' the address
+    to see the values in its 'dimension' array.
+    """
 
     HeightFirst = 0
     WidthFirst = 1
@@ -538,22 +553,23 @@ class PyDMImageView(ImageView, PyDMWidget, PyDMColorMap, ReadingOrder, Dimension
     @Property(DimensionOrder)
     def dimensionOrder(self):
         """
-        Return the reading order of the :attr:`imageChannel` array.
+        Return the dimension order of the :attr:`imageChannel` array.
+        (for more info see DimensionOrder class definition)
 
         Returns
         -------
-        ReadingOrder
+        DimensionOrder
         """
         return self._dimension_order
 
     @dimensionOrder.setter
     def dimensionOrder(self, new_order):
         """
-        Set reading order of the :attr:`imageChannel` array.
+        Set dimension order of the :attr:`imageChannel` array.
 
         Parameters
         ----------
-        new_order: ReadingOrder
+        new_order: DimensionOrder
         """
         if self._dimension_order != new_order:
             self._dimension_order = new_order

--- a/pydm/widgets/image.py
+++ b/pydm/widgets/image.py
@@ -28,6 +28,10 @@ class ImageUpdateThread(QThread):
 
     def run(self):
         img = self.image_view.image_waveform
+        #print('dim order: ', self.image_view._dimension_order)
+        if self.image_view._dimension_order:
+            shape = img.shape
+            img = img.reshape(shape[1], shape[0])
         needs_redraw = self.image_view.needs_redraw
         image_dimensions = len(img.shape)
         width = self.image_view.imageWidth
@@ -115,6 +119,7 @@ class PyDMImageView(ImageView, PyDMWidget, PyDMColorMap, ReadingOrder):
 
         # Set default reading order of numpy array data to Fortranlike.
         self._reading_order = ReadingOrder.Fortranlike
+        self._dimension_order = False
 
         self._redraw_rate = 30
 
@@ -519,6 +524,29 @@ class PyDMImageView(ImageView, PyDMWidget, PyDMColorMap, ReadingOrder):
         """
         if self._reading_order != new_order:
             self._reading_order = new_order
+
+    @Property(bool)
+    def dimensionOrder(self):
+        """
+        Return the reading order of the :attr:`imageChannel` array.
+
+        Returns
+        -------
+        ReadingOrder
+        """
+        return self._dimension_order
+
+    @dimensionOrder.setter
+    def dimensionOrder(self, new_order):
+        """
+        Set reading order of the :attr:`imageChannel` array.
+
+        Parameters
+        ----------
+        new_order: ReadingOrder
+        """
+        if self._dimension_order != new_order:
+            self._dimension_order = new_order
 
     def keyPressEvent(self, ev):
         """Handle keypress events."""

--- a/pydm/widgets/image.py
+++ b/pydm/widgets/image.py
@@ -31,7 +31,7 @@ class DimensionOrder(object):
 
     HeightFirst = [height, width]
     WidthFirst = [width, height]
-    (PyDM uses HeightFirst as default)
+    (PyDM assumes HeightFirst as default)
 
     If you are wondering what ordering a certain pva address is using, you can 'pvget' the address
     to see the ordering of values in its 'dimension' array.
@@ -53,6 +53,9 @@ class ImageUpdateThread(QThread):
 
         if self.image_view._dimension_order == DimensionOrder.WidthFirst:
             shape = img.shape
+            # numpy reshape asks for (height, width) as it's params,
+            # and if we know our 'img.shape' is ordered [width, height],
+            # we must pass reshape(height, width) which is (shape[1], shape[0])
             img = img.reshape(shape[1], shape[0])
 
         needs_redraw = self.image_view.needs_redraw

--- a/pydm/widgets/image.py
+++ b/pydm/widgets/image.py
@@ -27,14 +27,14 @@ class DimensionOrder(object):
     image (width and height) as part of the array 'dimension_t[] dimension'.
     (https://github.com/epics-base/normativeTypesCPP/wiki/Normative+Types+Specification#ntndarray)
     But if the array should be ordered [height, width] or [width, height] does not seem to be specified.
-    This option lets the user set which ordering PyDM should interpret the 'dimension' array as having.
+    This option lets the user set which ordering PyDM should interpret this 'dimension' array as having.
 
     HeightFirst = [height, width]
     WidthFirst = [width, height]
     (PyDM uses HeightFirst as default)
 
-    If you are wondering what ordering a certain pva address using, you can 'pvget' the address
-    to see the values in its 'dimension' array.
+    If you are wondering what ordering a certain pva address is using, you can 'pvget' the address
+    to see the ordering of values in its 'dimension' array.
     """
 
     HeightFirst = 0

--- a/pydm/widgets/image.py
+++ b/pydm/widgets/image.py
@@ -18,11 +18,12 @@ class ReadingOrder(object):
     Fortranlike = 0
     Clike = 1
 
+
 class DimensionOrder(object):
     """
     Class to build DimensionOrder ENUM property.
-    
-    This relates to how the pva image data is being sent. Included in this data are the dimensions of the 
+
+    This relates to how the pva image data is being sent. Included in this data are the dimensions of the
     image (width and height) as part of the array 'dimension_t[] dimension'.
     (https://github.com/epics-base/normativeTypesCPP/wiki/Normative+Types+Specification#ntndarray)
     But if the array should be ordered [height, width] or [width, height] does not seem to be specified.
@@ -39,7 +40,7 @@ class DimensionOrder(object):
     HeightFirst = 0
     WidthFirst = 1
 
-    
+
 class ImageUpdateThread(QThread):
     updateSignal = Signal(list)
 
@@ -49,12 +50,11 @@ class ImageUpdateThread(QThread):
 
     def run(self):
         img = self.image_view.image_waveform
-        
-        #print('dim order: ', self.image_view._dimension_order)
+
         if self.image_view._dimension_order == DimensionOrder.WidthFirst:
             shape = img.shape
             img = img.reshape(shape[1], shape[0])
-        
+
         needs_redraw = self.image_view.needs_redraw
         image_dimensions = len(img.shape)
         width = self.image_view.imageWidth

--- a/pydm/widgets/image.py
+++ b/pydm/widgets/image.py
@@ -18,7 +18,13 @@ class ReadingOrder(object):
     Fortranlike = 0
     Clike = 1
 
+class DimensionOrder(object):
+    """Class to build ReadingOrder ENUM property."""
 
+    HeightFirst = 0
+    WidthFirst = 1
+
+    
 class ImageUpdateThread(QThread):
     updateSignal = Signal(list)
 
@@ -28,10 +34,12 @@ class ImageUpdateThread(QThread):
 
     def run(self):
         img = self.image_view.image_waveform
+        
         #print('dim order: ', self.image_view._dimension_order)
-        if self.image_view._dimension_order:
+        if self.image_view._dimension_order == DimensionOrder.WidthFirst:
             shape = img.shape
             img = img.reshape(shape[1], shape[0])
+        
         needs_redraw = self.image_view.needs_redraw
         image_dimensions = len(img.shape)
         width = self.image_view.imageWidth
@@ -72,7 +80,7 @@ class ImageUpdateThread(QThread):
         self.image_view.needs_redraw = False
 
 
-class PyDMImageView(ImageView, PyDMWidget, PyDMColorMap, ReadingOrder):
+class PyDMImageView(ImageView, PyDMWidget, PyDMColorMap, ReadingOrder, DimensionOrder):
     """
     A PyQtGraph ImageView with support for Channels and more from PyDM.
 
@@ -98,8 +106,10 @@ class PyDMImageView(ImageView, PyDMWidget, PyDMColorMap, ReadingOrder):
     """
 
     ReadingOrder = ReadingOrder
+    DimensionOrder = DimensionOrder
 
     Q_ENUMS(ReadingOrder)
+    Q_ENUMS(DimensionOrder)
     Q_ENUMS(PyDMColorMap)
 
     color_maps = cmaps
@@ -119,7 +129,7 @@ class PyDMImageView(ImageView, PyDMWidget, PyDMColorMap, ReadingOrder):
 
         # Set default reading order of numpy array data to Fortranlike.
         self._reading_order = ReadingOrder.Fortranlike
-        self._dimension_order = False
+        self._dimension_order = DimensionOrder.HeightFirst
 
         self._redraw_rate = 30
 
@@ -525,7 +535,7 @@ class PyDMImageView(ImageView, PyDMWidget, PyDMColorMap, ReadingOrder):
         if self._reading_order != new_order:
             self._reading_order = new_order
 
-    @Property(bool)
+    @Property(DimensionOrder)
     def dimensionOrder(self):
         """
         Return the reading order of the :attr:`imageChannel` array.


### PR DESCRIPTION
add option for specifying how pydm should read pva image dimensions.

more context: https://github.com/slaclab/pydm/issues/1082