### PR TITLE
MNT: Be sure we use Qt.PenStyle enums for setting pen style, not ints.

### DIFF
--- a/pydm/widgets/archiver_time_plot.py
+++ b/pydm/widgets/archiver_time_plot.py
@@ -9,7 +9,7 @@ from pydm.utilities import remove_protocol, is_qt_designer
 from pydm.widgets.channel import PyDMChannel
 from pydm.widgets.timeplot import TimePlotCurveItem
 from pydm.widgets import PyDMTimePlot
-from qtpy.QtCore import QObject, QTimer, Property, Signal, Slot
+from qtpy.QtCore import Qt, QObject, QTimer, Property, Signal, Slot
 from qtpy.QtGui import QColor, QPen
 import logging
 from math import *  # noqa
@@ -298,7 +298,7 @@ class ArchivePlotCurveItem(TimePlotCurveItem):
 
         # Set the error bar's pen to be the same as the curve, but solid
         solid_pen = QPen(self._pen)
-        solid_pen.setStyle(1)
+        solid_pen.setStyle(Qt.SolidLine)
 
         self.error_bar.setData(x=x_val, y=y_val, top=top_val, bottom=bot_val, beam=0.5, pen=solid_pen)
 

--- a/pydm/widgets/baseplot.py
+++ b/pydm/widgets/baseplot.py
@@ -100,6 +100,12 @@ class BasePlotCurveItem(PlotDataItem):
         if lineWidth is not None:
             self._pen.setWidth(lineWidth)
         if lineStyle is not None:
+            # The type hint for 'Optional' for lineStyle arg, which has allowed for some screens to
+            # pass int value for lineStyle. pyqt5 doesn't mind the int, but pyside6 complains so lets
+            # convert any ints here to the proper Qt.PenStyle enums. The int values get converted to enums
+            # according to: https://doc.qt.io/qt-6/qt.html#PenStyle-enum
+            if isinstance(lineStyle, int):
+                lineStyle = Qt.PenStyle(lineStyle)
             self._pen.setStyle(lineStyle)
         kws["pen"] = self._pen
         super(BasePlotCurveItem, self).__init__(**kws)

--- a/pydm/widgets/drawing.py
+++ b/pydm/widgets/drawing.py
@@ -289,7 +289,7 @@ class PyDMDrawing(QWidget, PyDMWidget):
 
         Returns
         -------
-        int
+        Qt.PenStyle
             Index at Qt.PenStyle enum
         """
         return self._pen_style
@@ -301,7 +301,7 @@ class PyDMDrawing(QWidget, PyDMWidget):
 
         Parameters
         ----------
-        new_style : int
+        new_style : Qt.PenStyle
             Index at Qt.PenStyle enum
         """
         if self._alarm_state == PyDMWidget.ALARM_NONE:


### PR DESCRIPTION
While ints works on pyqt5(qt5), PenStyle enums should be passed according to the docs. (https://doc.qt.io/qt-5/qpen.html#setStyle)

And with pyside6(qt6) ints do not work, b/c it seems to have stricter typing than pyqt5, so we must use the enums.