### PR TITLE
MNT: run automated tests on gh with python 3.13

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.13']
         pyqt-version: [5.12.3, 5.15.9]
     env:
       DISPLAY: ':99.0'


### PR DESCRIPTION
3.13 is the default version installed by conda when no version is specified, and is also the latest version pyside6 supports.