### PR TITLE
FIX: Store Data for FormulaCurveItem with Constant Value

### DIFF
--- a/pydm/widgets/archiver_time_plot.py
+++ b/pydm/widgets/archiver_time_plot.py
@@ -476,7 +476,9 @@ class FormulaCurveItem(BasePlotCurveItem):
         If one curve updates at a certain timestep and another does not, it uses the previously
         seen data of the second curve, and assumes it is accurate at the current timestep.
         """
-        if not self.checkFormula():
+        formula = self._trueFormula
+        if not formula or not self.checkFormula():
+            logger.error("invalid formula")
             self.formula_invalid_signal.emit()
             return
         if not self.pvs:
@@ -491,10 +493,6 @@ class FormulaCurveItem(BasePlotCurveItem):
         pvLiveData = dict()
         pvIndices = dict()
         pvValues = dict()
-        formula = self._trueFormula
-        if not formula:
-            logger.error("invalid formula")
-            return
 
         self.archive_data_buffer = np.zeros((2, 0), order="f", dtype=float)
         self.data_buffer = np.zeros((2, 0), order="f", dtype=float)

--- a/pydm/widgets/archiver_time_plot.py
+++ b/pydm/widgets/archiver_time_plot.py
@@ -482,10 +482,11 @@ class FormulaCurveItem(BasePlotCurveItem):
             self.formula_invalid_signal.emit()
             return
         if not self.pvs:
+            # If we are just a constant, then store a straight line from 1970 to ~2200
+            # Known Bug: Constants are hidden if the plot's x-axis range is between 30m and 1.5hr
             self.archive_data_buffer = np.array([[0], [eval(self._trueFormula)]])
-            self.archive_points_accumulated = 1
             self.data_buffer = np.array([[APPROX_SECONDS_300_YEARS], [eval(self._trueFormula)]])
-            self.points_accumulated = 1
+            self.points_accumulated = self.archive_points_accumulated = 1
             return
         if not (self.connected and self.arch_connected):
             return

--- a/pydm/widgets/archiver_time_plot.py
+++ b/pydm/widgets/archiver_time_plot.py
@@ -479,6 +479,12 @@ class FormulaCurveItem(BasePlotCurveItem):
         if not self.checkFormula():
             self.formula_invalid_signal.emit()
             return
+        if not self.pvs:
+            self.archive_data_buffer = np.array([[0], [eval(self._trueFormula)]])
+            self.archive_points_accumulated = 1
+            self.data_buffer = np.array([[APPROX_SECONDS_300_YEARS], [eval(self._trueFormula)]])
+            self.points_accumulated = 1
+            return
         if not (self.connected and self.arch_connected):
             return
         pvArchiveData = dict()
@@ -604,15 +610,6 @@ class FormulaCurveItem(BasePlotCurveItem):
         """
         Redraw the curve with any new data added since the last draw call.
         """
-        if not self.pvs:
-            # If we are just a constant, then forget about data
-            # just draw a straight line from 1970 to 300 years or so in the future
-            y = [eval(self._trueFormula), eval(self._trueFormula)]
-            x = [0, APPROX_SECONDS_300_YEARS]
-            # There is a known bug that this won't graph a constant with an x axis
-            # of between 30 minutes and 1hr 30 minutes in range. Unknown reason
-            self.setData(y=y, x=x)
-            return
         self.evaluate()
         try:
             x = np.concatenate(


### PR DESCRIPTION
Solves an edge case bug that came up, where we have one FormulaCurveItem with a constant value ('A': 'f://4') that is referenced in another FormulaCurveItem ('B': 'f://{A}*2'). An error would be thrown:
```
  File "/afs/slac.stanford.edu/u/cd/zdomke/workspace/pydm/pydm/widgets/timeplot.py", line 670, in redrawPlot
    curve.redrawCurve(min_x=min_x, max_x=max_x)
  File "/afs/slac.stanford.edu/u/cd/zdomke/workspace/pydm/pydm/widgets/archiver_time_plot.py", line 622, in redrawCurve
    self.evaluate()
  File "/afs/slac.stanford.edu/u/cd/zdomke/workspace/pydm/pydm/widgets/archiver_time_plot.py", line 520, in evaluate
    pvValues[pv] = pvLiveData[pv][1][pvIndices[pv] - 1]
IndexError: index -1 is out of bounds for axis 0 with size 0
```

This is because when a formula was a constant, no data was actually saved in the object's `archive_data_buffer` and `data_buffer`. Instead the curve was just drawn on the graph, but never saved any data.

My solution is to just save the data in the data buffers in `evaluation`. I also moved the check for formula existence to the beginning of `evaluation`.

(The previous bug with constant values still exists, in which the curve will not appear if the timerange is ~30min - ~1.5hr)