### PR TITLE
FIX: maintain reference to related displays to avoid gc

### DIFF
--- a/pydm/widgets/related_display_button.py
+++ b/pydm/widgets/related_display_button.py
@@ -84,6 +84,9 @@ class PyDMRelatedDisplayButton(QPushButton, PyDMWidget, new_properties=_relatedD
         # but standard icons are already colored and can not be set.
         self._pydm_icon_color = QColor(90, 90, 90)
 
+        # Retain references to subdisplays to avoid garbage collection
+        self._subdisplays = []
+
     @only_if_channel_set
     def check_enable_state(self) -> None:
         """
@@ -602,10 +605,13 @@ class PyDMRelatedDisplayButton(QPushButton, PyDMWidget, new_properties=_relatedD
             # Not a pydm app: need to give our new display proper pydm styling
             # Usually done in PyDMApplication
             merge_widget_stylesheet(widget=display)
-            # Parent the display to avoid garbage collection
-            display.setParent(self)
-            display.setWindowFlags(Qt.Window)
-            display.show()
+            # Clean up references to closed subdisplays
+            for old_display in list(self._subdisplays):
+                # isVisible only goes False after clicking "close"
+                if not old_display.isVisible():
+                    self._subdisplays.remove(old_display)
+            # Retain a reference to avoid garbage collection
+            self._subdisplays.append(display)
             return display
 
     def context_menu(self):

--- a/pydm/widgets/related_display_button.py
+++ b/pydm/widgets/related_display_button.py
@@ -602,6 +602,10 @@ class PyDMRelatedDisplayButton(QPushButton, PyDMWidget, new_properties=_relatedD
             # Not a pydm app: need to give our new display proper pydm styling
             # Usually done in PyDMApplication
             merge_widget_stylesheet(widget=display)
+            # Parent the display to avoid garbage collection
+            display.setParent(self)
+            display.setWindowFlags(Qt.Window)
+            display.show()
             return display
 
     def context_menu(self):


### PR DESCRIPTION
We noticed a niche issue when it comes to using the `PyDMRelatedDisplayButton` widget outside of a pydm application.

In these cases, the display that gets loaded is orphaned, and will eventually get garbage collected because there are no python references to the display object. This isn't a problem inside the pydm applications because in these cases we either start a new process, which retains a reference to the screen, or we replace our main widget with the new widget, so the window retains a reference.

Users have been reporting that their displays would "crash with no error message" and I tracked it down to this.

In this PR, I create a list and stash these related displays in the list. This means they have one python reference, so they aren't closed automatically.