### PR TITLE
FIX: Ensure previous instance of display class is fully cleaned up after reloading it

### DIFF
--- a/pydm/main_window.py
+++ b/pydm/main_window.py
@@ -434,6 +434,10 @@ class PyDMMainWindow(QMainWindow):
             logger.error("The display manager does not have a display loaded.")
             return
 
+        # Ensure the existing display is cleared out of the home widget attribute when it is reloaded
+        if curr_display == self.home_widget:
+            self.home_widget = None
+
         prev_display = curr_display.previous_display
         next_display = curr_display.next_display
 


### PR DESCRIPTION
## Context

Fixes #1114 

As suspected in #1114, the previous instance of the Display class was not getting garbage collected when using reload display. Checking what still had references to it after a reload showed that it was only the `PyDMMainWindow.home_widget` which still had a reference to it.

Fix is to clear that out during the reload. The home widget will get correctly set to the refreshed version of the display later on as part of the reload process so the home button continues to work fine after this change.

## Testing

Verified that the test display from #1114 now only ticks once per second after reloading when applying this fix. Added a unit test that catches this issue, fails prior to this fix, and passes after.