### PR TITLE
DEP: Remove Deprecated QVariant Checks

### DIFF
--- a/pydm/widgets/axis_table_model.py
+++ b/pydm/widgets/axis_table_model.py
@@ -83,8 +83,6 @@ class BasePlotAxesModel(QAbstractTableModel):
         column_name = self._column_names[index.column()]
         axis = self.plot._axes[index.row()]
         if role == Qt.EditRole:
-            if value is not None:
-                value = value.toString()
             if not self.set_data(column_name, axis, value):
                 return False
         else:

--- a/pydm/widgets/baseplot_table_model.py
+++ b/pydm/widgets/baseplot_table_model.py
@@ -113,8 +113,6 @@ class BasePlotCurvesModel(QAbstractTableModel):
         column_name = self._column_names[index.column()]
         curve = self.plot._curves[index.row()]
         if role == Qt.EditRole:
-            if value is not None:
-                value = value.toString()
             if not self.set_data(column_name, curve, value):
                 return False
         else:


### PR DESCRIPTION
Removing 2 if statements that were adapted from a check for empty QVariants. Since references to QVariants were removed entirely from PyDM, these checks aren't necessary anymore.

Including these checks resulted in the error below when entering data into the model:
`AttributeError: 'str' object has no attribute 'toString'`