### PR TITLE
MNT: '|' is only supported way to combine macros in qt6, and still works also for qt5

### DIFF
--- a/pydm/utilities/shortcuts.py
+++ b/pydm/utilities/shortcuts.py
@@ -23,7 +23,7 @@ def install_connection_inspector(parent, keys=None):
     parent = parent or QtWidgets.QApplication.desktop()
 
     if keys is None:
-        keys = QtGui.QKeySequence(QtCore.Qt.ALT | QtCore.Qt.Key_C) 
+        keys = QtGui.QKeySequence(QtCore.Qt.ALT | QtCore.Qt.Key_C)
     shortcut = QtWidgets.QShortcut(keys, parent)
     shortcut.setContext(QtCore.Qt.ApplicationShortcut)
     shortcut.activated.connect(show_inspector)

--- a/pydm/utilities/shortcuts.py
+++ b/pydm/utilities/shortcuts.py
@@ -23,7 +23,7 @@ def install_connection_inspector(parent, keys=None):
     parent = parent or QtWidgets.QApplication.desktop()
 
     if keys is None:
-        keys = QtGui.QKeySequence(QtCore.Qt.ALT + QtCore.Qt.Key_C)
+        keys = QtGui.QKeySequence(QtCore.Qt.ALT | QtCore.Qt.Key_C) 
     shortcut = QtWidgets.QShortcut(keys, parent)
     shortcut.setContext(QtCore.Qt.ApplicationShortcut)
     shortcut.activated.connect(show_inspector)


### PR DESCRIPTION
(QtCore.Qt.ALT | QtCore.Qt.Key_C) and (QtCore.Qt.ALT + QtCore.Qt.Key_C) both still result 'ALT + C' on qt5

https://doc.qt.io/qt-6/qkeysequence.html#details