### PR TITLE
ENH: FormulaCurveItem Connection Status

### DIFF
--- a/pydm/tests/widgets/test_archiver_timeplot.py
+++ b/pydm/tests/widgets/test_archiver_timeplot.py
@@ -206,6 +206,7 @@ def test_formula_curve_item():
     assert np.array_equal(formula_curve_3.archive_data_buffer, expected3)
     assert np.array_equal(formula_curve_4.archive_data_buffer, expected4)
 
+
 def test_disconnected_formula_curve_item():
     # Create a connected ArchivePlotCurveItem
     connected_curve = ArchivePlotCurveItem()
@@ -223,7 +224,9 @@ def test_disconnected_formula_curve_item():
 
     # Create a disconnected FormulaCurveItem
     disconnected_formula = FormulaCurveItem(formula="")
-    disconnected_formula.archive_data_buffer = np.array([[101, 106, 111, 116, 121, 126], [1, 2, 3, 4, 5, 6]], dtype=float)
+    disconnected_formula.archive_data_buffer = np.array(
+        [[101, 106, 111, 116, 121, 126], [1, 2, 3, 4, 5, 6]], dtype=float
+    )
     disconnected_formula.archive_points_accumulated = 6
     disconnected_formula.connected = False
     disconnected_formula.arch_connected = False

--- a/pydm/tests/widgets/test_archiver_timeplot.py
+++ b/pydm/tests/widgets/test_archiver_timeplot.py
@@ -154,13 +154,18 @@ def test_request_data_from_archiver(qtbot):
 
 def test_formula_curve_item():
     # Create two ArchivePlotCurveItems which we will make a few formulas out of
+    # Assume the curves have live and archive connections
     curve_item1 = ArchivePlotCurveItem()
     curve_item1.archive_data_buffer = np.array([[100, 105, 110, 115, 120, 125], [2, 3, 4, 5, 6, 7]], dtype=float)
     curve_item1.archive_points_accumulated = 6
+    curve_item1.connected = True
+    curve_item1.arch_connected = True
 
     curve_item2 = ArchivePlotCurveItem()
     curve_item2.archive_data_buffer = np.array([[101, 106, 111, 116, 121, 126], [1, 2, 3, 4, 5, 6]], dtype=float)
     curve_item2.archive_points_accumulated = 6
+    curve_item2.connected = True
+    curve_item2.arch_connected = True
 
     # Dictionary of PVS
     curves1 = dict()
@@ -200,3 +205,50 @@ def test_formula_curve_item():
     assert np.array_equal(formula_curve_2.archive_data_buffer, expected2)
     assert np.array_equal(formula_curve_3.archive_data_buffer, expected3)
     assert np.array_equal(formula_curve_4.archive_data_buffer, expected4)
+
+def test_disconnected_formula_curve_item():
+    # Create a connected ArchivePlotCurveItem
+    connected_curve = ArchivePlotCurveItem()
+    connected_curve.archive_data_buffer = np.array([[100, 105, 110, 115, 120, 125], [2, 3, 4, 5, 6, 7]], dtype=float)
+    connected_curve.archive_points_accumulated = 6
+    connected_curve.connected = True
+    connected_curve.arch_connected = True
+
+    # Create a disconnected ArchivePlotCurveItem
+    disconnected_curve = ArchivePlotCurveItem()
+    disconnected_curve.archive_data_buffer = np.array([[101, 106, 111, 116, 121, 126], [1, 2, 3, 4, 5, 6]], dtype=float)
+    disconnected_curve.archive_points_accumulated = 6
+    disconnected_curve.connected = False
+    disconnected_curve.arch_connected = False
+
+    # Create a disconnected FormulaCurveItem
+    disconnected_formula = FormulaCurveItem(formula="")
+    disconnected_formula.archive_data_buffer = np.array([[101, 106, 111, 116, 121, 126], [1, 2, 3, 4, 5, 6]], dtype=float)
+    disconnected_formula.archive_points_accumulated = 6
+    disconnected_formula.connected = False
+    disconnected_formula.arch_connected = False
+
+    formula = r"f://{A}+{B}"
+
+    # Create FormulaCurve using the 2 curves
+    # This formula curve should be disconnected
+    pv_dict = dict()
+    pv_dict["A"] = connected_curve
+    pv_dict["B"] = disconnected_curve
+
+    formula_curve_1 = FormulaCurveItem(formula=formula, pvs=pv_dict)
+
+    # Create FormulaCurve using the connected curve and the disconnected formula curve
+    # This formula curve should be disconnected
+    pv_dict = dict()
+    pv_dict["A"] = connected_curve
+    pv_dict["B"] = disconnected_formula
+
+    formula_curve_2 = FormulaCurveItem(formula=formula, pvs=pv_dict)
+
+    formula_curve_1.evaluate()
+    formula_curve_2.evaluate()
+
+    # Both curves should have no data
+    assert np.array_equal(formula_curve_1.archive_data_buffer, np.zeros((2, 0), dtype=float))
+    assert np.array_equal(formula_curve_2.archive_data_buffer, np.zeros((2, 0), dtype=float))

--- a/pydm/widgets/archiver_time_plot.py
+++ b/pydm/widgets/archiver_time_plot.py
@@ -269,7 +269,7 @@ class ArchivePlotCurveItem(TimePlotCurveItem):
             self._archiveBufferSize = DEFAULT_ARCHIVE_BUFFER_SIZE
             self.initializeArchiveBuffer()
 
-    Slot(bool)
+    @Slot(bool)
     def archiveConnectionStateChanged(self, connected: bool) -> None:
         """Capture the archive channel connection status and emit changes
 

--- a/pydm/widgets/archiver_time_plot.py
+++ b/pydm/widgets/archiver_time_plot.py
@@ -380,7 +380,7 @@ class FormulaCurveItem(BasePlotCurveItem):
         self._formula = formula
         # Have a formula for internal calculations, that the user does not see
         self._trueFormula = self.createTrueFormula()
-        self.pvs = pvs
+        self.pvs = pvs if pvs else {}
         self._liveData = liveData
         self.plot_style = plot_style
 

--- a/pydm/widgets/archiver_time_plot.py
+++ b/pydm/widgets/archiver_time_plot.py
@@ -90,6 +90,7 @@ class ArchivePlotCurveItem(TimePlotCurveItem):
                 return
             self.archive_channel.disconnect()
 
+        self.arch_connected = False
         if not new_address:
             self.archive_channel = None
             return
@@ -100,7 +101,7 @@ class ArchivePlotCurveItem(TimePlotCurveItem):
             address=archive_address,
             value_slot=self.receiveArchiveData,
             value_signal=self.archive_data_request_signal,
-            connection_slot=self.archive_channel_connection.emit,
+            connection_slot=self.archiveConnectionStateChanged,
         )
         self.archive_channel.connect()
 
@@ -267,6 +268,20 @@ class ArchivePlotCurveItem(TimePlotCurveItem):
         if self._archiveBufferSize != DEFAULT_ARCHIVE_BUFFER_SIZE:
             self._archiveBufferSize = DEFAULT_ARCHIVE_BUFFER_SIZE
             self.initializeArchiveBuffer()
+
+    Slot(bool)
+    def archiveConnectionStateChanged(self, connected: bool) -> None:
+        """Capture the archive channel connection status and emit changes
+
+        Parameters
+        ----------
+        connected : bool
+            The new connection status of the archive channel
+        """
+        if self.arch_connected == connected:
+            return
+        self.arch_connected = connected
+        self.archive_channel_connection.emit(connected)
 
     def channels(self) -> List[PyDMChannel]:
         """Return the list of channels this curve is connected to"""


### PR DESCRIPTION
Adds connection status checks to the FormulaCurveItem for both live and archive state. More details below:
1. `FormulaCurveItem` changes:
  a. Add properties `connected`, `arch_connected`, `live_connections` and `arch_connections` for storing the status of the curve an all used curves. The curve is only connected if **all** used curves are connected.
  b. If the `FormulaCurveItem` has no live and no archive connection then the formula's evaluations are skipped.
  c. Set `plot_style` default in `__init__` arguments definition.

2. `ArchivePlotCurveItem` change:
  a. Store the archiver channel's connection status in `arch_connected`.