### PR TITLE
FIX: Unlinking a curve from an axis now removes it from the legend

### DIFF
--- a/pydm/widgets/multi_axis_plot.py
+++ b/pydm/widgets/multi_axis_plot.py
@@ -256,6 +256,7 @@ class MultiAxisPlot(PlotItem):
             and curve.y_axis_name in self.axes
             and curve in self.axes[curve.y_axis_name]["item"]._curves
         ):
+            self.legend.removeItem(curve.name())
             self.axes[curve.y_axis_name]["item"]._curves.remove(curve)
             self.autoVisible(curve.y_axis_name)
 


### PR DESCRIPTION
MultiAxisPlot.py linkDataToAxis automatically adds the curve to the legend, but unlinking doesn't remove it, leading to multiple of the same curve existing on the legend if it changes axes. One liner fix.