### PR TITLE
MNT: make gh actions setup use conda and pip to install packages

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -35,25 +35,34 @@ jobs:
         miniforge-variant: Miniforge3
         miniforge-version: latest
         activate-environment: pydm-env
-    - name: Install python packages
+
+    - name: Install PyDM with Mamba
       shell: bash -el {0}
       run: |
+        mamba install -c conda-forge pydm pyqt=${{ matrix.pyqt-version }}
+
+    - name: Install additional Python dependencies with pip
+      shell: bash -el {0}
+      run: |
+        pip install -r requirements.txt
         if [ "$RUNNER_OS" == "Windows" ]; then
-          mamba install pyqt=${{ matrix.pyqt-version }}
-          mamba install --file requirements.txt --file windows-dev-requirements.txt
+          pip install -r windows-dev-requirements.txt
         else
-          mamba install pyqt=${{ matrix.pyqt-version }} $(cat requirements.txt dev-requirements.txt)
+          pip install -r dev-requirements.txt
         fi
-    - name: Install packages for testing a pyqt app on linux
+
+    - name: Install packages for testing a PyQt app on Linux
       shell: bash -el {0}
       run: |
         if [ "$RUNNER_OS" == "Linux" ]; then
-          sudo apt install xvfb herbstluftwm libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 x11-utils
+          sudo apt update
+          sudo apt install -y xvfb herbstluftwm libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 x11-utils
           sudo /sbin/start-stop-daemon --start --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1024x768x24 -ac +extension GLX +render -noreset
           sleep 3
           sudo /sbin/start-stop-daemon --start --pidfile /tmp/custom_herbstluftwm_99.pid --make-pidfile --background --exec /usr/bin/herbstluftwm
           sleep 1
         fi
+
     - name: Test with pytest
       shell: bash -el {0}
       run: |

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.9', '3.10']
         pyqt-version: [5.12.3, 5.15.9]
     env:
       DISPLAY: ':99.0'

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ as the abstraction layer for the Qt Python wrappers (PyQt5/PyQt4/PySide2/PySide)
 **All tests are performed with PyQt5**.
 
 # Prerequisites
-* Python 3.7+
+* Python 3.9+
 * Qt 5.6 or higher
 * qtpy
 * PyQt5 >= 5.7 or any other Qt Python wrapper.

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -14,13 +14,13 @@ build:
 
 requirements:
   host:
-    - python
+    - python >=3.9
     - pip
     - setuptools
     - pyqt =5
     - qtpy
   run:
-    - python
+    - python >=3.9
     - six
     - numpy
     - scipy


### PR DESCRIPTION
Before it was using the pip '.txt' package files to install packages with conda. 

But that doesn't mimic how we instruct users to locally install packages with conda+pip, and causes some issues with packages in coda (ex=p4p) being outdated compared to pip and causing actions setup to fail. 

The outdated packages are why this patch is needed to later add tests for most recent python version (can't do now b/c pyqt5 only supports up to 3.10, but pyside6 support will test with python latest)

Also this drops python 3.8 automated tests, and update docs and conda recipe for 3.9+ (min supported python version).