### PR TITLE
MNT: make enums use python Enum class and updated Q_ENUM (no 's')

### DIFF
--- a/pydm/tests/widgets/test_enum_button.py
+++ b/pydm/tests/widgets/test_enum_button.py
@@ -4,6 +4,7 @@ from qtpy.QtCore import Qt, QSize
 
 from ...widgets.enum_button import PyDMEnumButton, WidgetType, class_for_type
 from ... import data_plugins
+from ...utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
 
 
 def test_construct(qtbot):
@@ -43,11 +44,15 @@ def test_widget_type(qtbot, widget_type):
     qtbot.addWidget(widget)
 
     assert widget.widgetType == WidgetType.PushButton
-    assert isinstance(widget._widgets[0], class_for_type[WidgetType.PushButton.value])
+    # Support both pyqt enums (inherit from 'object') and pyside6 enums (inherit from python 'Enum' and
+    # therefore require '.value')
+    index = WidgetType.PushButton if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT5 else WidgetType.PushButton.value
+    assert isinstance(widget._widgets[0], class_for_type[index])
 
     widget.widgetType = widget_type
     assert widget.widgetType == widget_type
-    assert isinstance(widget._widgets[0], class_for_type[widget_type.value])
+    index = widget_type if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT5 else widget_type.value
+    assert isinstance(widget._widgets[0], class_for_type[index])
 
 
 @pytest.mark.parametrize("orientation", [Qt.Horizontal, Qt.Vertical])
@@ -82,7 +87,8 @@ def test_widget_orientation(qtbot, orientation):
     w = item.widget()
     qtbot.addWidget(w)
     assert w is not None
-    assert isinstance(w, class_for_type[widget.widgetType.value])
+    index = widget.widgetType if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT5 else widget.widgetType.value
+    assert isinstance(w, class_for_type[index])
 
 
 @pytest.mark.parametrize(

--- a/pydm/tests/widgets/test_enum_button.py
+++ b/pydm/tests/widgets/test_enum_button.py
@@ -43,11 +43,11 @@ def test_widget_type(qtbot, widget_type):
     qtbot.addWidget(widget)
 
     assert widget.widgetType == WidgetType.PushButton
-    assert isinstance(widget._widgets[0], class_for_type[WidgetType.PushButton])
+    assert isinstance(widget._widgets[0], class_for_type[WidgetType.PushButton.value])
 
     widget.widgetType = widget_type
     assert widget.widgetType == widget_type
-    assert isinstance(widget._widgets[0], class_for_type[widget_type])
+    assert isinstance(widget._widgets[0], class_for_type[widget_type.value])
 
 
 @pytest.mark.parametrize("orientation", [Qt.Horizontal, Qt.Vertical])
@@ -82,7 +82,7 @@ def test_widget_orientation(qtbot, orientation):
     w = item.widget()
     qtbot.addWidget(w)
     assert w is not None
-    assert isinstance(w, class_for_type[widget.widgetType])
+    assert isinstance(w, class_for_type[widget.widgetType.value])
 
 
 @pytest.mark.parametrize(

--- a/pydm/utilities/__init__.py
+++ b/pydm/utilities/__init__.py
@@ -12,7 +12,7 @@ import uuid
 import errno
 
 from typing import List, Optional
-
+from enum import IntEnum
 from qtpy import QtCore, QtGui, QtWidgets
 
 from . import colors, macro, shortcuts
@@ -37,6 +37,34 @@ __all__ = [
 ]
 
 logger = logging.getLogger(__name__)
+
+
+# The qtpy abstraction layer decides which qt python wrapper to use by the QT_API.
+# Atm for pydm we only intend to support PyQt5 (legacy) and PySide6.
+# ACTIVE_QT_WRAPPER is implemented basically to have easier access to the QT_API env variable,
+# and we need to know the current wrapper being used to support both pyqt5 and pyside6.
+class QtWrapperTypes(IntEnum):
+    UNSUPPORTED = 0
+    PYSIDE6 = 1
+    PYQT5 = 2
+
+
+ACTIVE_QT_WRAPPER = QtWrapperTypes.UNSUPPORTED
+
+# QT_API should be set according to the qtpy docs: https://github.com/spyder-ide/qtpy?tab=readme-ov-file#requirements
+qt_api = os.getenv("QT_API", "").lower()
+if qt_api == "pyside6":
+    ACTIVE_QT_WRAPPER = QtWrapperTypes.PYSIDE6
+elif qt_api == "pyqt5":
+    ACTIVE_QT_WRAPPER = QtWrapperTypes.PYQT5
+
+if ACTIVE_QT_WRAPPER == QtWrapperTypes.UNSUPPORTED:
+    error_message = (
+        "The QT_API variable is not set to a supported Qt Python wrapper "
+        "(PySide6 or PyQt5). Please set QT_API to 'pyside6' or 'pyqt5'."
+    )
+    logger.error(error_message)
+    raise RuntimeError(error_message)
 
 
 def is_ssh_session():

--- a/pydm/widgets/datetime.py
+++ b/pydm/widgets/datetime.py
@@ -1,6 +1,7 @@
 import logging
 from qtpy import QtWidgets, QtCore
 from enum import Enum
+from PyQt5.QtCore import Q_ENUM
 
 from .base import PyDMWritableWidget, PyDMWidget
 
@@ -13,7 +14,7 @@ class TimeBase(Enum):
 
 
 class PyDMDateTimeEdit(QtWidgets.QDateTimeEdit, PyDMWritableWidget):
-    QtCore.Q_ENUM(TimeBase)
+    Q_ENUM(TimeBase)
     returnPressed = QtCore.Signal()
     """
     A QDateTimeEdit with support for setting the text via a PyDM Channel, or
@@ -109,7 +110,7 @@ class PyDMDateTimeEdit(QtWidgets.QDateTimeEdit, PyDMWritableWidget):
 
 
 class PyDMDateTimeLabel(QtWidgets.QLabel, PyDMWidget):
-    QtCore.Q_ENUM(TimeBase)
+    Q_ENUM(TimeBase)
     """
     A QLabel with support for setting the text via a PyDM Channel, or
     through the PyDM Rules system.

--- a/pydm/widgets/datetime.py
+++ b/pydm/widgets/datetime.py
@@ -4,17 +4,32 @@ from enum import Enum
 from PyQt5.QtCore import Q_ENUM
 
 from .base import PyDMWritableWidget, PyDMWidget
+from ..utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
+
+# if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT5:
+# from PyQt5.QtCore import Q_ENUM
 
 logger = logging.getLogger(__name__)
 
 
+# Inheriting from 'Enum' class is requried for enums in pyside6
 class TimeBase(Enum):
     Milliseconds = 0
     Seconds = 1
 
 
-class PyDMDateTimeEdit(QtWidgets.QDateTimeEdit, PyDMWritableWidget):
-    Q_ENUM(TimeBase)
+if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT5:
+    # But inheriting from object class is requried for enums in pyqt5, since we need widgets to
+    # inherit from the enum class so the enums work in QtDesigner.
+    # This definition of the enum will override the previous definition.
+    # Doing this is pretty messy, but it seems like only way to support pyqt5 and pyside6 enums at same time,
+    # can be removed latter if we eventually drop pyqt5 support.
+    class TimeBase(object):  # noqa F811
+        Milliseconds = 0
+        Seconds = 1
+
+
+class PyDMDateTimeEditBase(QtWidgets.QDateTimeEdit, PyDMWritableWidget):
     returnPressed = QtCore.Signal()
     """
     A QDateTimeEdit with support for setting the text via a PyDM Channel, or
@@ -74,7 +89,7 @@ class PyDMDateTimeEdit(QtWidgets.QDateTimeEdit, PyDMWritableWidget):
             self._block_past_date = block
 
     def keyPressEvent(self, key_event):
-        ret = super(PyDMDateTimeEdit, self).keyPressEvent(key_event)
+        ret = super(PyDMDateTimeEditBase, self).keyPressEvent(key_event)
         if key_event.key() in [QtCore.Qt.Key_Return, QtCore.Qt.Key_Enter]:
             self.returnPressed.emit()
         return ret
@@ -96,7 +111,7 @@ class PyDMDateTimeEdit(QtWidgets.QDateTimeEdit, PyDMWritableWidget):
         self.send_value_signal.emit(new_value)
 
     def value_changed(self, new_val):
-        super(PyDMDateTimeEdit, self).value_changed(new_val)
+        super(PyDMDateTimeEditBase, self).value_changed(new_val)
 
         if self.timeBase == TimeBase.Seconds:
             new_val *= 1000
@@ -109,7 +124,18 @@ class PyDMDateTimeEdit(QtWidgets.QDateTimeEdit, PyDMWritableWidget):
         self.setDateTime(val)
 
 
-class PyDMDateTimeLabel(QtWidgets.QLabel, PyDMWidget):
+# works with pyside6
+class PyDMDateTimeEdit(PyDMDateTimeEditBase):
+    pass
+
+
+if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT5:
+    # Overrides the previous class defintion
+    class PyDMDateTimeEdit(PyDMDateTimeEditBase, TimeBase):  # noqa F811
+        pass
+
+
+class PyDMDateTimeLabelBase(QtWidgets.QLabel, PyDMWidget):
     Q_ENUM(TimeBase)
     """
     A QLabel with support for setting the text via a PyDM Channel, or
@@ -168,7 +194,7 @@ class PyDMDateTimeLabel(QtWidgets.QLabel, PyDMWidget):
             self._relative = checked
 
     def value_changed(self, new_val):
-        super(PyDMDateTimeLabel, self).value_changed(new_val)
+        super(PyDMDateTimeLabelBase, self).value_changed(new_val)
 
         if self.timeBase == TimeBase.Seconds:
             new_val *= 1000
@@ -179,3 +205,20 @@ class PyDMDateTimeLabel(QtWidgets.QLabel, PyDMWidget):
         else:
             val.setMSecsSinceEpoch(new_val)
         self.setText(val.toString(self.textFormat))
+
+
+# We define a '...Base' of the class so here we can 'conditionally define' the class as either inheriting
+# from an enum or not, in order to support enums in QtDesigner for both pyqt5 and pyside6.
+# We basically need to support the two ways of defining enums as explained here: https://stackoverflow.com/a/46919848.
+class PyDMDateTimeLabel(PyDMDateTimeLabelBase):
+    pass
+
+
+if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT5:
+    # Having the widget inherit from the enum class is requried in pyqt5 for the enums to load in QtDesigner.
+    # This definition of the enum will override the previous definition.
+    class PyDMDateTimeLabel(PyDMDateTimeLabelBase, TimeBase):  # noqa F811
+        Q_ENUM(TimeBase)
+
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)

--- a/pydm/widgets/datetime.py
+++ b/pydm/widgets/datetime.py
@@ -1,18 +1,19 @@
 import logging
 from qtpy import QtWidgets, QtCore
+from enum import Enum
 
 from .base import PyDMWritableWidget, PyDMWidget
 
 logger = logging.getLogger(__name__)
 
 
-class TimeBase(object):
+class TimeBase(Enum):
     Milliseconds = 0
     Seconds = 1
 
 
-class PyDMDateTimeEdit(QtWidgets.QDateTimeEdit, PyDMWritableWidget, TimeBase):
-    QtCore.Q_ENUMS(TimeBase)
+class PyDMDateTimeEdit(QtWidgets.QDateTimeEdit, PyDMWritableWidget):
+    QtCore.Q_ENUM(TimeBase)
     returnPressed = QtCore.Signal()
     """
     A QDateTimeEdit with support for setting the text via a PyDM Channel, or
@@ -107,8 +108,8 @@ class PyDMDateTimeEdit(QtWidgets.QDateTimeEdit, PyDMWritableWidget, TimeBase):
         self.setDateTime(val)
 
 
-class PyDMDateTimeLabel(QtWidgets.QLabel, PyDMWidget, TimeBase):
-    QtCore.Q_ENUMS(TimeBase)
+class PyDMDateTimeLabel(QtWidgets.QLabel, PyDMWidget):
+    QtCore.Q_ENUM(TimeBase)
     """
     A QLabel with support for setting the text via a PyDM Channel, or
     through the PyDM Rules system.

--- a/pydm/widgets/display_format.py
+++ b/pydm/widgets/display_format.py
@@ -5,10 +5,12 @@ from typing import Any
 import logging
 import warnings
 from enum import Enum
+from ..utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
 
 logger = logging.getLogger(__name__)
 
 
+# works with pyside6
 class DisplayFormat(Enum):
     """Display format for showing data in a PyDM widget."""
 
@@ -24,6 +26,17 @@ class DisplayFormat(Enum):
     Hex = 4
     #: Show numerical values in base 2 (binary) notation.
     Binary = 5
+
+
+if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT5:
+
+    class DisplayFormat(object):  # noqa F811
+        Default = 0
+        String = 1
+        Decimal = 2
+        Exponential = 3
+        Hex = 4
+        Binary = 5
 
 
 def parse_value_for_display(

--- a/pydm/widgets/display_format.py
+++ b/pydm/widgets/display_format.py
@@ -4,11 +4,12 @@ from typing import Any
 
 import logging
 import warnings
+from enum import Enum
 
 logger = logging.getLogger(__name__)
 
 
-class DisplayFormat(object):
+class DisplayFormat(Enum):
     """Display format for showing data in a PyDM widget."""
 
     #: The default display format.

--- a/pydm/widgets/enum_button.py
+++ b/pydm/widgets/enum_button.py
@@ -1,6 +1,8 @@
 import logging
+from enum import Enum
 
-from qtpy.QtCore import Qt, QSize, Property, Slot, Q_ENUMS, QMargins
+from qtpy.QtCore import Qt, QSize, Property, Slot, QMargins
+from PyQt5.QtCore import Q_ENUM
 from qtpy.QtGui import QPainter
 from qtpy.QtWidgets import QWidget, QButtonGroup, QGridLayout, QPushButton, QRadioButton, QStyleOption, QStyle
 
@@ -8,7 +10,7 @@ from .base import PyDMWritableWidget
 from .. import data_plugins
 
 
-class WidgetType(object):
+class WidgetType(Enum):
     PushButton = 0
     RadioButton = 1
 
@@ -18,7 +20,7 @@ class_for_type = [QPushButton, QRadioButton]
 logger = logging.getLogger(__name__)
 
 
-class PyDMEnumButton(QWidget, PyDMWritableWidget, WidgetType):
+class PyDMEnumButton(QWidget, PyDMWritableWidget):
     """
     A QWidget that renders buttons for every option of Enum Items.
     For now, two types of buttons can be rendered:
@@ -38,7 +40,7 @@ class PyDMEnumButton(QWidget, PyDMWritableWidget, WidgetType):
         Emitted when the user changes the value.
     """
 
-    Q_ENUMS(WidgetType)
+    Q_ENUM(WidgetType)
     WidgetType = WidgetType
 
     def __init__(self, parent=None, init_channel=None):
@@ -399,7 +401,7 @@ class PyDMEnumButton(QWidget, PyDMWritableWidget, WidgetType):
                 w.deleteLater()
 
             for idx, entry in enumerate(items):
-                w = class_for_type[self._widget_type](parent=self)
+                w = class_for_type[self._widget_type.value](parent=self)
                 w.setCheckable(self.checkable)
                 w.setText(entry)
                 w.setVisible(False)

--- a/pydm/widgets/image.py
+++ b/pydm/widgets/image.py
@@ -10,10 +10,12 @@ from enum import Enum
 from .channel import PyDMChannel
 from .colormaps import cmaps, cmap_names, PyDMColorMap
 from .base import PyDMWidget
+from ..utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
 
 logger = logging.getLogger(__name__)
 
 
+# works with pyside6
 class ReadingOrder(Enum):
     """Class to build ReadingOrder ENUM property."""
 
@@ -21,6 +23,14 @@ class ReadingOrder(Enum):
     Clike = 1
 
 
+if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT5:
+
+    class ReadingOrder(object):  # noqa F811
+        Fortranlike = 0
+        Clike = 1
+
+
+# works with pyside6
 class DimensionOrder(Enum):
     """
     Class to build DimensionOrder ENUM property.
@@ -41,6 +51,13 @@ class DimensionOrder(Enum):
 
     HeightFirst = 0
     WidthFirst = 1
+
+
+if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT5:
+
+    class DimensionOrder(object):  # noqa F811
+        HeightFirst = 0
+        WidthFirst = 1
 
 
 class ImageUpdateThread(QThread):
@@ -100,7 +117,7 @@ class ImageUpdateThread(QThread):
         self.image_view.needs_redraw = False
 
 
-class PyDMImageView(
+class PyDMImageViewBase(
     ImageView,
     PyDMWidget,
     PyDMColorMap,
@@ -753,3 +770,14 @@ class PyDMImageView(
     @scaleYAxis.setter
     def scaleYAxis(self, new_scale):
         self.getView().getAxis("left").setScale(new_scale)
+
+
+# works with pyside6
+class PyDMImageView(PyDMImageViewBase):
+    pass
+
+
+if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT5:
+    # Overrides the previous class defintion
+    class PyDMImageView(PyDMImageViewBase, ReadingOrder, DimensionOrder):  # noqa F811
+        pass

--- a/pydm/widgets/image.py
+++ b/pydm/widgets/image.py
@@ -1,10 +1,12 @@
 from qtpy.QtWidgets import QActionGroup
-from qtpy.QtCore import Signal, Slot, Property, QTimer, Q_ENUMS, QThread
+from qtpy.QtCore import Signal, Slot, Property, QTimer, QThread
+from PyQt5.QtCore import Q_ENUM
 from pyqtgraph import ImageView, PlotItem
 from pyqtgraph import ColorMap
 from pyqtgraph.graphicsItems.ViewBox.ViewBoxMenu import ViewBoxMenu
 import numpy as np
 import logging
+from enum import Enum
 from .channel import PyDMChannel
 from .colormaps import cmaps, cmap_names, PyDMColorMap
 from .base import PyDMWidget
@@ -12,14 +14,14 @@ from .base import PyDMWidget
 logger = logging.getLogger(__name__)
 
 
-class ReadingOrder(object):
+class ReadingOrder(Enum):
     """Class to build ReadingOrder ENUM property."""
 
     Fortranlike = 0
     Clike = 1
 
 
-class DimensionOrder(object):
+class DimensionOrder(Enum):
     """
     Class to build DimensionOrder ENUM property.
 
@@ -98,7 +100,11 @@ class ImageUpdateThread(QThread):
         self.image_view.needs_redraw = False
 
 
-class PyDMImageView(ImageView, PyDMWidget, PyDMColorMap, ReadingOrder, DimensionOrder):
+class PyDMImageView(
+    ImageView,
+    PyDMWidget,
+    PyDMColorMap,
+):
     """
     A PyQtGraph ImageView with support for Channels and more from PyDM.
 
@@ -126,9 +132,9 @@ class PyDMImageView(ImageView, PyDMWidget, PyDMColorMap, ReadingOrder, Dimension
     ReadingOrder = ReadingOrder
     DimensionOrder = DimensionOrder
 
-    Q_ENUMS(ReadingOrder)
-    Q_ENUMS(DimensionOrder)
-    Q_ENUMS(PyDMColorMap)
+    Q_ENUM(ReadingOrder)
+    Q_ENUM(DimensionOrder)
+    Q_ENUM(PyDMColorMap)
 
     color_maps = cmaps
 

--- a/pydm/widgets/label.py
+++ b/pydm/widgets/label.py
@@ -1,15 +1,16 @@
 from .base import PyDMWidget, TextFormatter, str_types
 from qtpy.QtWidgets import QLabel, QApplication
-from qtpy.QtCore import Qt, Property, Q_ENUMS
+from qtpy.QtCore import Qt, Property
 from .display_format import DisplayFormat, parse_value_for_display
 from pydm.utilities import is_pydm_app, is_qt_designer
 from pydm import config
 from pydm.widgets.base import only_if_channel_set
+from PyQt5.QtCore import Q_ENUM
 
 _labelRuleProperties = {"Text": ["value_changed", str]}
 
 
-class PyDMLabel(QLabel, TextFormatter, PyDMWidget, DisplayFormat, new_properties=_labelRuleProperties):
+class PyDMLabel(QLabel, TextFormatter, PyDMWidget, new_properties=_labelRuleProperties):
     """
     A QLabel with support for setting the text via a PyDM Channel, or
     through the PyDM Rules system.
@@ -27,7 +28,7 @@ class PyDMLabel(QLabel, TextFormatter, PyDMWidget, DisplayFormat, new_properties
         The channel to be used by the widget.
     """
 
-    Q_ENUMS(DisplayFormat)
+    Q_ENUM(DisplayFormat)
     DisplayFormat = DisplayFormat
 
     def __init__(self, parent=None, init_channel=None):

--- a/pydm/widgets/line_edit.py
+++ b/pydm/widgets/line_edit.py
@@ -5,7 +5,8 @@ import shlex
 import logging
 from functools import partial
 from qtpy.QtWidgets import QLineEdit, QMenu, QApplication
-from qtpy.QtCore import Property, Q_ENUMS, Qt
+from qtpy.QtCore import Property, Qt
+from PyQt5.QtCore import Q_ENUM
 from qtpy.QtGui import QFocusEvent
 from .. import utilities
 from .base import PyDMWritableWidget, TextFormatter, str_types
@@ -14,7 +15,7 @@ from .display_format import DisplayFormat, parse_value_for_display
 logger = logging.getLogger(__name__)
 
 
-class PyDMLineEdit(QLineEdit, TextFormatter, PyDMWritableWidget, DisplayFormat):
+class PyDMLineEdit(QLineEdit, TextFormatter, PyDMWritableWidget):
     """
     A QLineEdit (writable text field) with support for Channels and more
     from PyDM.
@@ -29,7 +30,7 @@ class PyDMLineEdit(QLineEdit, TextFormatter, PyDMWritableWidget, DisplayFormat):
         The channel to be used by the widget.
     """
 
-    Q_ENUMS(DisplayFormat)
+    Q_ENUM(DisplayFormat)
     DisplayFormat = DisplayFormat
 
     def __init__(self, parent=None, init_channel=None):

--- a/pydm/widgets/logdisplay.py
+++ b/pydm/widgets/logdisplay.py
@@ -2,8 +2,10 @@ import logging
 import functools
 
 from collections import OrderedDict
+from enum import Enum
 
-from qtpy.QtCore import QObject, Slot, Signal, Property, Q_ENUMS, QSize
+from qtpy.QtCore import QObject, Slot, Signal, Property, QSize
+from PyQt5.QtCore import Q_ENUM
 from qtpy.QtWidgets import (
     QWidget,
     QPlainTextEdit,
@@ -81,7 +83,7 @@ class GuiHandler(QObject, logging.Handler):
             logger.debug("Handler was destroyed at the C++ level.")
 
 
-class LogLevels(object):
+class LogLevels(Enum):
     NOTSET = 0
     DEBUG = 10
     INFO = 20
@@ -99,16 +101,11 @@ class LogLevels(object):
         OrderedDict
         """
         # First let's remove the internals
-        entries = [
-            (k, v)
-            for k, v in LogLevels.__dict__.items()
-            if not k.startswith("__") and not callable(v) and not isinstance(v, staticmethod)
-        ]
-
+        entries = [(k, v.value) for k, v in LogLevels.__members__.items()]
         return OrderedDict(sorted(entries, key=lambda x: x[1], reverse=False))
 
 
-class PyDMLogDisplay(QWidget, LogLevels):
+class PyDMLogDisplay(QWidget):
     """
     Standard display for Log Output
 
@@ -129,7 +126,7 @@ class PyDMLogDisplay(QWidget, LogLevels):
 
     """
 
-    Q_ENUMS(LogLevels)
+    Q_ENUM(LogLevels)
     LogLevels = LogLevels
     terminator = "\n"
     default_format = "%(asctime)s %(message)s"

--- a/pydm/widgets/template_repeater.py
+++ b/pydm/widgets/template_repeater.py
@@ -2,8 +2,10 @@ import os
 import json
 import copy
 import logging
+from enum import Enum
 from qtpy.QtWidgets import QFrame, QApplication, QLabel, QVBoxLayout, QHBoxLayout, QWidget, QStyle, QSizePolicy, QLayout
-from qtpy.QtCore import Qt, QSize, QRect, Property, QPoint, Q_ENUMS
+from qtpy.QtCore import Qt, QSize, QRect, Property, QPoint
+from PyQt5.QtCore import Q_ENUM
 from .base import PyDMPrimitiveWidget
 from pydm.utilities import is_qt_designer
 import pydm.data_plugins
@@ -111,7 +113,7 @@ class FlowLayout(QLayout):
             return parent.spacing()
 
 
-class LayoutType(object):
+class LayoutType(Enum):
     Vertical = 0
     Horizontal = 1
     Flow = 2
@@ -120,7 +122,7 @@ class LayoutType(object):
 layout_class_for_type = (QVBoxLayout, QHBoxLayout, FlowLayout)
 
 
-class PyDMTemplateRepeater(QFrame, PyDMPrimitiveWidget, LayoutType):
+class PyDMTemplateRepeater(QFrame, PyDMPrimitiveWidget):
     """
     PyDMTemplateRepeater takes a .ui file with macro variables as a template, and a JSON
     file (or a list of dictionaries) with a list of values to use to fill in
@@ -140,7 +142,7 @@ class PyDMTemplateRepeater(QFrame, PyDMPrimitiveWidget, LayoutType):
         The parent of this widget.
     """
 
-    Q_ENUMS(LayoutType)
+    Q_ENUM(LayoutType)
     LayoutType = LayoutType
 
     def __init__(self, parent=None):
@@ -391,7 +393,7 @@ class PyDMTemplateRepeater(QFrame, PyDMPrimitiveWidget, LayoutType):
             return
         self.setUpdatesEnabled(False)
 
-        layout_class = layout_class_for_type[self.layoutType]
+        layout_class = layout_class_for_type[self.layoutType.value]
         if type(self.layout()) != layout_class:
             if self.layout() is not None:
                 # Trick to remove the existing layout by re-parenting it in an empty widget.

--- a/pydm/widgets/timeplot.py
+++ b/pydm/widgets/timeplot.py
@@ -5,12 +5,14 @@ from typing import Optional
 from pyqtgraph import BarGraphItem, ViewBox, AxisItem
 import numpy as np
 from qtpy.QtGui import QColor
-from qtpy.QtCore import Signal, Slot, Property, QTimer, Q_ENUMS
+from qtpy.QtCore import Signal, Slot, Property, QTimer
+from PyQt5.QtCore import Q_ENUM
 from .baseplot import BasePlot, BasePlotCurveItem
 from .channel import PyDMChannel
 from ..utilities import remove_protocol
 
 import logging
+from enum import Enum
 
 logger = logging.getLogger(__name__)
 
@@ -24,7 +26,7 @@ DEFAULT_TIME_SPAN = 5.0
 DEFAULT_UPDATE_INTERVAL = 1000  # Plot update rate for fixed rate mode in milliseconds
 
 
-class updateMode(object):
+class updateMode(Enum):
     """updateMode as new type for plot update"""
 
     OnValueChange = 1
@@ -376,7 +378,7 @@ class TimePlotCurveItem(BasePlotCurveItem):
         Check if value is from updatesAsynchronously(bool) or updateMode(int)
         """
         if isinstance(value, int) and value == updateMode.AtFixedRate or isinstance(value, bool) and value is True:
-            self._update_mode = PyDMTimePlot.AtFixedRate
+            self._update_mode = PyDMTimePlot.AtFixedRated
         else:
             self._update_mode = PyDMTimePlot.OnValueChange
         self.initialize_buffer()
@@ -412,7 +414,7 @@ class TimePlotCurveItem(BasePlotCurveItem):
         return [self.channel]
 
 
-class PyDMTimePlot(BasePlot, updateMode):
+class PyDMTimePlot(BasePlot):
     """
     PyDMTimePlot is a widget to plot one or more channels vs. time.
 
@@ -440,7 +442,7 @@ class PyDMTimePlot(BasePlot, updateMode):
     OnValueChange = 1
     AtFixedRated = 2
 
-    Q_ENUMS(updateMode)
+    Q_ENUM(updateMode)
     updateMode = updateMode
 
     plot_redrawn_signal = Signal(TimePlotCurveItem)


### PR DESCRIPTION
Using the python Enum class is a first step required for later support of enum macros in PySide6,
see https://doc.qt.io/qtforpython-6/PySide6/QtCore/QEnum.html.

Also these python 'Enums' provide some minor benefits like easier iteration, and are already compatible with PyQt5 enum macro.

Also remove our subclassing of enum classes, this isn't needed and not even allowed now that the enums are python 'Enums'.

Also we switch from 'Q_ENUMS' -> 'Q_ENUM' since its a newer verison of the enum macro for PyQt5.

We import 'Q_ENUM' directly from PyQt5 b/c its not provided by the qtpy abstraction layer. But this is fine since seems there is no nice enum abstraction that works for both PyQt5 and PySide6 anyway. The new enum macro for PySide6 will be added later, and which we use will be determined with conditional check of Qt wrapper.