### PR TITLE
MNT: appease newer python by not using enum to index into tuple

### DIFF
--- a/pydm/widgets/template_repeater.py
+++ b/pydm/widgets/template_repeater.py
@@ -130,7 +130,11 @@ if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
         Flow = 2
 
 
-layout_class_for_type = (QVBoxLayout, QHBoxLayout, FlowLayout)
+layout_class_for_type = {
+    LayoutType.Vertical: QVBoxLayout,
+    LayoutType.Horizontal: QHBoxLayout,
+    LayoutType.Flow: FlowLayout,
+}
 
 
 class PyDMTemplateRepeater(QFrame, PyDMPrimitiveWidget):


### PR DESCRIPTION
Seems like the newer python im running pyside6 on doesn't like using enums to index into a tuple: "TypeError: tuple indices must be integers or slices, not LayoutType"

so use a map for 'layout_class_for_type' instead. (using the enum's '.value' should allow for indexing into the tuple too, but imo using the map is more readable.)

this works fine still older python