### PR TITLE
MNT: Move some calls to children classes to stop pyside6 throwing an error about __init__ in classes that use multiple inheritence.

### DIFF
--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -657,7 +657,6 @@ class PyDMWidget(PyDMPrimitiveWidget):
         if not is_qt_designer():
             self._connected = False
             self.alarmSeverityChanged(self.ALARM_DISCONNECTED)
-            self.check_enable_state()
 
     def widget_ctx_menu(self):
         """

--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -2,7 +2,6 @@ import enum
 import os
 import re
 import platform
-import weakref
 import logging
 import functools
 import json
@@ -149,10 +148,6 @@ class PyDMPrimitiveWidget(object):
         self.app = QApplication.instance()
         self._rules = None
         self._opacity = 1.0
-        if not is_qt_designer():
-            # We should  install the Event Filter only if we are running
-            # and not at the Designer
-            self.installEventFilter(self)
 
     def __init_subclass__(cls):
         """
@@ -657,15 +652,12 @@ class PyDMWidget(PyDMPrimitiveWidget):
 
         # If this label is inside a PyDMApplication (not Designer) start it in
         # the disconnected state.
-        self.setContextMenuPolicy(Qt.DefaultContextMenu)
         self.contextMenuEvent = self.open_context_menu
         self.channel = init_channel
         if not is_qt_designer():
             self._connected = False
             self.alarmSeverityChanged(self.ALARM_DISCONNECTED)
             self.check_enable_state()
-
-        self.destroyed.connect(functools.partial(widget_destroyed, self.channels, weakref.ref(self)))
 
     def widget_ctx_menu(self):
         """

--- a/pydm/widgets/byte.py
+++ b/pydm/widgets/byte.py
@@ -1,8 +1,12 @@
+import functools
+import weakref
+
 from qtpy.QtWidgets import QWidget, QTabWidget, QGridLayout, QLabel, QStyle, QStyleOption
 from qtpy.QtGui import QColor, QPen, QFontMetrics, QPainter, QPaintEvent, QBrush
 from qtpy.QtCore import Property, Qt, QSize, QPoint
 from typing import List, Optional
-from .base import PyDMWidget
+from .base import PyDMWidget, widget_destroyed
+from ..utilities import is_qt_designer
 
 
 class PyDMBitIndicator(QWidget):
@@ -113,6 +117,14 @@ class PyDMByteIndicator(QWidget, PyDMWidget):
         self.numBits = 1  # Need to set the property to initialize
         # _labels and _indicators setting numBits there also performs
         # the first rebuild_layout.
+
+        if not is_qt_designer():
+            # We should  install the Event Filter only if we are running
+            # and not at the Designer
+            self.installEventFilter(self)
+            self.check_enable_state()
+
+        self.destroyed.connect(functools.partial(widget_destroyed, self.channels, weakref.ref(self)))
 
     def init_for_designer(self) -> None:
         """
@@ -580,6 +592,14 @@ class PyDMMultiStateIndicator(QWidget, PyDMWidget):
         self._brush = QBrush(Qt.SolidPattern)
         self._pen = QPen(Qt.SolidLine)
         self._render_as_rectangle = False
+
+        if not is_qt_designer():
+            # We should  install the Event Filter only if we are running
+            # and not at the Designer
+            self.installEventFilter(self)
+            self.check_enable_state()
+
+        self.destroyed.connect(functools.partial(widget_destroyed, self.channels, weakref.ref(self)))
 
     # whether or not we render the widget as a circle (default) or a rectangle
     @Property(bool)

--- a/pydm/widgets/byte.py
+++ b/pydm/widgets/byte.py
@@ -118,12 +118,16 @@ class PyDMByteIndicator(QWidget, PyDMWidget):
         # _labels and _indicators setting numBits there also performs
         # the first rebuild_layout.
 
+        # Note: the following calls can *not* be moved to the PyDMWidget parent class,
+        # this is b/c on pyside6 these calls (if done in PyDMWidget's __init__) throw an error.
+        # The error is that pyside6 thinks this child class's __init__ functions have not been called yet,
+        # even though we explicitly call them and there is no real issue.
+        # (use git blame and see this change's commit msg for more explanation)
         if not is_qt_designer():
             # We should  install the Event Filter only if we are running
             # and not at the Designer
             self.installEventFilter(self)
             self.check_enable_state()
-
         self.destroyed.connect(functools.partial(widget_destroyed, self.channels, weakref.ref(self)))
 
     def init_for_designer(self) -> None:

--- a/pydm/widgets/datetime.py
+++ b/pydm/widgets/datetime.py
@@ -161,12 +161,16 @@ class PyDMDateTimeLabel(QtWidgets.QLabel, PyDMWidget):
         self._text_format = "yyyy/MM/dd hh:mm:ss.zzz"
         self.setText("")
 
+        # Note: the following calls can *not* be moved to the PyDMWidget parent class,
+        # this is b/c on pyside6 these calls (if done in PyDMWidget's __init__) throw an error.
+        # The error is that pyside6 thinks this child class's __init__ functions have not been called yet,
+        # even though we explicitly call them and there is no real issue.
+        # (use git blame and see this change's commit msg for more explanation)
         if not is_qt_designer():
             # We should  install the Event Filter only if we are running
             # and not at the Designer
             self.installEventFilter(self)
             self.check_enable_state()
-
         self.destroyed.connect(functools.partial(widget_destroyed, self.channels, weakref.ref(self)))
 
     @QtCore.Property(str)

--- a/pydm/widgets/drawing.py
+++ b/pydm/widgets/drawing.py
@@ -104,6 +104,7 @@ class PyDMDrawing(QWidget, PyDMWidget):
             # We should  install the Event Filter only if we are running
             # and not at the Designer
             self.installEventFilter(self)
+            self.check_enable_state()
         self.setContextMenuPolicy(Qt.DefaultContextMenu)
         self.destroyed.connect(functools.partial(widget_destroyed, self.channels, weakref.ref(self)))
 

--- a/pydm/widgets/drawing.py
+++ b/pydm/widgets/drawing.py
@@ -2,14 +2,12 @@ import ast
 import math
 import os
 import logging
-import functools
-import weakref
 
 from qtpy.QtWidgets import QWidget, QStyle, QStyleOption
 from qtpy.QtGui import QColor, QPainter, QBrush, QPen, QPolygonF, QPixmap, QMovie
 from qtpy.QtCore import Property, Qt, QPoint, QPointF, QSize, Slot, QTimer, QRectF
 from qtpy.QtDesigner import QDesignerFormWindowInterface
-from .base import PyDMWidget, widget_destroyed
+from .base import PyDMWidget, PostParentClassInitSetup
 from ..utilities import is_qt_designer, find_file
 from typing import List, Optional
 
@@ -94,19 +92,10 @@ class PyDMDrawing(QWidget, PyDMWidget):
         QWidget.__init__(self, parent)
         PyDMWidget.__init__(self, init_channel=init_channel)
         self.alarmSensitiveBorder = False
-
-        # Note: the following calls can *not* be moved to the PyDMWidget parent class,
-        # this is b/c on pyside6 these calls (if done in PyDMWidget's __init__) throw an error.
-        # The error is that pyside6 thinks this child class's __init__ functions have not been called yet,
-        # even though we explicitly call them and there is no real issue.
-        # (use git blame and see this change's commit msg for more explanation)
-        if not is_qt_designer():
-            # We should  install the Event Filter only if we are running
-            # and not at the Designer
-            self.installEventFilter(self)
-            self.check_enable_state()
-        self.setContextMenuPolicy(Qt.DefaultContextMenu)
-        self.destroyed.connect(functools.partial(widget_destroyed, self.channels, weakref.ref(self)))
+        # Execute setup calls that must be done here in the widget class's __init__,
+        # and after it's parent __init__ calls have completed.
+        # (so we can avoid pyside6 throwing an error, see func def for more info)
+        PostParentClassInitSetup(self)
 
     def sizeHint(self):
         return QSize(100, 100)

--- a/pydm/widgets/drawing.py
+++ b/pydm/widgets/drawing.py
@@ -95,12 +95,16 @@ class PyDMDrawing(QWidget, PyDMWidget):
         PyDMWidget.__init__(self, init_channel=init_channel)
         self.alarmSensitiveBorder = False
 
+        # Note: the following calls can *not* be moved to the PyDMWidget parent class,
+        # this is b/c on pyside6 these calls (if done in PyDMWidget's __init__) throw an error.
+        # The error is that pyside6 thinks this child class's __init__ functions have not been called yet,
+        # even though we explicitly call them and there is no real issue.
+        # (use git blame and see this change's commit msg for more explanation)
         if not is_qt_designer():
             # We should  install the Event Filter only if we are running
             # and not at the Designer
             self.installEventFilter(self)
         self.setContextMenuPolicy(Qt.DefaultContextMenu)
-
         self.destroyed.connect(functools.partial(widget_destroyed, self.channels, weakref.ref(self)))
 
     def sizeHint(self):

--- a/pydm/widgets/frame.py
+++ b/pydm/widgets/frame.py
@@ -1,10 +1,6 @@
-import functools
-import weakref
-
 from qtpy.QtWidgets import QFrame
 from qtpy.QtCore import Property
-from .base import PyDMWidget, widget_destroyed
-from ..utilities import is_qt_designer
+from .base import PyDMWidget, PostParentClassInitSetup
 
 
 class PyDMFrame(QFrame, PyDMWidget):
@@ -27,17 +23,10 @@ class PyDMFrame(QFrame, PyDMWidget):
         self._disable_on_disconnect = False
         self.alarmSensitiveBorder = False
 
-        # Note: the following calls can *not* be moved to the PyDMWidget parent class,
-        # this is b/c on pyside6 these calls (if done in PyDMWidget's __init__) throw an error.
-        # The error is that pyside6 thinks this child class's __init__ functions have not been called yet,
-        # even though we explicitly call them and there is no real issue.
-        # (use git blame and see this change's commit msg for more explanation)
-        if not is_qt_designer():
-            # We should  install the Event Filter only if we are running
-            # and not at the Designer
-            self.installEventFilter(self)
-            self.check_enable_state()
-        self.destroyed.connect(functools.partial(widget_destroyed, self.channels, weakref.ref(self)))
+        # Execute setup calls that must be done here in the widget class's __init__,
+        # and after it's parent __init__ calls have completed.
+        # (so we can avoid pyside6 throwing an error, see func def for more info)
+        PostParentClassInitSetup(self)
 
     @Property(bool)
     def disableOnDisconnect(self):

--- a/pydm/widgets/frame.py
+++ b/pydm/widgets/frame.py
@@ -27,12 +27,16 @@ class PyDMFrame(QFrame, PyDMWidget):
         self._disable_on_disconnect = False
         self.alarmSensitiveBorder = False
 
+        # Note: the following calls can *not* be moved to the PyDMWidget parent class,
+        # this is b/c on pyside6 these calls (if done in PyDMWidget's __init__) throw an error.
+        # The error is that pyside6 thinks this child class's __init__ functions have not been called yet,
+        # even though we explicitly call them and there is no real issue.
+        # (use git blame and see this change's commit msg for more explanation)
         if not is_qt_designer():
             # We should  install the Event Filter only if we are running
             # and not at the Designer
             self.installEventFilter(self)
             self.check_enable_state()
-
         self.destroyed.connect(functools.partial(widget_destroyed, self.channels, weakref.ref(self)))
 
     @Property(bool)

--- a/pydm/widgets/frame.py
+++ b/pydm/widgets/frame.py
@@ -1,6 +1,10 @@
+import functools
+import weakref
+
 from qtpy.QtWidgets import QFrame
 from qtpy.QtCore import Property
-from .base import PyDMWidget
+from .base import PyDMWidget, widget_destroyed
+from ..utilities import is_qt_designer
 
 
 class PyDMFrame(QFrame, PyDMWidget):
@@ -22,6 +26,14 @@ class PyDMFrame(QFrame, PyDMWidget):
 
         self._disable_on_disconnect = False
         self.alarmSensitiveBorder = False
+
+        if not is_qt_designer():
+            # We should  install the Event Filter only if we are running
+            # and not at the Designer
+            self.installEventFilter(self)
+            self.check_enable_state()
+
+        self.destroyed.connect(functools.partial(widget_destroyed, self.channels, weakref.ref(self)))
 
     @Property(bool)
     def disableOnDisconnect(self):

--- a/pydm/widgets/image.py
+++ b/pydm/widgets/image.py
@@ -1,14 +1,17 @@
+import numpy as np
+import logging
+import functools
+import weakref
+
 from qtpy.QtWidgets import QActionGroup
 from qtpy.QtCore import Signal, Slot, Property, QTimer, QThread
 from pyqtgraph import ImageView, PlotItem
 from pyqtgraph import ColorMap
 from pyqtgraph.graphicsItems.ViewBox.ViewBoxMenu import ViewBoxMenu
-import numpy as np
-import logging
 from .channel import PyDMChannel
 from .colormaps import cmaps, cmap_names, PyDMColorMap
-from .base import PyDMWidget
-from ..utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
+from .base import PyDMWidget, widget_destroyed
+from ..utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes, is_qt_designer
 
 logger = logging.getLogger(__name__)
 
@@ -232,6 +235,14 @@ class PyDMImageView(ImageView, PyDMWidget):
             self.imageChannel = image_channel or ""
         if width_channel:
             self.widthChannel = width_channel or ""
+
+        if not is_qt_designer():
+            # We should  install the Event Filter only if we are running
+            # and not at the Designer
+            self.installEventFilter(self)
+            self.check_enable_state()
+
+        self.destroyed.connect(functools.partial(widget_destroyed, self.channels, weakref.ref(self)))
 
     @Property(str, designable=False)
     def channel(self):

--- a/pydm/widgets/label.py
+++ b/pydm/widgets/label.py
@@ -61,12 +61,16 @@ class PyDMLabel(QLabel, TextFormatter, PyDMWidget):
         if is_pydm_app():
             self._string_encoding = self.app.get_string_encoding()
 
+        # Note: the following calls can *not* be moved to the PyDMWidget parent class,
+        # this is b/c on pyside6 these calls (if done in PyDMWidget's __init__) throw an error.
+        # The error is that pyside6 thinks this child class's __init__ functions have not been called yet,
+        # even though we explicitly call them and there is no real issue.
+        # (use git blame and see this change's commit msg for more explanation)
         if not is_qt_designer():
             # We should  install the Event Filter only if we are running
             # and not at the Designer
             self.installEventFilter(self)
             self.check_enable_state()
-
         self.destroyed.connect(functools.partial(widget_destroyed, self.channels, weakref.ref(self)))
 
     @Property(bool)

--- a/pydm/widgets/label.py
+++ b/pydm/widgets/label.py
@@ -1,11 +1,14 @@
-from .base import PyDMWidget, TextFormatter, str_types
+import functools
+import weakref
+
+from .base import PyDMWidget, TextFormatter, str_types, widget_destroyed
 from qtpy.QtWidgets import QLabel, QApplication
 from qtpy.QtCore import Qt, Property
 from .display_format import DisplayFormat, parse_value_for_display
-from pydm.utilities import is_pydm_app, is_qt_designer
+from pydm.utilities import is_pydm_app, is_qt_designer, ACTIVE_QT_WRAPPER, QtWrapperTypes
 from pydm import config
 from pydm.widgets.base import only_if_channel_set
-from ..utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
+
 
 _labelRuleProperties = {"Text": ["value_changed", str]}
 
@@ -57,6 +60,14 @@ class PyDMLabel(QLabel, TextFormatter, PyDMWidget):
         self._enable_rich_text = False
         if is_pydm_app():
             self._string_encoding = self.app.get_string_encoding()
+
+        if not is_qt_designer():
+            # We should  install the Event Filter only if we are running
+            # and not at the Designer
+            self.installEventFilter(self)
+            self.check_enable_state()
+
+        self.destroyed.connect(functools.partial(widget_destroyed, self.channels, weakref.ref(self)))
 
     @Property(bool)
     def enableRichText(self):

--- a/pydm/widgets/related_display_button.py
+++ b/pydm/widgets/related_display_button.py
@@ -88,12 +88,16 @@ class PyDMRelatedDisplayButton(QPushButton, PyDMWidget):
         # Retain references to subdisplays to avoid garbage collection
         self._subdisplays = []
 
+        # Note: the following calls can *not* be moved to the PyDMWidget parent class,
+        # this is b/c on pyside6 these calls (if done in PyDMWidget's __init__) throw an error.
+        # The error is that pyside6 thinks this child class's __init__ functions have not been called yet,
+        # even though we explicitly call them and there is no real issue.
+        # (use git blame and see this change's commit msg for more explanation)
         if not is_qt_designer():
             # We should  install the Event Filter only if we are running
             # and not at the Designer
             self.installEventFilter(self)
             self.check_enable_state()
-
         self.destroyed.connect(partial(widget_destroyed, self.channels, weakref.ref(self)))
 
     @only_if_channel_set

--- a/pydm/widgets/scale.py
+++ b/pydm/widgets/scale.py
@@ -1,8 +1,4 @@
-import functools
-import weakref
-
-from .base import PyDMWidget, TextFormatter, widget_destroyed
-from ..utilities import is_qt_designer
+from .base import PyDMWidget, TextFormatter, PostParentClassInitSetup
 from qtpy.QtGui import QColor, QPolygon, QPen, QPainter, QPaintEvent
 from qtpy.QtWidgets import QFrame, QVBoxLayout, QHBoxLayout, QLabel, QSizePolicy, QWidget, QGridLayout
 from qtpy.QtCore import Qt, QPoint, Property
@@ -411,18 +407,10 @@ class PyDMScaleIndicator(QFrame, TextFormatter, PyDMWidget):
 
         self.value_label.setSizePolicy(QSizePolicy.Minimum, QSizePolicy.Minimum)
         self.setup_widgets_for_orientation(Qt.Horizontal, False, False, self._value_position)
-
-        # Note: the following calls can *not* be moved to the PyDMWidget parent class,
-        # this is b/c on pyside6 these calls (if done in PyDMWidget's __init__) throw an error.
-        # The error is that pyside6 thinks this child class's __init__ functions have not been called yet,
-        # even though we explicitly call them and there is no real issue.
-        # (use git blame and see this change's commit msg for more explanation)
-        if not is_qt_designer():
-            # We should  install the Event Filter only if we are running
-            # and not at the Designer
-            self.installEventFilter(self)
-            self.check_enable_state()
-        self.destroyed.connect(functools.partial(widget_destroyed, self.channels, weakref.ref(self)))
+        # Execute setup calls that must be done here in the widget class's __init__,
+        # and after it's parent __init__ calls have completed.
+        # (so we can avoid pyside6 throwing an error, see func def for more info)
+        PostParentClassInitSetup(self)
 
     def update_labels(self) -> None:
         """

--- a/pydm/widgets/scale.py
+++ b/pydm/widgets/scale.py
@@ -1,4 +1,8 @@
-from .base import PyDMWidget, TextFormatter
+import functools
+import weakref
+
+from .base import PyDMWidget, TextFormatter, widget_destroyed
+from ..utilities import is_qt_designer
 from qtpy.QtGui import QColor, QPolygon, QPen, QPainter, QPaintEvent
 from qtpy.QtWidgets import QFrame, QVBoxLayout, QHBoxLayout, QLabel, QSizePolicy, QWidget, QGridLayout
 from qtpy.QtCore import Qt, QPoint, Property
@@ -407,6 +411,14 @@ class PyDMScaleIndicator(QFrame, TextFormatter, PyDMWidget):
 
         self.value_label.setSizePolicy(QSizePolicy.Minimum, QSizePolicy.Minimum)
         self.setup_widgets_for_orientation(Qt.Horizontal, False, False, self._value_position)
+
+        if not is_qt_designer():
+            # We should  install the Event Filter only if we are running
+            # and not at the Designer
+            self.installEventFilter(self)
+            self.check_enable_state()
+
+        self.destroyed.connect(functools.partial(widget_destroyed, self.channels, weakref.ref(self)))
 
     def update_labels(self) -> None:
         """

--- a/pydm/widgets/scale.py
+++ b/pydm/widgets/scale.py
@@ -412,12 +412,16 @@ class PyDMScaleIndicator(QFrame, TextFormatter, PyDMWidget):
         self.value_label.setSizePolicy(QSizePolicy.Minimum, QSizePolicy.Minimum)
         self.setup_widgets_for_orientation(Qt.Horizontal, False, False, self._value_position)
 
+        # Note: the following calls can *not* be moved to the PyDMWidget parent class,
+        # this is b/c on pyside6 these calls (if done in PyDMWidget's __init__) throw an error.
+        # The error is that pyside6 thinks this child class's __init__ functions have not been called yet,
+        # even though we explicitly call them and there is no real issue.
+        # (use git blame and see this change's commit msg for more explanation)
         if not is_qt_designer():
             # We should  install the Event Filter only if we are running
             # and not at the Designer
             self.installEventFilter(self)
             self.check_enable_state()
-
         self.destroyed.connect(functools.partial(widget_destroyed, self.channels, weakref.ref(self)))
 
     def update_labels(self) -> None:

--- a/pydm/widgets/shell_command.py
+++ b/pydm/widgets/shell_command.py
@@ -125,12 +125,16 @@ class PyDMShellCommand(QPushButton, PyDMWidget):
         # but standard icons are already colored and can not be set.
         self._pydm_icon_color = QColor(90, 90, 90)
 
+        # Note: the following calls can *not* be moved to the PyDMWidget parent class,
+        # this is b/c on pyside6 these calls (if done in PyDMWidget's __init__) throw an error.
+        # The error is that pyside6 thinks this child class's __init__ functions have not been called yet,
+        # even though we explicitly call them and there is no real issue.
+        # (use git blame and see this change's commit msg for more explanation)
         if not is_qt_designer():
             # We should  install the Event Filter only if we are running
             # and not at the Designer
             self.installEventFilter(self)
             self.check_enable_state()
-
         self.destroyed.connect(partial(widget_destroyed, self.channels, weakref.ref(self)))
 
     def confirmDialog(self) -> bool:

--- a/pydm/widgets/symbol.py
+++ b/pydm/widgets/symbol.py
@@ -40,13 +40,17 @@ class PyDMSymbol(QWidget, PyDMWidget):
         self._sizeHint = self.minimumSizeHint()
         self._painter = QPainter()
 
+        # Note: the following calls can *not* be moved to the PyDMWidget parent class,
+        # this is b/c on pyside6 these calls (if done in PyDMWidget's __init__) throw an error.
+        # The error is that pyside6 thinks this child class's __init__ functions have not been called yet,
+        # even though we explicitly call them and there is no real issue.
+        # (use git blame and see this change's commit msg for more explanation)
         if not is_qt_designer():
             # We should  install the Event Filter only if we are running
             # and not at the Designer
             self.installEventFilter(self)
             self.check_enable_state()
         self.setContextMenuPolicy(Qt.DefaultContextMenu)
-
         self.destroyed.connect(functools.partial(widget_destroyed, self.channels, weakref.ref(self)))
 
     def init_for_designer(self):

--- a/pydm/widgets/tab_bar.py
+++ b/pydm/widgets/tab_bar.py
@@ -1,15 +1,11 @@
-import functools
-import weakref
-
 from qtpy.QtWidgets import QTabBar, QTabWidget
 from qtpy.QtGui import QIcon, QColor
 from qtpy.QtCore import QByteArray
-from .base import PyDMWidget, widget_destroyed
+from .base import PyDMWidget, PostParentClassInitSetup
 from .channel import PyDMChannel
 from qtpy.QtCore import Property
 from functools import partial
 from ..utilities.iconfont import IconFont
-from ..utilities import is_qt_designer
 
 
 class PyDMTabBar(QTabBar, PyDMWidget):
@@ -29,17 +25,10 @@ class PyDMTabBar(QTabBar, PyDMWidget):
         self.alarm_icons = None
         self.generate_alarm_icons()
 
-        # Note: the following calls can *not* be moved to the PyDMWidget parent class,
-        # this is b/c on pyside6 these calls (if done in PyDMWidget's __init__) throw an error.
-        # The error is that pyside6 thinks this child class's __init__ functions have not been called yet,
-        # even though we explicitly call them and there is no real issue.
-        # (use git blame and see this change's commit msg for more explanation)
-        if not is_qt_designer():
-            # We should  install the Event Filter only if we are running
-            # and not at the Designer
-            self.installEventFilter(self)
-            self.check_enable_state()
-        self.destroyed.connect(functools.partial(widget_destroyed, self.channels, weakref.ref(self)))
+        # Execute setup calls that must be done here in the widget class's __init__,
+        # and after it's parent __init__ calls have completed.
+        # (so we can avoid pyside6 throwing an error, see func def for more info)
+        PostParentClassInitSetup(self)
 
     @Property(str)
     def currentTabAlarmChannel(self):

--- a/pydm/widgets/tab_bar.py
+++ b/pydm/widgets/tab_bar.py
@@ -29,12 +29,16 @@ class PyDMTabBar(QTabBar, PyDMWidget):
         self.alarm_icons = None
         self.generate_alarm_icons()
 
+        # Note: the following calls can *not* be moved to the PyDMWidget parent class,
+        # this is b/c on pyside6 these calls (if done in PyDMWidget's __init__) throw an error.
+        # The error is that pyside6 thinks this child class's __init__ functions have not been called yet,
+        # even though we explicitly call them and there is no real issue.
+        # (use git blame and see this change's commit msg for more explanation)
         if not is_qt_designer():
             # We should  install the Event Filter only if we are running
             # and not at the Designer
             self.installEventFilter(self)
             self.check_enable_state()
-
         self.destroyed.connect(functools.partial(widget_destroyed, self.channels, weakref.ref(self)))
 
     @Property(str)


### PR DESCRIPTION
There is no issue running on pyqt5, but on pyside6 throws a runtime error when initializing classes that use multiple inheritance of a qt base class and a pydm class.

example class:
```
    class PyDMDrawing(QWidget, PyDMWidget, new_properties=_penRuleProperties))
    ...
    def __init__(self, parent=None, init_channel=None):
       ...
       # explicitly calling base class __init__ functions
       QWidget.__init__(self, parent)
       PyDMWidget.__init__(self, init_channel=init_channel)
       ...
```

The runtime error happens when a call is made in the base class that relies on the qt base class's \_\_init\_\_ call to have completed setting things up (such as 'installEventFilter()).

example error:
```
    -> self.installEventFilter(self)
    RuntimeError: '__init__' method of object's base class (PyDMDrawingImage) not called
```

This error is thrown despite that we explicitly call each of it's base class \_\_init\_\_ functions. It seems like pyside6 is just being extra cautious here.

The fix here is to move these "problem" calls out of our pydm base classes \_\_init\_\_ and into the children class's \_\_init\_\_, after we explicity call the parent class constructors. To match the functionality of b4, these calls need to be added to any classes with PyDMWidget as their parent.