### PR TITLE
MNT: move some QWidget setup calls out of the drawing class's __init__ to appease pyside6

### DIFF
--- a/pydm/utilities/shortcuts.py
+++ b/pydm/utilities/shortcuts.py
@@ -23,7 +23,7 @@ def install_connection_inspector(parent, keys=None):
     parent = parent or QtWidgets.QApplication.desktop()
 
     if keys is None:
-        keys = QtGui.QKeySequence(QtCore.Qt.ALT + QtCore.Qt.Key_C)
+        keys = QtGui.QKeySequence(QtCore.Qt.ALT | QtCore.Qt.Key_C)
     shortcut = QtWidgets.QShortcut(keys, parent)
     shortcut.setContext(QtCore.Qt.ApplicationShortcut)
     shortcut.activated.connect(show_inspector)

--- a/pydm/utilities/shortcuts.py
+++ b/pydm/utilities/shortcuts.py
@@ -23,7 +23,7 @@ def install_connection_inspector(parent, keys=None):
     parent = parent or QtWidgets.QApplication.desktop()
 
     if keys is None:
-        keys = QtGui.QKeySequence(QtCore.Qt.ALT | QtCore.Qt.Key_C)
+        keys = QtGui.QKeySequence(QtCore.Qt.ALT + QtCore.Qt.Key_C)
     shortcut = QtWidgets.QShortcut(keys, parent)
     shortcut.setContext(QtCore.Qt.ApplicationShortcut)
     shortcut.activated.connect(show_inspector)

--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -149,9 +149,10 @@ class PyDMPrimitiveWidget(object):
         self.app = QApplication.instance()
         self._rules = None
         self._opacity = 1.0
-        # Qt6 won't allow us to call self._install_event_filter(self) here inside of __init__,
-        # seems like it can't be sure the event-related setup in QWidget's __init__ has been completed.
-        # (even though we do explicitly make QWidget's __init__ goes first, Qt6 is generally more strict than Qt5)
+        # Qt6 won't allow us to call 'self.installEventFilter(self)' here inside of __init__,
+        # since it can't seem to be sure the event-related setup in QWidget's __init__ has already been completed.
+        # (even though we do explicitly call QWidget's __init__ first, Qt6 generally tries to prevent us more from
+        # doing 'potentially bad things' than Qt5)
         self._have_installed_event_filter = False
 
     def _install_event_filter(self):
@@ -167,7 +168,7 @@ class PyDMPrimitiveWidget(object):
             self._install_event_filter(self)
 
     def event(self, event):
-        # Fallback installation for if widget never gets shown (like if gets set '.hidden')
+        # Fallback installation for if widget never gets shown (like if set '.hidden')
         if not self._have_installed_event_filter:
             self._install_event_filter()
         return super().event(event)
@@ -678,9 +679,10 @@ class PyDMWidget(PyDMPrimitiveWidget, new_properties=_positionRuleProperties):
             self.alarmSeverityChanged(self.ALARM_DISCONNECTED)
             self.check_enable_state()
         
-        # Qt6 won't allow us to do some calls related to setting QWidget related things,
-        # since it seems like can't be sure if __init__ of QWidget has already been called.
-        # (even though we do explicitly make QWidget's __init__ goes first, Qt6 is generally more strict than Qt5)
+        # Qt6 won't let us to do some calls related to setting QWidget related things here in __init__,
+        # it can't seem to be sure if the __init__ of QWidget has already been called.
+        # (even though we do explicitly make QWidget's __init__ goes first, Qt6 generally tries to prevent us more from
+        # doing 'potentially bad things' than Qt5)
         self._have_done_post_init_setup = False
 
     def _post_init_setup(self):
@@ -690,7 +692,7 @@ class PyDMWidget(PyDMPrimitiveWidget, new_properties=_positionRuleProperties):
             self.destroyed.connect(functools.partial(widget_destroyed, self.channels, weakref.ref(self)))
 
     def showEvent(self, event):
-        # Fallback installation for if widget never gets shown (like if it gets set '.hidden')
+        # Fallback installation for if widget never gets shown (like if set '.hidden')
         super().showEvent(event)
         if not is_qt_designer():
             # We should install the Event Filter only if we are running

--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -678,7 +678,7 @@ class PyDMWidget(PyDMPrimitiveWidget, new_properties=_positionRuleProperties):
             self._connected = False
             self.alarmSeverityChanged(self.ALARM_DISCONNECTED)
             self.check_enable_state()
-        
+
         # Qt6 won't let us to do some calls related to setting QWidget related things here in __init__,
         # it can't seem to be sure if the __init__ of QWidget has already been called.
         # (even though we do explicitly make QWidget's __init__ goes first, Qt6 generally tries to prevent us more from

--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -169,8 +169,7 @@ class PyDMPrimitiveWidget(object):
 
     def event(self, event):
         # Fallback installation for if widget never gets shown (like if set '.hidden')
-        if not self._have_installed_event_filter:
-            self._install_event_filter()
+        self._install_event_filter()
         return super().event(event)
 
     def __init_subclass__(cls, new_properties={}):
@@ -701,8 +700,7 @@ class PyDMWidget(PyDMPrimitiveWidget, new_properties=_positionRuleProperties):
 
     def event(self, event):
         """Fallback installation if the widget is never shown (e.g., stays hidden)."""
-        if not self._have_done_post_init_setup:
-            self._post_init_setup()
+        self._post_init_setup()
         return super().event(event)
 
     def widget_ctx_menu(self):

--- a/pydm/widgets/drawing.py
+++ b/pydm/widgets/drawing.py
@@ -888,7 +888,7 @@ class PyDMDrawingImage(PyDMDrawing):
         self._aspect_ratio_mode = Qt.KeepAspectRatio
         self._movie = None
         self._file = None
-        # Make sure we don't set a non-existant file
+        # Make sure we don't set a non-existent file
         if filename:
             self.filename = filename
         # But we always have an internal value to reference


### PR DESCRIPTION
This is related to the specific setup of the drawing classe's hierarchy, where the parent class (PyDMDrawing) subclasses QWidget and explicity call its \_\_init\_\_ function, and then it's subclass makes calls (ex='self.installEventFilter()') that rely on QWidget's \_\_init\_\_ call having already been executed.

This works fine and PyQt5/Qt5 doesn't complain about this, but PySide6/Qt6 is often more strict in enforcing 'potentially bad' things like this and throws error. (error is that its not sure QWidet's \_\_init\_\_ was called first)