### PR TITLE
DEP: Remove References to Deprecated QVariant

### DIFF
--- a/pydm/widgets/archiver_time_plot_editor.py
+++ b/pydm/widgets/archiver_time_plot_editor.py
@@ -1,7 +1,7 @@
 from typing import Any, Optional
 from qtpy.QtCore import Qt, QModelIndex, QObject
 from qtpy.QtGui import QColor
-from .archiver_time_plot import ArchivePlotCurveItem, FormulaCurveItem
+from .archiver_time_plot import ArchivePlotCurveItem
 from .baseplot import BasePlot, BasePlotCurveItem
 from .baseplot_table_model import BasePlotCurvesModel
 from .baseplot_curve_editor import BasePlotCurveEditorDialog, PlotStyleColumnDelegate
@@ -39,15 +39,13 @@ class PyDMArchiverTimePlotCurvesModel(BasePlotCurvesModel):
     def get_data(self, column_name: str, curve: BasePlotCurveItem) -> Any:
         """Get data for the input column name"""
         if column_name == "Channel":
-            if isinstance(curve, FormulaCurveItem):
-                if curve.formula is None:
-                    return ""
-                return str(curve.formula)
+            if hasattr(curve, "address"):
+                return curve.address
+            elif hasattr(curve, "formula"):
+                return curve.formula
             # We are either a Formula or a PV (for now at leasts)
             else:
-                if curve.address is None:
-                    return ""
-                return str(curve.address)
+                return None
 
         elif column_name == "Live Data":
             return bool(curve.liveData)


### PR DESCRIPTION
In `AbstractItemModel.data` and `AbstractItemModel.setData`, returns `None` instead of an empty `QVariant` object. This is done because QVariant is not really needed in PyQt like it is in Qt.

While [this documentation](https://doc.qt.io/qtforpython-5/PySide2/QtCore/QAbstractItemModel.html#PySide2.QtCore.PySide2.QtCore.QAbstractItemModel.data) suggests returning an invalid QVariant, it doesn't specify what an invalid QVariant should be
[This documentation](https://doc.qt.io/qtforpython-5/considerations.html#qvariant) suggests that `None` can be used as an invalid `QVariant`.