### PR TITLE
FIX: Addressed two bugs on the slider. Middle click to see PV name and click and drag on the slider handle 

### DIFF
--- a/pydm/tests/widgets/test_slider.py
+++ b/pydm/tests/widgets/test_slider.py
@@ -3,13 +3,12 @@ from logging import ERROR
 import numpy as np
 
 from qtpy.QtWidgets import QLabel, QVBoxLayout, QHBoxLayout, QSizePolicy, QApplication
-from qtpy.QtCore import Qt, QMargins, QPoint, QEvent, QRect
+from qtpy.QtCore import Qt, QMargins, QPoint, QEvent, QRect, QSize
 from qtpy.QtGui import QMouseEvent
 from ...widgets.slider import PyDMSlider, PyDMPrimitiveSlider
 from ...widgets.base import PyDMWidget
 
 # Unit Tests for the PyDMPrimitiveSlider class
-
 
 @pytest.fixture(scope="module")
 def app():
@@ -21,7 +20,7 @@ def app():
 
 
 @pytest.fixture
-def test_slider(app):
+def horizontal_slider(app):
     """Fixture to create a PyDMPrimitiveSlider instance for each test."""
     test_slider = PyDMPrimitiveSlider(Qt.Horizontal)
     test_slider.setMinimum(0)
@@ -32,28 +31,53 @@ def test_slider(app):
     test_slider.show()
     return test_slider
 
+@pytest.fixture
+def vertical_slider(app):
+    """Fixture to create a vertical PyDMPrimitiveSlider instance for each test."""
+    test_slider = PyDMPrimitiveSlider(Qt.Vertical)
+    test_slider.setMinimum(0)
+    test_slider.setMaximum(100)
+    test_slider.setValue(50)
+    test_slider.setSingleStep(1)
+    test_slider.resize(30, 200)
+    test_slider.show()
+    return test_slider
 
-def test_mousePressEvent(test_slider, qtbot):
+@pytest.mark.parametrize("slider_fixture", ['horizontal_slider', 'vertical_slider'])
+def test_mousePressEvent(slider_fixture, qtbot, request):
     """Test mousePressEvent when clicking off and on the handle"""
+    test_slider = request.getfixturevalue(slider_fixture)
     handle_rect = test_slider.getHandleRect()
-    pos_off_handle = QPoint(handle_rect.right() + 10, handle_rect.center().y())
+
+    if test_slider.orientation() == Qt.Horizontal:
+        pos_off_handle = QPoint(handle_rect.right() + 10, handle_rect.center().y())
+        increment = 1
+    else:  # Vertical
+        pos_off_handle = QPoint(handle_rect.center().x(), handle_rect.bottom() + 10)
+        increment = -1
+
     qtbot.mouseClick(test_slider, Qt.LeftButton, pos=pos_off_handle)
     assert not test_slider.isDraggingHandle
-    assert test_slider.value() == 51
+    assert test_slider.value() == 50 + increment
 
     pos_on_handle = handle_rect.center()
     qtbot.mousePress(test_slider, Qt.LeftButton, pos=pos_on_handle)
     assert test_slider.isDraggingHandle
-    assert test_slider.dragStartValue == 51
+    assert test_slider.dragStartValue == test_slider.value()
 
-
-def test_mouseMoveEvent(test_slider, qtbot):
+@pytest.mark.parametrize("slider_fixture", ['horizontal_slider', 'vertical_slider'])
+def test_mouseMoveEvent(slider_fixture, qtbot, request):
     """Test the mouseMoveEvent method by posting QMouseEvent instances."""
+    test_slider = request.getfixturevalue(slider_fixture)
     handle_rect = test_slider.getHandleRect()
     start_pos = handle_rect.center()
     drag_distance = 100
-    end_pos = QPoint(start_pos.x() + drag_distance, start_pos.y())
 
+    if test_slider.orientation() == Qt.Horizontal:
+        end_pos = QPoint(start_pos.x() + drag_distance, start_pos.y())
+    else:
+        end_pos = QPoint(start_pos.x(), start_pos.y() - drag_distance)
+   
     initial_value = test_slider.value()
 
     press_event = QMouseEvent(QEvent.MouseButtonPress, start_pos, Qt.LeftButton, Qt.LeftButton, Qt.NoModifier)
@@ -71,10 +95,12 @@ def test_mouseMoveEvent(test_slider, qtbot):
     actual_value = test_slider.value()
 
     assert actual_value != initial_value
+    assert actual_value == 100
 
-
-def test_mouseReleaseEvent(test_slider, qtbot):
+@pytest.mark.parametrize("slider_fixture", ['horizontal_slider', 'vertical_slider'])
+def test_mouseReleaseEvent(slider_fixture, qtbot, request):
     """Test mouseReleaseEvent to stop dragging."""
+    test_slider = request.getfixturevalue(slider_fixture)
     handle_rect = test_slider.getHandleRect()
     pos_on_handle = handle_rect.center()
     qtbot.mousePress(test_slider, Qt.LeftButton, pos=pos_on_handle)
@@ -85,54 +111,79 @@ def test_mouseReleaseEvent(test_slider, qtbot):
     assert not test_slider.isDraggingHandle
     assert test_slider.cursor().shape() == Qt.ArrowCursor
 
-
-def test_getHandleRect(test_slider):
+@pytest.mark.parametrize("slider_fixture", ['horizontal_slider', 'vertical_slider'])
+def test_getHandleRect(slider_fixture, request):
     """Test getHandleRect method."""
+    test_slider = request.getfixturevalue(slider_fixture)
     handle_rect = test_slider.getHandleRect()
     assert isinstance(handle_rect, QRect)
     assert test_slider.rect().contains(handle_rect)
 
-
-def test_getPositions(test_slider):
+@pytest.mark.parametrize("slider_fixture", ['horizontal_slider', 'vertical_slider'])
+def test_getPositions(slider_fixture, request):
     """Test getPositions method."""
+    test_slider = request.getfixturevalue(slider_fixture)
     event = QMouseEvent(QEvent.MouseButtonPress, QPoint(50, 10), Qt.LeftButton, Qt.LeftButton, Qt.NoModifier)
     handle_pos, click_pos = test_slider.getPositions(event)
     assert isinstance(handle_pos, float)
     assert isinstance(click_pos, int)
-    assert 0 <= click_pos <= test_slider.width()
+    if test_slider.orientation() == Qt.Horizontal:
+        assert 0 <= click_pos <= test_slider.width()
+    else:
+        assert 0 <= click_pos <= test_slider.height()
 
-
-def test_shouldIncrement(test_slider):
+@pytest.mark.parametrize("slider_fixture", ['horizontal_slider', 'vertical_slider'])
+def test_shouldIncrement(slider_fixture, request):
     """Test shouldIncrement method."""
+    test_slider = request.getfixturevalue(slider_fixture)
 
-    # Click is to the right of the handle
-    assert test_slider.shouldIncrement(50, 70) is True
+    if test_slider.orientation() == Qt.Horizontal:
+        # Click is to the right of the handle
+        assert test_slider.shouldIncrement(50, 70) is True
+        # Click is to the left of the handle
+        assert test_slider.shouldIncrement(70, 50) is False
+    else:
+        # Click is above the handle (smaller y)
+        assert test_slider.shouldIncrement(70, 50) is True
+        # Click is below the handle (larger y)
+        assert test_slider.shouldIncrement(50, 70) is False
 
-    # Click is to the left of the handle
-    assert test_slider.shouldIncrement(70, 50) is False
 
-
-def test_getHandleSize(test_slider):
+@pytest.mark.parametrize("slider_fixture", ['horizontal_slider', 'vertical_slider'])
+def test_getHandleSize(slider_fixture, request):
     """Test getHandleSize method."""
+    test_slider = request.getfixturevalue(slider_fixture)
     handle_size = test_slider.getHandleSize()
     assert handle_size is not None
     assert isinstance(handle_size.width(), int)
     assert isinstance(handle_size.height(), int)
+    
+    if test_slider.orientation() == Qt.Horizontal:
+        assert handle_size == QSize(20, test_slider.height() // 2)
+    else:
+        assert handle_size == QSize(test_slider.width() // 2, 20)
 
-
-def test_getSliderLength(test_slider):
+@pytest.mark.parametrize("slider_fixture", ['horizontal_slider', 'vertical_slider'])
+def test_getSliderLength(slider_fixture, request):
     """Test getSliderLength method."""
+    test_slider = request.getfixturevalue(slider_fixture)
     slider_length = test_slider.getSliderLength()
     assert isinstance(slider_length, int)
-    assert slider_length < test_slider.width()
+    if test_slider.orientation() == Qt.Horizontal:
+        assert slider_length <= test_slider.width()
+    else:
+        assert slider_length <= test_slider.height()
 
-
-def test_getSliderPosition(test_slider):
+@pytest.mark.parametrize("slider_fixture", ['horizontal_slider', 'vertical_slider'])
+def test_getSliderPosition(slider_fixture, request):
     """Test getSliderPosition method."""
+    test_slider = request.getfixturevalue(slider_fixture)
     slider_position = test_slider.getSliderPosition()
     assert isinstance(slider_position, float)
-    assert 0 <= slider_position <= test_slider.width()
-
+    if test_slider.orientation() == Qt.Horizontal:
+        assert 0 <= slider_position <= test_slider.width()
+    else:
+        assert 0 <= slider_position <= test_slider.height()
 
 # Unit Tests for the PyDMSlider Widget
 

--- a/pydm/tests/widgets/test_slider.py
+++ b/pydm/tests/widgets/test_slider.py
@@ -10,6 +10,7 @@ from ...widgets.base import PyDMWidget
 
 # Unit Tests for the PyDMPrimitiveSlider class
 
+
 @pytest.fixture(scope="module")
 def app():
     """Fixture to create a QApplication instance."""
@@ -31,6 +32,7 @@ def horizontal_slider(app):
     test_slider.show()
     return test_slider
 
+
 @pytest.fixture
 def vertical_slider(app):
     """Fixture to create a vertical PyDMPrimitiveSlider instance for each test."""
@@ -43,7 +45,8 @@ def vertical_slider(app):
     test_slider.show()
     return test_slider
 
-@pytest.mark.parametrize("slider_fixture", ['horizontal_slider', 'vertical_slider'])
+
+@pytest.mark.parametrize("slider_fixture", ["horizontal_slider", "vertical_slider"])
 def test_mousePressEvent(slider_fixture, qtbot, request):
     """Test mousePressEvent when clicking off and on the handle"""
     test_slider = request.getfixturevalue(slider_fixture)
@@ -65,7 +68,8 @@ def test_mousePressEvent(slider_fixture, qtbot, request):
     assert test_slider.isDraggingHandle
     assert test_slider.dragStartValue == test_slider.value()
 
-@pytest.mark.parametrize("slider_fixture", ['horizontal_slider', 'vertical_slider'])
+
+@pytest.mark.parametrize("slider_fixture", ["horizontal_slider", "vertical_slider"])
 def test_mouseMoveEvent(slider_fixture, qtbot, request):
     """Test the mouseMoveEvent method by posting QMouseEvent instances."""
     test_slider = request.getfixturevalue(slider_fixture)
@@ -77,7 +81,7 @@ def test_mouseMoveEvent(slider_fixture, qtbot, request):
         end_pos = QPoint(start_pos.x() + drag_distance, start_pos.y())
     else:
         end_pos = QPoint(start_pos.x(), start_pos.y() - drag_distance)
-   
+
     initial_value = test_slider.value()
 
     press_event = QMouseEvent(QEvent.MouseButtonPress, start_pos, Qt.LeftButton, Qt.LeftButton, Qt.NoModifier)
@@ -97,7 +101,8 @@ def test_mouseMoveEvent(slider_fixture, qtbot, request):
     assert actual_value != initial_value
     assert actual_value == 100
 
-@pytest.mark.parametrize("slider_fixture", ['horizontal_slider', 'vertical_slider'])
+
+@pytest.mark.parametrize("slider_fixture", ["horizontal_slider", "vertical_slider"])
 def test_mouseReleaseEvent(slider_fixture, qtbot, request):
     """Test mouseReleaseEvent to stop dragging."""
     test_slider = request.getfixturevalue(slider_fixture)
@@ -111,7 +116,8 @@ def test_mouseReleaseEvent(slider_fixture, qtbot, request):
     assert not test_slider.isDraggingHandle
     assert test_slider.cursor().shape() == Qt.ArrowCursor
 
-@pytest.mark.parametrize("slider_fixture", ['horizontal_slider', 'vertical_slider'])
+
+@pytest.mark.parametrize("slider_fixture", ["horizontal_slider", "vertical_slider"])
 def test_getHandleRect(slider_fixture, request):
     """Test getHandleRect method."""
     test_slider = request.getfixturevalue(slider_fixture)
@@ -119,7 +125,8 @@ def test_getHandleRect(slider_fixture, request):
     assert isinstance(handle_rect, QRect)
     assert test_slider.rect().contains(handle_rect)
 
-@pytest.mark.parametrize("slider_fixture", ['horizontal_slider', 'vertical_slider'])
+
+@pytest.mark.parametrize("slider_fixture", ["horizontal_slider", "vertical_slider"])
 def test_getPositions(slider_fixture, request):
     """Test getPositions method."""
     test_slider = request.getfixturevalue(slider_fixture)
@@ -132,7 +139,8 @@ def test_getPositions(slider_fixture, request):
     else:
         assert 0 <= click_pos <= test_slider.height()
 
-@pytest.mark.parametrize("slider_fixture", ['horizontal_slider', 'vertical_slider'])
+
+@pytest.mark.parametrize("slider_fixture", ["horizontal_slider", "vertical_slider"])
 def test_shouldIncrement(slider_fixture, request):
     """Test shouldIncrement method."""
     test_slider = request.getfixturevalue(slider_fixture)
@@ -149,7 +157,7 @@ def test_shouldIncrement(slider_fixture, request):
         assert test_slider.shouldIncrement(50, 70) is False
 
 
-@pytest.mark.parametrize("slider_fixture", ['horizontal_slider', 'vertical_slider'])
+@pytest.mark.parametrize("slider_fixture", ["horizontal_slider", "vertical_slider"])
 def test_getHandleSize(slider_fixture, request):
     """Test getHandleSize method."""
     test_slider = request.getfixturevalue(slider_fixture)
@@ -157,13 +165,14 @@ def test_getHandleSize(slider_fixture, request):
     assert handle_size is not None
     assert isinstance(handle_size.width(), int)
     assert isinstance(handle_size.height(), int)
-    
+
     if test_slider.orientation() == Qt.Horizontal:
         assert handle_size == QSize(20, test_slider.height() // 2)
     else:
         assert handle_size == QSize(test_slider.width() // 2, 20)
 
-@pytest.mark.parametrize("slider_fixture", ['horizontal_slider', 'vertical_slider'])
+
+@pytest.mark.parametrize("slider_fixture", ["horizontal_slider", "vertical_slider"])
 def test_getSliderLength(slider_fixture, request):
     """Test getSliderLength method."""
     test_slider = request.getfixturevalue(slider_fixture)
@@ -174,7 +183,8 @@ def test_getSliderLength(slider_fixture, request):
     else:
         assert slider_length <= test_slider.height()
 
-@pytest.mark.parametrize("slider_fixture", ['horizontal_slider', 'vertical_slider'])
+
+@pytest.mark.parametrize("slider_fixture", ["horizontal_slider", "vertical_slider"])
 def test_getSliderPosition(slider_fixture, request):
     """Test getSliderPosition method."""
     test_slider = request.getfixturevalue(slider_fixture)
@@ -184,6 +194,7 @@ def test_getSliderPosition(slider_fixture, request):
         assert 0 <= slider_position <= test_slider.width()
     else:
         assert 0 <= slider_position <= test_slider.height()
+
 
 # Unit Tests for the PyDMSlider Widget
 

--- a/pydm/widgets/slider.py
+++ b/pydm/widgets/slider.py
@@ -26,8 +26,6 @@ _step_size_properties = {
 
 
 class PyDMPrimitiveSlider(QSlider):
-    # middleClicked = pyqtSignal()
-
     def __init__(self, orientation=Qt.Horizontal, parent=None):
         super().__init__(orientation, parent)
         self.isDraggingHandle = False

--- a/pydm/widgets/slider.py
+++ b/pydm/widgets/slider.py
@@ -143,12 +143,11 @@ class PyDMPrimitiveSlider(QSlider):
             A tuple containing the handle position and the click position.
         """
         slider_pos = self.getSliderPosition()
-
-        if self.orientation() == Qt.Horizontal:
-            handle_pos = slider_pos
+        handle_pos = slider_pos
+        
+        if self.orientation() == Qt.Horizontal:            
             click_pos = event.pos().x()
         else:
-            handle_pos = slider_pos
             click_pos = event.pos().y()
 
         return handle_pos, click_pos
@@ -228,6 +227,7 @@ class PyDMPrimitiveSlider(QSlider):
             return proportion * slider_length + self.getHandleSize().width() / 2
         else:
             slider_length = self.getSliderLength()
+            # 1 - proportion, because the largest positional value is at the bottom of the slider.  
             return (1 - proportion) * slider_length + self.getHandleSize().height() / 2
 
 
@@ -286,8 +286,11 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget, new_properties=_step
         self.high_lim_label.setSizePolicy(label_size_policy)
         self.high_lim_label.setAlignment(Qt.AlignRight | Qt.AlignTrailing | Qt.AlignVCenter)
         self._slider = PyDMPrimitiveSlider(parent=self)
+
+        # Pass PyDMPrimitiveWidget eventfilter to self._slider so it will have the tooltip display 
+        # the address name from middle clicking on the widget
         self._slider.installEventFilter(self)
-        # self._slider.middleClicked.connect()
+        
         self._slider.setOrientation(Qt.Horizontal)
 
         self._orig_wheel_event = self._slider.wheelEvent
@@ -297,7 +300,7 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget, new_properties=_step
         self._slider.sliderPressed.connect(self.internal_slider_pressed)
         self._slider.sliderReleased.connect(self.internal_slider_released)
         self._slider.valueChanged.connect(self.internal_slider_value_changed)
-        # self.vertical_layout.addWidget(self._slider)
+
         # Other internal variables and final setup steps
         self._slider_position_to_value_map = None
         self._mute_internal_slider_changes = False

--- a/pydm/widgets/slider.py
+++ b/pydm/widgets/slider.py
@@ -144,8 +144,8 @@ class PyDMPrimitiveSlider(QSlider):
         """
         slider_pos = self.getSliderPosition()
         handle_pos = slider_pos
-        
-        if self.orientation() == Qt.Horizontal:            
+
+        if self.orientation() == Qt.Horizontal:
             click_pos = event.pos().x()
         else:
             click_pos = event.pos().y()
@@ -227,7 +227,7 @@ class PyDMPrimitiveSlider(QSlider):
             return proportion * slider_length + self.getHandleSize().width() / 2
         else:
             slider_length = self.getSliderLength()
-            # 1 - proportion, because the largest positional value is at the bottom of the slider.  
+            # 1 - proportion, because the largest positional value is at the bottom of the slider.
             return (1 - proportion) * slider_length + self.getHandleSize().height() / 2
 
 
@@ -287,10 +287,10 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget, new_properties=_step
         self.high_lim_label.setAlignment(Qt.AlignRight | Qt.AlignTrailing | Qt.AlignVCenter)
         self._slider = PyDMPrimitiveSlider(parent=self)
 
-        # Pass PyDMPrimitiveWidget eventfilter to self._slider so it will have the tooltip display 
+        # Pass PyDMPrimitiveWidget eventfilter to self._slider so it will have the tooltip display
         # the address name from middle clicking on the widget
         self._slider.installEventFilter(self)
-        
+
         self._slider.setOrientation(Qt.Horizontal)
 
         self._orig_wheel_event = self._slider.wheelEvent

--- a/pydm/widgets/slider.py
+++ b/pydm/widgets/slider.py
@@ -185,9 +185,9 @@ class PyDMPrimitiveSlider(QSlider):
         """
         handle_length = 20  # Fixed length for the handle
         if self.orientation() == Qt.Horizontal:
-            return QSize(handle_length, self.height() / 2)
+            return QSize(handle_length, self.height() // 2)
         else:
-            return QSize(self.width() / 2, handle_length)
+            return QSize(self.width() // 2, handle_length)
 
     def getSliderLength(self):
         """


### PR DESCRIPTION
This PR fixes two bugs with the PyDMSlider. The first was with middle clicking on the slider, which did nothing, indeed of the expected behavior of displaying the PV name. The second was that the Slider was unable to be dragged. Now if a user clicks then holds on the handle of the slider they are able to drag the slider. 