### PR TITLE
MNT: Update versions of checkout and setup-miniconda actions

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -27,9 +27,9 @@ jobs:
       QT_MAC_WANTS_LAYER: 1  # PyQT gui tests involving qtbot interaction on macOS will fail without this
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Setup conda
-      uses: conda-incubator/setup-miniconda@v2
+      uses: conda-incubator/setup-miniconda@v3
       with:
         python-version: ${{ matrix.python-version }}
         miniforge-variant: Miniforge3

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -41,7 +41,11 @@ jobs:
     - name: Install PyDM with Mamba
       shell: bash -el {0}
       run: |
-        mamba install -c conda-forge pydm pyqt=${{ matrix.pyqt-version }}
+        if [ "$RUNNER_OS" == "Windows" ]; then
+          conda install -c conda-forge pydm pyqt=${{ matrix.pyqt-version }}
+        else
+          mamba install -c conda-forge pydm pyqt=${{ matrix.pyqt-version }}
+        fi
 
     - name: Install additional Python dependencies with pip
       shell: bash -el {0}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -35,6 +35,8 @@ jobs:
         miniforge-variant: Miniforge3
         miniforge-version: latest
         activate-environment: pydm-env
+        conda-remove-defaults: true
+        architecture: x64  # Ensure macOS finds PyQt 5.12.3 which isn't available with osx-arm64
 
     - name: Install PyDM with Mamba
       shell: bash -el {0}

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright (c) 2017-2020, The Board of Trustees of the Leland Stanford
+Copyright (c) 2017-2025, The Board of Trustees of the Leland Stanford
 Junior University, through SLAC National Accelerator Laboratory
 (subject to receipt of any required approvals from the U.S. Dept. of
 Energy). All rights reserved. Redistribution and use in source and


### PR DESCRIPTION
Before looking too much into the intermittent failures on mamba setup during the `conda-incubator/setup-miniconda`, update the action to the latest version. Updates checkout action too.

Have seen recently among others:

`Error: The process '/usr/share/miniconda3/condabin/mamba' failed with exit code 1`

```
error    libmamba Error when extracting package: Could not chdir include/openssl/rsaerr.h
openssl-1.1.1w-hd590300_0.conda extraction failed
Found incorrect download: openssl. Aborting
```

etc...

Will make a separate issue if they continue.