### PR TITLE
MNT: On pyside6 use == for signal comparison (can't use .signal like in  pyqt5)

### DIFF
--- a/pydm/widgets/channel.py
+++ b/pydm/widgets/channel.py
@@ -2,6 +2,8 @@ import logging
 
 import pydm.data_plugins
 
+from ..utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
+
 logger = logging.getLogger(__name__)
 
 
@@ -185,7 +187,13 @@ class PyDMChannel(object):
 
             value_signal_matched = self.value_signal is None and other.value_signal is None
             if self.value_signal and other.value_signal:
-                value_signal_matched = self.value_signal.signal == other.value_signal.signal
+                if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT5:
+                    value_signal_matched = self.value_signal.signal == other.value_signal.signal
+                else:
+                    # PySide6 changes how we do signal comparison, if we try to use .signal it throws error:
+                    # "AttributeError: 'PySide6.QtCore.SignalInstance' object has no attribute 'signal'"
+                    # Instead we can do 'signalA is signalB' or 'signalA == SignalB' to compare.
+                    value_signal_matched = self.value_signal == other.value_signal
 
             return (
                 address_matched


### PR DESCRIPTION
Corrects for the pyside6 error:
"AttributeError: 'PySide6.QtCore.SignalInstance' object has no attribute 'signal'"

Docs don't seem to say how to compare signals in pyside6,
so i verified by checking 'value_signal_matched' result during tests is same on pyside6 and pyqt5.

also verified with following script which acts as expected:

    from PySide6.QtCore import Signal

    a = Signal(int)
    b = Signal(str)
    c = b

    print("a is b: ", a is b) # False
    print("b is c: ", b is c) # True

    print("a == b: ", a == b) # False
    print("b == c: ", b == c) # True
