### PR TITLE
MNT: parent args passed into Qt provided class __init__ should be positional args not use keyword arguments

### DIFF
--- a/pydm/widgets/datetime.py
+++ b/pydm/widgets/datetime.py
@@ -50,8 +50,10 @@ class PyDMDateTimeEdit(QtWidgets.QDateTimeEdit, PyDMWritableWidget):
         self._block_past_date = True
         self._relative = True
         self._time_base = TimeBase.Milliseconds
-
-        QtWidgets.QDateTimeEdit.__init__(self, parent=parent)
+        # We can't do 'parent=parent' here since its only a positional argument, since the python qt
+        # docs can sometimes be sparse you can use python's inspect module to see function's arg details,
+        # like 'print(inspect.signature(QLabel.__init__)'
+        QtWidgets.QDateTimeEdit.__init__(self, parent)
         PyDMWritableWidget.__init__(self, init_channel=init_channel)
         self.setDisplayFormat("yyyy/MM/dd hh:mm:ss.zzz")
         self.setDateTime(QtCore.QDateTime.currentDateTime())
@@ -121,9 +123,9 @@ class PyDMDateTimeEdit(QtWidgets.QDateTimeEdit, PyDMWritableWidget):
 
         val = QtCore.QDateTime.currentDateTime()
         if self._relative:
-            val = val.addMSecs(new_val)
+            val = val.addMSecs(int(new_val))
         else:
-            val.setMSecsSinceEpoch(new_val)
+            val.setMSecsSinceEpoch(int(new_val))
         self.setDateTime(val)
 
 
@@ -150,7 +152,10 @@ class PyDMDateTimeLabel(QtWidgets.QLabel, PyDMWidget):
     """
 
     def __init__(self, parent=None, init_channel=None):
-        QtWidgets.QLabel.__init__(self, parent=parent)
+        # We can't do 'parent=parent' here since its only a positional argument, since the python qt
+        # docs can sometimes be sparse you can use python's inspect module to see function's arg details,
+        # like 'print(inspect.signature(QLabel.__init__)'
+        QtWidgets.QLabel.__init__(self, parent)
         PyDMWidget.__init__(self, init_channel=init_channel)
 
         self._block_past_date = True
@@ -201,7 +206,7 @@ class PyDMDateTimeLabel(QtWidgets.QLabel, PyDMWidget):
 
         val = QtCore.QDateTime.currentDateTime()
         if self._relative:
-            val = val.addMSecs(new_val)
+            val = val.addMSecs(int(new_val))
         else:
-            val.setMSecsSinceEpoch(new_val)
+            val.setMSecsSinceEpoch(int(new_val))
         self.setText(val.toString(self.textFormat))

--- a/pydm/widgets/logdisplay.py
+++ b/pydm/widgets/logdisplay.py
@@ -69,8 +69,11 @@ class GuiHandler(QObject, logging.Handler):
     message = Signal(str)
 
     def __init__(self, level=logging.NOTSET, parent=None):
-        logging.Handler.__init__(self, level=level)
-        QObject.__init__(self, parent=parent)
+        # We can't do 'arg=arg' here since they are only positionals argument, since the python qt
+        # docs can sometimes be sparse you can use python's inspect module to see function's arg details,
+        # like 'print(inspect.signature(QLabel.__init__)'
+        logging.Handler.__init__(self, level)
+        QObject.__init__(self, parent)
 
     def emit(self, record):
         """Emit formatted log messages when received but only if level is set."""

--- a/pydm/widgets/tab_bar.py
+++ b/pydm/widgets/tab_bar.py
@@ -12,7 +12,10 @@ class PyDMTabBar(QTabBar, PyDMWidget):
     """PyDMTabBar is used internally by PyDMTabWidget, and shouldn't be directly used on its own."""
 
     def __init__(self, parent=None):
-        super(PyDMTabBar, self).__init__(parent=parent)
+        # We can't do 'parent=parent' here since its only a positional argument, since the python qt
+        # docs can sometimes be sparse you can use python's inspect module to see function's arg details,
+        # like 'print(inspect.signature(QLabel.__init__)'
+        super(PyDMTabBar, self).__init__(parent)
         self.tab_channels = {}
         self.tab_connection_status = {}
         self.tab_alarm_severity = {}


### PR DESCRIPTION
This stops the following type of error on pyside6:
```
QtWidgets.QDateTimeEdit.__init__(self, parent=parent)
TypeError: PyDMWritableWidget.__init__() got an unexpected keyword argument 'parent'
```


For context:
- Positional args: Func(1, 2)
- Keyword args: Func(a=1, b=2)

pyqt5 works still if we use the keyword argument 'parent' for super calls to qt provided classes  \_\_init\_\_ calls, but pyside6 throws an error (it generally seems a bit more strict about things).

You can inspect an \_\_init\_\_ call (ex: 'print(inspect.signature(QLabel.\_\_init\_\_))') to see if/what keyword arguments are accepted by it.

The \_\_init\_\_ calls changed in this patch don't accept a 'parent' keyword arg, just a positional arg for it.

Also use int casting to avoid type erros in datetime widget.