### PR TITLE
MNT: fix error when using numpy 2+

### DIFF
--- a/pydm/data_plugins/epics_plugins/pva_codec.py
+++ b/pydm/data_plugins/epics_plugins/pva_codec.py
@@ -12,7 +12,7 @@ ScalarType = (
     np.int8,
     np.int16,
     np.int32,
-    np.compat.long,
+    np.int64,  # same as np.long
     np.uint8,
     np.uint16,
     np.uint32,


### PR DESCRIPTION
If you specify python 3.10+ in the conda install,
numpy will then be installed with the latest version 2.20.

Updated numpy has removed np.compat.long, which was for compatibility with python 2's 'long' variable, and we don't support python 2. ('long' is replaced with the just an expanded 'int' in python 3).