### PR TITLE
FIX: Switching Y Axis orientation was not properly updating

### DIFF
--- a/pydm/widgets/axis_table_model.py
+++ b/pydm/widgets/axis_table_model.py
@@ -98,7 +98,8 @@ class BasePlotAxesModel(QAbstractTableModel):
             else:
                 axis.orientation = str(value)
             self.plot.plotItem.rebuildLayout()
-            axis.show()
+            if axis.isVisible():
+                axis.show()
         elif column_name == "Y-Axis Label":
             axis.label_text = str(value)
         elif column_name == "Min Y Range":

--- a/pydm/widgets/axis_table_model.py
+++ b/pydm/widgets/axis_table_model.py
@@ -97,6 +97,8 @@ class BasePlotAxesModel(QAbstractTableModel):
                 axis.orientation = "left"  # The PyQtGraph default is the left axis
             else:
                 axis.orientation = str(value)
+            self.plot.plotItem.rebuildLayout()
+            axis.show()
         elif column_name == "Y-Axis Label":
             axis.label_text = str(value)
         elif column_name == "Min Y Range":


### PR DESCRIPTION
In the axis table model, when switching an axis from left to right orientation, it was not actually moving the axis. There is a function in multi_plot_axis.py called "rebuildLayout" that moves the axes to where they need to be in the layout, which is one of the added lines.

The axis would then be physically moved, but it would also require being flipped around such that the label would be on the right side of the axis, which wasn't being done either. Prompting the axis to show causes it to redraw properly, so now by switching orientation of a y-axis from left to right (or vice versa) will correctly and immediately update the axis to the opposite side.