### PR TITLE
DEV: don't use mambaforge installers in github actions setup

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -32,7 +32,7 @@ jobs:
       uses: conda-incubator/setup-miniconda@v2
       with:
         python-version: ${{ matrix.python-version }}
-        miniforge-variant: Mambaforge
+        miniforge-variant: Miniforge3
         miniforge-version: latest
         activate-environment: pydm-env
     - name: Install python packages


### PR DESCRIPTION
This address the follwing warning during CI:
"Warning: Mambaforge is now deprecated! Future Miniforge releases will NOT build Mambaforge installers. We advise you switch to Miniforge at your earliest convenience. More details at
https://conda-forge.org/news/2024/07/29/sunsetting-mambaforge/."

This seemed to have caused CI failures pretty recently, although oddly doesn't atm. (perhaps there was an update to miniforge installer?).

But regardless, this change is needed to make sure CI setup doesn't break in the future.