### PR TITLE
ENH: ArchivePlotCurveItem Connection Status

### DIFF
--- a/pydm/data_plugins/archiver_plugin.py
+++ b/pydm/data_plugins/archiver_plugin.py
@@ -91,7 +91,12 @@ class Connection(PyDMConnection):
         # will be delivered to the data_request_finished method below via the "finished" signal
         self.connection_state_signal.emit(False)
         reply = self.network_manager.get(request)
-        QTimer.singleShot(7500, reply.abort)
+
+        def timeout():
+            if isinstance(reply, QNetworkReply):
+                reply.abort()
+
+        QTimer.singleShot(7500, timeout)
 
     @Slot(QNetworkReply)
     def data_request_finished(self, reply: QNetworkReply) -> None:

--- a/pydm/data_plugins/archiver_plugin.py
+++ b/pydm/data_plugins/archiver_plugin.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from typing import Optional
 
 from pydm.widgets.channel import PyDMChannel
+from qtpy import sip
 from qtpy.QtCore import Slot, QObject, QUrl, QTimer
 from qtpy.QtNetwork import QNetworkAccessManager, QNetworkRequest, QNetworkReply
 from pydm.data_plugins.plugin import PyDMPlugin, PyDMConnection
@@ -89,12 +90,12 @@ class Connection(PyDMConnection):
         request = QNetworkRequest(QUrl(url_string))
         # This get call is non-blocking, can be made in parallel with others, and when the results are ready they
         # will be delivered to the data_request_finished method below via the "finished" signal
-        self.connection_state_signal.emit(False)
         reply = self.network_manager.get(request)
 
         def timeout():
-            if isinstance(reply, QNetworkReply):
-                reply.abort()
+            if not isinstance(reply, QNetworkReply) or sip.isdeleted(reply):
+                return
+            reply.abort()
 
         QTimer.singleShot(7500, timeout)
 

--- a/pydm/data_plugins/archiver_plugin.py
+++ b/pydm/data_plugins/archiver_plugin.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from typing import Optional
 
 from pydm.widgets.channel import PyDMChannel
-from qtpy.QtCore import Slot, QObject, QUrl
+from qtpy.QtCore import Slot, QObject, QUrl, QTimer
 from qtpy.QtNetwork import QNetworkAccessManager, QNetworkRequest, QNetworkReply
 from pydm.data_plugins.plugin import PyDMPlugin, PyDMConnection
 
@@ -89,7 +89,9 @@ class Connection(PyDMConnection):
         request = QNetworkRequest(QUrl(url_string))
         # This get call is non-blocking, can be made in parallel with others, and when the results are ready they
         # will be delivered to the data_request_finished method below via the "finished" signal
-        self.network_manager.get(request)
+        self.connection_state_signal.emit(False)
+        reply = self.network_manager.get(request)
+        QTimer.singleShot(7500, reply.abort)
 
     @Slot(QNetworkReply)
     def data_request_finished(self, reply: QNetworkReply) -> None:

--- a/pydm/data_plugins/archiver_plugin.py
+++ b/pydm/data_plugins/archiver_plugin.py
@@ -78,6 +78,7 @@ class Connection(PyDMConnection):
                 "Environment variable: PYDM_ARCHIVER_URL must be defined to use the archiver plugin, for "
                 "example: http://lcls-archapp.slac.stanford.edu"
             )
+            self.connection_state_signal.emit(False)
             return
 
         url_string = f"{base_url}/retrieval/data/getData.json?{self.address}&from={from_date_str}&to={to_date_str}"
@@ -100,10 +101,10 @@ class Connection(PyDMConnection):
         ----------
         reply: The response from the archiver appliance
         """
-        if (
-            reply.error() == QNetworkReply.NoError
-            and reply.header(QNetworkRequest.ContentTypeHeader) == "application/json"
-        ):
+        success = (reply.error() == QNetworkReply.NoError
+                   and reply.header(QNetworkRequest.ContentTypeHeader) == "application/json")
+        self.connection_state_signal.emit(success)
+        if success:
             bytes_str = reply.readAll()
             data_dict = json.loads(str(bytes_str, "utf-8"))
 

--- a/pydm/data_plugins/archiver_plugin.py
+++ b/pydm/data_plugins/archiver_plugin.py
@@ -101,8 +101,10 @@ class Connection(PyDMConnection):
         ----------
         reply: The response from the archiver appliance
         """
-        success = (reply.error() == QNetworkReply.NoError
-                   and reply.header(QNetworkRequest.ContentTypeHeader) == "application/json")
+        success = (
+            reply.error() == QNetworkReply.NoError
+            and reply.header(QNetworkRequest.ContentTypeHeader) == "application/json"
+        )
         self.connection_state_signal.emit(success)
         if success:
             bytes_str = reply.readAll()

--- a/pydm/widgets/archiver_time_plot.py
+++ b/pydm/widgets/archiver_time_plot.py
@@ -925,7 +925,7 @@ class PyDMArchiverTimePlot(PyDMTimePlot):
         """
         Overrides timeplot addYChannel method to be able to pass the liveData flag.
         """
-        return super().addYChannel(
+        curve = super().addYChannel(
             y_channel=y_channel,
             plot_style=plot_style,
             name=name,
@@ -942,6 +942,8 @@ class PyDMArchiverTimePlot(PyDMTimePlot):
             useArchiveData=useArchiveData,
             liveData=liveData,
         )
+        self.requestDataFromArchiver()
+        return curve
 
     def addFormulaChannel(self, yAxisName: str, **kwargs) -> FormulaCurveItem:
         """Creates a FormulaCurveItem and links it to the given y axis"""

--- a/pydm/widgets/timeplot.py
+++ b/pydm/widgets/timeplot.py
@@ -120,10 +120,13 @@ class TimePlotCurveItem(BasePlotCurveItem):
     @address.setter
     def address(self, new_address: str):
         """Creates the channel for the input address for communicating with the address' plugin."""
+        if self.channel:
+            if new_address == self.channel.address:
+                return
+            self.channel.disconnect()
+
         if not new_address:
             self.channel = None
-            return
-        elif self.channel and new_address == self.channel.address:
             return
 
         self.channel = PyDMChannel(
@@ -132,6 +135,7 @@ class TimePlotCurveItem(BasePlotCurveItem):
             value_slot=self.receiveNewValue,
             unit_slot=self.unitsChanged,
         )
+        self.channel.connect()
 
         # Clear the data from the previous channel and redraw the curve
         if self.points_accumulated:

--- a/pydm/widgets/timeplot.py
+++ b/pydm/widgets/timeplot.py
@@ -102,9 +102,10 @@ class TimePlotCurveItem(BasePlotCurveItem):
         self.points_accumulated = 0
         self.latest_value = None
         self.channel = None
-        self.address = channel_address
         self.units = ""
+
         super(TimePlotCurveItem, self).__init__(**kws)
+        self.address = channel_address
 
     def to_dict(self):
         dic_ = OrderedDict([("channel", self.address), ("plot_style", self.plot_style)])

--- a/pydm/widgets/timeplot.py
+++ b/pydm/widgets/timeplot.py
@@ -65,6 +65,7 @@ class TimePlotCurveItem(BasePlotCurveItem):
 
     _channels = ("channel",)
     unitSignal = Signal(str)
+    live_channel_connection = Signal(bool)
 
     def __init__(self, channel_address=None, plot_by_timestamps=True, plot_style="Line", **kws):
         """
@@ -181,6 +182,7 @@ class TimePlotCurveItem(BasePlotCurveItem):
     @Slot(bool)
     def connectionStateChanged(self, connected):
         # Maybe change pen stroke?
+        self.live_channel_connection.emit(connected)
         self.connected = connected
         if not self.connected:
             self.latest_value = np.nan


### PR DESCRIPTION
Adds `connection_state_signal` to the Archiver Plugin and makes use of it in the `ArchivePlotCurveItem`. More details given below:

1. Archiver Plugin will emit to the connection_state_signal when
  a. The Archiver URL doesn't exist ( --> False)
  b. The network request returns an error and/or data that isn't JSON formatted ( --> False)
  c. The network request returns no error and data in JSON format ( --> True)

2. `TimePlotCurveItem` change:
  a. Create a channel connection signal that is emitted in `connectionStateChanged`
  b. In address setter, disconnect channel (if one exists) and connect the new channel

3. `ArchiverPlotCurveItem` changes:
  a. Create a channel connection signal that is directly tied to the archive_channel connection signal
  b. In address setter, disconnect archive_channel (if one exists) and connect the new archive_channel
  c. In the address setter, prompt the PyDMArchivePlot to request archive data (needs to be done through the plot to get the time range)

4. In `PyDMArchiveTimePlot`, fix an issue with the default timespan not being set properly in `updateXAxis`