### PR TITLE
FIX: Check Validity of QAbstractTableModel Classes

### DIFF
--- a/pydm/tests/widgets/test_curve_editor.py
+++ b/pydm/tests/widgets/test_curve_editor.py
@@ -8,7 +8,10 @@ from ...widgets.baseplot_curve_editor import (
     RedrawModeColumnDelegate,
     PlotStyleColumnDelegate,
 )
+from ...widgets import PyDMArchiverTimePlot
+from ...widgets.axis_table_model import BasePlotAxesModel
 from ...widgets.baseplot_table_model import BasePlotCurvesModel
+from ...widgets.archiver_time_plot_editor import PyDMArchiverTimePlotCurvesModel
 from ...widgets.scatterplot_curve_editor import ScatterPlotCurveEditorDialog
 from ...widgets.timeplot_curve_editor import TimePlotCurveEditorDialog
 from ...widgets.waveformplot import WaveformCurveItem
@@ -118,6 +121,33 @@ def test_axis_editor(qtbot):
     # Verify the column count is correct, and the axis column delegate is placed correctly
     axis_orientation_index = axis_model._column_names.index("Y-Axis Orientation")
     assert type(axis_view.itemDelegateForColumn(axis_orientation_index)) is AxisColumnDelegate
+
+
+def test_axis_table_model(qtmodeltester):
+    "Check the validity of the BasePlotAxesModel with pytest-qt"
+    base_plot = BasePlot()
+    axis_model = BasePlotAxesModel(plot=base_plot)
+    axis_model.append("FooBar")
+
+    qtmodeltester.check(axis_model, force_py=True)
+
+
+def test_curves_table_model(qtmodeltester):
+    "Check the validity of the BasePlotCurvesModel with pytest-qt"
+    base_plot = BasePlot()
+    curves_model = BasePlotCurvesModel(plot=base_plot)
+    curves_model.append()
+
+    qtmodeltester.check(curves_model, force_py=True)
+
+
+def test_archive_table_model(qtmodeltester):
+    "Check the validity of the PyDMArchiverTimePlotCurvesModel with pytest-qt"
+    archiver_plot = PyDMArchiverTimePlot()
+    archive_model = PyDMArchiverTimePlotCurvesModel(plot=archiver_plot)
+    archive_model.append()
+
+    qtmodeltester.check(archive_model, force_py=True)
 
 
 def test_plot_style_column_delegate(qtbot):

--- a/pydm/tests/widgets/test_curve_editor.py
+++ b/pydm/tests/widgets/test_curve_editor.py
@@ -124,7 +124,7 @@ def test_axis_editor(qtbot):
 
 
 def test_axis_table_model(qtmodeltester):
-    "Check the validity of the BasePlotAxesModel with pytest-qt"
+    """Check the validity of the BasePlotAxesModel with pytest-qt"""
     base_plot = BasePlot()
     axis_model = BasePlotAxesModel(plot=base_plot)
     axis_model.append("FooBar")
@@ -133,7 +133,7 @@ def test_axis_table_model(qtmodeltester):
 
 
 def test_curves_table_model(qtmodeltester):
-    "Check the validity of the BasePlotCurvesModel with pytest-qt"
+    """Check the validity of the BasePlotCurvesModel with pytest-qt"""
     base_plot = BasePlot()
     curves_model = BasePlotCurvesModel(plot=base_plot)
     curves_model.append()
@@ -142,7 +142,7 @@ def test_curves_table_model(qtmodeltester):
 
 
 def test_archive_table_model(qtmodeltester):
-    "Check the validity of the PyDMArchiverTimePlotCurvesModel with pytest-qt"
+    """Check the validity of the PyDMArchiverTimePlotCurvesModel with pytest-qt"""
     archiver_plot = PyDMArchiverTimePlot()
     archive_model = PyDMArchiverTimePlotCurvesModel(plot=archiver_plot)
     archive_model.append()

--- a/pydm/widgets/archiver_time_plot_editor.py
+++ b/pydm/widgets/archiver_time_plot_editor.py
@@ -1,5 +1,5 @@
 from typing import Any, Optional
-from qtpy.QtCore import Qt, QModelIndex, QObject, QVariant
+from qtpy.QtCore import Qt, QModelIndex, QObject
 from qtpy.QtGui import QColor
 from .archiver_time_plot import ArchivePlotCurveItem, FormulaCurveItem
 from .baseplot import BasePlot, BasePlotCurveItem
@@ -16,7 +16,11 @@ class PyDMArchiverTimePlotCurvesModel(BasePlotCurvesModel):
 
         self.checkable_cols = {self.getColumnIndex("Live Data"), self.getColumnIndex("Archive Data")}
 
-    def flags(self, index):
+    def flags(self, index: QModelIndex) -> Qt.ItemFlags:
+        """Return flags that determine how users can interact with the items in the table"""
+        if not index.isValid():
+            return Qt.NoItemFlags
+
         flags = super().flags(index)
         if index.column() in self.checkable_cols:
             flags = Qt.ItemIsEnabled | Qt.ItemIsUserCheckable | Qt.ItemIsSelectable
@@ -24,7 +28,7 @@ class PyDMArchiverTimePlotCurvesModel(BasePlotCurvesModel):
 
     def data(self, index, role=Qt.DisplayRole):
         if not index.isValid():
-            return QVariant()
+            return None
         if role == Qt.CheckStateRole and index.column() in self.checkable_cols:
             value = super().data(index, Qt.DisplayRole)
             return Qt.Checked if value else Qt.Unchecked
@@ -37,12 +41,12 @@ class PyDMArchiverTimePlotCurvesModel(BasePlotCurvesModel):
         if column_name == "Channel":
             if isinstance(curve, FormulaCurveItem):
                 if curve.formula is None:
-                    return QVariant()
+                    return ""
                 return str(curve.formula)
             # We are either a Formula or a PV (for now at leasts)
             else:
                 if curve.address is None:
-                    return QVariant()
+                    return ""
                 return str(curve.address)
 
         elif column_name == "Live Data":
@@ -53,7 +57,7 @@ class PyDMArchiverTimePlotCurvesModel(BasePlotCurvesModel):
 
     def setData(self, index, value, role=Qt.DisplayRole):
         if not index.isValid():
-            return QVariant()
+            return None
         elif role == Qt.CheckStateRole and index.column() in self.checkable_cols:
             return super().setData(index, value, Qt.EditRole)
         elif index.column() not in self.checkable_cols:

--- a/pydm/widgets/axis_table_model.py
+++ b/pydm/widgets/axis_table_model.py
@@ -29,7 +29,10 @@ class BasePlotAxesModel(QAbstractTableModel):
     def plot(self, new_plot):
         self._plot = new_plot
 
-    def flags(self, index):
+    def flags(self, index: QModelIndex) -> Qt.ItemFlags:
+        """Return flags that determine how users can interact with the items in the table"""
+        if not index.isValid():
+            return Qt.NoItemFlags
         return Qt.ItemIsSelectable | Qt.ItemIsEnabled | Qt.ItemIsEditable
 
     def rowCount(self, parent=None):
@@ -42,17 +45,17 @@ class BasePlotAxesModel(QAbstractTableModel):
 
     def data(self, index, role=Qt.DisplayRole):
         if not index.isValid():
-            return QVariant()
+            return None
         if index.row() >= self.rowCount():
-            return QVariant()
+            return None
         if index.column() >= self.columnCount():
-            return QVariant()
+            return None
         column_name = self._column_names[index.column()]
         axis = self.plot._axes[index.row()]
         if role == Qt.DisplayRole or role == Qt.EditRole:
             return self.get_data(column_name, axis)
         else:
-            return QVariant()
+            return None
 
     def get_data(self, column_name, axis):
         if column_name == "Y-Axis Name":

--- a/pydm/widgets/baseplot_table_model.py
+++ b/pydm/widgets/baseplot_table_model.py
@@ -1,4 +1,4 @@
-from qtpy.QtCore import QAbstractTableModel, Qt, QVariant
+from qtpy.QtCore import QAbstractTableModel, Qt, QVariant, QModelIndex
 from qtpy.QtGui import QBrush
 from .baseplot import BasePlotCurveItem
 
@@ -42,7 +42,10 @@ class BasePlotCurvesModel(QAbstractTableModel):
     def clear(self):
         self.plot.clearCurves()
 
-    def flags(self, index):
+    def flags(self, index: QModelIndex) -> Qt.ItemFlags:
+        """Return flags that determine how users can interact with the items in the table"""
+        if not index.isValid():
+            return None
         column_name = self._column_names[index.column()]
         if column_name == "Color" or column_name == "Limit Color":
             return Qt.ItemIsSelectable | Qt.ItemIsEnabled
@@ -58,11 +61,11 @@ class BasePlotCurvesModel(QAbstractTableModel):
 
     def data(self, index, role=Qt.DisplayRole):
         if not index.isValid():
-            return QVariant()
+            return None
         if index.row() >= self.rowCount():
-            return QVariant()
+            return None
         if index.column() >= self.columnCount():
-            return QVariant()
+            return None
         column_name = self._column_names[index.column()]
         curve = self.plot._curves[index.row()]
         if role == Qt.DisplayRole or role == Qt.EditRole:
@@ -72,12 +75,12 @@ class BasePlotCurvesModel(QAbstractTableModel):
         elif role == Qt.BackgroundRole and column_name == "Limit Color":
             return QBrush(curve.threshold_color)
         else:
-            return QVariant()
+            return None
 
     def get_data(self, column_name, curve):
         if column_name == "Label":
             if curve.name() is None:
-                return QVariant()
+                return ""
             return str(curve.name())
         elif column_name == "Y-Axis Name":
             return curve.y_axis_name


### PR DESCRIPTION
This started with adding basic tests to check the validity of 3 `QAbstractTableModel` classes:
- `BasePlotAxesModel`
- `BasePlotCurvesModel`
- `PyDMArchiverTimePlotCurvesModel`

I fixed the issues that came up when the models were declared invalid. These fixes include:
- In `flags()`, the models check the validity of the given `QModelIndex`
- In `data()` and `setData()`, returns `None` instead of an empty `QVariant` object. This is done because `QVariant` is not really needed in PyQt like it is in Qt. In some cases where it makes more sense, I replaced the `QVariant` with empty strings.
  - While [this documentation](https://doc.qt.io/qtforpython-5/PySide2/QtCore/QAbstractItemModel.html#PySide2.QtCore.PySide2.QtCore.QAbstractItemModel.data) suggests returning an invalid QVariant, it doesn't specify what an invalid QVariant should be
  - [This documentation](https://doc.qt.io/qtforpython-5/considerations.html#qvariant) suggests that `None` is an invalid QVariant, and that is what we should use
  - `pytest-qt`'s `qtmodeltester` fixture that I used to test the models' validity checks that `None` is being returned for invalid `data()` requests, not `QVariant`

Also added basic docstrings to `flags()` methods.