### PR TITLE
Fix Container class move for python 3.10

### DIFF
--- a/pydm/data_plugins/epics_plugins/p4p_plugin_component.py
+++ b/pydm/data_plugins/epics_plugins/p4p_plugin_component.py
@@ -262,7 +262,7 @@ class Connection(PyDMConnection):
                     if self.nttable_data_location:
                         msg = f"Invalid channel... {self.nttable_data_location}"
                         for subfield in self.nttable_data_location:
-                            if isinstance(new_value, collections.Container) and not isinstance(new_value, str):
+                            if isinstance(new_value, collections.abc.Container) and not isinstance(new_value, str):
                                 if isinstance(subfield, str):
                                     try:
                                         new_value = new_value[subfield]


### PR DESCRIPTION
Use `collections.abc.Container` instead of `collections.Container` (which was deprecated in Python 3.3 and removed in 3.10).
This should fix issue #1103.