### PR TITLE
FIX: changes to publish-to-pypi.yml

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -31,7 +31,7 @@ jobs:
       run: python setup.py sdist
 
     - name: Upload package
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4.4.2
       with:
         name: package
         path: dist/*
@@ -45,7 +45,7 @@ jobs:
       id-token: write # Used for trusted publishing
     steps:
       - name: Download package
-        uses: actions/download-artifact@v4.1.7
+        uses: actions/download-artifact@v4.1.8
         with:
           name: package
           path: dist/


### PR DESCRIPTION
changes to the actions/upload-artifact and actions/download-artifact versions to address an issue with pushing to pypi on the release of v1.25.0