### PR TITLE
ENH: Axis labels show which curves are on the axis

### DIFF
--- a/pydm/widgets/baseplot.py
+++ b/pydm/widgets/baseplot.py
@@ -640,15 +640,13 @@ class BasePlotAxisItem(AxisItem):
 
     def setHidden(self, shouldHide: bool):
         if shouldHide:
-            self.hide()
             for curve in self._curves:
-                curve.hide
-
+                curve.hide()
+            self.hide()
         else:
-            self.show()
             for curve in self._curves:
                 curve.show()
-                # Potentially can be fixed to not show curves previously marked hidden
+            self.show()
 
     def to_dict(self) -> OrderedDict:
         """

--- a/pydm/widgets/multi_axis_plot.py
+++ b/pydm/widgets/multi_axis_plot.py
@@ -111,7 +111,11 @@ class MultiAxisPlot(PlotItem):
 
     def change_axis_name(self, old_name: str, new_name: str):
         """Change the name of the axis by changing the item's key in the axes dictionary."""
+        axis = self.axes[old_name]["item"]
         self.axes[new_name] = self.axes[old_name]
+        if hasattr(axis, "_curves"):
+            for curve in axis._curves:
+                curve.y_axis_name = new_name
         del self.axes[old_name]
 
     def addStackedView(self, view):

--- a/pydm/widgets/multi_axis_plot.py
+++ b/pydm/widgets/multi_axis_plot.py
@@ -261,10 +261,10 @@ class MultiAxisPlot(PlotItem):
         axis = self.axes[axisName]["item"]
         shouldShow = False
         if hasattr(axis, "_curves"):
-            label = axisName+": "
+            label = axisName + ": "
             for curve in axis._curves:
                 if curve.isVisible():
-                    label += curve.name()+", "
+                    label += str(curve.name()) + ", "
                     shouldShow = True
             axis.setLabel(label[:-2])
             if shouldShow:

--- a/pydm/widgets/multi_axis_plot.py
+++ b/pydm/widgets/multi_axis_plot.py
@@ -265,7 +265,10 @@ class MultiAxisPlot(PlotItem):
             for curve in axis._curves:
                 if curve.isVisible():
                     if curve.name() != "":
-                        label += str(curve.name()) + " (" + str(curve.units or "") + "), "
+                        label += str(curve.name())
+                        if hasattr(curve, "units"):
+                            label += " (" + str(curve.units or "") + ")"
+                        label += ", "
                     shouldShow = True
             axis.setLabel(label[:-2])
             if shouldShow:

--- a/pydm/widgets/multi_axis_plot.py
+++ b/pydm/widgets/multi_axis_plot.py
@@ -264,7 +264,8 @@ class MultiAxisPlot(PlotItem):
             label = axisName + ": "
             for curve in axis._curves:
                 if curve.isVisible():
-                    label += str(curve.name()) + ", "
+                    if curve.name() != "":
+                        label += str(curve.name()) + " (" + str(curve.units or "") + "), "
                     shouldShow = True
             axis.setLabel(label[:-2])
             if shouldShow:

--- a/pydm/widgets/multi_axis_plot.py
+++ b/pydm/widgets/multi_axis_plot.py
@@ -225,6 +225,7 @@ class MultiAxisPlot(PlotItem):
         if hasattr(axisToLink, "_curves"):
             axisToLink._curves.append(plotDataItem)
         axisToLink.show()
+
         for otherAxisName in self.axes.keys():
             self.autoVisible(otherAxisName)
 
@@ -258,12 +259,17 @@ class MultiAxisPlot(PlotItem):
     def autoVisible(self, axisName):
         # Do we have any visible curves?
         axis = self.axes[axisName]["item"]
+        shouldShow = False
         if hasattr(axis, "_curves"):
+            label = axisName+": "
             for curve in axis._curves:
                 if curve.isVisible():
-                    axis.show()
-                    return
-
+                    label += curve.name()+", "
+                    shouldShow = True
+            axis.setLabel(label[:-2])
+            if shouldShow:
+                axis.show()
+                return
             # We don't have any visible curves, but are we the only curve being shown?
             for otherAxis in self.axes.keys():
                 otherItem = self.axes[otherAxis]["item"]

--- a/pydm/widgets/timeplot.py
+++ b/pydm/widgets/timeplot.py
@@ -9,6 +9,7 @@ from qtpy.QtCore import Signal, Slot, Property, QTimer, Q_ENUMS
 from .baseplot import BasePlot, BasePlotCurveItem
 from .channel import PyDMChannel
 from ..utilities import remove_protocol
+from epics import caget
 
 import logging
 
@@ -101,6 +102,7 @@ class TimePlotCurveItem(BasePlotCurveItem):
         self.latest_value = None
         self.channel = None
         self.address = channel_address
+        self.units = caget(self.address + ".EGU") if self.address else None
         super(TimePlotCurveItem, self).__init__(**kws)
 
     def to_dict(self):
@@ -117,6 +119,7 @@ class TimePlotCurveItem(BasePlotCurveItem):
     @address.setter
     def address(self, new_address: str):
         """Creates the channel for the input address for communicating with the address' plugin."""
+        self.units = caget(new_address + ".EGU") if new_address else None
         if not new_address:
             self.channel = None
             return


### PR DESCRIPTION
This builds on #1097, because it requires the use of the _curves attribute added to BasePlotAxisItems in that PR.

Given that each axis can have many curves on it, and you can freely move curves around, it can be confusing which curves are attached to which axes. As such, users will want to see which curves are attached to which axes.

Every time a curve is linked, unlinked, or its name changes, we are calling autoVisible to make sure the axis should or should not be shown. As a subroutine, we edit the label to include the names of the curves attached to this axis. If it is to be shown, the label will be updated; if not, it will remain hidden anyway.