### PR TITLE
MNT: switch from python2 style super() calls to python3

### DIFF
--- a/docs/source/_static/tutorials/code/all_motors.py
+++ b/docs/source/_static/tutorials/code/all_motors.py
@@ -19,7 +19,7 @@ from pydm.widgets import PyDMEmbeddedDisplay
 
 class AllMotorsDisplay(Display):
     def __init__(self, parent=None, args=[], macros=None):
-        super(AllMotorsDisplay, self).__init__(parent=parent, args=args, macros=None)
+        super().__init__(parent=parent, args=args, macros=macros)
         # Placeholder for data to filter
         self.data = []
         # Reference to the PyDMApplication

--- a/docs/source/_static/tutorials/code/main.py
+++ b/docs/source/_static/tutorials/code/main.py
@@ -5,7 +5,7 @@ from scipy.ndimage.measurements import maximum_position
 
 class BeamPositioning(Display):
     def __init__(self, parent=None, args=None):
-        super(BeamPositioning, self).__init__(parent=parent, args=args)
+        super().__init__(parent=parent, args=args)
         # Attach our custom process_image method
         self.ui.imageView.process_image = self.process_image
         # Hook up to the newImageSignal so we can update

--- a/docs/source/tutorials/action/intro_python.rst
+++ b/docs/source/tutorials/action/intro_python.rst
@@ -45,7 +45,7 @@ Your display must subclass Display, and implement a few required methods::
   from pydm import Display
   class MyDisplay(Display):
     def __init__(self, parent=None, args=None, macros=None):
-      super(MyDisplay, self).__init__(parent=parent, args=args, macros=macros)
+      super().__init__(parent=parent, args=args, macros=macros)
 
     def ui_filename(self):
       return 'my_display.ui'
@@ -65,7 +65,7 @@ Next, we define our Display subclass, and its initializer::
 
   class MyDisplay(Display):
     def __init__(self, parent=None, args=None):
-      super(MyDisplay, self).__init__(parent=parent)
+      super().__init__(parent=parent)
 
 It is important to remember that you must always call the superclass' initializer
 in your own, and pass it the 'parent' argument from your initializer.  Otherwise,

--- a/docs/source/tutorials/action/little_code.rst
+++ b/docs/source/tutorials/action/little_code.rst
@@ -40,7 +40,7 @@ This is accomplished by subclassing `pydm.Display` (See :ref:`Display` for more 
       class BeamPositioning(Display):
 
           def __init__(self, parent=None, args=None, macros=None):
-              super(BeamPositioning, self).__init__(parent=parent, args=args, macros=None)
+              super().__init__(parent=parent, args=args, macros=None)
               # Attach our custom process_image method
               self.ui.imageView.process_image = self.process_image
               # Hook up to the newImageSignal so we can update

--- a/docs/source/tutorials/action/python.rst
+++ b/docs/source/tutorials/action/python.rst
@@ -61,7 +61,7 @@ Here is how it will look once we are done:
 
      class AllMotorsDisplay(Display):
          def __init__(self, parent=None, args=[], macros=None):
-             super(AllMotorsDisplay, self).__init__(parent=parent, args=args, macros=None)
+             super().__init__(parent=parent, args=args, macros=None)
              # Placeholder for data to filter
              self.data = []
              # Reference to the PyDMApplication

--- a/docs/source/tutorials/intro/features.rst
+++ b/docs/source/tutorials/intro/features.rst
@@ -30,7 +30,7 @@ An example:
     class MyDisplay(Display):
 
         def __init__(self, parent=None, args=None, macros=None):
-            super(MyDisplay, self).__init__(parent=parent, args=args, macros=macros)
+            super().__init__(parent=parent, args=args, macros=macros)
 
         def file_menu_items(self):
             return {"save": self.save_function, "load": (self.load_function, "Ctrl+L")}

--- a/examples/accessory_window/accessory_window.py
+++ b/examples/accessory_window/accessory_window.py
@@ -7,7 +7,7 @@ from qtpy.QtCore import Slot
 
 class MyDisplay(Display):
     def __init__(self, parent=None, args=[]):
-        super(MyDisplay, self).__init__(parent=parent, args=args)
+        super().__init__(parent=parent, args=args)
         self.tracks = [
             "Humming",
             "Cowboys",

--- a/examples/archiver_time_plot/archiver_time_plot_example.py
+++ b/examples/archiver_time_plot/archiver_time_plot_example.py
@@ -7,7 +7,7 @@ from pydm.widgets import PyDMArchiverTimePlot
 
 class archiver_time_plot_example(Display):
     def __init__(self, parent=None, args=None, macros=None):
-        super(archiver_time_plot_example, self).__init__(parent=parent, args=args, macros=None)
+        super().__init__(parent=parent, args=args, macros=macros)
         self.app = QApplication.instance()
         self.setup_ui()
 

--- a/examples/archiver_time_plot/formula_curve_example.py
+++ b/examples/archiver_time_plot/formula_curve_example.py
@@ -7,7 +7,7 @@ from pydm.widgets import PyDMArchiverTimePlot
 
 class archiver_time_plot_example(Display):
     def __init__(self, parent=None, args=None, macros=None):
-        super(archiver_time_plot_example, self).__init__(parent=parent, args=args, macros=None)
+        super().__init__(parent=parent, args=args, macros=macros)
         self.app = QApplication.instance()
         self.setup_ui()
 

--- a/examples/camviewer/camviewer.py
+++ b/examples/camviewer/camviewer.py
@@ -23,7 +23,7 @@ class CamViewer(Display):
     roi_h_signal = Signal(str)
 
     def __init__(self, parent=None, args=None):
-        super(CamViewer, self).__init__(parent=parent, args=args)
+        super().__init__(parent=parent, args=args)
 
         # Set up the list of cameras, and all the PVs
         test_dict = {

--- a/examples/code_only/code_only.py
+++ b/examples/code_only/code_only.py
@@ -4,7 +4,7 @@ from qtpy.QtWidgets import QLabel, QVBoxLayout, QHBoxLayout
 
 class MyDisplay(Display):
     def __init__(self, parent=None, args=[]):
-        super(MyDisplay, self).__init__(parent=parent, args=args)
+        super().__init__(parent=parent, args=args)
         self.setup_ui()
 
     def setup_ui(self):

--- a/examples/exception/demo.py
+++ b/examples/exception/demo.py
@@ -6,7 +6,7 @@ from pydm import exception
 
 class Screen(QtWidgets.QFrame):
     def __init__(self, *args, **kwargs):
-        super(Screen, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.setup_ui()
 
     def setup_ui(self):

--- a/examples/image_processing/image_view.py
+++ b/examples/image_processing/image_view.py
@@ -7,7 +7,7 @@ from pyqtgraph import mkPen
 
 class ImageViewer(Display):
     def __init__(self, parent=None, args=None):
-        super(ImageViewer, self).__init__(parent=parent, args=args)
+        super().__init__(parent=parent, args=args)
         self.markers_lock = threading.Lock()
         self.ui.imageView.process_image = self.process_image
         self.ui.imageView.newImageSignal.connect(self.draw_markers)

--- a/examples/macros/macros_and_python/macro_addition.py
+++ b/examples/macros/macros_and_python/macro_addition.py
@@ -3,7 +3,7 @@ from pydm import Display
 
 class MacroAddition(Display):
     def __init__(self, parent=None, args=None, macros=None):
-        super(MacroAddition, self).__init__(parent=parent, macros=macros)
+        super().__init__(parent=parent, macros=macros)
         self.ui.resultLabel.setText("{}".format(float(macros["a"]) + float(macros["b"])))
 
     def ui_filename(self):

--- a/examples/macros/nested_embedded_windows/macro_addition.py
+++ b/examples/macros/nested_embedded_windows/macro_addition.py
@@ -3,7 +3,7 @@ from pydm import Display
 
 class MacroAddition(Display):
     def __init__(self, parent=None, args=None, macros=None):
-        super(MacroAddition, self).__init__(parent=parent, macros=macros)
+        super().__init__(parent=parent, macros=macros)
         self.ui.resultLabel.setText("{}".format(float(macros["a"]) + float(macros["b"])))
 
     def ui_filename(self):

--- a/examples/positioner/positioner_ioc.py
+++ b/examples/positioner/positioner_ioc.py
@@ -49,7 +49,7 @@ pvdb = {
 
 class myDriver(Driver):
     def __init__(self):
-        super(myDriver, self).__init__()
+        super().__init__()
 
 
 if __name__ == "__main__":

--- a/examples/positioner/positioner_module.py
+++ b/examples/positioner/positioner_module.py
@@ -8,7 +8,7 @@ from pydm import Display
 
 class Positioner(Display):
     def __init__(self, parent=None, args=None):
-        super(Positioner, self).__init__(parent=parent, args=args)
+        super().__init__(parent=parent, args=args)
         self.moving = False
         self.ui.pushButton.clicked.connect(self.move_motors)
         self.motor1pv = epics.PV("MOTOR:1:VAL")

--- a/examples/tutorial/all_motors.py
+++ b/examples/tutorial/all_motors.py
@@ -19,7 +19,7 @@ from pydm.widgets import PyDMEmbeddedDisplay
 
 class AllMotorsDisplay(Display):
     def __init__(self, parent=None, args=[], macros=None):
-        super(AllMotorsDisplay, self).__init__(parent=parent, args=args, macros=None)
+        super().__init__(parent=parent, args=args, macros=macros)
         # Placeholder for data to filter
         self.data = []
         # Reference to the PyDMApplication

--- a/examples/tutorial/main.py
+++ b/examples/tutorial/main.py
@@ -5,7 +5,7 @@ from scipy.ndimage.measurements import maximum_position
 
 class BeamPositioning(Display):
     def __init__(self, parent=None, args=None):
-        super(BeamPositioning, self).__init__(parent=parent, args=args)
+        super().__init__(parent=parent, args=args)
         # Attach our custom process_image method
         self.ui.imageView.process_image = self.process_image
         # Hook up to the newImageSignal so we can update

--- a/pydm/about_pydm/about.py
+++ b/pydm/about_pydm/about.py
@@ -21,7 +21,7 @@ else:
 
 class AboutWindow(QWidget):
     def __init__(self, parent=None):
-        super(AboutWindow, self).__init__(parent, Qt.Window)
+        super().__init__(parent, Qt.Window)
         self.ui = Ui_Form()
         self.ui.setupUi(self)
         self.ui.pydmVersionLabel.setText(str(self.ui.pydmVersionLabel.text()).format(version=pydm.__version__))

--- a/pydm/application.py
+++ b/pydm/application.py
@@ -89,7 +89,7 @@ class PyDMApplication(QApplication):
         fullscreen=False,
         home_file=None,
     ):
-        super(PyDMApplication, self).__init__(command_line_args)
+        super().__init__(command_line_args)
         # Enable High DPI display, if available.
         if hasattr(Qt, "AA_UseHighDpiPixmaps"):
             self.setAttribute(Qt.AA_UseHighDpiPixmaps)
@@ -149,7 +149,7 @@ class PyDMApplication(QApplication):
         """
         Execute the QApplication.
         """
-        return super(PyDMApplication, self).exec_()
+        return super().exec_()
 
     def is_read_only(self):
         warnings.warn("'PyDMApplication.is_read_only' is deprecated, " "use 'pydm.data_plugins.is_read_only' instead.")

--- a/pydm/connection_inspector/connection_inspector.py
+++ b/pydm/connection_inspector/connection_inspector.py
@@ -19,7 +19,7 @@ from .. import data_plugins
 
 class ConnectionInspector(QWidget):
     def __init__(self, parent=None):
-        super(ConnectionInspector, self).__init__(parent, Qt.Window)
+        super().__init__(parent, Qt.Window)
         connections = self.fetch_data()
         self.table_view = ConnectionTableView(connections, self)
         self.setLayout(QVBoxLayout(self))
@@ -89,7 +89,7 @@ class ConnectionInspector(QWidget):
 
 class ConnectionTableView(QTableView):
     def __init__(self, connections=[], parent=None):
-        super(ConnectionTableView, self).__init__(parent)
+        super().__init__(parent)
         self.setSizeAdjustPolicy(QAbstractScrollArea.AdjustToContentsOnFirstShow)
         self.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
         self.horizontalHeader().setStretchLastSection(True)

--- a/pydm/connection_inspector/connection_table_model.py
+++ b/pydm/connection_inspector/connection_table_model.py
@@ -4,7 +4,7 @@ from operator import attrgetter
 
 class ConnectionTableModel(QAbstractTableModel):
     def __init__(self, connections=[], parent=None):
-        super(ConnectionTableModel, self).__init__(parent=parent)
+        super().__init__(parent=parent)
         self._column_names = ("protocol", "address", "connected")
         self.update_timer = QTimer(self)
         self.update_timer.setInterval(1000)
@@ -61,7 +61,7 @@ class ConnectionTableModel(QAbstractTableModel):
 
     def headerData(self, section, orientation, role=Qt.DisplayRole):
         if role != Qt.DisplayRole:
-            return super(ConnectionTableModel, self).headerData(section, orientation, role)
+            return super().headerData(section, orientation, role)
         if orientation == Qt.Horizontal and section < self.columnCount():
             return str(self._column_names[section]).capitalize()
         elif orientation == Qt.Vertical and section < self.rowCount():

--- a/pydm/data_plugins/calc_plugin.py
+++ b/pydm/data_plugins/calc_plugin.py
@@ -176,7 +176,7 @@ class CalcThread(QThread):
 
 class Connection(PyDMConnection):
     def __init__(self, channel, address, protocol=None, parent=None):
-        super(Connection, self).__init__(channel, address, protocol, parent)
+        super().__init__(channel, address, protocol, parent)
         self._calc_thread = None
         self.value = None
         self._configuration = {}
@@ -190,7 +190,7 @@ class Connection(PyDMConnection):
 
     def add_listener(self, channel):
         self._setup_calc(channel)
-        super(Connection, self).add_listener(channel)
+        super().add_listener(channel)
         self.broadcast_value()
 
     def broadcast_value(self):

--- a/pydm/data_plugins/epics_plugins/caproto_plugin_component.py
+++ b/pydm/data_plugins/epics_plugins/caproto_plugin_component.py
@@ -40,7 +40,7 @@ float_types = set(
 
 class Connection(PyDMConnection):
     def __init__(self, channel, pv, protocol=None, parent=None):
-        super(Connection, self).__init__(channel, pv, protocol, parent)
+        super().__init__(channel, pv, protocol, parent)
         self.app = QApplication.instance()
         self._value = None
         self._severity = None
@@ -194,7 +194,7 @@ class Connection(PyDMConnection):
                 logger.exception("Unable to put %s to %s.  Exception: %s", new_val, self.pv.pvname, str(e))
 
     def add_listener(self, channel):
-        super(Connection, self).add_listener(channel)
+        super().add_listener(channel)
         # If we are adding a listener to an already existing PV, we need to
         # manually send the signals indicating that the PV is connected, what the latest value is, etc.
         if self.pv.connected:

--- a/pydm/data_plugins/epics_plugins/psp_plugin_component.py
+++ b/pydm/data_plugins/epics_plugins/psp_plugin_component.py
@@ -143,7 +143,7 @@ class Connection(PyDMConnection):
         :param parent: PyQt widget that this widget is inside of.
         :type parent:  QWidget
         """
-        super(Connection, self).__init__(channel, pv, protocol, parent)
+        super().__init__(channel, pv, protocol, parent)
         self.python_type = None
         self.pv = setup_pv(
             pv, con_cb=self.connected_cb, mon_cb=self.monitor_cb, rwaccess_cb=self.rwaccess_cb, control=True
@@ -524,7 +524,7 @@ class Connection(PyDMConnection):
         :param channel: The channel to connect.
         :type channel:  :class:`PyDMChannel`
         """
-        super(Connection, self).add_listener(channel)
+        super().add_listener(channel)
         # If we are adding a listener to an already existing PV, we need to
         # manually send the signals indicating that the PV is connected, what
         # the latest value is, etc.

--- a/pydm/data_plugins/epics_plugins/pyepics_plugin_component.py
+++ b/pydm/data_plugins/epics_plugins/pyepics_plugin_component.py
@@ -53,7 +53,7 @@ float_types = set(
 
 class Connection(PyDMConnection):
     def __init__(self, channel, pv, protocol=None, parent=None):
-        super(Connection, self).__init__(channel, pv, protocol, parent)
+        super().__init__(channel, pv, protocol, parent)
         self.app = QApplication.instance()
         self.pv = epics.PV(
             pv,
@@ -213,7 +213,7 @@ class Connection(PyDMConnection):
                 logger.exception("Unable to put %s to %s.  Exception: %s", new_val, self.pv.pvname, str(e))
 
     def add_listener(self, channel):
-        super(Connection, self).add_listener(channel)
+        super().add_listener(channel)
         # If we are adding a listener to an already existing PV, we need to
         # manually send the signals indicating that the PV is connected, what the latest value is, etc.
         if epics.ca.isConnected(self.pv.chid):

--- a/pydm/data_plugins/fake_plugin.py
+++ b/pydm/data_plugins/fake_plugin.py
@@ -5,7 +5,7 @@ import random
 
 class Connection(PyDMConnection):
     def __init__(self, widget, address, protocol=None, parent=None):
-        super(Connection, self).__init__(widget, address, protocol, parent)
+        super().__init__(widget, address, protocol, parent)
         self.add_listener(widget)
         self.value = address
         self.rand = 0
@@ -22,7 +22,7 @@ class Connection(PyDMConnection):
         self.connection_state_signal.emit(conn)
 
     def add_listener(self, widget):
-        super(Connection, self).add_listener(widget)
+        super().add_listener(widget)
         self.send_connection_state(True)
 
 

--- a/pydm/data_plugins/local_plugin.py
+++ b/pydm/data_plugins/local_plugin.py
@@ -36,7 +36,7 @@ class Connection(PyDMConnection):
         self._lower_limit = None
         self._enum_string = None
 
-        super(Connection, self).__init__(channel, address, protocol, parent)
+        super().__init__(channel, address, protocol, parent)
         self._configuration = {}
         self.add_listener(channel)
         self.send_connection_state(False)
@@ -330,7 +330,7 @@ class Connection(PyDMConnection):
         self.connection_state_signal.emit(conn)
 
     def add_listener(self, channel):
-        super(Connection, self).add_listener(channel)
+        super().add_listener(channel)
         self._configure_local_plugin(channel)
         # send write access == True to the listeners
         self.send_access_state()

--- a/pydm/data_plugins/plugin.py
+++ b/pydm/data_plugins/plugin.py
@@ -28,7 +28,7 @@ class PyDMConnection(QObject):
     timestamp_signal = Signal(float)
 
     def __init__(self, channel, address, protocol=None, parent=None):
-        super(PyDMConnection, self).__init__(parent)
+        super().__init__(parent)
         self.protocol = protocol
         self.address = address
         self.connected = False

--- a/pydm/display.py
+++ b/pydm/display.py
@@ -331,7 +331,7 @@ _extension_to_loader = {
 
 class Display(QWidget):
     def __init__(self, parent=None, args=None, macros=None, ui_filename=None):
-        super(Display, self).__init__(parent=parent)
+        super().__init__(parent=parent)
         self.ui = None
         self.help_window = None
         self._ui_filename = ui_filename
@@ -482,4 +482,4 @@ class Display(QWidget):
             with open(stylesheet_filename) as f:
                 self._local_style = f.read()
         logger.debug("Setting stylesheet to: %s", self._local_style)
-        super(Display, self).setStyleSheet(self._local_style)
+        super().setStyleSheet(self._local_style)

--- a/pydm/exception.py
+++ b/pydm/exception.py
@@ -36,7 +36,7 @@ class ExceptionDispatcher(QtCore.QThread):
     def __init__(self, *args, **kwargs):
         if self.__initialized:
             return
-        super(ExceptionDispatcher, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.__initialized = True
         self.app = QtWidgets.QApplication.instance()
         self.app.aboutToQuit.connect(self.requestInterruption)
@@ -100,7 +100,7 @@ class DefaultExceptionNotifier(QtCore.QObject):
     def __init__(self, *args, **kwargs):
         if self.__initialized:
             return
-        super(DefaultExceptionNotifier, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.__initialized = True
         ExceptionDispatcher().newException.connect(self.receiveException)
 

--- a/pydm/main_window.py
+++ b/pydm/main_window.py
@@ -33,7 +33,7 @@ class PyDMMainWindow(QMainWindow):
         macros=None,
         command_line_args=None,
     ):
-        super(PyDMMainWindow, self).__init__(parent)
+        super().__init__(parent)
         self.app = QApplication.instance()
         self.font_factor = 1
         self.iconFont = IconFont()

--- a/pydm/tests/conftest.py
+++ b/pydm/tests/conftest.py
@@ -47,7 +47,7 @@ class ConnectionSignals(QObject):
     lower_warning_limit_signal = Signal((float,))
 
     def __init__(self):
-        super(ConnectionSignals, self).__init__()
+        super().__init__()
         self._value = None
         self._received_values = {}
 

--- a/pydm/utilities/iconfont.py
+++ b/pydm/utilities/iconfont.py
@@ -161,7 +161,7 @@ class CharIconEngine(QIconEngine):
     """Subclass of QIconEngine that is designed to draw characters from icon fonts."""
 
     def __init__(self, icon_font, char, color=None):
-        super(CharIconEngine, self).__init__()
+        super().__init__()
         self.icon_font = icon_font
         self.char = char
         if color is None:

--- a/pydm/widgets/analog_indicator.py
+++ b/pydm/widgets/analog_indicator.py
@@ -17,7 +17,7 @@ class QScaleAlarmed(QScale):
     """
 
     def __init__(self, parent=None):
-        super(QScaleAlarmed, self).__init__(parent)
+        super().__init__(parent)
         self._lower_minor_alarm = 0
         self._upper_minor_alarm = 0
         self._lower_major_alarm = 0
@@ -438,7 +438,7 @@ class PyDMAnalogIndicator(PyDMScaleIndicator):
         """
         Callback updates the lower minor alarm boundary
         """
-        super(PyDMAnalogIndicator, self).lower_warning_limit_changed(new_minor_alarm)
+        super().lower_warning_limit_changed(new_minor_alarm)
         if self.minorAlarmFromChannel:
             self.scale_indicator.set_lower_minor_alarm(new_minor_alarm)
             self.update_labels()
@@ -447,7 +447,7 @@ class PyDMAnalogIndicator(PyDMScaleIndicator):
         """
         Callback updates the upper minor alarm boundary
         """
-        super(PyDMAnalogIndicator, self).upper_warning_limit_changed(new_minor_alarm)
+        super().upper_warning_limit_changed(new_minor_alarm)
         if self.minorAlarmFromChannel:
             self.scale_indicator.set_upper_minor_alarm(new_minor_alarm)
             self.update_labels()
@@ -456,7 +456,7 @@ class PyDMAnalogIndicator(PyDMScaleIndicator):
         """
         Callback updates the lower major alarm boundary
         """
-        super(PyDMAnalogIndicator, self).lower_alarm_limit_changed(new_major_alarm)
+        super().lower_alarm_limit_changed(new_major_alarm)
         if self.majorAlarmFromChannel:
             self.scale_indicator.set_lower_major_alarm(new_major_alarm)
             self.update_labels()
@@ -465,7 +465,7 @@ class PyDMAnalogIndicator(PyDMScaleIndicator):
         """
         Callback updates the upper major alarm boundary
         """
-        super(PyDMAnalogIndicator, self).upper_alarm_limit_changed(new_major_alarm)
+        super().upper_alarm_limit_changed(new_major_alarm)
         if self.majorAlarmFromChannel:
             self.scale_indicator.set_upper_major_alarm(new_major_alarm)
             self.update_labels()

--- a/pydm/widgets/archiver_time_plot.py
+++ b/pydm/widgets/archiver_time_plot.py
@@ -56,7 +56,7 @@ class ArchivePlotCurveItem(TimePlotCurveItem):
         self, channel_address: Optional[str] = None, use_archive_data: bool = True, liveData: bool = True, **kws
     ):
         self.archive_channel = None
-        super(ArchivePlotCurveItem, self).__init__(**kws)
+        super().__init__(**kws)
         self.use_archive_data = use_archive_data
         self.archive_points_accumulated = 0
         self._archiveBufferSize = DEFAULT_ARCHIVE_BUFFER_SIZE
@@ -229,7 +229,7 @@ class ArchivePlotCurveItem(TimePlotCurveItem):
         Redraw the curve with any new data added since the last draw call.
         """
         if self.archive_points_accumulated == 0:
-            super(ArchivePlotCurveItem, self).redrawCurve()
+            super().redrawCurve()
         else:
             try:
                 x = np.concatenate(
@@ -471,7 +471,7 @@ class FormulaCurveItem(BasePlotCurveItem):
             else:
                 curveDict[header] = curve.formula
         dic_.update({"curveDict": curveDict})
-        dic_.update(super(FormulaCurveItem, self).to_dict())
+        dic_.update(super().to_dict())
         return dic_
 
     @property
@@ -831,7 +831,7 @@ class PyDMArchiverTimePlot(PyDMTimePlot):
         background: str = "default",
         optimized_data_bins: int = 2000,
     ):
-        super(PyDMArchiverTimePlot, self).__init__(
+        super().__init__(
             parent=parent,
             init_y_channels=init_y_channels,
             plot_by_timestamps=True,

--- a/pydm/widgets/axis_table_model.py
+++ b/pydm/widgets/axis_table_model.py
@@ -9,7 +9,7 @@ class BasePlotAxesModel(QAbstractTableModel):
     name_for_orientations = {v: k for k, v in BasePlotAxisItem.axis_orientations.items()}
 
     def __init__(self, plot, parent=None):
-        super(BasePlotAxesModel, self).__init__(parent=parent)
+        super().__init__(parent=parent)
         self._plot = plot
         self._column_names = (
             "Y-Axis Name",
@@ -117,7 +117,7 @@ class BasePlotAxesModel(QAbstractTableModel):
 
     def headerData(self, section, orientation, role=Qt.DisplayRole):
         if role != Qt.DisplayRole:
-            return super(BasePlotAxesModel, self).headerData(section, orientation, role)
+            return super().headerData(section, orientation, role)
         if orientation == Qt.Horizontal and section < self.columnCount():
             return str(self._column_names[section])
         elif orientation == Qt.Vertical and section < self.rowCount():

--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -581,7 +581,7 @@ class TextFormatter(object):
         new_val : str, int, float, bool or np.ndarray
             The new value from the channel. The type depends on the channel.
         """
-        super(TextFormatter, self).value_changed(new_val)
+        super().value_changed(new_val)
         self.update_format_string()
 
 
@@ -612,7 +612,7 @@ class PyDMWidget(PyDMPrimitiveWidget):
     ALARM_DISCONNECTED = 4
 
     def __init__(self, init_channel=None):
-        super(PyDMWidget, self).__init__()
+        super().__init__()
 
         self._connected = True
         self._channel = None
@@ -1376,14 +1376,14 @@ class PyDMWritableWidget(PyDMWidget):
         self._disp_channel = None
         self._disable_put = False
         self._monitor_disp = False
-        super(PyDMWritableWidget, self).__init__(init_channel=init_channel)
+        super().__init__(init_channel=init_channel)
 
     def init_for_designer(self):
         """
         Method called after the constructor to tweak configurations for
         when using the widget with the Qt Designer
         """
-        super(PyDMWritableWidget, self).init_for_designer()
+        super().init_for_designer()
         self._write_access = True
 
     def eventFilter(self, obj, event):

--- a/pydm/widgets/baseplot.py
+++ b/pydm/widgets/baseplot.py
@@ -108,7 +108,7 @@ class BasePlotCurveItem(PlotDataItem):
                 lineStyle = Qt.PenStyle(lineStyle)
             self._pen.setStyle(lineStyle)
         kws["pen"] = self._pen
-        super(BasePlotCurveItem, self).__init__(**kws)
+        super().__init__(**kws)
         self.setSymbolBrush(None)
         if color is not None:
             self.color = color
@@ -480,7 +480,7 @@ class BasePlotAxisItem(AxisItem):
         logMode: Optional[bool] = False,
         **kws,
     ) -> None:
-        super(BasePlotAxisItem, self).__init__(orientation, **kws)
+        super().__init__(orientation, **kws)
         self._curves: List[BasePlotCurveItem] = []
         self._name = name
         self._orientation = orientation
@@ -711,7 +711,7 @@ class BasePlot(PlotWidget, PyDMPrimitiveWidget):
             # The pyqtgraph PlotItem.setAxisItems() will always add an an AxisItem called left whether you asked
             # it to or not. This will clear it if not specifically requested.
             plotItem.removeAxis("left")
-        super(BasePlot, self).__init__(parent=parent, background=background, plotItem=plotItem)
+        super().__init__(parent=parent, background=background, plotItem=plotItem)
 
         self.plotItem = plotItem
         self.plotItem.hideButtons()
@@ -780,7 +780,7 @@ class BasePlot(PlotWidget, PyDMPrimitiveWidget):
 
     def eventFilter(self, obj: QObject, event: QEvent) -> bool:
         """Display a tool tip upon mousing over the plot in Qt designer explaining how to edit curves on it"""
-        ret = super(BasePlot, self).eventFilter(obj, event)
+        ret = super().eventFilter(obj, event)
         if utilities.is_qt_designer():
             if event.type() == QEvent.Enter:
                 QToolTip.showText(

--- a/pydm/widgets/baseplot_curve_editor.py
+++ b/pydm/widgets/baseplot_curve_editor.py
@@ -38,7 +38,7 @@ class BasePlotCurveEditorDialog(QDialog):
     AXIS_MODEL_TAB_INDEX = 1
 
     def __init__(self, plot, parent=None):
-        super(BasePlotCurveEditorDialog, self).__init__(parent)
+        super().__init__(parent)
         self.tab_widget = QTabWidget()
         self.plot = plot
         self.setup_ui()

--- a/pydm/widgets/baseplot_table_model.py
+++ b/pydm/widgets/baseplot_table_model.py
@@ -12,7 +12,7 @@ class BasePlotCurvesModel(QAbstractTableModel):
     """
 
     def __init__(self, plot, parent=None):
-        super(BasePlotCurvesModel, self).__init__(parent=parent)
+        super().__init__(parent=parent)
         self._plot = plot
         self._column_names = (
             "Label",
@@ -152,7 +152,7 @@ class BasePlotCurvesModel(QAbstractTableModel):
 
     def headerData(self, section, orientation, role=Qt.DisplayRole):
         if role != Qt.DisplayRole:
-            return super(BasePlotCurvesModel, self).headerData(section, orientation, role)
+            return super().headerData(section, orientation, role)
         if orientation == Qt.Horizontal and section < self.columnCount():
             return str(self._column_names[section])
         elif orientation == Qt.Vertical and section < self.rowCount():

--- a/pydm/widgets/byte.py
+++ b/pydm/widgets/byte.py
@@ -17,7 +17,7 @@ class PyDMBitIndicator(QWidget):
     """
 
     def __init__(self, parent: Optional[QWidget] = None, circle: bool = False):
-        super(PyDMBitIndicator, self).__init__(parent)
+        super().__init__(parent)
         self.circle = circle
         self._painter = QPainter()
         self._brush = QBrush(Qt.SolidPattern)
@@ -134,7 +134,7 @@ class PyDMByteIndicator(QWidget, PyDMWidget):
         connected : bool
             When this value is False the channel is disconnected, True otherwise.
         """
-        super(PyDMByteIndicator, self).connection_changed(connected)
+        super().connection_changed(connected)
         self.update_indicators()
 
     def rebuild_layout(self) -> None:
@@ -508,7 +508,7 @@ class PyDMByteIndicator(QWidget, PyDMWidget):
         new_val : int
             The new value from the channel.
         """
-        super(PyDMByteIndicator, self).value_changed(new_val)
+        super().value_changed(new_val)
         try:
             int(new_val)
             self.update_indicators()
@@ -549,7 +549,7 @@ class PyDMByteIndicator(QWidget, PyDMWidget):
         if new_alarm_severity == self._alarm_state:
             return
         else:
-            super(PyDMByteIndicator, self).alarm_severity_changed(new_alarm_severity)
+            super().alarm_severity_changed(new_alarm_severity)
 
             # Checks if _shift attribute exits because base class can call method
             # before the object constructor is complete
@@ -599,7 +599,7 @@ class PyDMMultiStateIndicator(QWidget, PyDMWidget):
         new_val : int
             The new value from the channel.
         """
-        super(PyDMMultiStateIndicator, self).value_changed(new_val)
+        super().value_changed(new_val)
         try:
             int(new_val)
             if new_val >= 0 and new_val <= 15:  # use states 0-15 (16 total states)

--- a/pydm/widgets/checkbox.py
+++ b/pydm/widgets/checkbox.py
@@ -30,7 +30,7 @@ class PyDMCheckbox(QCheckBox, PyDMWritableWidget):
         new_val : int
             The new value from the channel.
         """
-        super(PyDMCheckbox, self).value_changed(new_val)
+        super().value_changed(new_val)
         if new_val is None:
             return
         if new_val > 0:

--- a/pydm/widgets/datetime.py
+++ b/pydm/widgets/datetime.py
@@ -92,7 +92,7 @@ class PyDMDateTimeEdit(QtWidgets.QDateTimeEdit, PyDMWritableWidget):
             self._block_past_date = block
 
     def keyPressEvent(self, key_event):
-        ret = super(PyDMDateTimeEdit, self).keyPressEvent(key_event)
+        ret = super().keyPressEvent(key_event)
         if key_event.key() in [QtCore.Qt.Key_Return, QtCore.Qt.Key_Enter]:
             self.returnPressed.emit()
         return ret
@@ -114,7 +114,7 @@ class PyDMDateTimeEdit(QtWidgets.QDateTimeEdit, PyDMWritableWidget):
         self.send_value_signal.emit(new_value)
 
     def value_changed(self, new_val):
-        super(PyDMDateTimeEdit, self).value_changed(new_val)
+        super().value_changed(new_val)
 
         if self.timeBase == TimeBase.Seconds:
             new_val *= 1000
@@ -194,7 +194,7 @@ class PyDMDateTimeLabel(QtWidgets.QLabel, PyDMWidget):
             self._relative = checked
 
     def value_changed(self, new_val):
-        super(PyDMDateTimeLabel, self).value_changed(new_val)
+        super().value_changed(new_val)
 
         if self.timeBase == TimeBase.Seconds:
             new_val *= 1000

--- a/pydm/widgets/designer_settings.py
+++ b/pydm/widgets/designer_settings.py
@@ -324,7 +324,7 @@ class BasicSettingsEditor(QtWidgets.QDialog):
     }
 
     def __init__(self, widget, parent=None):
-        super(BasicSettingsEditor, self).__init__(parent)
+        super().__init__(parent)
 
         self.widget = widget
 

--- a/pydm/widgets/drawing.py
+++ b/pydm/widgets/drawing.py
@@ -471,7 +471,7 @@ class PyDMDrawingLineBase(PyDMDrawing):
     """
 
     def __init__(self, parent=None, init_channel=None):
-        super(PyDMDrawingLineBase, self).__init__(parent, init_channel)
+        super().__init__(parent, init_channel)
         self.penStyle = Qt.SolidLine
         self.penWidth = 1
         self._arrow_size = 6  # 6 is arbitrary size that looked good for default, not in any specific 'units'
@@ -641,14 +641,14 @@ class PyDMDrawingLine(PyDMDrawingLineBase):
     new_properties = _penRuleProperties
 
     def __init__(self, parent=None, init_channel=None):
-        super(PyDMDrawingLine, self).__init__(parent, init_channel)
+        super().__init__(parent, init_channel)
 
     def draw_item(self, painter) -> None:
         """
         Draws the line after setting up the canvas with a call to
         ```PyDMDrawing.draw_item```.
         """
-        super(PyDMDrawingLine, self).draw_item(painter)
+        super().draw_item(painter)
         x, y, w, h = self.get_bounds()
 
         # Figure out how long to make the line to touch the bounding box
@@ -723,7 +723,7 @@ class PyDMDrawingPolyline(PyDMDrawingLineBase):
     """
 
     def __init__(self, parent=None, init_channel=None):
-        super(PyDMDrawingPolyline, self).__init__(parent, init_channel)
+        super().__init__(parent, init_channel)
         self._points = []
 
     def draw_item(self, painter) -> None:
@@ -731,7 +731,7 @@ class PyDMDrawingPolyline(PyDMDrawingLineBase):
         Draws the segmented line after setting up the canvas with a call to
         ``PyDMDrawing.draw_item``.
         """
-        super(PyDMDrawingPolyline, self).draw_item(painter)
+        super().draw_item(painter)
         x, y, w, h = self.get_bounds()
 
         def p2d(pt):
@@ -885,8 +885,8 @@ class PyDMDrawingImage(PyDMDrawing):
     null_color = Qt.gray
 
     def __init__(self, parent=None, init_channel=None, filename=""):
-        super(PyDMDrawingImage, self).__init__(parent, init_channel)
-        hint = super(PyDMDrawingImage, self).sizeHint()
+        super().__init__(parent, init_channel)
+        hint = super().sizeHint()
         self._pixmap = QPixmap(hint)
         self._pixmap.fill(self.null_color)
         self._aspect_ratio_mode = Qt.KeepAspectRatio
@@ -993,7 +993,7 @@ class PyDMDrawingImage(PyDMDrawing):
 
     def sizeHint(self):
         if self._pixmap.size().isEmpty():
-            return super(PyDMDrawingImage, self).sizeHint()
+            return super().sizeHint()
         return self._pixmap.size()
 
     @Property(Qt.AspectRatioMode)
@@ -1029,7 +1029,7 @@ class PyDMDrawingImage(PyDMDrawing):
         Draws the image after setting up the canvas with a call to
         ```PyDMDrawing.draw_item```.
         """
-        super(PyDMDrawingImage, self).draw_item(painter)
+        super().draw_item(painter)
         x, y, w, h = self.get_bounds(maxsize=True, force_no_pen=True)
         if not isinstance(self._pixmap, QMovie):
             _scaled = self._pixmap.scaled(int(w), int(h), self._aspect_ratio_mode, Qt.SmoothTransformation)
@@ -1090,14 +1090,14 @@ class PyDMDrawingRectangle(PyDMDrawing):
     """
 
     def __init__(self, parent=None, init_channel=None):
-        super(PyDMDrawingRectangle, self).__init__(parent, init_channel)
+        super().__init__(parent, init_channel)
 
     def draw_item(self, painter):
         """
         Draws the rectangle after setting up the canvas with a call to
         ```PyDMDrawing.draw_item```.
         """
-        super(PyDMDrawingRectangle, self).draw_item(painter)
+        super().draw_item(painter)
         x, y, w, h = self.get_bounds(maxsize=True)
         painter.drawRect(QRectF(x, y, w, h))
 
@@ -1116,7 +1116,7 @@ class PyDMDrawingTriangle(PyDMDrawing):
     """
 
     def __init__(self, parent=None, init_channel=None):
-        super(PyDMDrawingTriangle, self).__init__(parent, init_channel)
+        super().__init__(parent, init_channel)
 
     def _calculate_drawing_points(self, x, y, w, h):
         return [QPointF(x, h / 2.0), QPointF(x, y), QPointF(w / 2.0, y)]
@@ -1126,7 +1126,7 @@ class PyDMDrawingTriangle(PyDMDrawing):
         Draws the triangle after setting up the canvas with a call to
         ```PyDMDrawing.draw_item```.
         """
-        super(PyDMDrawingTriangle, self).draw_item(painter)
+        super().draw_item(painter)
         x, y, w, h = self.get_bounds(maxsize=True)
         points = self._calculate_drawing_points(x, y, w, h)
 
@@ -1147,14 +1147,14 @@ class PyDMDrawingEllipse(PyDMDrawing):
     """
 
     def __init__(self, parent=None, init_channel=None):
-        super(PyDMDrawingEllipse, self).__init__(parent, init_channel)
+        super().__init__(parent, init_channel)
 
     def draw_item(self, painter):
         """
         Draws the ellipse after setting up the canvas with a call to
         ```PyDMDrawing.draw_item```.
         """
-        super(PyDMDrawingEllipse, self).draw_item(painter)
+        super().draw_item(painter)
         maxsize = not self.is_square()
         _, _, w, h = self.get_bounds(maxsize=maxsize)
         painter.drawEllipse(QPoint(0, 0), w / 2.0, h / 2.0)
@@ -1174,7 +1174,7 @@ class PyDMDrawingCircle(PyDMDrawing):
     """
 
     def __init__(self, parent=None, init_channel=None):
-        super(PyDMDrawingCircle, self).__init__(parent, init_channel)
+        super().__init__(parent, init_channel)
 
     def _calculate_radius(self, width, height):
         return min(width, height) / 2.0
@@ -1184,7 +1184,7 @@ class PyDMDrawingCircle(PyDMDrawing):
         Draws the circle after setting up the canvas with a call to
         ```PyDMDrawing.draw_item```.
         """
-        super(PyDMDrawingCircle, self).draw_item(painter)
+        super().draw_item(painter)
         _, _, w, h = self.get_bounds()
         r = self._calculate_radius(w, h)
         painter.drawEllipse(QPoint(0, 0), r, r)
@@ -1206,7 +1206,7 @@ class PyDMDrawingArc(PyDMDrawing):
     new_properties = {"Start Angle": ["startAngle", float], "Span Angle": ["spanAngle", float]}
 
     def __init__(self, parent=None, init_channel=None):
-        super(PyDMDrawingArc, self).__init__(parent, init_channel)
+        super().__init__(parent, init_channel)
         self.penStyle = Qt.SolidLine
         self.penWidth = 1.0
         self._start_angle = 0
@@ -1269,7 +1269,7 @@ class PyDMDrawingArc(PyDMDrawing):
         Draws the arc after setting up the canvas with a call to
         ```PyDMDrawing.draw_item```.
         """
-        super(PyDMDrawingArc, self).draw_item(painter)
+        super().draw_item(painter)
         maxsize = not self.is_square()
         x, y, w, h = self.get_bounds(maxsize=maxsize)
         painter.drawArc(QRectF(x, y, w, h), int(self._start_angle), int(self._span_angle))
@@ -1289,14 +1289,14 @@ class PyDMDrawingPie(PyDMDrawingArc):
     """
 
     def __init__(self, parent=None, init_channel=None):
-        super(PyDMDrawingPie, self).__init__(parent, init_channel)
+        super().__init__(parent, init_channel)
 
     def draw_item(self, painter):
         """
         Draws the pie after setting up the canvas with a call to
         ```PyDMDrawing.draw_item```.
         """
-        super(PyDMDrawingPie, self).draw_item(painter)
+        super().draw_item(painter)
         maxsize = not self.is_square()
         x, y, w, h = self.get_bounds(maxsize=maxsize)
         painter.drawPie(QRectF(x, y, w, h), int(self._start_angle), int(self._span_angle))
@@ -1316,14 +1316,14 @@ class PyDMDrawingChord(PyDMDrawingArc):
     """
 
     def __init__(self, parent=None, init_channel=None):
-        super(PyDMDrawingChord, self).__init__(parent, init_channel)
+        super().__init__(parent, init_channel)
 
     def draw_item(self, painter):
         """
         Draws the chord after setting up the canvas with a call to
         ```PyDMDrawing.draw_item```.
         """
-        super(PyDMDrawingChord, self).draw_item(painter)
+        super().draw_item(painter)
         maxsize = not self.is_square()
         x, y, w, h = self.get_bounds(maxsize=maxsize)
         painter.drawChord(QRectF(x, y, w, h), int(self._start_angle), int(self._span_angle))
@@ -1343,7 +1343,7 @@ class PyDMDrawingPolygon(PyDMDrawing):
     """
 
     def __init__(self, parent=None, init_channel=None):
-        super(PyDMDrawingPolygon, self).__init__(parent, init_channel)
+        super().__init__(parent, init_channel)
         self._num_points = 3
 
     @Property(int)
@@ -1382,7 +1382,7 @@ class PyDMDrawingPolygon(PyDMDrawing):
         Draws the Polygon after setting up the canvas with a call to
         ```PyDMDrawing.draw_item```.
         """
-        super(PyDMDrawingPolygon, self).draw_item(painter)
+        super().draw_item(painter)
         not self.is_square()
         x, y, w, h = self.get_bounds(maxsize=not self.is_square())
         poly = self._calculate_drawing_points(x, y, w, h)
@@ -1407,10 +1407,10 @@ class PyDMDrawingIrregularPolygon(PyDMDrawingPolyline):
     """
 
     def getPoints(self):
-        return super(PyDMDrawingIrregularPolygon, self).getPoints()
+        return super().getPoints()
 
     def resetPoints(self):
-        super(PyDMDrawingIrregularPolygon, self).resetPoints()
+        super().resetPoints()
 
     def setPoints(self, points):
         verified = self._validator(points)

--- a/pydm/widgets/enum_button.py
+++ b/pydm/widgets/enum_button.py
@@ -498,7 +498,7 @@ class PyDMEnumButton(QWidget, PyDMWritableWidget):
             The new value from the channel.
         """
         if new_val is not None and new_val != self.value:
-            super(PyDMEnumButton, self).value_changed(new_val)
+            super().value_changed(new_val)
             btn = self._btn_group.button(new_val)
             if btn:
                 btn.setChecked(True)
@@ -515,7 +515,7 @@ class PyDMEnumButton(QWidget, PyDMWritableWidget):
             The new list of values
         """
         if new_enum_strings is not None and new_enum_strings != self.enum_strings:
-            super(PyDMEnumButton, self).enum_strings_changed(new_enum_strings)
+            super().enum_strings_changed(new_enum_strings)
             self._has_enums = True
             self.check_enable_state()
             self.rebuild_widgets()

--- a/pydm/widgets/enum_combo_box.py
+++ b/pydm/widgets/enum_combo_box.py
@@ -62,7 +62,7 @@ class PyDMEnumComboBox(QComboBox, PyDMWritableWidget):
         userData : object
             Arbitrary user data that is stored in the Qt.UserRole
         """
-        super(PyDMEnumComboBox, self).addItem(text, userData)
+        super().addItem(text, userData)
         self._new_item_added = True
 
     def setItemText(self, index, text):
@@ -76,11 +76,11 @@ class PyDMEnumComboBox(QComboBox, PyDMWritableWidget):
         text : str
             Title for the item
         """
-        super(PyDMEnumComboBox, self).setItemText(index, text)
+        super().setItemText(index, text)
         if self._new_item_added:
             self._new_item_added = False
             # Recalculate the enums
-            super(PyDMEnumComboBox, self).enum_strings_changed(tuple(self.itemText(i) for i in range(self.count())))
+            super().enum_strings_changed(tuple(self.itemText(i) for i in range(self.count())))
             self._has_enums = True
             self.check_enable_state()
 
@@ -152,7 +152,7 @@ class PyDMEnumComboBox(QComboBox, PyDMWritableWidget):
         new_enum_strings : tuple
             The new list of values
         """
-        super(PyDMEnumComboBox, self).enum_strings_changed(new_enum_strings)
+        super().enum_strings_changed(new_enum_strings)
         self.set_items(new_enum_strings)
 
     def value_changed(self, new_val):
@@ -166,7 +166,7 @@ class PyDMEnumComboBox(QComboBox, PyDMWritableWidget):
             The new value from the channel. The type depends on the channel.
         """
         if new_val is not None:
-            super(PyDMEnumComboBox, self).value_changed(new_val)
+            super().value_changed(new_val)
             # Integers are straight forward
             if isinstance(new_val, int):
                 idx = new_val

--- a/pydm/widgets/eventplot.py
+++ b/pydm/widgets/eventplot.py
@@ -32,7 +32,7 @@ class EventPlotCurveItem(BasePlotCurveItem):
             kws["symbol"] = "o"
         if "lineStyle" not in kws.keys():
             kws["lineStyle"] = Qt.NoPen
-        super(EventPlotCurveItem, self).__init__(**kws)
+        super().__init__(**kws)
         self.bufferSizeChannelAddress = bufferSizeChannelAddress
 
     def to_dict(self):
@@ -46,7 +46,7 @@ class EventPlotCurveItem(BasePlotCurveItem):
             needed to recreate this curve.
         """
         dic_ = OrderedDict([("channel", self.address), ("y_idx", self.y_idx), ("x_idx", self.x_idx)])
-        dic_.update(super(EventPlotCurveItem, self).to_dict())
+        dic_.update(super().to_dict())
         dic_["buffer_size"] = self.getBufferSize()
         dic_["bufferSizeChannelAddress"] = self.bufferSizeChannelAddress
         return dic_
@@ -256,7 +256,7 @@ class PyDMEventPlot(BasePlot):
     """
 
     def __init__(self, parent=None, channel=None, init_x_indices=[], init_y_indices=[], background="default"):
-        super(PyDMEventPlot, self).__init__(parent, background)
+        super().__init__(parent, background)
         # If the user supplies a single integer instead of a list,
         # wrap it in a list.
         if isinstance(init_x_indices, int):
@@ -406,7 +406,7 @@ class PyDMEventPlot(BasePlot):
         """
         Remove all curves from the plot.
         """
-        super(PyDMEventPlot, self).clear()
+        super().clear()
 
     def getCurves(self):
         """

--- a/pydm/widgets/eventplot_curve_editor.py
+++ b/pydm/widgets/eventplot_curve_editor.py
@@ -10,7 +10,7 @@ class PyDMEventPlotCurvesModel(BasePlotCurvesModel):
     """
 
     def __init__(self, plot, parent=None):
-        super(PyDMEventPlotCurvesModel, self).__init__(plot, parent=parent)
+        super().__init__(plot, parent=parent)
         self._column_names = ("Channel", "Y Index", "X Index") + self._column_names
         self._column_names += ("Buffer Size", "Buffer Size Channel")
 
@@ -31,7 +31,7 @@ class PyDMEventPlotCurvesModel(BasePlotCurvesModel):
             return curve.getBufferSize()
         elif column_name == "Buffer Size Channel":
             return curve.bufferSizeChannelAddress or ""
-        return super(PyDMEventPlotCurvesModel, self).get_data(column_name, curve)
+        return super().get_data(column_name, curve)
 
     def set_data(self, column_name, curve, value):
         if column_name == "Channel":
@@ -47,7 +47,7 @@ class PyDMEventPlotCurvesModel(BasePlotCurvesModel):
                 value = None
             curve.bufferSizeChannelAddress = str(value)
         else:
-            return super(PyDMEventPlotCurvesModel, self).set_data(column_name=column_name, curve=curve, value=value)
+            return super().set_data(column_name=column_name, curve=curve, value=value)
         return True
 
     def append(self, channel=None, y_idx=None, x_idx=None, name=None, color=None):
@@ -73,7 +73,7 @@ class EventPlotCurveEditorDialog(BasePlotCurveEditorDialog):
     TABLE_MODEL_CLASS = PyDMEventPlotCurvesModel
 
     def __init__(self, plot, parent=None):
-        super(EventPlotCurveEditorDialog, self).__init__(plot, parent)
+        super().__init__(plot, parent)
 
         plot_style_delegate = PlotStyleColumnDelegate(self, self.table_model, self.table_view)
         plot_style_delegate.hideColumns(hide_line_columns=False, hide_bar_columns=True)

--- a/pydm/widgets/label.py
+++ b/pydm/widgets/label.py
@@ -103,7 +103,7 @@ class PyDMLabel(QLabel, TextFormatter, PyDMWidget):
         new_value : str, int, float, bool or np.ndarray
             The new value from the channel. The type depends on the channel.
         """
-        super(PyDMLabel, self).value_changed(new_value)
+        super().value_changed(new_value)
         new_value = parse_value_for_display(
             value=new_value,
             precision=self.precision,

--- a/pydm/widgets/line_edit.py
+++ b/pydm/widgets/line_edit.py
@@ -84,7 +84,7 @@ class PyDMLineEdit(QLineEdit, TextFormatter, PyDMWritableWidget):
         value: str, float or int
             The new value of the channel
         """
-        super(PyDMLineEdit, self).value_changed(new_val)
+        super().value_changed(new_val)
         self.set_display()
 
     def send_value(self):
@@ -153,15 +153,15 @@ class PyDMLineEdit(QLineEdit, TextFormatter, PyDMWritableWidget):
 
     def setReadOnly(self, readOnly):
         self._user_set_read_only = readOnly
-        super(PyDMLineEdit, self).setReadOnly(True if self._user_set_read_only else not self._write_access)
+        super().setReadOnly(True if self._user_set_read_only else not self._write_access)
 
     def write_access_changed(self, new_write_access):
         """
         Change the PyDMLineEdit to read only if write access is denied
         """
-        super(PyDMLineEdit, self).write_access_changed(new_write_access)
+        super().write_access_changed(new_write_access)
         if not self._user_set_read_only:
-            super(PyDMLineEdit, self).setReadOnly(not new_write_access)
+            super().setReadOnly(not new_write_access)
 
     def unit_changed(self, new_unit):
         """
@@ -171,7 +171,7 @@ class PyDMLineEdit(QLineEdit, TextFormatter, PyDMWritableWidget):
         attribute. Receiving a new value for the unit causes the display to
         reset.
         """
-        super(PyDMLineEdit, self).unit_changed(new_unit)
+        super().unit_changed(new_unit)
         self._scale = 1
 
     def create_unit_options(self):
@@ -324,7 +324,7 @@ class PyDMLineEdit(QLineEdit, TextFormatter, PyDMWritableWidget):
         """
         if self._display is not None:
             self.setText(self._display)
-        super(PyDMLineEdit, self).focusOutEvent(event)
+        super().focusOutEvent(event)
 
     @staticmethod
     def strtobool(val):

--- a/pydm/widgets/multi_axis_plot.py
+++ b/pydm/widgets/multi_axis_plot.py
@@ -29,7 +29,7 @@ class MultiAxisPlot(PlotItem):
         # Create a view box that will support multiple axes to pass to the PyQtGraph PlotItem
         viewBox = MultiAxisViewBox()
         viewBox.menu = MultiAxisViewBoxMenu(viewBox)
-        super(MultiAxisPlot, self).__init__(viewBox=viewBox, axisItems=axisItems, **kargs)
+        super().__init__(viewBox=viewBox, axisItems=axisItems, **kargs)
 
         self.axesOriginalRanges = {}  # Dict from axis name to floats (x, y) representing original range of the axis
 
@@ -308,7 +308,7 @@ class MultiAxisPlot(PlotItem):
             view.setXRange(minX, maxX, padding=padding)
         if "bottom" not in self.axesOriginalRanges:
             self.axesOriginalRanges["bottom"] = (minX, maxX)
-        super(MultiAxisPlot, self).setXRange(minX, maxX, padding=padding)
+        super().setXRange(minX, maxX, padding=padding)
 
     def setYRange(self, minY, maxY, padding=0, update=True):
         """
@@ -328,7 +328,7 @@ class MultiAxisPlot(PlotItem):
 
         for view in self.stackedViews:
             view.setYRange(minY, maxY, padding=padding)
-        super(MultiAxisPlot, self).setYRange(minY, maxY, padding=padding)
+        super().setYRange(minY, maxY, padding=padding)
 
     def isAnyXAutoRange(self) -> bool:
         """Return true if any view boxes are set to autorange on the x-axis, false otherwise"""

--- a/pydm/widgets/multi_axis_viewbox.py
+++ b/pydm/widgets/multi_axis_viewbox.py
@@ -42,7 +42,7 @@ class MultiAxisViewBox(ViewBox):
         if axis != ViewBox.YAxis and not fromSignal:
             # This event happened within the view box area itself or the x axis so propagate to any stacked view boxes
             self.sigMouseWheelZoomed.emit(self, ev, axis)
-        super(MultiAxisViewBox, self).wheelEvent(ev, axis)
+        super().wheelEvent(ev, axis)
 
     def mouseDragEvent(self, ev, axis=None, fromSignal=False):
         """
@@ -63,7 +63,7 @@ class MultiAxisViewBox(ViewBox):
             self.sigMouseDragged.emit(self, ev, axis)
             if ev.isFinish() and self.state["mouseMode"] == ViewBox.RectMode and axis is None:
                 self.sigMouseDraggedDone.emit()  # Indicates the end of a mouse drag event
-        super(MultiAxisViewBox, self).mouseDragEvent(ev, axis)
+        super().mouseDragEvent(ev, axis)
 
     def keyPressEvent(self, ev):
         """

--- a/pydm/widgets/multi_axis_viewbox_menu.py
+++ b/pydm/widgets/multi_axis_viewbox_menu.py
@@ -37,7 +37,7 @@ class MultiAxisViewBoxMenu(ViewBoxMenu):
     sigYManualRange = Signal(float, float)
 
     def __init__(self, view):
-        super(MultiAxisViewBoxMenu, self).__init__(view)
+        super().__init__(view)
         self.restoreRangesAction = QAction(QCoreApplication.translate("ViewBox", "Restore default X/Y ranges"), self)
         self.restoreRangesAction.triggered.connect(self.restoreRanges)
 
@@ -48,12 +48,12 @@ class MultiAxisViewBoxMenu(ViewBoxMenu):
 
     def set3ButtonMode(self):
         """Change the mouse left-click functionality to pan the plot"""
-        super(MultiAxisViewBoxMenu, self).set3ButtonMode()
+        super().set3ButtonMode()
         self.sigMouseModeChanged.emit("pan")
 
     def set1ButtonMode(self):
         """Change the mouse left-click functionality to zoom in on the plot"""
-        super(MultiAxisViewBoxMenu, self).set1ButtonMode()
+        super().set1ButtonMode()
         self.sigMouseModeChanged.emit("rect")
 
     def xAutoClicked(self):

--- a/pydm/widgets/nt_table.py
+++ b/pydm/widgets/nt_table.py
@@ -87,7 +87,7 @@ class PythonTableModel(QtCore.QAbstractTableModel):
 
     def headerData(self, section, orientation, role=QtCore.Qt.DisplayRole):
         if role != QtCore.Qt.DisplayRole:
-            return super(PythonTableModel, self).headerData(section, orientation, role)
+            return super().headerData(section, orientation, role)
         if orientation == QtCore.Qt.Horizontal and section < self.columnCount():
             return str(self._column_names[section])
         elif orientation == QtCore.Qt.Vertical and section < self.rowCount():
@@ -232,7 +232,7 @@ class PyDMNTTable(QtWidgets.QWidget, PyDMWritableWidget):
         if data is None:
             return
 
-        super(PyDMNTTable, self).value_changed(data)
+        super().value_changed(data)
 
         labels = data.get("labels", None)
         values = data.get("value", {})

--- a/pydm/widgets/qtplugin_base.py
+++ b/pydm/widgets/qtplugin_base.py
@@ -82,7 +82,7 @@ def qtplugin_factory(
         __doc__ = "PyDMDesigner Plugin for {}".format(cls.__name__)
 
         def __init__(self):
-            super(Plugin, self).__init__(cls, is_container, group, extensions, icon)
+            super().__init__(cls, is_container, group, extensions, icon)
 
     return Plugin
 

--- a/pydm/widgets/qtplugin_extensions.py
+++ b/pydm/widgets/qtplugin_extensions.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 
 class PyDMExtensionFactory(QExtensionFactory):
     def __init__(self, parent=None):
-        super(PyDMExtensionFactory, self).__init__(parent)
+        super().__init__(parent)
 
     def createExtension(self, obj, iid, parent):
         if not isinstance(obj, PyDMPrimitiveWidget):
@@ -40,7 +40,7 @@ class PyDMExtensionFactory(QExtensionFactory):
 
 class PyDMTaskMenuExtension(QPyDesignerTaskMenuExtension):
     def __init__(self, widget, parent):
-        super(PyDMTaskMenuExtension, self).__init__(parent)
+        super().__init__(parent)
 
         self.widget = widget
         self.__actions = None
@@ -77,7 +77,7 @@ class PyDMExtension(object):
 
 class BasicSettingsExtension(PyDMExtension):
     def __init__(self, widget):
-        super(BasicSettingsExtension, self).__init__(widget)
+        super().__init__(widget)
         self.widget = widget
         self.edit_settings_action = QtWidgets.QAction("Py&DM basic settings...", self.widget)
         self.edit_settings_action.triggered.connect(self.open_dialog)
@@ -132,7 +132,7 @@ class BasicSettingsExtension(PyDMExtension):
 
 class RulesExtension(PyDMExtension):
     def __init__(self, widget):
-        super(RulesExtension, self).__init__(widget)
+        super().__init__(widget)
         self.widget = widget
         self.edit_rules_action = QtWidgets.QAction("Edit Rules...", self.widget)
         self.edit_rules_action.triggered.connect(self.edit_rules)
@@ -147,7 +147,7 @@ class RulesExtension(PyDMExtension):
 
 class SymbolExtension(PyDMExtension):
     def __init__(self, widget):
-        super(SymbolExtension, self).__init__(widget)
+        super().__init__(widget)
         self.widget = widget
         self.edit_symbols_action = QtWidgets.QAction("Edit Symbols...", self.widget)
         self.edit_symbols_action.triggered.connect(self.edit_symbols)
@@ -162,7 +162,7 @@ class SymbolExtension(PyDMExtension):
 
 class BasePlotExtension(PyDMExtension):
     def __init__(self, widget, curve_editor_class):
-        super(BasePlotExtension, self).__init__(widget)
+        super().__init__(widget)
         self.widget = widget
         self.curve_editor_class = curve_editor_class
         self.edit_curves_action = QtWidgets.QAction("Edit Curves...", self.widget)
@@ -178,24 +178,24 @@ class BasePlotExtension(PyDMExtension):
 
 class WaveformCurveEditorExtension(BasePlotExtension):
     def __init__(self, widget):
-        super(WaveformCurveEditorExtension, self).__init__(widget, WaveformPlotCurveEditorDialog)
+        super().__init__(widget, WaveformPlotCurveEditorDialog)
 
 
 class ArchiveTimeCurveEditorExtension(BasePlotExtension):
     def __init__(self, widget):
-        super(ArchiveTimeCurveEditorExtension, self).__init__(widget, ArchiverTimePlotCurveEditorDialog)
+        super().__init__(widget, ArchiverTimePlotCurveEditorDialog)
 
 
 class TimeCurveEditorExtension(BasePlotExtension):
     def __init__(self, widget):
-        super(TimeCurveEditorExtension, self).__init__(widget, TimePlotCurveEditorDialog)
+        super().__init__(widget, TimePlotCurveEditorDialog)
 
 
 class ScatterCurveEditorExtension(BasePlotExtension):
     def __init__(self, widget):
-        super(ScatterCurveEditorExtension, self).__init__(widget, ScatterPlotCurveEditorDialog)
+        super().__init__(widget, ScatterPlotCurveEditorDialog)
 
 
 class EventCurveEditorExtension(BasePlotExtension):
     def __init__(self, widget):
-        super(EventCurveEditorExtension, self).__init__(widget, EventPlotCurveEditorDialog)
+        super().__init__(widget, EventPlotCurveEditorDialog)

--- a/pydm/widgets/related_display_button.py
+++ b/pydm/widgets/related_display_button.py
@@ -458,7 +458,7 @@ class PyDMRelatedDisplayButton(QPushButton, PyDMWidget):
             self._shift_key_was_down = True
         else:
             self._shift_key_was_down = False
-        super(PyDMRelatedDisplayButton, self).mousePressEvent(event)
+        super().mousePressEvent(event)
 
     def push_button_release_event(self, mouse_event: QMouseEvent) -> None:
         """
@@ -477,7 +477,7 @@ class PyDMRelatedDisplayButton(QPushButton, PyDMWidget):
 
         """
         if mouse_event.button() != Qt.LeftButton:
-            return super(PyDMRelatedDisplayButton, self).mouseReleaseEvent(mouse_event)
+            return super().mouseReleaseEvent(mouse_event)
         if self.menu() is not None:
             return super(PyDMRelatedDisplayButton, self).mouseReleaseEvent(mouse_event)
         try:
@@ -487,7 +487,7 @@ class PyDMRelatedDisplayButton(QPushButton, PyDMWidget):
         except Exception:
             logger.exception("Failed to open display.")
         finally:
-            super(PyDMRelatedDisplayButton, self).mouseReleaseEvent(mouse_event)
+            super().mouseReleaseEvent(mouse_event)
 
     def validate_password(self) -> bool:
         """
@@ -616,7 +616,7 @@ class PyDMRelatedDisplayButton(QPushButton, PyDMWidget):
 
     def context_menu(self):
         try:
-            menu = super(PyDMRelatedDisplayButton, self).context_menu()
+            menu = super().context_menu()
         except Exception:
             menu = QMenu(self)
         if len(menu.findChildren(QAction)) > 0:

--- a/pydm/widgets/rules_editor.py
+++ b/pydm/widgets/rules_editor.py
@@ -20,7 +20,7 @@ class RulesEditor(QtWidgets.QDialog):
     """
 
     def __init__(self, widget, parent=None):
-        super(RulesEditor, self).__init__(parent)
+        super().__init__(parent)
 
         self.widget = widget
         self.lst_rule_item = None

--- a/pydm/widgets/scale.py
+++ b/pydm/widgets/scale.py
@@ -18,7 +18,7 @@ class QScale(QFrame):
     """
 
     def __init__(self, parent: Optional[QWidget] = None) -> None:
-        super(QScale, self).__init__(parent)
+        super().__init__(parent)
         self._value = 1
         self._lower_limit = -5
         self._upper_limit = 5
@@ -425,7 +425,7 @@ class PyDMScaleIndicator(QFrame, TextFormatter, PyDMWidget):
         new_value : int or float
             The new value from the channel.
         """
-        super(PyDMScaleIndicator, self).value_changed(new_value)
+        super().value_changed(new_value)
         self.scale_indicator.set_value(new_value)
         self.update_labels()
 
@@ -439,7 +439,7 @@ class PyDMScaleIndicator(QFrame, TextFormatter, PyDMWidget):
         ----------
         new_limit : float
         """
-        super(PyDMScaleIndicator, self).upperCtrlLimitChanged(new_limit)
+        super().upperCtrlLimitChanged(new_limit)
         if self.limitsFromChannel:
             self.scale_indicator.set_upper_limit(new_limit)
             self.update_labels()
@@ -454,7 +454,7 @@ class PyDMScaleIndicator(QFrame, TextFormatter, PyDMWidget):
         ----------
         new_limit : float
         """
-        super(PyDMScaleIndicator, self).lowerCtrlLimitChanged(new_limit)
+        super().lowerCtrlLimitChanged(new_limit)
         if self.limitsFromChannel:
             self.scale_indicator.set_lower_limit(new_limit)
             self.update_labels()

--- a/pydm/widgets/scatterplot.py
+++ b/pydm/widgets/scatterplot.py
@@ -45,7 +45,7 @@ class ScatterPlotCurveItem(BasePlotCurveItem):
             kws["symbol"] = "o"
         if "lineStyle" not in kws.keys():
             kws["lineStyle"] = Qt.NoPen
-        super(ScatterPlotCurveItem, self).__init__(**kws)
+        super().__init__(**kws)
         self.bufferSizeChannelAddress = bufferSizeChannelAddress
 
     def to_dict(self):
@@ -59,7 +59,7 @@ class ScatterPlotCurveItem(BasePlotCurveItem):
             needed to recreate this curve.
         """
         dic_ = OrderedDict([("y_channel", self.y_address), ("x_channel", self.x_address)])
-        dic_.update(super(ScatterPlotCurveItem, self).to_dict())
+        dic_.update(super().to_dict())
         dic_["redraw_mode"] = self.redraw_mode
         dic_["buffer_size"] = self.getBufferSize()
         dic_["bufferSizeChannelAddress"] = self.bufferSizeChannelAddress
@@ -341,7 +341,7 @@ class PyDMScatterPlot(BasePlot):
     """
 
     def __init__(self, parent=None, init_x_channels=[], init_y_channels=[], background="default"):
-        super(PyDMScatterPlot, self).__init__(parent, background)
+        super().__init__(parent, background)
         # If the user supplies a single string instead of a list,
         # wrap it in a list.
         if isinstance(init_x_channels, str):
@@ -495,7 +495,7 @@ class PyDMScatterPlot(BasePlot):
         """
         Remove all curves from the plot.
         """
-        super(PyDMScatterPlot, self).clear()
+        super().clear()
 
     def getCurves(self):
         """

--- a/pydm/widgets/scatterplot_curve_editor.py
+++ b/pydm/widgets/scatterplot_curve_editor.py
@@ -10,7 +10,7 @@ class PyDMScatterPlotCurvesModel(BasePlotCurvesModel):
     """
 
     def __init__(self, plot, parent=None):
-        super(PyDMScatterPlotCurvesModel, self).__init__(plot, parent=parent)
+        super().__init__(plot, parent=parent)
         self._column_names = ("Y Channel", "X Channel") + self._column_names
         self._column_names += ("Redraw Mode", "Buffer Size", "Buffer Size Channel")
 
@@ -29,7 +29,7 @@ class PyDMScatterPlotCurvesModel(BasePlotCurvesModel):
             return curve.getBufferSize()
         elif column_name == "Buffer Size Channel":
             return curve.bufferSizeChannelAddress or ""
-        return super(PyDMScatterPlotCurvesModel, self).get_data(column_name, curve)
+        return super().get_data(column_name, curve)
 
     def set_data(self, column_name, curve, value):
         if column_name == "Y Channel":
@@ -45,7 +45,7 @@ class PyDMScatterPlotCurvesModel(BasePlotCurvesModel):
                 value = None
             curve.bufferSizeChannelAddress = str(value)
         else:
-            return super(PyDMScatterPlotCurvesModel, self).set_data(column_name=column_name, curve=curve, value=value)
+            return super().set_data(column_name=column_name, curve=curve, value=value)
         return True
 
     def append(self, y_address=None, x_address=None, name=None, color=None):
@@ -71,7 +71,7 @@ class ScatterPlotCurveEditorDialog(BasePlotCurveEditorDialog):
     TABLE_MODEL_CLASS = PyDMScatterPlotCurvesModel
 
     def __init__(self, plot, parent=None):
-        super(ScatterPlotCurveEditorDialog, self).__init__(plot, parent)
+        super().__init__(plot, parent)
 
         redraw_mode_delegate = RedrawModeColumnDelegate(self)
         self.table_view.setItemDelegateForColumn(self.table_model.getColumnIndex("Redraw Mode"), redraw_mode_delegate)

--- a/pydm/widgets/shell_command.py
+++ b/pydm/widgets/shell_command.py
@@ -615,7 +615,7 @@ class PyDMShellCommand(QPushButton, PyDMWidget):
     def mousePressEvent(self, event: QMouseEvent) -> None:
         if self._menu_needs_rebuild:
             self._rebuild_menu()
-        super(PyDMShellCommand, self).mousePressEvent(event)
+        super().mousePressEvent(event)
 
     def mouseReleaseEvent(self, mouse_event: QMouseEvent) -> None:
         """
@@ -629,12 +629,12 @@ class PyDMShellCommand(QPushButton, PyDMWidget):
         mouse_event :
         """
         if mouse_event.button() != Qt.LeftButton:
-            return super(PyDMShellCommand, self).mouseReleaseEvent(mouse_event)
+            return super().mouseReleaseEvent(mouse_event)
         if self.menu() is not None:
-            return super(PyDMShellCommand, self).mouseReleaseEvent(mouse_event)
+            return super().mouseReleaseEvent(mouse_event)
         assert len(self.commands) == 1, "More than one command present, but no menu created."
         self.execute_command(self.commands[0])
-        super(PyDMShellCommand, self).mouseReleaseEvent(mouse_event)
+        super().mouseReleaseEvent(mouse_event)
 
     def show_warning_icon(self) -> None:
         """Show the warning icon.  This is called when a shell command fails

--- a/pydm/widgets/slider.py
+++ b/pydm/widgets/slider.py
@@ -325,7 +325,7 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget):
         if self._ignore_mouse_wheel:
             e.ignore()
         else:
-            super(PyDMSlider, self).wheelEvent(e)
+            super().wheelEvent(e)
         return
 
     def mousePressEvent(self, mouse_event):
@@ -773,7 +773,7 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget):
         connected : int
             When this value is 0 the channel is disconnected, 1 otherwise.
         """
-        super(PyDMSlider, self).connection_changed(connected)
+        super().connection_changed(connected)
         self.set_enable_state()
 
     def write_access_changed(self, new_write_access):
@@ -787,7 +787,7 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget):
         new_write_access : bool
             True if write operations to the channel are allowed.
         """
-        super(PyDMSlider, self).write_access_changed(new_write_access)
+        super().write_access_changed(new_write_access)
         self.set_enable_state()
 
     def value_changed(self, new_val):
@@ -849,7 +849,7 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget):
             The format string to be used including or not the precision
             and unit
         """
-        fs = super(PyDMSlider, self).update_format_string()
+        fs = super().update_format_string()
         self.update_labels()
         return fs
 

--- a/pydm/widgets/spinbox.py
+++ b/pydm/widgets/spinbox.py
@@ -45,7 +45,7 @@ class PyDMSpinbox(QDoubleSpinBox, TextFormatter, PyDMWritableWidget):
         ----------
         step: int
         """
-        super(PyDMSpinbox, self).stepBy(step)
+        super().stepBy(step)
         if self._write_on_press:
             self.send_value()
 
@@ -75,7 +75,7 @@ class PyDMSpinbox(QDoubleSpinBox, TextFormatter, PyDMWritableWidget):
             self.send_value()
 
         else:
-            super(PyDMSpinbox, self).keyPressEvent(ev)
+            super().keyPressEvent(ev)
 
     def widget_ctx_menu(self):
         """
@@ -144,7 +144,7 @@ class PyDMSpinbox(QDoubleSpinBox, TextFormatter, PyDMWritableWidget):
             # SpinBox is unable to work with None and
             # but sometimes it can arrive as an initial value
             return
-        super(PyDMSpinbox, self).value_changed(new_val)
+        super().value_changed(new_val)
         self.valueBeingSet = True
         self.setValue(new_val)
         self.valueBeingSet = False
@@ -259,7 +259,7 @@ class PyDMSpinbox(QDoubleSpinBox, TextFormatter, PyDMWritableWidget):
         new_limit : float
             New value for the control limit
         """
-        super(PyDMSpinbox, self).ctrl_limit_changed(which, new_limit)
+        super().ctrl_limit_changed(which, new_limit)
         if not self.userDefinedLimits:
             if which == "UPPER":
                 self.setMaximum(new_limit)
@@ -277,7 +277,7 @@ class PyDMSpinbox(QDoubleSpinBox, TextFormatter, PyDMWritableWidget):
         new_precison : int or float
             The new precision value
         """
-        super(PyDMSpinbox, self).precision_changed(new_precision)
+        super().precision_changed(new_precision)
         self.setDecimals(self.precision)
 
     @Property(int)

--- a/pydm/widgets/symbol.py
+++ b/pydm/widgets/symbol.py
@@ -157,7 +157,7 @@ class PyDMSymbol(QWidget, PyDMWidget):
         connected : int
             When this value is 0 the channel is disconnected, 1 otherwise.
         """
-        super(PyDMSymbol, self).connection_changed(connected)
+        super().connection_changed(connected)
         self.update()
 
     def value_changed(self, new_val):
@@ -169,7 +169,7 @@ class PyDMSymbol(QWidget, PyDMWidget):
         new_val : int
             The new value from the channel.
         """
-        super(PyDMSymbol, self).value_changed(new_val)
+        super().value_changed(new_val)
         self._current_key = new_val
         self.update()
 

--- a/pydm/widgets/symbol_editor.py
+++ b/pydm/widgets/symbol_editor.py
@@ -21,7 +21,7 @@ class SymbolEditor(QtWidgets.QDialog):
     """
 
     def __init__(self, widget, parent=None):
-        super(SymbolEditor, self).__init__(parent)
+        super().__init__(parent)
 
         self.widget = widget
         self.lst_file_item = None

--- a/pydm/widgets/tab_bar.py
+++ b/pydm/widgets/tab_bar.py
@@ -12,7 +12,7 @@ class PyDMTabBar(QTabBar, PyDMWidget):
     """PyDMTabBar is used internally by PyDMTabWidget, and shouldn't be directly used on its own."""
 
     def __init__(self, parent=None):
-        super(PyDMTabBar, self).__init__(parent=parent)
+        super().__init__(parent=parent)
         self.tab_channels = {}
         self.tab_connection_status = {}
         self.tab_alarm_severity = {}
@@ -104,7 +104,7 @@ class PyDMTabBar(QTabBar, PyDMWidget):
             self.setTabIcon(index, self.alarm_icons[icon_index])
 
     def tabInserted(self, index):
-        super(PyDMTabBar, self).tabInserted(index)
+        super().tabInserted(index)
         if index not in self.tab_channels:
             self.tab_channels[index] = {"address": ""}
         self.set_initial_icon_for_tab(index)
@@ -184,7 +184,7 @@ class PyDMTabWidget(QTabWidget):
     """
 
     def __init__(self, parent=None):
-        super(PyDMTabWidget, self).__init__(parent=parent)
+        super().__init__(parent=parent)
         self.tb = PyDMTabBar(parent=self)
         self.setTabBar(self.tb)
 

--- a/pydm/widgets/tab_bar_qtplugin.py
+++ b/pydm/widgets/tab_bar_qtplugin.py
@@ -9,7 +9,7 @@ class TabWidgetPlugin(PyDMDesignerPlugin):
     TabClass = PyDMTabWidget
 
     def __init__(self, extensions=None):
-        super(TabWidgetPlugin, self).__init__(self.TabClass, group=WidgetCategory.CONTAINER, extensions=extensions)
+        super().__init__(self.TabClass, group=WidgetCategory.CONTAINER, extensions=extensions)
 
     def domXml(self):
         """

--- a/pydm/widgets/template_repeater.py
+++ b/pydm/widgets/template_repeater.py
@@ -62,7 +62,7 @@ class FlowLayout(QLayout):
         return self.do_layout(QRect(0, 0, width, 0), True)
 
     def setGeometry(self, rect):
-        super(FlowLayout, self).setGeometry(rect)
+        super().setGeometry(rect)
         self.do_layout(rect, False)
 
     def sizeHint(self):

--- a/pydm/widgets/terminator.py
+++ b/pydm/widgets/terminator.py
@@ -20,7 +20,7 @@ class PyDMTerminator(QLabel, PyDMPrimitiveWidget):
     """
 
     def __init__(self, parent=None, timeout=60, *args, **kwargs):
-        super(PyDMTerminator, self).__init__(parent=parent, *args, **kwargs)
+        super().__init__(parent=parent, *args, **kwargs)
         self.setText("")
         self._hook_setup = False
         self._timeout = 60
@@ -85,7 +85,7 @@ class PyDMTerminator(QLabel, PyDMPrimitiveWidget):
     def eventFilter(self, obj, ev):
         if ev.type() in (QEvent.MouseMove, QEvent.KeyPress, QEvent.KeyRelease):
             self.reset()
-        return super(PyDMTerminator, self).eventFilter(obj, ev)
+        return super().eventFilter(obj, ev)
 
     def reset(self):
         if self._time_rem_ms != self._timeout * 1000:

--- a/pydm/widgets/timeplot.py
+++ b/pydm/widgets/timeplot.py
@@ -115,12 +115,12 @@ class TimePlotCurveItem(BasePlotCurveItem):
         self.channel = None
         self.units = ""
 
-        super(TimePlotCurveItem, self).__init__(**kws)
+        super().__init__(**kws)
         self.address = channel_address
 
     def to_dict(self):
         dic_ = OrderedDict([("channel", self.address), ("plot_style", self.plot_style)])
-        dic_.update(super(TimePlotCurveItem, self).to_dict())
+        dic_.update(super().to_dict())
         return dic_
 
     @property
@@ -490,9 +490,7 @@ class PyDMTimePlot(BasePlot):
             self.starting_epoch_time = time.time()
             self._bottom_axis = AxisItem("bottom")
 
-        super(PyDMTimePlot, self).__init__(
-            parent=parent, background=background, axisItems={"bottom": self._bottom_axis}
-        )
+        super().__init__(parent=parent, background=background, axisItems={"bottom": self._bottom_axis})
 
         # Removing the downsampling while PR 763 is not merged at pyqtgraph
         # Reference: https://github.com/pyqtgraph/pyqtgraph/pull/763
@@ -529,7 +527,7 @@ class PyDMTimePlot(BasePlot):
         """Adds attribute specific to TimePlot to add onto BasePlot's to_dict.
         This helps to recreate the Plot Config if we import a save file of it"""
         dic_ = OrderedDict([("refreshInterval", self.auto_scroll_timer.interval() / 1000)])
-        dic_.update(super(PyDMTimePlot, self).to_dict())
+        dic_.update(super().to_dict())
         return dic_
 
     def initialize_for_designer(self):
@@ -722,7 +720,7 @@ class PyDMTimePlot(BasePlot):
         """
         Remove all curves from the graph.
         """
-        super(PyDMTimePlot, self).clear()
+        super().clear()
 
     def getCurves(self):
         """
@@ -1071,14 +1069,14 @@ class PyDMTimePlot(BasePlot):
     def getAutoRangeX(self):
         if self._plot_by_timestamps:
             return False
-        return super(PyDMTimePlot, self).getAutoRangeX()
+        return super().getAutoRangeX()
 
     def setAutoRangeX(self, value):
         if self._plot_by_timestamps:
             self._auto_range_x = False
             self.plotItem.enableAutoRange(ViewBox.XAxis, enable=self._auto_range_x)
         else:
-            super(PyDMTimePlot, self).setAutoRangeX(value)
+            super().setAutoRangeX(value)
 
     def channels(self):
         return [curve.channel for curve in self._curves]
@@ -1143,7 +1141,7 @@ class PyDMTimePlot(BasePlot):
         horizontal_movable : bool
             True if the user can move the horizontal line; False if not
         """
-        super(PyDMTimePlot, self).enableCrosshair(
+        super().enableCrosshair(
             is_enabled,
             starting_x_pos,
             starting_y_pos,
@@ -1160,7 +1158,7 @@ class TimeAxisItem(AxisItem):
     """
 
     def __init__(self, *args, **kwargs):
-        super(TimeAxisItem, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.enableAutoSIPrefix(False)
 
     def tickStrings(self, values, scale, spacing):

--- a/pydm/widgets/timeplot_curve_editor.py
+++ b/pydm/widgets/timeplot_curve_editor.py
@@ -7,7 +7,7 @@ from .timeplot import PyDMTimePlot
 
 class PyDMTimePlotCurvesModel(BasePlotCurvesModel):
     def __init__(self, plot, parent=None):
-        super(PyDMTimePlotCurvesModel, self).__init__(plot, parent=parent)
+        super().__init__(plot, parent=parent)
         self._column_names = ("Channel", "Style") + self._column_names
 
     def get_data(self, column_name, curve):
@@ -17,7 +17,7 @@ class PyDMTimePlotCurvesModel(BasePlotCurvesModel):
             return str(curve.address)
         elif column_name == "Style":
             return curve.plot_style
-        return super(PyDMTimePlotCurvesModel, self).get_data(column_name, curve)
+        return super().get_data(column_name, curve)
 
     def set_data(self, column_name, curve, value):
         if column_name == "Channel":
@@ -25,7 +25,7 @@ class PyDMTimePlotCurvesModel(BasePlotCurvesModel):
         elif column_name == "Style":
             curve.plot_style = str(value)
         else:
-            return super(PyDMTimePlotCurvesModel, self).set_data(column_name=column_name, curve=curve, value=value)
+            return super().set_data(column_name=column_name, curve=curve, value=value)
         return True
 
     def append(self, address=None, name=None, color=None):

--- a/pydm/widgets/waveformplot.py
+++ b/pydm/widgets/waveformplot.py
@@ -75,7 +75,7 @@ class WaveformCurveItem(BasePlotCurveItem):
         self.latest_y = None
         self.plot_style = plot_style
 
-        super(WaveformCurveItem, self).__init__(**kws)
+        super().__init__(**kws)
 
     def to_dict(self):
         """
@@ -89,7 +89,7 @@ class WaveformCurveItem(BasePlotCurveItem):
         dic_ = OrderedDict(
             [("y_channel", self.y_address), ("x_channel", self.x_address), ("plot_style", self.plot_style)]
         )
-        dic_.update(super(WaveformCurveItem, self).to_dict())
+        dic_.update(super().to_dict())
         dic_["redraw_mode"] = self.redraw_mode
         return dic_
 
@@ -337,7 +337,7 @@ class PyDMWaveformPlot(BasePlot):
     """
 
     def __init__(self, parent=None, init_x_channels=[], init_y_channels=[], background="default"):
-        super(PyDMWaveformPlot, self).__init__(parent, background)
+        super().__init__(parent, background)
         # If the user supplies a single string instead of a list,
         # wrap it in a list.
         if isinstance(init_x_channels, str):
@@ -504,7 +504,7 @@ class PyDMWaveformPlot(BasePlot):
         """
         Remove all curves from the plot.
         """
-        super(PyDMWaveformPlot, self).clear()
+        super().clear()
 
     def getCurves(self):
         """

--- a/pydm/widgets/waveformplot_curve_editor.py
+++ b/pydm/widgets/waveformplot_curve_editor.py
@@ -16,7 +16,7 @@ class PyDMWaveformPlotCurvesModel(BasePlotCurvesModel):
     """
 
     def __init__(self, plot, parent=None):
-        super(PyDMWaveformPlotCurvesModel, self).__init__(plot, parent=parent)
+        super().__init__(plot, parent=parent)
         self._column_names = ("Y Channel", "X Channel", "Style") + self._column_names
         self._column_names += ("Redraw Mode",)
 
@@ -33,7 +33,7 @@ class PyDMWaveformPlotCurvesModel(BasePlotCurvesModel):
             return curve.plot_style
         elif column_name == "Redraw Mode":
             return curve.redraw_mode
-        return super(PyDMWaveformPlotCurvesModel, self).get_data(column_name, curve)
+        return super().get_data(column_name, curve)
 
     def set_data(self, column_name, curve, value):
         if column_name == "Y Channel":
@@ -45,7 +45,7 @@ class PyDMWaveformPlotCurvesModel(BasePlotCurvesModel):
         elif column_name == "Redraw Mode":
             curve.redraw_mode = int(value)
         else:
-            return super(PyDMWaveformPlotCurvesModel, self).set_data(column_name=column_name, curve=curve, value=value)
+            return super().set_data(column_name=column_name, curve=curve, value=value)
         return True
 
     def append(self, y_address=None, x_address=None, name=None, color=None):


### PR DESCRIPTION
The background on this patch is that running on pyside6 exposes some weirdness with how we are doing super() \_\_init\_\_ calls, so this comes as some cleanup before another fix that will follow.

these calls are equivalent (in python3):
python2 style: `super(ClassName, self).__init__()`
python3 style: `super().__init__()`

While these python2 style calls work on python3, the new way is cleaner and imo it's best to follow python3's conventions as we officially don't support python2.

references:
https://docs.python.org/3/library/functions.html#super 
https://stackoverflow.com/a/19776143