### PR TITLE
MNT: Deal with pyside6 throwing an error about __init__ functions in classes with multiple inheritence not getting called, when we actually are calling them.

### DIFF
--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -152,7 +152,13 @@ class PyDMPrimitiveWidget(object):
         if not is_qt_designer():
             # We should  install the Event Filter only if we are running
             # and not at the Designer
-            self.installEventFilter(self)
+            try:
+                self.installEventFilter(self)
+            except RuntimeError:
+                # Catch an error from pyside6 about not having called child classes __init__ functions,
+                # since we actually explicitly call them and there is not a real issue.
+                # (use git blame and see this change's commit msg for more explanation)
+                pass
 
     def __init_subclass__(cls, new_properties={}):
         """
@@ -652,17 +658,23 @@ class PyDMWidget(PyDMPrimitiveWidget, new_properties=_positionRuleProperties):
             "TIME": "timestamp",
         }
 
-        # If this label is inside a PyDMApplication (not Designer) start it in
-        # the disconnected state.
-        self.setContextMenuPolicy(Qt.DefaultContextMenu)
-        self.contextMenuEvent = self.open_context_menu
         self.channel = init_channel
-        if not is_qt_designer():
-            self._connected = False
-            self.alarmSeverityChanged(self.ALARM_DISCONNECTED)
-            self.check_enable_state()
+        try:
+            if not is_qt_designer():
+                # If this label is inside a PyDMApplication (not Designer) start it in
+                # the disconnected state.
+                self._connected = False
+                self.alarmSeverityChanged(self.ALARM_DISCONNECTED)
+                self.check_enable_state()
 
-        self.destroyed.connect(functools.partial(widget_destroyed, self.channels, weakref.ref(self)))
+            self.setContextMenuPolicy(Qt.DefaultContextMenu)
+            self.contextMenuEvent = self.open_context_menu
+            self.destroyed.connect(functools.partial(widget_destroyed, self.channels, weakref.ref(self)))
+        except RuntimeError:
+            # Catch an error from pyside6 about not having called child classes __init__ functions,
+            # since we actually explicitly call them and there is not a real issue.
+            # (use git blame and see this change's commit msg for more explanation)
+            pass
 
     def widget_ctx_menu(self):
         """

--- a/pydm/widgets/enum_button.py
+++ b/pydm/widgets/enum_button.py
@@ -485,8 +485,14 @@ class PyDMEnumButton(QWidget, PyDMWritableWidget):
         elif not self._has_enums:
             tooltip += "Enums not available."
 
-        self.setToolTip(tooltip)
-        self.setEnabled(status)
+        try:
+            self.setToolTip(tooltip)
+            self.setEnabled(status)
+        except RuntimeError:
+            # Catch an error from pyside6 about not having called child classes __init__ functions,
+            # since we actually explicitly call them and there is not a real issue.
+            # (use git blame and see this change's commit msg for more explanation)
+            pass
 
     def value_changed(self, new_val):
         """

--- a/pydm/widgets/frame.py
+++ b/pydm/widgets/frame.py
@@ -60,4 +60,10 @@ class PyDMFrame(QFrame, PyDMWidget):
         if hasattr(self, "_disable_on_disconnect") and self._disable_on_disconnect:
             PyDMWidget.check_enable_state(self)
         else:
-            self.setEnabled(True)
+            try:
+                self.setEnabled(True)
+            except RuntimeError:
+                # Catch an error from pyside6 about not having called child classes __init__ functions,
+                # since we actually explicitly call them and there is not a real issue.
+                # (use git blame and see this change's commit msg for more explanation)
+                pass


### PR DESCRIPTION
There is no issue with this when running on pyqt5, but pyside6 throws a runtime error when initializing classes
that use multiple inheritance of a qt base class and a pydm class.

example class:
    
```
class PyDMDrawing(QWidget, PyDMWidget, new_properties=_penRuleProperties))
    ...
    def __init__(self, parent=None, init_channel=None):
         ...
         # explicitly calling base class __init__ functions
	 QWidget.__init__(self, parent)
         PyDMWidget.__init__(self, init_channel=init_channel)
	 ...

```
The runtime error happens when a call is made in the base class that
relies on the qt base class's \_\_init\_\_ call to have already completed setting
things up (such as 'installEventFilter()).

example error:
```
    -> self.installEventFilter(self)
    RuntimeError: '__init__' method of object's base class (PyDMDrawingImage) not called.
```

This error is thrown despite that we explicitly call each of it's base class \_\_init\_\_
functions. It seems like pyside6 is just being extra cautious here.

This is maybe not so great, but to avoid a larger rework of the widget class structures just to appease
this pyside6 error, I propose we just catch this error where it occurs.