### PR TITLE
FIX: Small change to addess a valueError in PyDMSlider when they are being dragged 

### DIFF
--- a/pydm/widgets/slider.py
+++ b/pydm/widgets/slider.py
@@ -78,9 +78,9 @@ class PyDMPrimitiveSlider(QSlider):
             delta = event.pos() - self.dragStartPos
 
             if self.orientation() == Qt.Horizontal:
-                delta_value = (delta.x() / self.getSliderLength()) * (self.maximum() - self.minimum())
+                delta_value = int(round((delta.x() / self.getSliderLength()) * (self.maximum() - self.minimum())))
             else:
-                delta_value = (-delta.y() / self.getSliderLength()) * (self.maximum() - self.minimum())
+                delta_value = int(round((-delta.y() / self.getSliderLength()) * (self.maximum() - self.minimum())))
 
             new_value = self.dragStartValue + delta_value
             new_value = min(max(self.minimum(), new_value), self.maximum())

--- a/pydm/widgets/slider.py
+++ b/pydm/widgets/slider.py
@@ -78,10 +78,9 @@ class PyDMPrimitiveSlider(QSlider):
             delta = event.pos() - self.dragStartPos
 
             if self.orientation() == Qt.Horizontal:
-                delta_value = int(round((delta.x() / self.getSliderLength()) * (self.maximum() - self.minimum())))
+                delta_value = round((delta.x() / self.getSliderLength()) * (self.maximum() - self.minimum()))
             else:
-                delta_value = int(round((-delta.y() / self.getSliderLength()) * (self.maximum() - self.minimum())))
-
+                delta_value = round((-delta.y() / self.getSliderLength()) * (self.maximum() - self.minimum()))
             new_value = self.dragStartValue + delta_value
             new_value = min(max(self.minimum(), new_value), self.maximum())
             self.setValue(new_value)


### PR DESCRIPTION
Currently a value error can be thrown when dragging the handle of a slider that has floating point values. This fix rounds and casts to int the value change while dragging the handle of the PyDMSlider 