### PR TITLE
MNT: switch signal type overloading to use syntax that works for both pyqt5 and pyside6

### DIFF
--- a/pydm/data_plugins/plugin.py
+++ b/pydm/data_plugins/plugin.py
@@ -12,19 +12,19 @@ from .. import config
 
 
 class PyDMConnection(QObject):
-    new_value_signal = Signal([float], [int], [str], [bool], [object])
+    new_value_signal = Signal((float,), (int,), (str,), (bool,), (object,))
     connection_state_signal = Signal(bool)
     new_severity_signal = Signal(int)
     write_access_signal = Signal(bool)
     enum_strings_signal = Signal(tuple)
     unit_signal = Signal(str)
     prec_signal = Signal(int)
-    upper_ctrl_limit_signal = Signal([float], [int])
-    lower_ctrl_limit_signal = Signal([float], [int])
-    upper_alarm_limit_signal = Signal([float], [int])
-    lower_alarm_limit_signal = Signal([float], [int])
-    upper_warning_limit_signal = Signal([float], [int])
-    lower_warning_limit_signal = Signal([float], [int])
+    upper_ctrl_limit_signal = Signal((float,), (int,))
+    lower_ctrl_limit_signal = Signal((float,), (int,))
+    upper_alarm_limit_signal = Signal((float,), (int,))
+    lower_alarm_limit_signal = Signal((float,), (int,))
+    upper_warning_limit_signal = Signal((float,), (int,))
+    lower_warning_limit_signal = Signal((float,), (int,))
     timestamp_signal = Signal(float)
 
     def __init__(self, channel, address, protocol=None, parent=None):

--- a/pydm/tests/conftest.py
+++ b/pydm/tests/conftest.py
@@ -29,22 +29,22 @@ class ConnectionSignals(QObject):
     An assortment of signals, to which a unit test can choose from and bind an appropriate slot
     """
 
-    new_value_signal = Signal([float], [int], [str], [np.ndarray])
+    new_value_signal = Signal((float,), (int,), (str,), (np.ndarray,))
     connection_state_signal = Signal(bool)
     new_severity_signal = Signal(int)
     write_access_signal = Signal(bool)
     enum_strings_signal = Signal(tuple)
     internal_slider_moved = Signal(int)
     internal_slider_clicked = Signal()
-    send_value_signal = Signal([int], [float], [str], [bool], [np.ndarray])
+    send_value_signal = Signal((int,), (float,), (str,), (bool,), (np.ndarray,))
     unit_signal = Signal(str)
     prec_signal = Signal(int)
-    upper_ctrl_limit_signal = Signal([float])
-    lower_ctrl_limit_signal = Signal([float])
-    upper_alarm_limit_signal = Signal([float])
-    lower_alarm_limit_signal = Signal([float])
-    upper_warning_limit_signal = Signal([float])
-    lower_warning_limit_signal = Signal([float])
+    upper_ctrl_limit_signal = Signal((float,))
+    lower_ctrl_limit_signal = Signal((float,))
+    upper_alarm_limit_signal = Signal((float,))
+    lower_alarm_limit_signal = Signal((float,))
+    upper_warning_limit_signal = Signal((float,))
+    lower_warning_limit_signal = Signal((float,))
 
     def __init__(self):
         super(ConnectionSignals, self).__init__()

--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -1363,10 +1363,10 @@ class PyDMWritableWidget(PyDMWidget):
         Emitted when the user changes the value
     """
 
-    __Signals__ = "send_value_signal([int], [float], [str], [bool], [object])"
+    __Signals__ = "send_value_signal((int, ), (float, ), (str, ), (bool, ), (object, ))"
 
     # Emitted when the user changes the value.
-    send_value_signal = Signal([int], [float], [str], [bool], [object])
+    send_value_signal = Signal((int,), (float,), (str,), (bool,), (object,))
 
     def __init__(self, init_channel=None):
         self._write_access = False


### PR DESCRIPTION
syntax is described here in the pyside6 docs:
https://doc.qt.io/qtforpython-6/tutorials/basictutorial/signals_and_slots.html#overloading-signals-and-slots-with-different-types

using this syntax doesn't have effect on pyqt5 functionality.