### PR TITLE
MNT: remove widget classes inheritance from enum, as preperation for qt6 enum support

### DIFF
--- a/pydm/tests/widgets/test_timeplot.py
+++ b/pydm/tests/widgets/test_timeplot.py
@@ -117,7 +117,7 @@ def test_timeplotcurveitem_receive_value(qtbot, signals, async_update, new_data)
     pydm_timeplot_curve_item.setUpdatesAsynchronously(async_update)
     if async_update:
         assert (
-            pydm_timeplot_curve_item._update_mode == PyDMTimePlot.AtFixedRated
+            pydm_timeplot_curve_item._update_mode == PyDMTimePlot.AtFixedRate
             if async_update
             else pydm_timeplot_curve_item._update_mode == PyDMTimePlot.OnValueChange
         )

--- a/pydm/widgets/datetime.py
+++ b/pydm/widgets/datetime.py
@@ -11,8 +11,13 @@ class TimeBase(object):
     Seconds = 1
 
 
-class PyDMDateTimeEdit(QtWidgets.QDateTimeEdit, PyDMWritableWidget, TimeBase):
+class PyDMDateTimeEdit(QtWidgets.QDateTimeEdit, PyDMWritableWidget):
     QtCore.Q_ENUMS(TimeBase)
+
+    # Make enum definitions known to this class
+    Milliseconds = TimeBase.Milliseconds
+    Seconds = TimeBase.Seconds
+
     returnPressed = QtCore.Signal()
     """
     A QDateTimeEdit with support for setting the text via a PyDM Channel, or
@@ -107,8 +112,13 @@ class PyDMDateTimeEdit(QtWidgets.QDateTimeEdit, PyDMWritableWidget, TimeBase):
         self.setDateTime(val)
 
 
-class PyDMDateTimeLabel(QtWidgets.QLabel, PyDMWidget, TimeBase):
+class PyDMDateTimeLabel(QtWidgets.QLabel, PyDMWidget):
     QtCore.Q_ENUMS(TimeBase)
+
+    # Make enum definitions known to this class
+    Milliseconds = TimeBase.Milliseconds
+    Seconds = TimeBase.Seconds
+
     """
     A QLabel with support for setting the text via a PyDM Channel, or
     through the PyDM Rules system.

--- a/pydm/widgets/display_format.py
+++ b/pydm/widgets/display_format.py
@@ -1,7 +1,6 @@
 import math
 import numpy as np
 from typing import Any
-
 import logging
 import warnings
 

--- a/pydm/widgets/enum_button.py
+++ b/pydm/widgets/enum_button.py
@@ -18,7 +18,7 @@ class_for_type = [QPushButton, QRadioButton]
 logger = logging.getLogger(__name__)
 
 
-class PyDMEnumButton(QWidget, PyDMWritableWidget, WidgetType):
+class PyDMEnumButton(QWidget, PyDMWritableWidget):
     """
     A QWidget that renders buttons for every option of Enum Items.
     For now, two types of buttons can be rendered:
@@ -40,6 +40,10 @@ class PyDMEnumButton(QWidget, PyDMWritableWidget, WidgetType):
 
     Q_ENUMS(WidgetType)
     WidgetType = WidgetType
+
+    # Make enum definitions known to this class
+    PushButton = WidgetType.PushButton
+    RadioButton = WidgetType.RadioButton
 
     def __init__(self, parent=None, init_channel=None):
         QWidget.__init__(self, parent)

--- a/pydm/widgets/image.py
+++ b/pydm/widgets/image.py
@@ -98,7 +98,7 @@ class ImageUpdateThread(QThread):
         self.image_view.needs_redraw = False
 
 
-class PyDMImageView(ImageView, PyDMWidget, PyDMColorMap, ReadingOrder, DimensionOrder):
+class PyDMImageView(ImageView, PyDMWidget):
     """
     A PyQtGraph ImageView with support for Channels and more from PyDM.
 
@@ -129,6 +129,21 @@ class PyDMImageView(ImageView, PyDMWidget, PyDMColorMap, ReadingOrder, Dimension
     Q_ENUMS(ReadingOrder)
     Q_ENUMS(DimensionOrder)
     Q_ENUMS(PyDMColorMap)
+
+    # Make enum definitions known to this class
+    Fortranlike = ReadingOrder.Fortranlike
+    Clike = ReadingOrder.Clike
+
+    HeightFirst = DimensionOrder.HeightFirst
+    WidthFirst = DimensionOrder.WidthFirst
+
+    Magma = PyDMColorMap.Magma
+    Inferno = PyDMColorMap.Inferno
+    Plasma = PyDMColorMap.Plasma
+    Viridis = PyDMColorMap.Viridis
+    Jet = PyDMColorMap.Jet
+    Monochrome = PyDMColorMap.Monochrome
+    Hot = PyDMColorMap.Hot
 
     color_maps = cmaps
 

--- a/pydm/widgets/label.py
+++ b/pydm/widgets/label.py
@@ -9,7 +9,7 @@ from pydm.widgets.base import only_if_channel_set
 _labelRuleProperties = {"Text": ["value_changed", str]}
 
 
-class PyDMLabel(QLabel, TextFormatter, PyDMWidget, DisplayFormat, new_properties=_labelRuleProperties):
+class PyDMLabel(QLabel, TextFormatter, PyDMWidget, new_properties=_labelRuleProperties):
     """
     A QLabel with support for setting the text via a PyDM Channel, or
     through the PyDM Rules system.
@@ -26,6 +26,13 @@ class PyDMLabel(QLabel, TextFormatter, PyDMWidget, DisplayFormat, new_properties
     init_channel : str, optional
         The channel to be used by the widget.
     """
+
+    Default = DisplayFormat.Default
+    String = DisplayFormat.String
+    Decimal = DisplayFormat.Decimal
+    Exponential = DisplayFormat.Exponential
+    Hex = DisplayFormat.Hex
+    Binary = DisplayFormat.Binary
 
     Q_ENUMS(DisplayFormat)
     DisplayFormat = DisplayFormat

--- a/pydm/widgets/line_edit.py
+++ b/pydm/widgets/line_edit.py
@@ -14,7 +14,7 @@ from .display_format import DisplayFormat, parse_value_for_display
 logger = logging.getLogger(__name__)
 
 
-class PyDMLineEdit(QLineEdit, TextFormatter, PyDMWritableWidget, DisplayFormat):
+class PyDMLineEdit(QLineEdit, TextFormatter, PyDMWritableWidget):
     """
     A QLineEdit (writable text field) with support for Channels and more
     from PyDM.
@@ -31,6 +31,14 @@ class PyDMLineEdit(QLineEdit, TextFormatter, PyDMWritableWidget, DisplayFormat):
 
     Q_ENUMS(DisplayFormat)
     DisplayFormat = DisplayFormat
+
+    # Make enum definitions known to this class
+    Default = DisplayFormat.Default
+    String = DisplayFormat.String
+    Decimal = DisplayFormat.Decimal
+    Exponential = DisplayFormat.Exponential
+    Hex = DisplayFormat.Hex
+    Binary = DisplayFormat.Binary
 
     def __init__(self, parent=None, init_channel=None):
         QLineEdit.__init__(self, parent)

--- a/pydm/widgets/logdisplay.py
+++ b/pydm/widgets/logdisplay.py
@@ -108,7 +108,7 @@ class LogLevels(object):
         return OrderedDict(sorted(entries, key=lambda x: x[1], reverse=False))
 
 
-class PyDMLogDisplay(QWidget, LogLevels):
+class PyDMLogDisplay(QWidget):
     """
     Standard display for Log Output
 
@@ -131,6 +131,15 @@ class PyDMLogDisplay(QWidget, LogLevels):
 
     Q_ENUMS(LogLevels)
     LogLevels = LogLevels
+
+    # Make enum definitions known to this class
+    NOTSET = LogLevels.NOTSET
+    DEBUG = LogLevels.DEBUG
+    INFO = LogLevels.INFO
+    WARNING = LogLevels.WARNING
+    ERROR = LogLevels.ERROR
+    CRITICAL = LogLevels.CRITICAL
+
     terminator = "\n"
     default_format = "%(asctime)s %(message)s"
     default_level = logging.INFO

--- a/pydm/widgets/template_repeater.py
+++ b/pydm/widgets/template_repeater.py
@@ -120,7 +120,7 @@ class LayoutType(object):
 layout_class_for_type = (QVBoxLayout, QHBoxLayout, FlowLayout)
 
 
-class PyDMTemplateRepeater(QFrame, PyDMPrimitiveWidget, LayoutType):
+class PyDMTemplateRepeater(QFrame, PyDMPrimitiveWidget):
     """
     PyDMTemplateRepeater takes a .ui file with macro variables as a template, and a JSON
     file (or a list of dictionaries) with a list of values to use to fill in
@@ -142,6 +142,11 @@ class PyDMTemplateRepeater(QFrame, PyDMPrimitiveWidget, LayoutType):
 
     Q_ENUMS(LayoutType)
     LayoutType = LayoutType
+
+    # Make enum definitions known to this class
+    Vertical = LayoutType.Vertical
+    Horizontal = LayoutType.Horizontal
+    Flow = LayoutType.Flow
 
     def __init__(self, parent=None):
         pydm.data_plugins.initialize_plugins_if_needed()

--- a/pydm/widgets/timeplot.py
+++ b/pydm/widgets/timeplot.py
@@ -224,7 +224,7 @@ class TimePlotCurveItem(BasePlotCurveItem):
             if self.points_accumulated < self._bufferSize:
                 self.points_accumulated += 1
             self.data_changed.emit()
-        elif self._update_mode == PyDMTimePlot.AtFixedRated:
+        elif self._update_mode == PyDMTimePlot.AtFixedRate:
             self.latest_value = new_value
 
     @Slot()
@@ -234,7 +234,7 @@ class TimePlotCurveItem(BasePlotCurveItem):
         buffer, together with the timestamp when this happens. Also increments
         the accumulated point counter.
         """
-        if self._update_mode != PyDMTimePlot.AtFixedRated:
+        if self._update_mode != PyDMTimePlot.AtFixedRate:
             return
         self.data_buffer = np.roll(self.data_buffer, -1)
         self.data_buffer[0, self._bufferSize - 1] = time.time()
@@ -412,7 +412,7 @@ class TimePlotCurveItem(BasePlotCurveItem):
         return [self.channel]
 
 
-class PyDMTimePlot(BasePlot, updateMode):
+class PyDMTimePlot(BasePlot):
     """
     PyDMTimePlot is a widget to plot one or more channels vs. time.
 
@@ -437,11 +437,12 @@ class PyDMTimePlot(BasePlot, updateMode):
         to either a TimeAxisItem if plot_by_timestamps is true, or a regular AxisItem otherwise
     """
 
-    OnValueChange = 1
-    AtFixedRated = 2
-
     Q_ENUMS(updateMode)
     updateMode = updateMode
+
+    # Make enum definitions known to this class
+    OnValueChange = updateMode.OnValueChange
+    AtFixedRate = updateMode.AtFixedRate
 
     plot_redrawn_signal = Signal(TimePlotCurveItem)
 
@@ -918,7 +919,7 @@ class PyDMTimePlot(BasePlot, updateMode):
     bufferSize = Property("int", getBufferSize, setBufferSize, resetBufferSize)
 
     def getUpdatesAsynchronously(self):
-        return self._update_mode == PyDMTimePlot.AtFixedRated
+        return self._update_mode == PyDMTimePlot.AtFixedRate
 
     def setUpdatesAsynchronously(self, value):
         for curve in self._curves:


### PR DESCRIPTION
This should fix main issue making it difficult to support both PyQt5 and PySide6 enums at same time!

The need for inheritance was b/c  when an enum gets written to a ui file by designer, its in the form of \<widget class name\>::\<enum value\> (ex='PyDMLabel::STRING').

On loading the ui file, unless the widget class had subclassed the enum class it wouldn't find the definition of the enum.

The issue with subclassing the enum is:  in qt6 enums must inherit from python 'Enum' (ex = class MyNewEnum(Enum)), and these classes can not be inherited from.

So instead we can just re-declare the values of the enum in the class itself, mimicking if the class had inherited from the enum.