### PR TITLE
FIX: PyDMChannel Connection Removal Error

### DIFF
--- a/pydm/data_plugins/plugin.py
+++ b/pydm/data_plugins/plugin.py
@@ -5,6 +5,7 @@ import threading
 from typing import Optional, Callable
 
 from ..utilities.remove_protocol import parsed_address
+from qtpy import sip
 from qtpy.QtCore import Signal, QObject, Qt
 from qtpy.QtWidgets import QApplication
 from .. import config
@@ -317,5 +318,6 @@ class PyDMPlugin(object):
                 self.connections[connection_id].remove_listener(channel, destroying=destroying)
                 self.channels.remove(channel)
                 if self.connections[connection_id].listener_count < 1:
-                    self.connections[connection_id].deleteLater()
+                    if not sip.isdeleted(self.connections[connection_id]):
+                        self.connections[connection_id].deleteLater()
                     del self.connections[connection_id]


### PR DESCRIPTION
Fix for an error when closing PyDM displays. The error occurs when closing a PyDM application and a PyDMChannel attempts to close its connections. Somehow the connections are already deleted before PyDMChannel can delete them explicitly.

Error text example: 
[2024-06-26 14:13:39,082] [ERROR   ] - Unable to remove connection for <PyDMChannel (archiver://pv=KLYS:LI22:31:KVAC)>
Traceback (most recent call last):
  File "/afs/slac.stanford.edu/u/cd/zdomke/workspace/pydm/pydm/widgets/channel.py", line 164, in disconnect
    plugin.remove_connection(self, destroying=destroying)
  File "/afs/slac.stanford.edu/u/cd/zdomke/workspace/pydm/pydm/data_plugins/plugin.py", line 320, in remove_connection
    self.connections[connection_id].deleteLater()
RuntimeError: wrapped C/C++ object of type Connection has been deleted

The solution is to check if the connections are already closed using PyQT.sip.isdeleted()