### PR TITLE
MNT: stop high-dpi setting warning on pyside6(qt6)

### DIFF
--- a/pydm/application.py
+++ b/pydm/application.py
@@ -15,9 +15,8 @@ from qtpy.QtCore import Qt, QTimer, Slot
 from qtpy.QtWidgets import QApplication
 from .main_window import PyDMMainWindow
 
-from .utilities import which, path_info
+from .utilities import which, path_info, connection, ACTIVE_QT_WRAPPER, QtWrapperTypes
 from .utilities.stylesheet import apply_stylesheet
-from .utilities import connection
 from . import config, data_plugins
 
 logger = logging.getLogger(__name__)
@@ -91,7 +90,7 @@ class PyDMApplication(QApplication):
     ):
         super(PyDMApplication, self).__init__(command_line_args)
         # Enable High DPI display, if available.
-        if hasattr(Qt, "AA_UseHighDpiPixmaps"):
+        if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT5:
             self.setAttribute(Qt.AA_UseHighDpiPixmaps)
 
         data_plugins.set_read_only(read_only)


### PR DESCRIPTION
The check already in place:

'if hasattr(Qt, "AA_UseHighDpiPixmaps"):'
 
was not stopping the warning, I think b/c the attribute still exists in Qt6 (was getting ran), but is marked internally as depreciated.