### PR TITLE
MNT: use the correct signal for comboboxes in the camviewer example, stops error on pyside6

### DIFF
--- a/examples/camviewer/camviewer.py
+++ b/examples/camviewer/camviewer.py
@@ -46,14 +46,14 @@ class CamViewer(Display):
             self.ui.cameraComboBox.addItem(camera)
 
         # When the camera combo box changes, disconnect from PVs, re-initialize, then reconnect.
-        self.ui.cameraComboBox.activated[str].connect(self.cameraChanged)
+        self.ui.cameraComboBox.currentTextChanged.connect(self.cameraChanged)
 
         # Set up the color map combo box.
         self.ui.colorMapComboBox.clear()
         for key, map_name in cmap_names.items():
             self.ui.colorMapComboBox.addItem(map_name, userData=key)
         self.ui.imageView.colorMap = self.ui.colorMapComboBox.currentData()
-        self.ui.colorMapComboBox.activated[str].connect(self.colorMapChanged)
+        self.ui.colorMapComboBox.currentTextChanged.connect(self.colorMapChanged)
 
         # Set up the color map limit sliders and line edits.
         # self._color_map_limit_sliders_need_config = True


### PR DESCRIPTION
Docs point to currentTextChanged being the correct signal to use here: https://doc.qt.io/qt-6/qcombobox.html#activated