### PR TITLE
MNT: in tests, access style pixmaps using StandardPixmap

### DIFF
--- a/pydm/tests/widgets/test_pushbutton.py
+++ b/pydm/tests/widgets/test_pushbutton.py
@@ -104,7 +104,7 @@ def test_construct(qtbot, label, press_value, relative, init_channel, icon_font_
 
         # verify that qt standard icons can be set through our custom property
         style = pydm_pushbutton.style()
-        test_icon = style.standardIcon(style.SP_DesktopIcon)
+        test_icon = style.standardIcon(style.StandardPixmap.SP_DesktopIcon)
         test_icon_image = test_icon.pixmap(size).toImage()
 
         pydm_pushbutton.PyDMIcon = "SP_DesktopIcon"

--- a/pydm/tests/widgets/test_related_display_button.py
+++ b/pydm/tests/widgets/test_related_display_button.py
@@ -69,7 +69,7 @@ def test_press_with_filename(qtbot):
 
     # verify that qt standard icons can be set through our custom property
     style = button.style()
-    test_icon = style.standardIcon(style.SP_DesktopIcon)
+    test_icon = style.standardIcon(style.StandardPixmap.SP_DesktopIcon)
     test_icon_image = test_icon.pixmap(DEFAULT_ICON_SIZE).toImage()
 
     button.PyDMIcon = "SP_DesktopIcon"

--- a/pydm/tests/widgets/test_shell_command.py
+++ b/pydm/tests/widgets/test_shell_command.py
@@ -77,7 +77,7 @@ def test_construct(qtbot, command, title):
 
     # verify that qt standard icons can be set through our custom property
     style = pydm_shell_command.style()
-    test_icon = style.standardIcon(style.SP_DesktopIcon)
+    test_icon = style.standardIcon(style.StandardPixmap.SP_DesktopIcon)
     test_icon_image = test_icon.pixmap(DEFAULT_ICON_SIZE).toImage()
 
     pydm_shell_command.PyDMIcon = "SP_DesktopIcon"


### PR DESCRIPTION
This approach is required for pyside6(qt6), but also still works and seems to be correct way to access pixmaps in pyqt5(qt5).

https://doc.qt.io/qt-6/qstyle.html#StandardPixmap-enum 
https://doc.qt.io/qt-5/qstyle.html#StandardPixmap-enum