### PR TITLE
ENH/FIX: shell command output options

### DIFF
--- a/pydm/tests/widgets/test_shell_command.py
+++ b/pydm/tests/widgets/test_shell_command.py
@@ -321,11 +321,14 @@ def test_output_options(qtbot, capfd, stdout_setting, stderr_setting):
 
     qtbot.addWidget(pydm_shell_command)
 
-    capfd.readouterr()
     if platform.system() == "Windows":
         cmdsep = " & "
+        outterm = " \r\n"
     else:
         cmdsep = "; "
+        outterm = "\n"
+
+    capfd.readouterr()
     pydm_shell_command.execute_command(f"echo stdout{cmdsep}echo stderr 1>&2")
     pydm_shell_command.process.wait()
     out_show, err_show = capfd.readouterr()
@@ -335,11 +338,11 @@ def test_output_options(qtbot, capfd, stdout_setting, stderr_setting):
         assert out_show == ""
         assert out_store is None
     elif stdout_setting == TermOutputMode.SHOW:
-        assert out_show == "stdout\n"
+        assert out_show == f"stdout{outterm}"
         assert out_store is None
     elif stdout_setting == TermOutputMode.STORE:
         assert out_show == ""
-        assert out_store == b"stdout\n"
+        assert out_store.decode("utf-8") == f"stdout{outterm}"
     else:
         raise RuntimeError("Test written wrong, invalid stdout_setting")
 
@@ -347,11 +350,11 @@ def test_output_options(qtbot, capfd, stdout_setting, stderr_setting):
         assert err_show == ""
         assert err_store is None
     elif stderr_setting == TermOutputMode.SHOW:
-        assert err_show == "stderr\n"
+        assert err_show == f"stderr{outterm}"
         assert err_store is None
     elif stderr_setting == TermOutputMode.STORE:
         assert err_show == ""
-        assert err_store == b"stderr\n"
+        assert err_store.decode("utf-8") == f"stderr{outterm}"
     else:
         raise RuntimeError("Test written wrong, invalid stderr_setting")
 

--- a/pydm/tests/widgets/test_shell_command.py
+++ b/pydm/tests/widgets/test_shell_command.py
@@ -101,7 +101,8 @@ def test_construct(qtbot, command, title):
 def test_deprecated_command_property_with_no_commands(qtbot):
     pydm_shell_command = PyDMShellCommand()
     qtbot.addWidget(pydm_shell_command)
-    pydm_shell_command.command = "test"
+    with pytest.warns(UserWarning):
+        pydm_shell_command.command = "test"
     assert pydm_shell_command.commands == ["test"]
 
 
@@ -110,7 +111,8 @@ def test_deprecated_command_property_with_commands(qtbot):
     qtbot.addWidget(pydm_shell_command)
     existing_commands = ["existing", "commands"]
     pydm_shell_command.commands = existing_commands
-    pydm_shell_command.command = "This shouldn't work"
+    with pytest.warns(UserWarning):
+        pydm_shell_command.command = "This shouldn't work"
     assert pydm_shell_command.commands == existing_commands
 
 
@@ -124,7 +126,8 @@ def test_no_crash_without_any_commands(qtbot):
 def test_no_crash_with_none_command(qtbot):
     pydm_shell_command = PyDMShellCommand()
     qtbot.addWidget(pydm_shell_command)
-    pydm_shell_command.command = None
+    with pytest.warns(UserWarning):
+        pydm_shell_command.command = None
     qtbot.mouseClick(pydm_shell_command, QtCore.Qt.LeftButton)
 
 
@@ -132,7 +135,7 @@ def test_no_error_without_env_variable(qtbot, caplog):
     """Verify that the shell command works when the environment variable property is saved as an empty string"""
     pydm_shell_command = PyDMShellCommand()
     qtbot.addWidget(pydm_shell_command)
-    pydm_shell_command.command = "echo hello"
+    pydm_shell_command.commands = ["echo hello"]
     pydm_shell_command.environmentVariables = ""
     qtbot.mouseClick(pydm_shell_command, QtCore.Qt.LeftButton)
     assert "error" not in caplog.text.lower()

--- a/pydm/tests/widgets/test_shell_command.py
+++ b/pydm/tests/widgets/test_shell_command.py
@@ -322,7 +322,11 @@ def test_output_options(qtbot, capfd, stdout_setting, stderr_setting):
     qtbot.addWidget(pydm_shell_command)
 
     capfd.readouterr()
-    pydm_shell_command.execute_command("echo stdout; echo stderr 1>&2")
+    if platform.system() == "Windows":
+        cmdsep = " & "
+    else:
+        cmdsep = "; "
+    pydm_shell_command.execute_command(f"echo stdout{cmdsep}echo stderr 1>&2")
     pydm_shell_command.process.wait()
     out_show, err_show = capfd.readouterr()
     out_store, err_store = pydm_shell_command.process.communicate()

--- a/pydm/tests/widgets/test_shell_command.py
+++ b/pydm/tests/widgets/test_shell_command.py
@@ -177,6 +177,7 @@ def test_mouse_release_event(qtbot, caplog, cmd, retcode, stdout):
         The expected stdout for the command.
     """
     pydm_shell_command = PyDMShellCommand()
+    pydm_shell_command.stdout = pydm_shell_command.TermOutputMode.STORE
     qtbot.addWidget(pydm_shell_command)
 
     def check_command_output(command, expected_retcode, expected_stdout):
@@ -265,6 +266,8 @@ def test_env_var(qtbot):
         Window for widget testing
     """
     pydm_shell_command = PyDMShellCommand()
+    pydm_shell_command.stdout = pydm_shell_command.TermOutputMode.STORE
+
     qtbot.addWidget(pydm_shell_command)
 
     os.environ["PYDM_TEST_ENV_VAR"] = "this is a pydm test"

--- a/pydm/tests/widgets/test_shell_command.py
+++ b/pydm/tests/widgets/test_shell_command.py
@@ -327,25 +327,25 @@ def test_output_options(qtbot, capfd, stdout_setting, stderr_setting):
     out_show, err_show = capfd.readouterr()
     out_store, err_store = pydm_shell_command.process.communicate()
 
-    if stdout_setting == PyDMShellCommand.TermOutputMode.HIDE:
+    if stdout_setting == TermOutputMode.HIDE:
         assert out_show == ""
         assert out_store is None
-    elif stdout_setting == PyDMShellCommand.TermOutputMode.SHOW:
+    elif stdout_setting == TermOutputMode.SHOW:
         assert out_show == "stdout\n"
         assert out_store is None
-    elif stdout_setting == PyDMShellCommand.TermOutputMode.STORE:
+    elif stdout_setting == TermOutputMode.STORE:
         assert out_show == ""
         assert out_store == b"stdout\n"
     else:
         raise RuntimeError("Test written wrong, invalid stdout_setting")
 
-    if stderr_setting == PyDMShellCommand.TermOutputMode.HIDE:
+    if stderr_setting == TermOutputMode.HIDE:
         assert err_show == ""
         assert err_store is None
-    elif stderr_setting == PyDMShellCommand.TermOutputMode.SHOW:
+    elif stderr_setting == TermOutputMode.SHOW:
         assert err_show == "stderr\n"
         assert err_store is None
-    elif stderr_setting == PyDMShellCommand.TermOutputMode.STORE:
+    elif stderr_setting == TermOutputMode.STORE:
         assert err_show == ""
         assert err_store == b"stderr\n"
     else:
@@ -370,7 +370,7 @@ def test_output_options_backcompat(qtbot, caplog):
 
     # Defaults
     assert not pydm_shell_command.redirectCommandOutput
-    assert pydm_shell_command.stdout == PyDMShellCommand.TermOutputMode.HIDE
+    assert pydm_shell_command.stdout == TermOutputMode.HIDE
 
     def assert_backcompat(value: bool | TermOutputMode, expect_warning: bool):
         """Helper for repeated assert checks in this unit test."""

--- a/pydm/widgets/shell_command.py
+++ b/pydm/widgets/shell_command.py
@@ -350,7 +350,7 @@ class PyDMShellCommand(QPushButton, PyDMWidget, TermOutputMode):
         self._uses_redirect_intf = True
         if self._uses_stdout_intf:
             logger.warning(
-                f"In PydmShellCommand widget with commands {self.commands}, "
+                f"In PydmShellCommand named {self.objectName()}, "
                 'using deprecated "redirectCommandOutput" property to override '
                 '"stdout" property.'
             )
@@ -382,7 +382,7 @@ class PyDMShellCommand(QPushButton, PyDMWidget, TermOutputMode):
         self._uses_stdout_intf = True
         if self._uses_redirect_intf:
             logger.warning(
-                f"In PydmShellCommand widget with commands {self.commands}, "
+                f"In PydmShellCommand named {self.objectName()}, "
                 'using "stdout" property to override deprecated '
                 '"redirectCommandOutput" property.'
             )

--- a/pydm/widgets/shell_command.py
+++ b/pydm/widgets/shell_command.py
@@ -11,16 +11,15 @@ from qtpy.QtWidgets import QPushButton, QMenu, QMessageBox, QInputDialog, QLineE
 from qtpy.QtGui import QCursor, QIcon, QMouseEvent, QColor
 from qtpy.QtCore import Property, QSize, Qt, QTimer
 from qtpy import QtDesigner
-from PyQt5.QtCore import Q_ENUM
+from PyQt5.QtCore import Q_ENUMS
 from .base import PyDMWidget, only_if_channel_set
 from ..utilities import IconFont
 from typing import Optional, Union, List
-from enum import Enum
 
 logger = logging.getLogger(__name__)
 
 
-class TermOutputMode(Enum):
+class TermOutputMode:
     """
     Enum to select the behavior of the stdout/stderr output from a subprocess.
     """
@@ -30,8 +29,8 @@ class TermOutputMode(Enum):
     STORE = 2
 
 
-class PyDMShellCommand(QPushButton, PyDMWidget):
-    Q_ENUM(TermOutputMode)
+class PyDMShellCommand(QPushButton, PyDMWidget, TermOutputMode):
+    Q_ENUMS(TermOutputMode)
     """
     A QPushButton capable of execute shell commands.
 

--- a/pydm/widgets/shell_command.py
+++ b/pydm/widgets/shell_command.py
@@ -352,7 +352,7 @@ class PyDMShellCommand(QPushButton, PyDMWidget, TermOutputMode):
         if self._uses_stdout_intf:
             logger.warning(
                 f"In PydmShellCommand widget with commands {self.commands}, "
-                'using deprecated "redirectCommandOutput" propery to override '
+                'using deprecated "redirectCommandOutput" property to override '
                 '"stdout" property.'
             )
         if value:
@@ -385,7 +385,7 @@ class PyDMShellCommand(QPushButton, PyDMWidget, TermOutputMode):
             logger.warning(
                 f"In PydmShellCommand widget with commands {self.commands}, "
                 'using "stdout" property to override deprecated '
-                '"redirectCommandOutput" propery.'
+                '"redirectCommandOutput" property.'
             )
         self._stdout = value
 

--- a/pydm/widgets/shell_command.py
+++ b/pydm/widgets/shell_command.py
@@ -9,9 +9,8 @@ import hashlib
 from ast import literal_eval
 from qtpy.QtWidgets import QPushButton, QMenu, QMessageBox, QInputDialog, QLineEdit, QWidget, QStyle
 from qtpy.QtGui import QCursor, QIcon, QMouseEvent, QColor
-from qtpy.QtCore import Property, QSize, Qt, QTimer
+from qtpy.QtCore import Property, QSize, Qt, QTimer, Q_ENUMS
 from qtpy import QtDesigner
-from PyQt5.QtCore import Q_ENUMS
 from .base import PyDMWidget, only_if_channel_set
 from ..utilities import IconFont
 from typing import Optional, Union, List

--- a/pydm/widgets/shell_command.py
+++ b/pydm/widgets/shell_command.py
@@ -11,14 +11,27 @@ from qtpy.QtWidgets import QPushButton, QMenu, QMessageBox, QInputDialog, QLineE
 from qtpy.QtGui import QCursor, QIcon, QMouseEvent, QColor
 from qtpy.QtCore import Property, QSize, Qt, QTimer
 from qtpy import QtDesigner
+from PyQt5.QtCore import Q_ENUM
 from .base import PyDMWidget, only_if_channel_set
 from ..utilities import IconFont
 from typing import Optional, Union, List
+from enum import Enum
 
 logger = logging.getLogger(__name__)
 
 
+class TermOutputMode(Enum):
+    """
+    Enum to select the behavior of the stdout/stderr output from a subprocess.
+    """
+
+    HIDE = 0
+    SHOW = 1
+    STORE = 2
+
+
 class PyDMShellCommand(QPushButton, PyDMWidget):
+    Q_ENUM(TermOutputMode)
     """
     A QPushButton capable of execute shell commands.
 
@@ -35,6 +48,7 @@ class PyDMShellCommand(QPushButton, PyDMWidget):
     """
 
     DEFAULT_CONFIRM_MESSAGE = "Are you sure you want to proceed?"
+    TermOutputMode = TermOutputMode
 
     def __init__(
         self,
@@ -67,7 +81,9 @@ class PyDMShellCommand(QPushButton, PyDMWidget):
         self._allow_multiple = False
         self.process = None
         self._show_icon = True
-        self._redirect_output = False
+        self._stdout = TermOutputMode.HIDE
+        self._stderr = TermOutputMode.HIDE
+        self._uses_stdout_intf = False
         # shell allows for more options such as command chaining ("cmd1;cmd2", "cmd1 && cmd2", etc ...),
         # use of environment variables, glob expansion ('ls *.txt'), etc...
         self._run_commands_in_full_shell = False
@@ -326,27 +342,62 @@ class PyDMShellCommand(QPushButton, PyDMWidget):
         """
         Whether or not we should redirect the output of command to the shell.
 
-        Returns
-        -------
-        bool
+        This is deprecated in favor of the `stdout` property.
         """
-        return self._redirect_output
+        return self._stdout == TermOutputMode.SHOW
 
     @redirectCommandOutput.setter
     def redirectCommandOutput(self, value: bool) -> None:
-        """
-        Whether or not we should redirect the output of command to the shell.
+        if self._uses_stdout_intf:
+            logger.warning(
+                f"In PydmShellCommand widget with commands {self.commands}, "
+                'using deprecated "redirectCommandOutput" propery to override '
+                '"stdout" property.'
+            )
+        if value:
+            self._stdout = TermOutputMode.SHOW
+        else:
+            self._stdout = TermOutputMode.HIDE
 
-        Parameters
-        ----------
-        value : bool
-
-        Returns
-        -------
-        None.
+    @Property(TermOutputMode)
+    def stdout(self) -> TermOutputMode:
         """
-        if self._redirect_output != value:
-            self._redirect_output = value
+        The behavior of the subprocess's standard output stream.
+
+        The options are:
+
+        - `HIDE` (default): hide the stdout
+        - `SHOW`: print stdout to terminal
+        - `STORE`: capture stdout for programmatic retrieval
+
+        This is implicitly linked to the older, soft deprecated
+        parameter `redirectCommandOutput`, which can still be
+        set to `False` to `HIDE` the stdout or `True` to `SHOW`
+        the stdout.
+        """
+        return self._stdout
+
+    @stdout.setter
+    def stdout(self, value: TermOutputMode) -> None:
+        self._uses_stdout_intf = True
+        self._stdout = value
+
+    @Property(TermOutputMode)
+    def stderr(self) -> TermOutputMode:
+        """
+        The behavior of the subprocess's standard error stream.
+
+        The options are:
+
+        - `HIDE` (default): hide the stderr
+        - `SHOW`: print stderr to terminal
+        - `STORE`: capture stderr for programmatic retrieval
+        """
+        return self._stderr
+
+    @stderr.setter
+    def stderr(self, value: TermOutputMode) -> None:
+        self._stderr = value
 
     @Property(bool)
     def allowMultipleExecutions(self) -> bool:
@@ -634,17 +685,32 @@ class PyDMShellCommand(QPushButton, PyDMWidget):
                 args = cmd
             try:
                 logger.debug("Launching process: %s", repr(args))
-                stdout = subprocess.DEVNULL
+
+                if self._stdout == TermOutputMode.HIDE:
+                    stdout = subprocess.DEVNULL
+                elif self._stdout == TermOutputMode.SHOW:
+                    stdout = None
+                elif self._stdout == TermOutputMode.STORE:
+                    stdout = subprocess.PIPE
+                else:
+                    raise ValueError(f"Invalid stdout configuration {self._stdout}")
+
+                if self._stderr == TermOutputMode.HIDE:
+                    stderr = subprocess.DEVNULL
+                elif self._stderr == TermOutputMode.SHOW:
+                    stderr = None
+                elif self._stderr == TermOutputMode.STORE:
+                    stderr = subprocess.PIPE
+                else:
+                    raise ValueError(f"Invalid stderr configuration {self._stderr}")
 
                 if self.env_var:
                     env_var = literal_eval(self.env_var)
                 else:
                     env_var = None
 
-                if self._redirect_output:
-                    stdout = None
                 self.process = subprocess.Popen(
-                    args, stdout=stdout, stderr=subprocess.DEVNULL, env=env_var, shell=self._run_commands_in_full_shell
+                    args, stdout=stdout, stderr=stderr, env=env_var, shell=self._run_commands_in_full_shell
                 )
 
             except Exception as exc:

--- a/pydm/widgets/shell_command.py
+++ b/pydm/widgets/shell_command.py
@@ -84,6 +84,7 @@ class PyDMShellCommand(QPushButton, PyDMWidget):
         self._stdout = TermOutputMode.HIDE
         self._stderr = TermOutputMode.HIDE
         self._uses_stdout_intf = False
+        self._uses_redirect_intf = False
         # shell allows for more options such as command chaining ("cmd1;cmd2", "cmd1 && cmd2", etc ...),
         # use of environment variables, glob expansion ('ls *.txt'), etc...
         self._run_commands_in_full_shell = False
@@ -348,6 +349,7 @@ class PyDMShellCommand(QPushButton, PyDMWidget):
 
     @redirectCommandOutput.setter
     def redirectCommandOutput(self, value: bool) -> None:
+        self._uses_redirect_intf = True
         if self._uses_stdout_intf:
             logger.warning(
                 f"In PydmShellCommand widget with commands {self.commands}, "
@@ -380,6 +382,12 @@ class PyDMShellCommand(QPushButton, PyDMWidget):
     @stdout.setter
     def stdout(self, value: TermOutputMode) -> None:
         self._uses_stdout_intf = True
+        if self._uses_redirect_intf:
+            logger.warning(
+                f"In PydmShellCommand widget with commands {self.commands}, "
+                'using "stdout" property to override deprecated '
+                '"redirectCommandOutput" propery.'
+            )
         self._stdout = value
 
     @Property(TermOutputMode)

--- a/pydm/widgets/shell_command.py
+++ b/pydm/widgets/shell_command.py
@@ -634,7 +634,7 @@ class PyDMShellCommand(QPushButton, PyDMWidget):
                 args = cmd
             try:
                 logger.debug("Launching process: %s", repr(args))
-                stdout = subprocess.PIPE
+                stdout = subprocess.DEVNULL
 
                 if self.env_var:
                     env_var = literal_eval(self.env_var)
@@ -644,7 +644,7 @@ class PyDMShellCommand(QPushButton, PyDMWidget):
                 if self._redirect_output:
                     stdout = None
                 self.process = subprocess.Popen(
-                    args, stdout=stdout, stderr=subprocess.PIPE, env=env_var, shell=self._run_commands_in_full_shell
+                    args, stdout=stdout, stderr=subprocess.DEVNULL, env=env_var, shell=self._run_commands_in_full_shell
                 )
 
             except Exception as exc:


### PR DESCRIPTION
## Overview

This PR was created to address a bug, but in the process it grew to become a minor rework of how we parameterize `PyDMShellCommand` widgets.

## Bug Explainer

In the `PyDMShellCommand` widget, we've been using `subprocess.PIPE` for the `stdout` and `stderr` arguments to `subprocess.Popen` when we don't want these streams to show in the caller's terminal.

Unfortunately, this creates a problem. If the subprocess generates a certain amount of stdout or stderr, the pipe "fills up" so to speak, and then the subprocess is stuck waiting on being allowed to write more to stdout. The subprocess will then "freeze" until the calling process reads enough of the stdout buffer to allow the subprocess to finish writing data.

I'm not sure if this affects all flavors of subprocesses, but this definitely affects shell commands that open chatty Python processes.

## Changes Included
Overall, this PR expands and clarifies our options for stdout and stderr output from subprocesses launched from `PyDMShellCommand` widgets. Previously, we parameterized this via the `redirectCommandOutput` property, but this property name has become confusing. This parameter still exists and works similarly to before, but now we can explicitly swap between output modes for both stdout and stderr.

The new default, `HIDE`, will use `subprocess.DEVNULL` instead of the previous default that used `subprocess.PIPE`, which avoids the bug above. The legacy behavior is still accessible via the `STORE` option, but the user will need to be mindful that they don't keep a long-running process with lots of outputs to avoid the issues explained above.

### shell_command.py
- Add `TermOutputMode` enum for the new properties with options `HIDE`, `SHOW`, and `STORE`. This was originally created using the style in #1145 at the time of this PR but this broke designer for me so I've put it back to the `Q_ENUMS` etc. style.
- Create new `stdout` and `stderr` properties that can be set to the various options from `TermOutputMode`. These are used to select what we pass in as the stdout and stderr options to `subprocess.Popen`
- Switch the `redirectCommandOutput` property to modify the `stdout` property for backwards compatibility.
- Include a check that the user isn't setting both `redirectCommandOutput` and `stdout` on the same widget, logging a warning if they do.

### test_shell_command.py
- Incidental: update existing tests that intentionally trigger the `UserWarning` from the `command` -> `commands` deprecation to expect the user warning or avoid it as appropriate so that the warning doesn't bubble up to the pytest output. (This wasn't necessary but it was annoying me)
- In existing tests that expected to be able to `communicate` with the `Popen` instance, set `stdout` to `STORE` so that they can continue to do so.
- Add a test that verifies that the new options work as expected.
- Add a test that verifies that the old option still works and spawns warnings as expected.

![image](https://github.com/user-attachments/assets/f7f9a9b2-ce1c-4c25-bd60-02205070bd44)
