### PR TITLE
wip

### DIFF
--- a/pydm/widgets/baseplot.py
+++ b/pydm/widgets/baseplot.py
@@ -681,7 +681,7 @@ class BasePlotAxisItem(AxisItem):
         )
 
 
-class BasePlot(PlotWidget, PyDMPrimitiveWidget):
+class BasePlot(PyDMPrimitiveWidget, PlotWidget):
     crosshair_position_updated = Signal(float, float)
     """
     BasePlot is the parent class for all specific types of PyDM plots. It is built on top of the
@@ -711,7 +711,8 @@ class BasePlot(PlotWidget, PyDMPrimitiveWidget):
             # The pyqtgraph PlotItem.setAxisItems() will always add an an AxisItem called left whether you asked
             # it to or not. This will clear it if not specifically requested.
             plotItem.removeAxis("left")
-        super(BasePlot, self).__init__(parent=parent, background=background, plotItem=plotItem)
+        PlotWidget.__init__(self, background=background, plotItem=plotItem)
+        PyDMPrimitiveWidget.__init__(parent)
 
         self.plotItem = plotItem
         self.plotItem.hideButtons()

--- a/pydm/widgets/byte.py
+++ b/pydm/widgets/byte.py
@@ -66,7 +66,7 @@ class PyDMBitIndicator(QWidget):
         return QSize(fm.height(), fm.height())
 
 
-class PyDMByteIndicator(QWidget, PyDMWidget):
+class PyDMByteIndicator(PyDMWidget, QWidget):
     """
     Widget for graphical representation of bits from an integer number
     with support for Channels and more from PyDM
@@ -557,7 +557,7 @@ class PyDMByteIndicator(QWidget, PyDMWidget):
                 self.update_indicators()
 
 
-class PyDMMultiStateIndicator(QWidget, PyDMWidget):
+class PyDMMultiStateIndicator(PyDMWidget, QWidget):
     """
     Widget with 16 available states that are set by the connected channel.
     Each state represents a different color that can be configured.

--- a/pydm/widgets/checkbox.py
+++ b/pydm/widgets/checkbox.py
@@ -2,7 +2,7 @@ from qtpy.QtWidgets import QCheckBox
 from .base import PyDMWritableWidget
 
 
-class PyDMCheckbox(QCheckBox, PyDMWritableWidget):
+class PyDMCheckbox(PyDMWritableWidget, QCheckBox):
     """
     A QCheckbox with support for Channels and more from PyDM
 

--- a/pydm/widgets/drawing.py
+++ b/pydm/widgets/drawing.py
@@ -59,7 +59,7 @@ def qt_to_deg(deg):
     return deg / 16.0
 
 
-class PyDMDrawing(QWidget, PyDMWidget):
+class PyDMDrawing(PyDMWidget, QWidget):
     """
     Base class to be used for all PyDM Drawing Widgets.
     This class inherits from QWidget and PyDMWidget.

--- a/pydm/widgets/embedded_display.py
+++ b/pydm/widgets/embedded_display.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 _embeddedDisplayRuleProperties = {"Filename": ["filename", str]}
 
 
-class PyDMEmbeddedDisplay(QFrame, PyDMPrimitiveWidget):
+class PyDMEmbeddedDisplay(PyDMPrimitiveWidget, QFrame):
     """
     A QFrame capable of rendering a PyDM Display
 

--- a/pydm/widgets/enum_button.py
+++ b/pydm/widgets/enum_button.py
@@ -30,7 +30,7 @@ class_for_type = [QPushButton, QRadioButton]
 logger = logging.getLogger(__name__)
 
 
-class PyDMEnumButton(QWidget, PyDMWritableWidget):
+class PyDMEnumButton(PyDMWritableWidget, QWidget):
     """
     A QWidget that renders buttons for every option of Enum Items.
     For now, two types of buttons can be rendered:

--- a/pydm/widgets/enum_combo_box.py
+++ b/pydm/widgets/enum_combo_box.py
@@ -8,7 +8,7 @@ from .. import data_plugins
 logger = logging.getLogger(__name__)
 
 
-class PyDMEnumComboBox(QComboBox, PyDMWritableWidget):
+class PyDMEnumComboBox(PyDMWritableWidget, QComboBox):
     """
     A QComboBox with support for Channels and more from PyDM
 

--- a/pydm/widgets/frame.py
+++ b/pydm/widgets/frame.py
@@ -3,7 +3,7 @@ from qtpy.QtCore import Property
 from .base import PyDMWidget
 
 
-class PyDMFrame(QFrame, PyDMWidget):
+class PyDMFrame(PyDMWidget, QFrame):
     """
     QFrame with support for alarms
     This class inherits from QFrame and PyDMWidget.

--- a/pydm/widgets/image.py
+++ b/pydm/widgets/image.py
@@ -121,7 +121,7 @@ class ImageUpdateThread(QThread):
         self.image_view.needs_redraw = False
 
 
-class PyDMImageView(ImageView, PyDMWidget):
+class PyDMImageView(PyDMWidget, ImageView):
     """
     A PyQtGraph ImageView with support for Channels and more from PyDM.
 

--- a/pydm/widgets/pushbutton.py
+++ b/pydm/widgets/pushbutton.py
@@ -11,7 +11,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-class PyDMPushButton(QPushButton, PyDMWritableWidget):
+class PyDMPushButton(PyDMWritableWidget, QPushButton):
     """
     Basic PushButton to send a fixed value.
 

--- a/pydm/widgets/related_display_button.py
+++ b/pydm/widgets/related_display_button.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 _relatedDisplayRuleProperties = {"Text": ["setText", str], "Filenames": ["filenames", list]}
 
 
-class PyDMRelatedDisplayButton(QPushButton, PyDMWidget):
+class PyDMRelatedDisplayButton(PyDMWidget, QPushButton):
     """
     A QPushButton capable of opening a new Display in the same or a new window.
 

--- a/pydm/widgets/shell_command.py
+++ b/pydm/widgets/shell_command.py
@@ -40,7 +40,7 @@ if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
         STORE = 2
 
 
-class PyDMShellCommand(QPushButton, PyDMWidget):
+class PyDMShellCommand(PyDMWidget, QPushButton):
     """
     A QPushButton capable of execute shell commands.
 

--- a/pydm/widgets/symbol.py
+++ b/pydm/widgets/symbol.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 _symbolRuleProperties = {"Index": ["set_current_key", int]}
 
 
-class PyDMSymbol(QWidget, PyDMWidget):
+class PyDMSymbol(PyDMWidget, QWidget):
     """
     PyDMSymbol will render an image (symbol) for each value of a channel.
 

--- a/pydm/widgets/template_repeater.py
+++ b/pydm/widgets/template_repeater.py
@@ -133,7 +133,7 @@ if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
 layout_class_for_type = (QVBoxLayout, QHBoxLayout, FlowLayout)
 
 
-class PyDMTemplateRepeater(QFrame, PyDMPrimitiveWidget):
+class PyDMTemplateRepeater(PyDMPrimitiveWidget, QFrame):
     """
     PyDMTemplateRepeater takes a .ui file with macro variables as a template, and a JSON
     file (or a list of dictionaries) with a list of values to use to fill in

--- a/pydm/widgets/waveformtable.py
+++ b/pydm/widgets/waveformtable.py
@@ -5,7 +5,7 @@ import numpy as np
 from .base import PyDMWritableWidget
 
 
-class PyDMWaveformTable(QTableWidget, PyDMWritableWidget):
+class PyDMWaveformTable(PyDMWritableWidget, QTableWidget):
     """
     A QTableWidget with support for Channels and more from PyDM.
 


### PR DESCRIPTION
In python, the 'mro' of a python class is determined by the ordering in its definition of the classes it inherits from, for ex:

class PyDMByteIndicator(PyDMWidget, QWidget):
->  Method resolution order:
 |      PyDMByteIndicator
 |      pydm.widgets.base.PyDMWidget
 |      pydm.widgets.base.PyDMPrimitiveWidget
 |      PySide6.QtWidgets.QWidget
 |      PySide6.QtCore.QObject
 |      PySide6.QtGui.QPaintDevice
 |      Shiboken.Object
 |      builtins.object

This ordering will effect which parent class __init__ call will be done first when doing 'super().__init__()'

This ordering effects some other things too, such as if both parent classes have a same named function it decides which gets executed.

When using PySide6, we get thrown an error if the mro of classes that inherit from both a PyDM widget and a Qt widget does not have the Qt widget resolving fist, so for ex we must have:

class PyDMByteIndicator(QWidget, PyDMWidget): # swap ordering of inherited classes ->  Method resolution order:
 |      PyDMByteIndicator
 |      PyQt5.QtWidgets.QWidget # Qt class initialized first
 |      PyQt5.QtCore.QObject
 |      sip.wrapper
 |      PyQt5.QtGui.QPaintDevice
 |      sip.simplewrapper
 |      pydm.widgets.base.PyDMWidget # PyDM class initialized second
 |      pydm.widgets.base.PyDMPrimitiveWidget
 |      builtins.object

This is b/c our PyDM widget __init__ methods make calls that require it's Qt parent-class to have been initialized first. (ex: self.installEventFilter(self)). And while we do explicitly call the parent class __init__ functions in the correct ordering, for ex:

    def __init__(self, parent: Optional[QWidget] = None, init_channel=None):
        QWidget.__init__(self, parent)
        PyDMWidget.__init__(self, init_channel=init_channel)

this doesn't seem to convince PySide6 that the initialization will happen in the correct ordering. Only the mro ordering being correct appeases PySide6 and stops the error.

Note: we can't use 'super().__init__()' here and rely solely on the mro to resolve the ordering, for example in this case b/c QWidget __init__ takes a positional arg and PyDMWidget's takes a different named arg.