### PR TITLE
MNT: pyside6 just throws an IndexError instead when connecting to value_signals not overloaded with the specified type

### DIFF
--- a/pydm/data_plugins/epics_plugins/caproto_plugin_component.py
+++ b/pydm/data_plugins/epics_plugins/caproto_plugin_component.py
@@ -204,22 +204,13 @@ class Connection(PyDMConnection):
             self.send_connection_state(conn=False)
         # If the channel is used for writing to PVs, hook it up to the 'put' methods.
         if channel.value_signal is not None:
-            try:
-                channel.value_signal[str].connect(self.put_value, Qt.QueuedConnection)
-            except (KeyError, IndexError):  # pyqt5 throws a key error here, but pyside6 an index error
-                pass
-            try:
-                channel.value_signal[int].connect(self.put_value, Qt.QueuedConnection)
-            except (KeyError, IndexError):
-                pass
-            try:
-                channel.value_signal[float].connect(self.put_value, Qt.QueuedConnection)
-            except (KeyError, IndexError):
-                pass
-            try:
-                channel.value_signal[np.ndarray].connect(self.put_value, Qt.QueuedConnection)
-            except (KeyError, IndexError):
-                pass
+            for signal_type in (str, int, float, np.ndarray):
+                try:
+                    channel.value_signal[signal_type].connect(self.put_value, Qt.QueuedConnection)
+                # When signal type can't be found, PyQt5 throws KeyError here, but PySide6 index error.
+                # If signal type exists but doesn't match the slot, TypeError gets thrown.
+                except (KeyError, IndexError, TypeError):
+                    pass
 
     def close(self):
         self.pv.disconnect()

--- a/pydm/data_plugins/epics_plugins/caproto_plugin_component.py
+++ b/pydm/data_plugins/epics_plugins/caproto_plugin_component.py
@@ -206,19 +206,19 @@ class Connection(PyDMConnection):
         if channel.value_signal is not None:
             try:
                 channel.value_signal[str].connect(self.put_value, Qt.QueuedConnection)
-            except KeyError:
+            except (KeyError, IndexError):  # pyqt5 throws a key error here, but pyside6 an index error
                 pass
             try:
                 channel.value_signal[int].connect(self.put_value, Qt.QueuedConnection)
-            except KeyError:
+            except (KeyError, IndexError):
                 pass
             try:
                 channel.value_signal[float].connect(self.put_value, Qt.QueuedConnection)
-            except KeyError:
+            except (KeyError, IndexError):
                 pass
             try:
                 channel.value_signal[np.ndarray].connect(self.put_value, Qt.QueuedConnection)
-            except KeyError:
+            except (KeyError, IndexError):
                 pass
 
     def close(self):

--- a/pydm/data_plugins/epics_plugins/p4p_plugin_component.py
+++ b/pydm/data_plugins/epics_plugins/p4p_plugin_component.py
@@ -455,23 +455,23 @@ class Connection(PyDMConnection):
         if channel.value_signal is not None:
             try:
                 channel.value_signal[str].connect(self.put_value, Qt.QueuedConnection)
-            except KeyError:
+            except (KeyError, IndexError):  # pyqt5 throws a key error here, but pyside6 an index error
                 pass
             try:
                 channel.value_signal[int].connect(self.put_value, Qt.QueuedConnection)
-            except KeyError:
+            except (KeyError, IndexError):
                 pass
             try:
                 channel.value_signal[float].connect(self.put_value, Qt.QueuedConnection)
-            except KeyError:
+            except (KeyError, IndexError):
                 pass
             try:
                 channel.value_signal[np.ndarray].connect(self.put_value, Qt.QueuedConnection)
-            except KeyError:
+            except (KeyError, IndexError):
                 pass
             try:
                 channel.value_signal[dict].connect(self.put_value, Qt.QueuedConnection)
-            except KeyError:
+            except (KeyError, IndexError):
                 pass
 
     def close(self):

--- a/pydm/data_plugins/epics_plugins/p4p_plugin_component.py
+++ b/pydm/data_plugins/epics_plugins/p4p_plugin_component.py
@@ -453,26 +453,13 @@ class Connection(PyDMConnection):
                 self.send_new_value(value_to_send)
 
         if channel.value_signal is not None:
-            try:
-                channel.value_signal[str].connect(self.put_value, Qt.QueuedConnection)
-            except (KeyError, IndexError):  # pyqt5 throws a key error here, but pyside6 an index error
-                pass
-            try:
-                channel.value_signal[int].connect(self.put_value, Qt.QueuedConnection)
-            except (KeyError, IndexError):
-                pass
-            try:
-                channel.value_signal[float].connect(self.put_value, Qt.QueuedConnection)
-            except (KeyError, IndexError):
-                pass
-            try:
-                channel.value_signal[np.ndarray].connect(self.put_value, Qt.QueuedConnection)
-            except (KeyError, IndexError):
-                pass
-            try:
-                channel.value_signal[dict].connect(self.put_value, Qt.QueuedConnection)
-            except (KeyError, IndexError):
-                pass
+            for signal_type in (str, int, float, np.ndarray, dict):
+                try:
+                    channel.value_signal[signal_type].connect(self.put_value, Qt.QueuedConnection)
+                # When signal type can't be found, PyQt5 throws KeyError here, but PySide6 index error.
+                # If signal type exists but doesn't match the slot, TypeError gets thrown.
+                except (KeyError, IndexError, TypeError):
+                    pass
 
     def close(self):
         """Closes out this connection."""

--- a/pydm/data_plugins/epics_plugins/psp_plugin_component.py
+++ b/pydm/data_plugins/epics_plugins/psp_plugin_component.py
@@ -538,22 +538,13 @@ class Connection(PyDMConnection):
             self.send_access_state()
             self.send_ctrl_vars()
         if channel.value_signal is not None:
-            try:
-                channel.value_signal[str].connect(self.put_value, Qt.QueuedConnection)
-            except KeyError:
-                pass
-            try:
-                channel.value_signal[int].connect(self.put_value, Qt.QueuedConnection)
-            except KeyError:
-                pass
-            try:
-                channel.value_signal[float].connect(self.put_value, Qt.QueuedConnection)
-            except KeyError:
-                pass
-            try:
-                channel.value_signal[np.ndarray].connect(self.put_value, Qt.QueuedConnection)
-            except KeyError:
-                pass
+            for signal_type in (str, int, float, np.ndarray):
+                try:
+                    channel.value_signal[signal_type].connect(self.put_value, Qt.QueuedConnection)
+                # When signal type can't be found, PyQt5 throws KeyError here, but PySide6 index error.
+                # If signal type exists but doesn't match the slot, TypeError gets thrown.
+                except (KeyError, IndexError, TypeError):
+                    pass
 
     def close(self):
         """

--- a/pydm/data_plugins/epics_plugins/pyepics_plugin_component.py
+++ b/pydm/data_plugins/epics_plugins/pyepics_plugin_component.py
@@ -225,19 +225,19 @@ class Connection(PyDMConnection):
         if channel.value_signal is not None:
             try:
                 channel.value_signal[str].connect(self.put_value, Qt.QueuedConnection)
-            except KeyError:
+            except (KeyError, IndexError):  # pyqt5 throws a key error here, but pyside6 an index error
                 pass
             try:
                 channel.value_signal[int].connect(self.put_value, Qt.QueuedConnection)
-            except KeyError:
+            except (KeyError, IndexError):
                 pass
             try:
                 channel.value_signal[float].connect(self.put_value, Qt.QueuedConnection)
-            except KeyError:
+            except (KeyError, IndexError):
                 pass
             try:
                 channel.value_signal[np.ndarray].connect(self.put_value, Qt.QueuedConnection)
-            except KeyError:
+            except (KeyError, IndexError):
                 pass
 
     def close(self):

--- a/pydm/data_plugins/epics_plugins/pyepics_plugin_component.py
+++ b/pydm/data_plugins/epics_plugins/pyepics_plugin_component.py
@@ -223,22 +223,13 @@ class Connection(PyDMConnection):
             self.send_connection_state(conn=False)
         # If the channel is used for writing to PVs, hook it up to the 'put' methods.
         if channel.value_signal is not None:
-            try:
-                channel.value_signal[str].connect(self.put_value, Qt.QueuedConnection)
-            except (KeyError, IndexError):  # pyqt5 throws a key error here, but pyside6 an index error
-                pass
-            try:
-                channel.value_signal[int].connect(self.put_value, Qt.QueuedConnection)
-            except (KeyError, IndexError):
-                pass
-            try:
-                channel.value_signal[float].connect(self.put_value, Qt.QueuedConnection)
-            except (KeyError, IndexError):
-                pass
-            try:
-                channel.value_signal[np.ndarray].connect(self.put_value, Qt.QueuedConnection)
-            except (KeyError, IndexError):
-                pass
+            for signal_type in (str, int, float, np.ndarray):
+                try:
+                    channel.value_signal[signal_type].connect(self.put_value, Qt.QueuedConnection)
+                # When signal type can't be found, PyQt5 throws KeyError here, but PySide6 index error.
+                # If signal type exists but doesn't match the slot, TypeError gets thrown.
+                except (KeyError, IndexError, TypeError):
+                    pass
 
     def close(self):
         try:

--- a/pydm/data_plugins/local_plugin.py
+++ b/pydm/data_plugins/local_plugin.py
@@ -349,26 +349,13 @@ class Connection(PyDMConnection):
         # Connect the put_value slot to the channel's value_signal,
         # which captures the values sent through the plugin
         if channel.value_signal is not None:
-            try:
-                channel.value_signal[int].connect(self.put_value, Qt.QueuedConnection)
-            except (KeyError, IndexError):  # pyqt5 throws a key error here, but pyside6 an index error
-                pass
-            try:
-                channel.value_signal[float].connect(self.put_value, Qt.QueuedConnection)
-            except (KeyError, IndexError):
-                pass
-            try:
-                channel.value_signal[str].connect(self.put_value, Qt.QueuedConnection)
-            except (KeyError, IndexError):
-                pass
-            try:
-                channel.value_signal[bool].connect(self.put_value, Qt.QueuedConnection)
-            except (KeyError, IndexError):
-                pass
-            try:
-                channel.value_signal[np.ndarray].connect(self.put_value, Qt.QueuedConnection)
-            except (KeyError, IndexError):
-                pass
+            for signal_type in (int, float, str, bool, np.ndarray):
+                try:
+                    channel.value_signal[signal_type].connect(self.put_value, Qt.QueuedConnection)
+                # When signal type can't be found, PyQt5 throws KeyError here, but PySide6 index error.
+                # If signal type exists but doesn't match the slot, TypeError gets thrown.
+                except (KeyError, IndexError, TypeError):
+                    pass
 
     @Slot(int)
     @Slot(float)

--- a/pydm/data_plugins/local_plugin.py
+++ b/pydm/data_plugins/local_plugin.py
@@ -351,23 +351,23 @@ class Connection(PyDMConnection):
         if channel.value_signal is not None:
             try:
                 channel.value_signal[int].connect(self.put_value, Qt.QueuedConnection)
-            except KeyError:
+            except (KeyError, IndexError):  # pyqt5 throws a key error here, but pyside6 an index error
                 pass
             try:
                 channel.value_signal[float].connect(self.put_value, Qt.QueuedConnection)
-            except KeyError:
+            except (KeyError, IndexError):
                 pass
             try:
                 channel.value_signal[str].connect(self.put_value, Qt.QueuedConnection)
-            except KeyError:
+            except (KeyError, IndexError):
                 pass
             try:
                 channel.value_signal[bool].connect(self.put_value, Qt.QueuedConnection)
-            except KeyError:
+            except (KeyError, IndexError):
                 pass
             try:
                 channel.value_signal[np.ndarray].connect(self.put_value, Qt.QueuedConnection)
-            except KeyError:
+            except (KeyError, IndexError):
                 pass
 
     @Slot(int)

--- a/pydm/data_plugins/plugin.py
+++ b/pydm/data_plugins/plugin.py
@@ -42,26 +42,14 @@ class PyDMConnection(QObject):
             self.connection_state_signal.connect(channel.connection_slot, Qt.QueuedConnection)
 
         if channel.value_slot is not None:
-            try:
-                self.new_value_signal[int].connect(channel.value_slot, Qt.QueuedConnection)
-            except TypeError:
-                pass
-            try:
-                self.new_value_signal[float].connect(channel.value_slot, Qt.QueuedConnection)
-            except TypeError:
-                pass
-            try:
-                self.new_value_signal[str].connect(channel.value_slot, Qt.QueuedConnection)
-            except TypeError:
-                pass
-            try:
-                self.new_value_signal[bool].connect(channel.value_slot, Qt.QueuedConnection)
-            except TypeError:
-                pass
-            try:
-                self.new_value_signal[object].connect(channel.value_slot, Qt.QueuedConnection)
-            except TypeError:
-                pass
+            for signal_type in (int, float, str, bool, object):
+                try:
+                    self.new_value_signal[signal_type].connect(channel.value_slot, Qt.QueuedConnection)
+                # If the signal exists (always does in this case since we define it for all 'signal_type' values above)
+                # but doesn't match slot, TypeError is thrown. We also don't need to catch KeyError/IndexError here,
+                # since those are only thrown when signal type doesn't exist.
+                except TypeError:
+                    pass
 
         if channel.severity_slot is not None:
             self.new_severity_signal.connect(channel.severity_slot, Qt.QueuedConnection)
@@ -121,26 +109,14 @@ class PyDMConnection(QObject):
                 pass
 
         if self._should_disconnect(channel.value_slot, destroying):
-            try:
-                self.new_value_signal[int].disconnect(channel.value_slot)
-            except TypeError:
-                pass
-            try:
-                self.new_value_signal[float].disconnect(channel.value_slot)
-            except TypeError:
-                pass
-            try:
-                self.new_value_signal[str].disconnect(channel.value_slot)
-            except TypeError:
-                pass
-            try:
-                self.new_value_signal[bool].disconnect(channel.value_slot)
-            except TypeError:
-                pass
-            try:
-                self.new_value_signal[object].disconnect(channel.value_slot)
-            except TypeError:
-                pass
+            for signal_type in (int, float, str, bool, object):
+                try:
+                    self.new_value_signal[signal_type].disconnect(channel.value_slot)
+                # If the signal exists (always does in this case since we define it for all 'signal_type' earlier)
+                # but doesn't match slot, TypeError is thrown. We also don't need to catch KeyError/IndexError here,
+                # since those are only thrown when signal type doesn't exist.
+                except TypeError:
+                    pass
 
         if self._should_disconnect(channel.severity_slot, destroying):
             try:


### PR DESCRIPTION
pyqt5: missing overload = KeyError
pyside6: missing overload = IndexError

also make plugin channel connecting/disconnecting into a nicer equivalent for-loop, and add catching TypeErrors too (explanation in new comments)

and add comments to explain why we are catching these specific errors.