### PR TITLE
BUG: connect BasePlotAxisItem auto-range methods to the linked ViewBox auto-range methods

### DIFF
--- a/pydm/widgets/baseplot.py
+++ b/pydm/widgets/baseplot.py
@@ -457,8 +457,6 @@ class BasePlotAxisItem(AxisItem):
         The minimum value to be displayed on this axis
     maxRange: float, optional
         The maximum value to be displayed on this axis
-    autoRange: bool, optional
-        Whether or not this axis should automatically update its range as it receives new data
     logMode: bool, optional
         If true, this axis will start in logarithmic mode, will be linear otherwise
     **kws: optional
@@ -477,7 +475,6 @@ class BasePlotAxisItem(AxisItem):
         label: Optional[str] = None,
         minRange: Optional[float] = -1.0,
         maxRange: Optional[float] = 1.0,
-        autoRange: Optional[bool] = True,
         logMode: Optional[bool] = False,
         **kws,
     ) -> None:
@@ -486,7 +483,6 @@ class BasePlotAxisItem(AxisItem):
         self._name = name
         self._orientation = orientation
         self._label = label
-        self._auto_range = autoRange
         self._log_mode = logMode
         self.setRange(minRange, maxRange)
 
@@ -610,7 +606,11 @@ class BasePlotAxisItem(AxisItem):
         -------
         bool
         """
-        return self._auto_range
+        if self.orientation == "left" or self.orientation == "right":
+            axis = ViewBox.YAxis
+        elif self.orientation == "top" or self.orientation == "bottom":
+            axis = ViewBox.XAxis
+        return bool(self.linkedView().autoRangeEnabled()[axis])  # ViewBox axes map to 0 and 1
 
     @auto_range.setter
     def auto_range(self, auto_range: bool) -> None:
@@ -621,7 +621,11 @@ class BasePlotAxisItem(AxisItem):
         ----------
         auto_range: bool
         """
-        self._auto_range = auto_range
+        if self.orientation == "left" or self.orientation == "right":
+            axis = ViewBox.YAxis
+        elif self.orientation == "top" or self.orientation == "bottom":
+            axis = ViewBox.XAxis
+        self.linkedView().enableAutoRange(axis, auto_range)
 
     @property
     def log_mode(self) -> bool:
@@ -676,7 +680,7 @@ class BasePlotAxisItem(AxisItem):
                 ("label", self._label),
                 ("minRange", self.range[0]),
                 ("maxRange", self.range[1]),
-                ("autoRange", self._auto_range),
+                ("autoRange", self.auto_range),
                 ("logMode", self._log_mode),
             ]
         )

--- a/pydm/widgets/baseplot.py
+++ b/pydm/widgets/baseplot.py
@@ -490,8 +490,10 @@ class BasePlotAxisItem(AxisItem):
         if oldView := self.linkedView():
             oldView.sigXRangeChanged.disconnect(self.sigXRangeChanged.emit)
             oldView.sigYRangeChanged.disconnect(self.sigYRangeChanged.emit)
+            oldView.sigRangeChangedManually.disconnect(self.disable_auto_range)
         view.sigXRangeChanged.connect(self.sigXRangeChanged.emit)
         view.sigYRangeChanged.connect(self.sigYRangeChanged.emit)
+        view.sigRangeChangedManually.connect(self.disable_auto_range)
         super().linkToView(view)
 
     @property
@@ -626,6 +628,12 @@ class BasePlotAxisItem(AxisItem):
         elif self.orientation == "top" or self.orientation == "bottom":
             axis = ViewBox.XAxis
         self.linkedView().enableAutoRange(axis, auto_range)
+
+    def disable_auto_range(self) -> None:
+        self.auto_range = False
+
+    def enable_auto_range(self) -> None:
+        self.auto_range = True
 
     @property
     def log_mode(self) -> bool:


### PR DESCRIPTION
## Context
`BasePlotAxisItem.auto_range` was never being read, so setting auto-range to `True` or `False` had no effect on the drawn plot.  By passing assignments on to the linked `ViewBox`, setting auto-range in the baseplot does effect the range of the drawn plot.

Auto-range is also disabled whenever the plot range is manually adjusted.  This is achieved by connecting to `ViewBox.sigRangeChangedManually`.