### PR TITLE
ENH: ArchiveTimePlot Fetch Data on X-Axis Change

### DIFF
--- a/pydm/widgets/archiver_time_plot.py
+++ b/pydm/widgets/archiver_time_plot.py
@@ -757,11 +757,13 @@ class PyDMArchiverTimePlot(PyDMTimePlot):
         The parent of this widget.
     init_y_channels : list
         A list of scalar channels to plot vs time.
-    background: str
+    background : str
         The background color for the plot.  Accepts any arguments that
         pyqtgraph.mkColor will accept.
-    optimized_data_bins: int
+    optimized_data_bins : int
         The number of bins of data returned from the archiver when using optimized requests
+    request_cooldown : int
+        The time, in seconds, between requests to the archiver appliance
     cache_data : bool
         Whether curves should retain archive data or fetch new data when the x-axis changes
     show_all : bool
@@ -774,6 +776,7 @@ class PyDMArchiverTimePlot(PyDMTimePlot):
         init_y_channels: List[str] = [],
         background: str = "default",
         optimized_data_bins: int = 2000,
+        request_cooldown: int = 1000,
         cache_data: bool = True,
         show_all: bool = True,
     ):
@@ -787,6 +790,7 @@ class PyDMArchiverTimePlot(PyDMTimePlot):
         self._cache_data = None
 
         self.optimized_data_bins = optimized_data_bins
+        self.request_cooldown = request_cooldown
         self.cache_data = cache_data
         self._show_all = show_all  # Show all plotted data after archiver fetch
 
@@ -860,7 +864,7 @@ class PyDMArchiverTimePlot(PyDMTimePlot):
             self.setTimeSpan(max_x - min_x)
             if not self._archive_request_queued:
                 self._archive_request_queued = True
-                QTimer.singleShot(1000, self.requestDataFromArchiver)
+                QTimer.singleShot(self.request_cooldown, self.requestDataFromArchiver)
 
     def _handle_manual_scrolling_or_zoom(self, min_x: float, max_x: float) -> None:
         """Handles scenarios of manual scrolling or zooming when autorange is disabled."""
@@ -872,7 +876,7 @@ class PyDMArchiverTimePlot(PyDMTimePlot):
             self.setTimeSpan(max_point - min_x)
             if not self._archive_request_queued:
                 self._archive_request_queued = True
-                QTimer.singleShot(1000, self.requestDataFromArchiver)
+                QTimer.singleShot(self.request_cooldown, self.requestDataFromArchiver)
         elif max_x >= max_point - 10:
             # Check if we should update the x-axis
             if abs(min_x - self._prev_x) > 15:

--- a/pydm/widgets/archiver_time_plot.py
+++ b/pydm/widgets/archiver_time_plot.py
@@ -763,7 +763,7 @@ class PyDMArchiverTimePlot(PyDMTimePlot):
     optimized_data_bins : int
         The number of bins of data returned from the archiver when using optimized requests
     request_cooldown : int
-        The time, in seconds, between requests to the archiver appliance
+        The time, in milliseconds, between requests to the archiver appliance
     cache_data : bool
         Whether curves should retain archive data or fetch new data when the x-axis changes
     show_all : bool

--- a/pydm/widgets/archiver_time_plot.py
+++ b/pydm/widgets/archiver_time_plot.py
@@ -763,7 +763,9 @@ class PyDMArchiverTimePlot(PyDMTimePlot):
     optimized_data_bins: int
         The number of bins of data returned from the archiver when using optimized requests
     cache_data : bool
+        Whether curves should retain archive data or fetch new data when the x-axis changes
     show_all : bool
+        Shifts the x-axis range to show all data, or stay where the user set the x-axis to
     """
 
     def __init__(

--- a/pydm/widgets/archiver_time_plot.py
+++ b/pydm/widgets/archiver_time_plot.py
@@ -842,7 +842,7 @@ class PyDMArchiverTimePlot(PyDMTimePlot):
             processing_command = ""
             if curve.use_archive_data:
                 if max_x is None:
-                    max_x = curve.min_x()
+                    max_x = min(curve.min_x(), self._max_x)
                 requested_seconds = max_x - min_x
                 if requested_seconds <= 5:
                     continue  # Avoids noisy requests when first rendering the plot

--- a/pydm/widgets/archiver_time_plot.py
+++ b/pydm/widgets/archiver_time_plot.py
@@ -770,6 +770,7 @@ class PyDMArchiverTimePlot(PyDMTimePlot):
         init_y_channels: List[str] = [],
         background: str = "default",
         optimized_data_bins: int = 2000,
+        show_all: bool = True,
     ):
         super(PyDMArchiverTimePlot, self).__init__(
             parent=parent,
@@ -779,6 +780,7 @@ class PyDMArchiverTimePlot(PyDMTimePlot):
             bottom_axis=DateAxisItem("bottom"),
         )
         self.optimized_data_bins = optimized_data_bins
+        self._show_all = show_all  # Show all plotted data after archiver fetch
         self._starting_timestamp = time.time()  # The timestamp at which the plot was first rendered
         self._min_x = self._starting_timestamp - DEFAULT_TIME_SPAN
         self._prev_x = self._min_x  # Holds the minimum x-value of the previous update of the plot
@@ -895,7 +897,7 @@ class PyDMArchiverTimePlot(PyDMTimePlot):
     def archive_data_received(self):
         """Take any action needed when this plot receives new data from archiver appliance"""
         self._archive_request_queued = False
-        if self.auto_scroll_timer.isActive():
+        if self.auto_scroll_timer.isActive() or not self._show_all:
             return
 
         max_x = max([curve.max_x() for curve in self._curves])

--- a/pydm/widgets/archiver_time_plot.py
+++ b/pydm/widgets/archiver_time_plot.py
@@ -791,7 +791,7 @@ class PyDMArchiverTimePlot(PyDMTimePlot):
     def updateXAxis(self, update_immediately: bool = False) -> None:
         """Manages the requests to archiver appliance. When the user pans or zooms the x axis to the left,
         a request will be made for backfill data"""
-        if len(self._curves) == 0 or self.auto_scroll_timer.isActive():
+        if len(self._curves) == 0:
             return
 
         min_x = self.plotItem.getAxis("bottom").range[0]  # Gets the leftmost timestamp displayed on the x-axis


### PR DESCRIPTION
This change prompts the ArchiveTimePlot to get data from the Archiver Appliance every time the x-axis' range changes.

Previously, archive data was only fetched when the user showed a section of the plot that had no data. With this set up, zooming out will fetch a optimized data (averaged w/ min/max error bars), but zooming back in would still optimized data. This results in the "resolution" looking wrong.

Now zooming in on a section will get the data for the time range shown on the plot. This will result in showing the correct "resolution" at all times.