### PR TITLE
ENH: Add Manual XRange Change Signal

### DIFF
--- a/pydm/widgets/multi_axis_plot.py
+++ b/pydm/widgets/multi_axis_plot.py
@@ -535,7 +535,7 @@ class MultiAxisPlot(PlotItem):
     def handleWheelEvent(self, view, ev, axis):
         """
         A simple slot for propagating a mouse wheel event to all the stacked view boxes (except for the one
-        one emitting the signal)
+        one emitting the signal). Only called once per X-Axis wheel event.
         Parameters
         ----------
         view: ViewBox
@@ -548,12 +548,14 @@ class MultiAxisPlot(PlotItem):
         for stackedView in self.stackedViews:
             if stackedView is not view:
                 stackedView.wheelEvent(ev, axis, fromSignal=True)
+
+        # Manual changes to X-Axis signal. Function is called once per X-Axis wheel event
         self.sigXRangeChangedManually.emit()
 
     def handleMouseDragEvent(self, view, ev, axis):
         """
         A simple slot for propagating a mouse drag event to all the stacked view boxes (except for the one
-        one emitting the signal)
+        one emitting the signal). Only called once per X-Axis drag event.
         Parameters
         ----------
         view: ViewBox
@@ -566,6 +568,8 @@ class MultiAxisPlot(PlotItem):
         for stackedView in self.stackedViews:
             if stackedView is not view:
                 stackedView.mouseDragEvent(ev, axis, fromSignal=True)
+
+        # Manual changes to X-Axis signal. Function is called once per X-Axis drag event
         self.sigXRangeChangedManually.emit()
 
     def changeMouseMode(self, mode):

--- a/pydm/widgets/multi_axis_plot.py
+++ b/pydm/widgets/multi_axis_plot.py
@@ -548,8 +548,7 @@ class MultiAxisPlot(PlotItem):
         for stackedView in self.stackedViews:
             if stackedView is not view:
                 stackedView.wheelEvent(ev, axis, fromSignal=True)
-        if axis != MultiAxisViewBox.YAxis:
-            self.sigXRangeChangedManually.emit()
+        self.sigXRangeChangedManually.emit()
 
     def handleMouseDragEvent(self, view, ev, axis):
         """
@@ -567,8 +566,7 @@ class MultiAxisPlot(PlotItem):
         for stackedView in self.stackedViews:
             if stackedView is not view:
                 stackedView.mouseDragEvent(ev, axis, fromSignal=True)
-        if axis != MultiAxisViewBox.YAxis:
-            self.sigXRangeChangedManually.emit()
+        self.sigXRangeChangedManually.emit()
 
     def changeMouseMode(self, mode):
         """

--- a/pydm/widgets/multi_axis_plot.py
+++ b/pydm/widgets/multi_axis_plot.py
@@ -1,7 +1,7 @@
 import weakref
 from pyqtgraph import AxisItem, PlotDataItem, PlotItem, ViewBox
 from typing import List, Optional
-from qtpy.QtCore import Qt
+from qtpy.QtCore import Qt, Signal
 from .multi_axis_viewbox import MultiAxisViewBox
 from .multi_axis_viewbox_menu import MultiAxisViewBoxMenu
 from ..utilities import is_qt_designer
@@ -22,6 +22,8 @@ class MultiAxisPlot(PlotItem):
     **kargs: optional
         PlotItem keyword arguments
     """
+
+    sigXRangeChangedManually = Signal()
 
     def __init__(self, parent=None, axisItems=None, **kargs):
         # Create a view box that will support multiple axes to pass to the PyQtGraph PlotItem
@@ -546,6 +548,8 @@ class MultiAxisPlot(PlotItem):
         for stackedView in self.stackedViews:
             if stackedView is not view:
                 stackedView.wheelEvent(ev, axis, fromSignal=True)
+        if axis != MultiAxisViewBox.YAxis:
+            self.sigXRangeChangedManually.emit()
 
     def handleMouseDragEvent(self, view, ev, axis):
         """
@@ -563,6 +567,8 @@ class MultiAxisPlot(PlotItem):
         for stackedView in self.stackedViews:
             if stackedView is not view:
                 stackedView.mouseDragEvent(ev, axis, fromSignal=True)
+        if axis != MultiAxisViewBox.YAxis:
+            self.sigXRangeChangedManually.emit()
 
     def changeMouseMode(self, mode):
         """


### PR DESCRIPTION
Add a signal to MultiAxisPlot that is emitted when the user makes changes to the X-Axis. Mimics the ViewBox signal `sigRangeChangedManually` which emits which axes are mouse enabled, but this signal doesn't need to pass any info.

Adding this signal to the event handlers `handleWheelEvent` and `handleMouseDragEvent`. The signal can just be emitted from here because these handlers are only called when the X-Axis is changed manually and only once per change.

#### Is it necessary? Can't you just use `ViewBox.sigRangeChangedManually`
I can't use that signal because the X-Axis is linked to each new Y-Axis in `addAxis`, meaning that users need to change which ViewBox to listen to every time a new Y-Axis is added. Adding this signal removes this issue by emitting when the changes are being propagated out to all ViewBoxes.