### PR TITLE
ENH: DateTimeAxisItem custom class

### DIFF
--- a/pydm/widgets/archiver_time_plot.py
+++ b/pydm/widgets/archiver_time_plot.py
@@ -299,10 +299,16 @@ class DateTimeAxisItem(DateAxisItem):
             val = values[i]
             try:
                 date = datetime.fromtimestamp(val)
+                # Option 1:
                 if i == 0:
                     strings.append(date.strftime("%H:%M:%S\n%m/%d/%Y"))
                 else:
                     strings.append(DateAxisData[i])
+                # Option 2:
+                # if i % 2 == 0:
+                #     strings.append(date.strftime("%H:%M:%S\n%m/%d/%Y"))
+                # else:
+                #     strings.append("")
             except ValueError:
                 strings.append("")
         return strings


### PR DESCRIPTION
If a user zooms in on the ArchiveViewer, the x-axis would be a time line with no context. For example, you're looking at seconds 1-10 of which minute, of which hour, of which day, of which month, of which year?

Created a custom DateTimeAxisItem that uses the same timestamps for most points, except for the first one and at steps of large units that provide context for exactly what time stamp you are looking at