### PR TITLE
MNT: update enum-button widget's button-group to use proper clicked signal, avoid pyside6 error

### DIFF
--- a/pydm/widgets/enum_button.py
+++ b/pydm/widgets/enum_button.py
@@ -2,7 +2,16 @@ import logging
 
 from qtpy.QtCore import Qt, QSize, Property, Slot, QMargins
 from qtpy.QtGui import QPainter
-from qtpy.QtWidgets import QWidget, QButtonGroup, QGridLayout, QPushButton, QRadioButton, QStyleOption, QStyle
+from qtpy.QtWidgets import (
+    QWidget,
+    QButtonGroup,
+    QGridLayout,
+    QPushButton,
+    QRadioButton,
+    QStyleOption,
+    QStyle,
+    QAbstractButton,
+)
 
 from .base import PyDMWritableWidget
 from .. import data_plugins
@@ -25,7 +34,7 @@ if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
         RadioButton = 1
 
 
-class_for_type = [QPushButton, QRadioButton]
+class_for_type = {WidgetType.PushButton: QPushButton, WidgetType.RadioButton: QRadioButton}
 
 logger = logging.getLogger(__name__)
 
@@ -74,7 +83,7 @@ class PyDMEnumButton(QWidget, PyDMWritableWidget):
         self._layout_margins = QMargins(9, 9, 9, 9)
         self._btn_group = QButtonGroup()
         self._btn_group.setExclusive(True)
-        self._btn_group.buttonClicked[int].connect(self.handle_button_clicked)
+        self._btn_group.buttonClicked.connect(self.handle_button_clicked)
         self._widget_type = WidgetType.PushButton
         self._orientation = Qt.Vertical
         self._widgets = []
@@ -379,17 +388,18 @@ class PyDMEnumButton(QWidget, PyDMWritableWidget):
             for widget in self._widgets:
                 widget.setCheckable(value)
 
-    @Slot(int)
-    def handle_button_clicked(self, id):
+    @Slot(QAbstractButton)
+    def handle_button_clicked(self, button):
         """
         Handles the event of a button being clicked.
 
         Parameters
         ----------
-        id : int
-            The clicked button id.
+        id : QAbstractButton
+            The clicked button button.
         """
-        self.send_value_signal.emit(id)
+        button_id = self._btn_group.id(button)  # get id of the button in the group
+        self.send_value_signal.emit(button_id)
 
     def clear(self):
         """


### PR DESCRIPTION
Calling signal without overloaded int and expecting a button object back, is whats specified in qt5 docs:
https://doc.qt.io/qt-5/qbuttongroup.html#buttonClicked.

This is the same in the qt6 docs, and pyside6 even throws error if signal is not used in this correct way.

Also i think its the newer python im running with pyside6 that doesn't like using enums to index into an array, so use a map for 'class_for_type' instead. 
(using the enum's '.value' should also allow for indexing into an array, but imo using the map is more readable.)