### PR TITLE
FIX: changes to publish-to-pypi.yml

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -31,7 +31,7 @@ jobs:
       run: python setup.py sdist
 
     - name: Upload package
-      uses: actions/upload-artifact@v4.4.2
+      uses: actions/upload-artifact@v4.6.0
       with:
         name: package
         path: dist/*


### PR DESCRIPTION
changes to the actions/upload-artifact version to address an issue with pushing to pypi on the release of v1.25.2
