### PR TITLE
MNT: make RULE_PROPERTIES work with pyside6

### DIFF
--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -154,7 +154,7 @@ class PyDMPrimitiveWidget(object):
             # and not at the Designer
             self.installEventFilter(self)
 
-    def __init_subclass__(cls, new_properties={}):
+    def __init_subclass__(cls):
         """
         Adds or redefines rule-triggered property configuration for derivative
         classes.
@@ -171,9 +171,9 @@ class PyDMPrimitiveWidget(object):
             rule dispatch, and a type matching the one that we expect to
             receive from the PV value.
         """
-        if new_properties:
+        if hasattr(cls, "new_properties") and isinstance(cls.new_properties, dict):
             cls.RULE_PROPERTIES = cls.RULE_PROPERTIES.copy()
-            cls.RULE_PROPERTIES.update(new_properties)
+            cls.RULE_PROPERTIES.update(cls.new_properties)
 
     @staticmethod
     def get_designer_icon():
@@ -588,7 +588,7 @@ class TextFormatter(object):
 _positionRuleProperties = {"Position - X": ["setX", int], "Position - Y": ["setY", int]}
 
 
-class PyDMWidget(PyDMPrimitiveWidget, new_properties=_positionRuleProperties):
+class PyDMWidget(PyDMPrimitiveWidget):
     """
     PyDM base class for Read-Only widgets.
     This class implements all the functions of connection, alarm
@@ -600,6 +600,9 @@ class PyDMWidget(PyDMPrimitiveWidget, new_properties=_positionRuleProperties):
         The channel to be used by the widget.
 
     """
+
+    # this is same for all instances of the class, so don't define with '.self'
+    new_properties = _positionRuleProperties
 
     # Alarm types
     ALARM_NONE = 0

--- a/pydm/widgets/drawing.py
+++ b/pydm/widgets/drawing.py
@@ -59,7 +59,7 @@ def qt_to_deg(deg):
     return deg / 16.0
 
 
-class PyDMDrawing(QWidget, PyDMWidget, new_properties=_penRuleProperties):
+class PyDMDrawing(QWidget, PyDMWidget):
     """
     Base class to be used for all PyDM Drawing Widgets.
     This class inherits from QWidget and PyDMWidget.
@@ -71,6 +71,8 @@ class PyDMDrawing(QWidget, PyDMWidget, new_properties=_penRuleProperties):
     init_channel : str, optional
         The channel to be used by the widget.
     """
+
+    new_properties = _penRuleProperties
 
     def __init__(self, parent=None, init_channel=None):
         self._rotation = 0.0
@@ -623,7 +625,7 @@ class PyDMDrawingLineBase(PyDMDrawing):
         return QPolygonF([left, endpoint, right])
 
 
-class PyDMDrawingLine(PyDMDrawingLineBase, new_properties=_penRuleProperties):
+class PyDMDrawingLine(PyDMDrawingLineBase):
     """
     A widget with a line drawn in it.
     This class inherits from PyDMDrawingLineBase.
@@ -635,6 +637,8 @@ class PyDMDrawingLine(PyDMDrawingLineBase, new_properties=_penRuleProperties):
     init_channel : str, optional
         The channel to be used by the widget.
     """
+
+    new_properties = _penRuleProperties
 
     def __init__(self, parent=None, init_channel=None):
         super(PyDMDrawingLine, self).__init__(parent, init_channel)

--- a/pydm/widgets/embedded_display.py
+++ b/pydm/widgets/embedded_display.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 _embeddedDisplayRuleProperties = {"Filename": ["filename", str]}
 
 
-class PyDMEmbeddedDisplay(QFrame, PyDMPrimitiveWidget, new_properties=_embeddedDisplayRuleProperties):
+class PyDMEmbeddedDisplay(QFrame, PyDMPrimitiveWidget):
     """
     A QFrame capable of rendering a PyDM Display
 
@@ -32,6 +32,8 @@ class PyDMEmbeddedDisplay(QFrame, PyDMPrimitiveWidget, new_properties=_embeddedD
         The parent widget for the Label
 
     """
+
+    new_properties = _embeddedDisplayRuleProperties
 
     def __init__(self, parent=None):
         QFrame.__init__(self, parent)

--- a/pydm/widgets/label.py
+++ b/pydm/widgets/label.py
@@ -9,7 +9,7 @@ from pydm.widgets.base import only_if_channel_set
 _labelRuleProperties = {"Text": ["value_changed", str]}
 
 
-class PyDMLabel(QLabel, TextFormatter, PyDMWidget, DisplayFormat, new_properties=_labelRuleProperties):
+class PyDMLabel(QLabel, TextFormatter, PyDMWidget, DisplayFormat):
     """
     A QLabel with support for setting the text via a PyDM Channel, or
     through the PyDM Rules system.
@@ -26,6 +26,8 @@ class PyDMLabel(QLabel, TextFormatter, PyDMWidget, DisplayFormat, new_properties
     init_channel : str, optional
         The channel to be used by the widget.
     """
+
+    new_properties = _labelRuleProperties
 
     Q_ENUMS(DisplayFormat)
     DisplayFormat = DisplayFormat

--- a/pydm/widgets/label.py
+++ b/pydm/widgets/label.py
@@ -10,7 +10,7 @@ from ..utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
 _labelRuleProperties = {"Text": ["value_changed", str]}
 
 
-class PyDMLabel(QLabel, TextFormatter, PyDMWidget, DisplayFormat):
+class PyDMLabel(QLabel, TextFormatter, PyDMWidget):
     """
     A QLabel with support for setting the text via a PyDM Channel, or
     through the PyDM Rules system.

--- a/pydm/widgets/related_display_button.py
+++ b/pydm/widgets/related_display_button.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 _relatedDisplayRuleProperties = {"Text": ["setText", str], "Filenames": ["filenames", list]}
 
 
-class PyDMRelatedDisplayButton(QPushButton, PyDMWidget, new_properties=_relatedDisplayRuleProperties):
+class PyDMRelatedDisplayButton(QPushButton, PyDMWidget):
     """
     A QPushButton capable of opening a new Display in the same or a new window.
 
@@ -34,6 +34,7 @@ class PyDMRelatedDisplayButton(QPushButton, PyDMWidget, new_properties=_relatedD
         The channel to be used by the widget
     """
 
+    new_properties = _relatedDisplayRuleProperties
     # Constants for determining where to open the display.
     EXISTING_WINDOW = 0
     NEW_WINDOW = 1

--- a/pydm/widgets/slider.py
+++ b/pydm/widgets/slider.py
@@ -230,7 +230,7 @@ class PyDMPrimitiveSlider(QSlider):
             return (1 - proportion) * slider_length + self.getHandleSize().height() / 2
 
 
-class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget, new_properties=_step_size_properties):
+class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget):
     """
     A QSlider with support for Channels and more from PyDM.
 
@@ -241,6 +241,8 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget, new_properties=_step
     init_channel : str, optional
         The channel to be used by the widget.
     """
+
+    new_properties = _step_size_properties
 
     actionTriggered = Signal(int)
     rangeChanged = Signal(float, float)

--- a/pydm/widgets/symbol.py
+++ b/pydm/widgets/symbol.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 _symbolRuleProperties = {"Index": ["set_current_key", int]}
 
 
-class PyDMSymbol(QWidget, PyDMWidget, new_properties=_symbolRuleProperties):
+class PyDMSymbol(QWidget, PyDMWidget):
     """
     PyDMSymbol will render an image (symbol) for each value of a channel.
 
@@ -24,6 +24,8 @@ class PyDMSymbol(QWidget, PyDMWidget, new_properties=_symbolRuleProperties):
     init_channel : str, optional
         The channel to be used by the widget.
     """
+
+    new_properties = _symbolRuleProperties
 
     def __init__(self, parent=None, init_channel=None):
         QWidget.__init__(self, parent)


### PR DESCRIPTION
PySide6 uses the Shiboken library for its python bindings, which has stricter rules for class definition than PyQt's sip library. 

This means that pyside6 doesn't allow us to pass 'new_properties' to classes in their class-definitions.
  
Instead, we can store the properties as a class attribute defined inside the classes. 
Note: we don't use '.self' here for the variable since we want the properties to be defined at time of class definition and stay the same across all objects of the class.

And the RULE_PROPERTIES are getting tested already by this recent patch: https://github.com/slaclab/pydm/pull/1151