### PR TITLE
MNT: make gh-actions timeout and fail at 30 mins (instead of 6 hour default)

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -56,5 +56,6 @@ jobs:
         fi
     - name: Test with pytest
       shell: bash -el {0}
+      timeout-minutes: 30 # timeout applies to single run of run_tests.py, not all os/python combos
       run: |
         python run_tests.py


### PR DESCRIPTION
Some intermittent issues cause test to just run forever until hit 6 hour default timeout to fail ex: https://github.com/slaclab/pydm/actions/runs/12777372530/job/35622564890

Longest run of tests is on windows/mac and seems to take about 5 mins, so 30 min timeout should be long enough.