### PR TITLE
FIX: Plot Axis Name Change

### DIFF
--- a/pydm/widgets/baseplot.py
+++ b/pydm/widgets/baseplot.py
@@ -470,6 +470,9 @@ class BasePlotAxisItem(AxisItem):
         ----------
         name: str
         """
+        if name == self._name:
+            return
+        self.parentItem().change_axis_name(self._name, name)
         self._name = name
 
     @property

--- a/pydm/widgets/baseplot.py
+++ b/pydm/widgets/baseplot.py
@@ -507,6 +507,7 @@ class BasePlotAxisItem(AxisItem):
     def label_text(self, label: str):
         """Set the label to be displayed along this axis"""
         self._label = label
+        self.setLabel(self._label)
 
     @property
     def min_range(self) -> float:

--- a/pydm/widgets/multi_axis_plot.py
+++ b/pydm/widgets/multi_axis_plot.py
@@ -111,6 +111,11 @@ class MultiAxisPlot(PlotItem):
         # Rebuilding the layout of the plot item will put the new axis in the correct place
         self.rebuildLayout()
 
+    def change_axis_name(self, old_name: str, new_name: str):
+        """Change the name of the axis by changing the item's key in the axes dictionary."""
+        self.axes[new_name] = self.axes[old_name]
+        del self.axes[old_name]
+
     def addStackedView(self, view):
         """
         Add a view that will be stacked underneath the top level view box. Any mouse or key events handled by any of the
@@ -176,6 +181,8 @@ class MultiAxisPlot(PlotItem):
         if plotDataItem is None:
             return
 
+        if axisName not in self.axes:
+            return
         axisToLink = self.axes.get(axisName)["item"]
 
         # If this data is being moved from an existing view box, unlink that view box first


### PR DESCRIPTION
This fixes a bug in the BasePlotAxisItem class where the name property will be set internally, but the axis' associated MultiAxisPlot will contain a dictionary with the wrong key-value pairing for the axis object.

AxisItem name bug example scenario:
1. Create a BasePlotAxisItem with name "A"
    `my_axis = BasePlotAxisItem(name="A")`
2. Change the name of the previous BasePlotAxisItem to "B"
    `my_axis.name = "B"`
3. Create a BasePlotCurveItem and attach it to the BasePlotAxisItem using its new name
    `my_curve = BasePlotCurveItem(yAxisName = "B")`

This scenario produces a `KeyError` as the MultiAxisPlot.axes dictionary still uses "A" as the key to reference `my_axis`, but it should use "B".

Solution:
Include a method in MultiAxisPlot for changing the name/key of an axis. Then, update the MultiAxisPlot.axes key in the BasePlotAxisItem.name property setter.


Another small change made in this PR is to fix the BasePlotAxisItem.label setter. Now it will call `self.setLabel(self._label)` to update its label on any associated plots.