### PR TITLE
FIX: Set log mode and link/unlink ArchivePlotCurveItem.ErrorBarItems

### DIFF
--- a/pydm/widgets/archiver_time_plot.py
+++ b/pydm/widgets/archiver_time_plot.py
@@ -68,6 +68,7 @@ class ArchivePlotCurveItem(TimePlotCurveItem):
         self.error_bar = ErrorBarItem()
         self.error_bar_data = None
 
+        self.destroyed.connect(lambda: self.remove_error_bar())
         self.address = channel_address
 
     def to_dict(self) -> OrderedDict:
@@ -294,6 +295,14 @@ class ArchivePlotCurveItem(TimePlotCurveItem):
         solid_pen.setStyle(1)
 
         self.error_bar.setData(x=x_val, y=y_val, top=top_val, bottom=bot_val, beam=0.5, pen=solid_pen)
+
+    @Slot()
+    def remove_error_bar(self):
+        """Remove the curve's error bar when the curve is deleted."""
+        if self.error_bar is None:
+            return
+        vb = self.error_bar.getViewBox()
+        vb.removeItem(self.error_bar)
 
     def setLogMode(self, xState: bool, yState: bool) -> None:
         """When log mode is enabled for the respective axis by setting xState or
@@ -967,8 +976,8 @@ class PyDMArchiverTimePlot(PyDMTimePlot):
             # Need to clear out any bars from optimized data; only applicable to ArchivePlotCurveItems
             if not isinstance(curve, ArchivePlotCurveItem):
                 continue
-            vb = curve.error_bar_item.getViewBox()
-            vb.removeItem(curve.error_bar_item)
+            vb = curve.error_bar.getViewBox()
+            vb.removeItem(curve.error_bar)
 
         # reset _min_x to let updateXAxis make requests anew
         self._min_x = self._starting_timestamp

--- a/pydm/widgets/archiver_time_plot.py
+++ b/pydm/widgets/archiver_time_plot.py
@@ -67,7 +67,6 @@ class ArchivePlotCurveItem(TimePlotCurveItem):
         # the full range of values retrieved
         self.error_bar = ErrorBarItem()
         self.error_bar_data = None
-        self.getViewBox().addItem(self.error_bar)
 
         self.destroyed.connect(lambda: self.remove_error_bar())
         self.address = channel_address
@@ -182,6 +181,9 @@ class ArchivePlotCurveItem(TimePlotCurveItem):
         if data.shape[0] == 5:  # 5 indicates optimized data was requested from the archiver
             self.error_bar_data = data
             self.set_error_bar()
+            self.error_bar.show()
+        else:
+            self.error_bar.hide()
 
         self.data_changed.emit()
         self.archive_data_received_signal.emit()
@@ -277,6 +279,9 @@ class ArchivePlotCurveItem(TimePlotCurveItem):
         based on the curve's log mode.
         """
         x_val = self.error_bar_data[0]
+
+        if self.error_bar.getViewBox() is None:
+            self.getViewBox().addItem(self.error_bar)
 
         # Calculate y-value and range for error bars
         logMode = self.opts["logMode"][1]

--- a/pydm/widgets/archiver_time_plot.py
+++ b/pydm/widgets/archiver_time_plot.py
@@ -67,6 +67,7 @@ class ArchivePlotCurveItem(TimePlotCurveItem):
         # the full range of values retrieved
         self.error_bar = ErrorBarItem()
         self.error_bar_data = None
+        self.getViewBox().addItem(self.error_bar)
 
         self.destroyed.connect(lambda: self.remove_error_bar())
         self.address = channel_address

--- a/pydm/widgets/archiver_time_plot.py
+++ b/pydm/widgets/archiver_time_plot.py
@@ -66,6 +66,7 @@ class ArchivePlotCurveItem(TimePlotCurveItem):
         # When optimized or mean value data is requested, we can display error bars representing
         # the full range of values retrieved
         self.error_bar = ErrorBarItem()
+        self.error_bar_data = None
 
         self.address = channel_address
 
@@ -307,7 +308,7 @@ class ArchivePlotCurveItem(TimePlotCurveItem):
             Set log mode for the y-axis
         """
         super().setLogMode(xState, yState)
-        if self.error_bar_data:
+        if self.error_bar_data is not None:
             self.set_error_bar()
 
     @Slot(bool)

--- a/pydm/widgets/archiver_time_plot.py
+++ b/pydm/widgets/archiver_time_plot.py
@@ -301,8 +301,8 @@ class ArchivePlotCurveItem(TimePlotCurveItem):
         """Remove the curve's error bar when the curve is deleted."""
         if self.error_bar is None:
             return
-        vb = self.error_bar.getViewBox()
-        vb.removeItem(self.error_bar)
+        if vb := self.error_bar.getViewBox():
+            vb.removeItem(self.error_bar)
 
     def setLogMode(self, xState: bool, yState: bool) -> None:
         """When log mode is enabled for the respective axis by setting xState or

--- a/pydm/widgets/baseplot.py
+++ b/pydm/widgets/baseplot.py
@@ -458,7 +458,7 @@ class BasePlotAxisItem(AxisItem):
         Extra arguments for CSS style options for this axis
     """
 
-    log_mode_updated = Signal(str, bool)
+    log_mode_updated = Signal()
     sigXRangeChanged = Signal(object, object)
     sigYRangeChanged = Signal(object, object)
     axis_orientations = OrderedDict([("Left", "left"), ("Right", "right")])
@@ -638,7 +638,9 @@ class BasePlotAxisItem(AxisItem):
         """
         self._log_mode = log_mode
         self.setLogMode(x=False, y=log_mode)
-        self.log_mode_updated.emit(self.name, log_mode)
+        for curve in self._curves:
+            curve.setLogMode(xState=False, yState=log_mode)
+        self.log_mode_updated.emit()
 
     def setHidden(self, shouldHide: bool):
         """Set an axis to hide/show and do the same for all of its connected curves"""
@@ -898,7 +900,7 @@ class BasePlot(PlotWidget, PyDMPrimitiveWidget):
         if plot_data_item is not None:
             plot_data_item.setLogMode(False, log_mode)
         axis.setLogMode(log_mode)
-        axis.log_mode_updated.connect(self.setAxisLogMode)
+        axis.log_mode_updated.connect(self.plotItem.recomputeAverages)
         self._axes.append(axis)
         # If the x axis is just timestamps, we don't want autorange on the x axis
         setXLink = hasattr(self, "_plot_by_timestamps") and self._plot_by_timestamps
@@ -980,13 +982,6 @@ class BasePlot(PlotWidget, PyDMPrimitiveWidget):
     @Slot()
     def redrawPlot(self) -> None:
         pass
-
-    @Slot(str, bool)
-    def setAxisLogMode(self, axis_name: str, log_mode: bool) -> None:
-        axis_curves = [c for c in self._curves if c.y_axis_name == axis_name]
-        for curve in axis_curves:
-            curve.setLogMode(False, log_mode)
-        self.plotItem.recomputeAverages()
 
     def getShowXGrid(self) -> bool:
         """True if showing x grid lines on the plot, False otherwise"""

--- a/pydm/widgets/multi_axis_plot.py
+++ b/pydm/widgets/multi_axis_plot.py
@@ -195,10 +195,8 @@ class MultiAxisPlot(PlotItem):
             currentView.removeItem(plotDataItem)
             plotDataItem.forgetViewBox()
 
-        if axisToLink.logMode:
-            plotDataItem.setLogMode(False, True)
-        else:
-            plotDataItem.setLogMode(False, False)
+        # Match the curve's logMode to its new axis' logMode
+        plotDataItem.setLogMode(False, axisToLink.logMode)
 
         axisToLink.linkedView().addItem(plotDataItem)
         self.dataItems.append(plotDataItem)

--- a/pydm/widgets/multi_axis_plot.py
+++ b/pydm/widgets/multi_axis_plot.py
@@ -197,6 +197,8 @@ class MultiAxisPlot(PlotItem):
 
         if axisToLink.logMode:
             plotDataItem.setLogMode(False, True)
+        else:
+            plotDataItem.setLogMode(False, False)
 
         axisToLink.linkedView().addItem(plotDataItem)
         self.dataItems.append(plotDataItem)


### PR DESCRIPTION
Fixes some bugs found in the ErrorBarItems for the ArchiverPlotCurveItem. Below are a few of the problems I found and their solutions.

- Moving a curve to a new y-axis did not move the curve's error bars, they were just left on the previous axis. I fixed this by adding a `y_axis_name.setter` override in ArchivePlotCurveItem. This setter calls the `super().y_axis_name.setter`, but then moves the associated error bar as well.

- Setting a y-axis & curve to use log mode in the y direction did not set log mode for the error bars, their values were just off. This required overriding the curve's `setLogMode` method to update the error bar's data in addition to the `super()` method.

- Error bars do not get removed from the plot when the curve is removed. The solution was to use the `QObject.destroyed` signal to capture when the curve was being destroyed. Then the error bars can be removed at the same time.