### PR TITLE
MNT: stop install wrong pyca package through pip, and enabled psp test which uses pyca's psp library

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,5 +4,4 @@ pytest-qt
 pytest-cov
 pytest-timeout
 p4p
-pyca
 pre-commit

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,4 +4,5 @@ pytest-qt
 pytest-cov
 pytest-timeout
 p4p
+git+https://github.com/slaclab/pyca.git; platform_system != "Windows"
 pre-commit

--- a/pydm/tests/data_plugins/test_psp_plugin_component.py
+++ b/pydm/tests/data_plugins/test_psp_plugin_component.py
@@ -1,3 +1,4 @@
+import time
 import functools
 import pydm.data_plugins.epics_plugins.psp_plugin_component
 from pydm.data_plugins.epics_plugins.psp_plugin_component import Connection
@@ -18,6 +19,11 @@ class MockPV:
     @staticmethod
     def severity(self):
         return None
+
+    def timestamp(self):
+        secs = time.time()
+        nanos = time.time_ns()
+        return secs, nanos
 
 
 def test_update_ctrl_vars(monkeypatch: MonkeyPatch, signals: ConnectionSignals):

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ pyqtgraph>=0.12.0
 qtpy
 scipy>=0.12.0
 six
-git+https://github.com/slaclab/pyca.git
+git+https://github.com/slaclab/pyca.git; platform_system != "Windows"

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pyqtgraph>=0.12.0
 qtpy
 scipy>=0.12.0
 six
+git+https://github.com/slaclab/pyca.git

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,3 @@ pyqtgraph>=0.12.0
 qtpy
 scipy>=0.12.0
 six
-git+https://github.com/slaclab/pyca.git; platform_system != "Windows"

--- a/run_tests.py
+++ b/run_tests.py
@@ -21,7 +21,6 @@ if __name__ == "__main__":
     # and a Windows PyCA build exists
     if os.name == "nt":
         args.append("--ignore=pydm/tests/data_plugins/test_p4p_plugin_component.py")
-    args.append("--ignore=pydm/tests/data_plugins/test_psp_plugin_component.py")
 
     print("pytest arguments: {}".format(args))
 

--- a/run_tests.py
+++ b/run_tests.py
@@ -21,6 +21,7 @@ if __name__ == "__main__":
     # and a Windows PyCA build exists
     if os.name == "nt":
         args.append("--ignore=pydm/tests/data_plugins/test_p4p_plugin_component.py")
+        args.append("--ignore=pydm/tests/data_plugins/test_psp_plugin_component.py")
 
     print("pytest arguments: {}".format(args))
 


### PR DESCRIPTION
the psp test can be enabled (except still unsupported on windows) if we switch to using correct pyca package from github. (pyca from PyPI was the wrong package)

This fixes issue where user downloads pydm and runs the tests with pytest cmd directly (instead of run_tests.py) and gets 'no module named psp' failure. 
This failure seems to suggest to user to 'pip install psp', which is the wrong package and leads to further confusion.