### PR TITLE
ENH: Added a slot to capture units received from the PyDMChannel

### DIFF
--- a/pydm/widgets/timeplot.py
+++ b/pydm/widgets/timeplot.py
@@ -64,7 +64,7 @@ class TimePlotCurveItem(BasePlotCurveItem):
     """
 
     _channels = ("channel",)
-
+    unitSignal = Signal(str)
     def __init__(self, channel_address=None, plot_by_timestamps=True, plot_style="Line", **kws):
         """
         Parameters
@@ -101,6 +101,7 @@ class TimePlotCurveItem(BasePlotCurveItem):
         self.latest_value = None
         self.channel = None
         self.address = channel_address
+        self.units = ""
         super(TimePlotCurveItem, self).__init__(**kws)
 
     def to_dict(self):
@@ -124,7 +125,7 @@ class TimePlotCurveItem(BasePlotCurveItem):
             return
 
         self.channel = PyDMChannel(
-            address=new_address, connection_slot=self.connectionStateChanged, value_slot=self.receiveNewValue
+            address=new_address, connection_slot=self.connectionStateChanged, value_slot=self.receiveNewValue, unit_slot=self.unitsChanged
         )
 
         # Clear the data from the previous channel and redraw the curve
@@ -166,6 +167,12 @@ class TimePlotCurveItem(BasePlotCurveItem):
             The maximum y-value collected so far for this current curve.
         """
         return self._max_y_value
+
+    @Slot(str)
+    def unitsChanged(self, units: str):
+        self.units = units
+        self.unitSignal.emit(units)
+
 
     @Slot(bool)
     def connectionStateChanged(self, connected):

--- a/pydm/widgets/timeplot.py
+++ b/pydm/widgets/timeplot.py
@@ -65,6 +65,7 @@ class TimePlotCurveItem(BasePlotCurveItem):
 
     _channels = ("channel",)
     unitSignal = Signal(str)
+
     def __init__(self, channel_address=None, plot_by_timestamps=True, plot_style="Line", **kws):
         """
         Parameters
@@ -125,7 +126,10 @@ class TimePlotCurveItem(BasePlotCurveItem):
             return
 
         self.channel = PyDMChannel(
-            address=new_address, connection_slot=self.connectionStateChanged, value_slot=self.receiveNewValue, unit_slot=self.unitsChanged
+            address=new_address,
+            connection_slot=self.connectionStateChanged,
+            value_slot=self.receiveNewValue,
+            unit_slot=self.unitsChanged,
         )
 
         # Clear the data from the previous channel and redraw the curve
@@ -170,9 +174,9 @@ class TimePlotCurveItem(BasePlotCurveItem):
 
     @Slot(str)
     def unitsChanged(self, units: str):
+        """Slot to handle when units are received from the PyDMChannel."""
         self.units = units
         self.unitSignal.emit(units)
-
 
     @Slot(bool)
     def connectionStateChanged(self, connected):


### PR DESCRIPTION
We want to have curves be automatically attached to axes of the correct units. In order to receive the units, we will attach a slot to the PyDM channel plugin, and emit a signal to whatever curves model (in my case, the Archiver Time Plot Curve Model) we want for it to handle attaching to the correct axis.