### PR TITLE
MNT: fix precommit config, make all imports absolute with ruff + precommit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,4 +15,4 @@ repos:
     rev: v0.0.287
     hooks:
     -   id: ruff
-        args: [--line-length, '120', --fix, --exit-non-zero-on-fix]
+        args: [--line-length, '120', --fix, --exit-non-zero-on-fix, --select, TID] # TID = fix and enforce absolute imports

--- a/examples/testing_ioc/rpc_testing_ioc.py
+++ b/examples/testing_ioc/rpc_testing_ioc.py
@@ -5,6 +5,7 @@ To view demo, first run this file with 'python rpc_testing_ioc.py',
 and then run 'pydm examples/rpc/rpc_lables.ui' from another terminal.
 (code adapted from p4p docs: https://mdavidsaver.github.io/p4p/rpc.html)
 """
+
 from p4p.rpc import rpc, quickRPCServer
 from p4p.nt import NTScalar
 import random

--- a/pydm/PyQt/__init__.py
+++ b/pydm/PyQt/__init__.py
@@ -1,7 +1,5 @@
 import warnings
 
 warnings.warn(
-    "'pydm.PyQt' is deprecated, "
-    "please directly import from the 'qtpy' module.  "
-    "pydm.PyQt will be removed in PyDM v1.8"
+    "'pydm.PyQt' is deprecated, please directly import from the 'qtpy' module.  pydm.PyQt will be removed in PyDM v1.8"
 )

--- a/pydm/application.py
+++ b/pydm/application.py
@@ -4,6 +4,7 @@ Main Application Module
 Contains our PyDMApplication class with core connection and loading logic and
 our PyDMMainWindow class with navigation logic.
 """
+
 import os
 import signal
 import subprocess
@@ -151,7 +152,7 @@ class PyDMApplication(QApplication):
         return super().exec_()
 
     def is_read_only(self):
-        warnings.warn("'PyDMApplication.is_read_only' is deprecated, " "use 'pydm.data_plugins.is_read_only' instead.")
+        warnings.warn("'PyDMApplication.is_read_only' is deprecated, use 'pydm.data_plugins.is_read_only' instead.")
         return data_plugins.is_read_only()
 
     @Slot()
@@ -267,7 +268,7 @@ class PyDMApplication(QApplication):
         PyDMPlugin
         """
         warnings.warn(
-            "'PyDMApplication.plugin_for_channel' is deprecated, " "use 'pydm.data_plugins.plugin_for_address' instead."
+            "'PyDMApplication.plugin_for_channel' is deprecated, use 'pydm.data_plugins.plugin_for_address' instead."
         )
         if channel.address is None or channel.address == "":
             return None
@@ -281,7 +282,7 @@ class PyDMApplication(QApplication):
         ----------
         channel : PyDMChannel
         """
-        warnings.warn("'PyDMApplication.add_connection' is deprecated, " "use PyDMConnection.connect()")
+        warnings.warn("'PyDMApplication.add_connection' is deprecated, use PyDMConnection.connect()")
         channel.connect()
 
     def remove_connection(self, channel):
@@ -292,17 +293,15 @@ class PyDMApplication(QApplication):
         ----------
         channel : PyDMChannel
         """
-        warnings.warn("'PyDMApplication.remove_connection' is deprecated, " "use PyDMConnection.disconnect()")
+        warnings.warn("'PyDMApplication.remove_connection' is deprecated, use PyDMConnection.disconnect()")
         channel.disconnect()
 
     def eventFilter(self, obj, event):
-        warnings.warn("'PyDMApplication.eventFilter' is deprecated, " " this function is now found on PyDMWidget")
+        warnings.warn("'PyDMApplication.eventFilter' is deprecated,  this function is now found on PyDMWidget")
         obj.eventFilter(obj, event)
 
     def show_address_tooltip(self, obj, event):
-        warnings.warn(
-            "'PyDMApplication.show_address_tooltip' is deprecated, " " this function is now found on PyDMWidget"
-        )
+        warnings.warn("'PyDMApplication.show_address_tooltip' is deprecated,  this function is now found on PyDMWidget")
         obj.show_address_tooltip(event)
 
     def establish_widget_connections(self, widget):

--- a/pydm/connection_inspector/connection_inspector.py
+++ b/pydm/connection_inspector/connection_inspector.py
@@ -14,7 +14,7 @@ from qtpy.QtWidgets import (
 )
 from qtpy.QtCore import Qt, Slot, QTimer
 from .connection_table_model import ConnectionTableModel
-from .. import data_plugins
+from pydm import data_plugins
 
 
 class ConnectionInspector(QWidget):

--- a/pydm/data_plugins/__init__.py
+++ b/pydm/data_plugins/__init__.py
@@ -3,6 +3,7 @@ Loads all the data plugins available at the given PYDM_DATA_PLUGINS_PATH
 environment variable and subfolders that follows the *_plugin.py and have
 classes that inherits from the pydm.data_plugins.PyDMPlugin class.
 """
+
 import inspect
 import logging
 import os
@@ -140,7 +141,7 @@ def add_plugin(plugin: Type[PyDMPlugin]) -> Optional[PyDMPlugin]:
 
 @log_failures(
     logger,
-    explanation=("Unable to import plugin file: {args[0]}.  " "This plugin will be skipped."),
+    explanation=("Unable to import plugin file: {args[0]}.  This plugin will be skipped."),
     include_traceback=True,
 )
 def _get_plugins_from_source(source_filename: str) -> List[Type[PyDMPlugin]]:
@@ -208,7 +209,7 @@ def find_plugins_from_entrypoints(
             continue
 
         if not _is_valid_plugin_class(plugin_cls):
-            logger.warning("Invalid plugin class specified in entrypoint " "%s: %s", entry.name, plugin_cls)
+            logger.warning("Invalid plugin class specified in entrypoint %s: %s", entry.name, plugin_cls)
             continue
 
         yield plugin_cls

--- a/pydm/data_plugins/__init__.py
+++ b/pydm/data_plugins/__init__.py
@@ -13,8 +13,8 @@ from typing import Any, Dict, Generator, List, Optional, Type
 import entrypoints
 from qtpy.QtWidgets import QApplication
 
-from .. import config
-from ..utilities import import_module_by_filename, log_failures, parsed_address
+from pydm import config
+from pydm.utilities import import_module_by_filename, log_failures, parsed_address
 from .plugin import PyDMPlugin
 
 logger = logging.getLogger(__name__)

--- a/pydm/data_plugins/epics_plugins/psp_plugin_component.py
+++ b/pydm/data_plugins/epics_plugins/psp_plugin_component.py
@@ -2,6 +2,7 @@
 Plugin to handle EPICS connections using pyca through psp.Pv.
 This is used instead of pyepics for better performance.
 """
+
 import numpy as np
 import pyca
 from psp.Pv import Pv

--- a/pydm/data_plugins/local_plugin.py
+++ b/pydm/data_plugins/local_plugin.py
@@ -1,4 +1,5 @@
 """Local Plugin."""
+
 import decimal
 import logging
 import ast

--- a/pydm/data_plugins/plugin.py
+++ b/pydm/data_plugins/plugin.py
@@ -6,12 +6,12 @@ import threading
 from typing import Optional, Callable
 from urllib.parse import ParseResult
 
-from ..utilities.remove_protocol import parsed_address
-from ..widgets import PyDMChannel
+from pydm.utilities.remove_protocol import parsed_address
+from pydm.widgets import PyDMChannel
 from qtpy.compat import isalive
 from qtpy.QtCore import Signal, QObject, Qt
 from qtpy.QtWidgets import QApplication
-from .. import config
+from pydm import config
 
 
 class PyDMConnection(QObject):

--- a/pydm/display_module.py
+++ b/pydm/display_module.py
@@ -2,7 +2,7 @@ import warnings
 from pydm.display import Display, ScreenTarget, load_file, load_py_file, load_ui_file
 
 warnings.warn(
-    "The display_module was renamed to display." "Please modify your code to reflect this change.",
+    "The display_module was renamed to display.Please modify your code to reflect this change.",
     DeprecationWarning,
     stacklevel=2,
 )

--- a/pydm/tests/test_data/valid_display_test_file.py
+++ b/pydm/tests/test_data/valid_display_test_file.py
@@ -1,4 +1,5 @@
-""" This file is intended for use in Display related test files. """
+"""This file is intended for use in Display related test files."""
+
 import os
 from pydm import Display
 from pydm.widgets import PyDMPushButton, PyDMLabel

--- a/pydm/tests/test_display.py
+++ b/pydm/tests/test_display.py
@@ -3,7 +3,7 @@ import pytest
 from pydm import Display
 from pydm.display import load_file, load_py_file, _compile_ui_file, _load_compiled_ui_into_display, ScreenTarget
 from qtpy.QtWidgets import QLabel
-from ..utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
+from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
 
 # The path to the .ui file used in these tests
 test_ui_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "test_data", "test.ui")

--- a/pydm/tests/test_main_window.py
+++ b/pydm/tests/test_main_window.py
@@ -6,7 +6,7 @@ from pydm import PyDMApplication
 from pydm.display import Display, clear_compiled_ui_file_cache
 from qtpy import uic
 from unittest.mock import MagicMock, patch
-from ..utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
+from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
 
 # The path to the .ui file for creating a main window
 test_ui_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "test_data", "test.ui")

--- a/pydm/tests/test_plugins_import.py
+++ b/pydm/tests/test_plugins_import.py
@@ -1,23 +1,23 @@
-from ..widgets.qtplugin_base import qtplugin_factory
+from pydm.widgets.qtplugin_base import qtplugin_factory
 
 
 def test_import_byte_plugin():
     # Byte plugin
-    from ..widgets.byte import PyDMByteIndicator
+    from pydm.widgets.byte import PyDMByteIndicator
 
     qtplugin_factory(PyDMByteIndicator)
 
 
 def test_import_checkbox_plugin():
     # Checkbox plugin
-    from ..widgets.checkbox import PyDMCheckbox
+    from pydm.widgets.checkbox import PyDMCheckbox
 
     qtplugin_factory(PyDMCheckbox)
 
 
 def test_import_drawing_plugins():
     # Drawing plugins
-    from ..widgets.drawing import (
+    from pydm.widgets.drawing import (
         PyDMDrawingLine,
         PyDMDrawingRectangle,
         PyDMDrawingTriangle,
@@ -48,113 +48,113 @@ def test_import_drawing_plugins():
 
 def test_import_embedded_display_plugin():
     # Embedded Display plugin
-    from ..widgets.embedded_display import PyDMEmbeddedDisplay
+    from pydm.widgets.embedded_display import PyDMEmbeddedDisplay
 
     qtplugin_factory(PyDMEmbeddedDisplay)
 
 
 def test_import_frame_plugin():
     # Frame plugin
-    from ..widgets.frame import PyDMFrame
+    from pydm.widgets.frame import PyDMFrame
 
     qtplugin_factory(PyDMFrame, is_container=True)
 
 
 def test_import_enum_button_plugin():
     # Enum Button plugin
-    from ..widgets.enum_button import PyDMEnumButton
+    from pydm.widgets.enum_button import PyDMEnumButton
 
     qtplugin_factory(PyDMEnumButton)
 
 
 def test_import_combobox_plugin():
     # Enum Combobox plugin
-    from ..widgets.enum_combo_box import PyDMEnumComboBox
+    from pydm.widgets.enum_combo_box import PyDMEnumComboBox
 
     qtplugin_factory(PyDMEnumComboBox)
 
 
 def test_import_image_plugin():
     # Image plugin
-    from ..widgets.image import PyDMImageView
+    from pydm.widgets.image import PyDMImageView
 
     qtplugin_factory(PyDMImageView)
 
 
 def test_import_label_plugin():
     # Label plugin
-    from ..widgets.label import PyDMLabel
+    from pydm.widgets.label import PyDMLabel
 
     qtplugin_factory(PyDMLabel)
 
 
 def test_import_line_edit_plugin():
     # Line Edit plugin
-    from ..widgets.line_edit import PyDMLineEdit
+    from pydm.widgets.line_edit import PyDMLineEdit
 
     qtplugin_factory(PyDMLineEdit)
 
 
 def test_import_pushbutton_plugin():
     # Push Button plugin
-    from ..widgets.pushbutton import PyDMPushButton
+    from pydm.widgets.pushbutton import PyDMPushButton
 
     qtplugin_factory(PyDMPushButton)
 
 
 def test_import_related_display_plugin():
     # Related Display Button plugin
-    from ..widgets.related_display_button import PyDMRelatedDisplayButton
+    from pydm.widgets.related_display_button import PyDMRelatedDisplayButton
 
     qtplugin_factory(PyDMRelatedDisplayButton)
 
 
 def test_import_scale_indicator_plugin():
     # Scale Indicator plugin
-    from ..widgets.scale import PyDMScaleIndicator
+    from pydm.widgets.scale import PyDMScaleIndicator
 
     qtplugin_factory(PyDMScaleIndicator)
 
 
 def test_import_shellcmd_plugin():
     # Shell Command plugin
-    from ..widgets.shell_command import PyDMShellCommand
+    from pydm.widgets.shell_command import PyDMShellCommand
 
     qtplugin_factory(PyDMShellCommand)
 
 
 def test_import_slider_plugin():
     # Slider plugin
-    from ..widgets.slider import PyDMSlider
+    from pydm.widgets.slider import PyDMSlider
 
     qtplugin_factory(PyDMSlider)
 
 
 def test_import_spinbox_plugin():
     # Spinbox plugin
-    from ..widgets.spinbox import PyDMSpinbox
+    from pydm.widgets.spinbox import PyDMSpinbox
 
     qtplugin_factory(PyDMSpinbox)
 
 
 def test_import_symbol_plugin():
     # Symbol plugin
-    from ..widgets.symbol import PyDMSymbol
+    from pydm.widgets.symbol import PyDMSymbol
 
     qtplugin_factory(PyDMSymbol)
 
 
 def test_import_waveform_table_plugin():
     # Waveform Table plugin
-    from ..widgets.waveformtable import PyDMWaveformTable
+    from pydm.widgets.waveformtable import PyDMWaveformTable
 
     qtplugin_factory(PyDMWaveformTable)
 
 
 def test_import_timeplot_plugin():
     # Time Plot plugin
-    from ..widgets.timeplot import PyDMTimePlot
-    from ..widgets.timeplot_curve_editor import TimePlotCurveEditorDialog
+    from pydm.widgets.timeplot import PyDMTimePlot
+    from pydm.widgets.timeplot_curve_editor import TimePlotCurveEditorDialog
 
     # Time Plot plugin
     qtplugin_factory(PyDMTimePlot, TimePlotCurveEditorDialog)
@@ -162,16 +162,16 @@ def test_import_timeplot_plugin():
 
 def test_import_waveformplot_plugin():
     # Time Plot plugin
-    from ..widgets.waveformplot import PyDMWaveformPlot
-    from ..widgets.waveformplot_curve_editor import WaveformPlotCurveEditorDialog
+    from pydm.widgets.waveformplot import PyDMWaveformPlot
+    from pydm.widgets.waveformplot_curve_editor import WaveformPlotCurveEditorDialog
 
     # Waveform Plot plugin
     qtplugin_factory(PyDMWaveformPlot, WaveformPlotCurveEditorDialog)
 
 
 def test_import_scatterplot_plugin():
-    from ..widgets.scatterplot import PyDMScatterPlot
-    from ..widgets.scatterplot_curve_editor import ScatterPlotCurveEditorDialog
+    from pydm.widgets.scatterplot import PyDMScatterPlot
+    from pydm.widgets.scatterplot_curve_editor import ScatterPlotCurveEditorDialog
 
     # Scatter Plot plugin
     qtplugin_factory(PyDMScatterPlot, ScatterPlotCurveEditorDialog)
@@ -179,6 +179,6 @@ def test_import_scatterplot_plugin():
 
 def test_import_tab_widget_plugin():
     # Symbol plugin
-    from ..widgets.tab_bar_qtplugin import TabWidgetPlugin
+    from pydm.widgets.tab_bar_qtplugin import TabWidgetPlugin
 
     TabWidgetPlugin()

--- a/pydm/tests/test_tools.py
+++ b/pydm/tests/test_tools.py
@@ -18,12 +18,10 @@ examples_required = pytest.mark.skipif(
 )
 
 
-class ValidTool(tools.ExternalTool):
-    ...
+class ValidTool(tools.ExternalTool): ...
 
 
-class InvalidTool:
-    ...
+class InvalidTool: ...
 
 
 @pytest.mark.parametrize(

--- a/pydm/tests/test_tools.py
+++ b/pydm/tests/test_tools.py
@@ -7,8 +7,8 @@ from typing import Any, Set
 
 import pytest
 
-from .. import tools
-from ..application import PyDMApplication
+from pydm import tools
+from pydm.application import PyDMApplication
 
 EXAMPLE_PATH = pathlib.Path(__file__).parents[2] / "examples"
 EXAMPLE_EXT_TOOL_PATH = EXAMPLE_PATH / "external_tool"

--- a/pydm/tests/utilities/test_colors.py
+++ b/pydm/tests/utilities/test_colors.py
@@ -1,6 +1,6 @@
 import pytest
 
-from ...utilities import colors
+from pydm.utilities import colors
 
 
 def test_read_file():

--- a/pydm/tests/utilities/test_iconfont.py
+++ b/pydm/tests/utilities/test_iconfont.py
@@ -1,5 +1,5 @@
 import pytest
-from ...utilities import iconfont
+from pydm.utilities import iconfont
 from qtpy import QtGui, QtCore
 
 

--- a/pydm/tests/utilities/test_macro.py
+++ b/pydm/tests/utilities/test_macro.py
@@ -2,7 +2,7 @@ import os
 import tempfile
 import pytest
 
-from ...utilities.macro import substitute_in_file, parse_macro_string
+from pydm.utilities.macro import substitute_in_file, parse_macro_string
 
 
 @pytest.mark.parametrize(

--- a/pydm/tests/utilities/test_remove_protocol.py
+++ b/pydm/tests/utilities/test_remove_protocol.py
@@ -1,6 +1,6 @@
-from ...utilities.remove_protocol import remove_protocol
-from ...utilities.remove_protocol import protocol_and_address
-from ...utilities.remove_protocol import parsed_address
+from pydm.utilities.remove_protocol import remove_protocol
+from pydm.utilities.remove_protocol import protocol_and_address
+from pydm.utilities.remove_protocol import parsed_address
 
 
 def test_remove_protocol():

--- a/pydm/tests/utilities/test_stylesheet.py
+++ b/pydm/tests/utilities/test_stylesheet.py
@@ -2,8 +2,8 @@ import os
 import pytest
 import logging
 
-from ... import config
-from ...utilities import stylesheet
+from pydm import config
+from pydm.utilities import stylesheet
 from qtpy.QtWidgets import QApplication
 
 # The path to the stylesheet used in these unit tests

--- a/pydm/tests/utilities/test_units.py
+++ b/pydm/tests/utilities/test_units.py
@@ -1,6 +1,6 @@
 import pytest
 from scipy import constants
-from ...utilities import units
+from pydm.utilities import units
 
 
 @pytest.mark.parametrize("typ, expected", [("cm", "length"), ("non_existent", None)])

--- a/pydm/tests/utilities/test_utilities.py
+++ b/pydm/tests/utilities/test_utilities.py
@@ -5,7 +5,7 @@ import tempfile
 
 from qtpy import QtWidgets
 
-from ...utilities import find_display_in_path, is_pydm_app, is_qt_designer, log_failures, path_info, which
+from pydm.utilities import find_display_in_path, is_pydm_app, is_qt_designer, log_failures, path_info, which
 
 logger = logging.getLogger(__name__)
 

--- a/pydm/tests/widgets/test_archiver_timeplot.py
+++ b/pydm/tests/widgets/test_archiver_timeplot.py
@@ -2,8 +2,8 @@ import numpy as np
 import pytest
 from qtpy.QtCore import Slot
 
-from ..conftest import ConnectionSignals
-from ...widgets.archiver_time_plot import ArchivePlotCurveItem, PyDMArchiverTimePlot, FormulaCurveItem
+from pydm.tests.conftest import ConnectionSignals
+from pydm.widgets.archiver_time_plot import ArchivePlotCurveItem, PyDMArchiverTimePlot, FormulaCurveItem
 
 
 @pytest.mark.parametrize("address", ["ca://LINAC:PV1", "pva://LINAC:PV1", "LINAC:PV1"])

--- a/pydm/tests/widgets/test_base.py
+++ b/pydm/tests/widgets/test_base.py
@@ -6,13 +6,13 @@ import logging
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QMenu
 from qtpy.QtGui import QClipboard, QColor, QMouseEvent
-from ..conftest import ConnectionSignals
-from ...utilities import is_pydm_app
-from ... import data_plugins
-from ...widgets.base import AlarmLimit, is_channel_valid, PyDMWidget
-from ...widgets.label import PyDMLabel
-from ...widgets.line_edit import PyDMLineEdit
-from ...widgets.channel import PyDMChannel
+from pydm.tests.conftest import ConnectionSignals
+from pydm.utilities import is_pydm_app
+from pydm import data_plugins
+from pydm.widgets.base import AlarmLimit, is_channel_valid, PyDMWidget
+from pydm.widgets.label import PyDMLabel
+from pydm.widgets.line_edit import PyDMLineEdit
+from pydm.widgets.channel import PyDMChannel
 
 logger = logging.getLogger(__name__)
 

--- a/pydm/tests/widgets/test_baseplot.py
+++ b/pydm/tests/widgets/test_baseplot.py
@@ -9,7 +9,7 @@ from qtpy.QtGui import QColor, QFont
 from qtpy.QtCore import QTimer, Qt, QPointF
 
 from collections import OrderedDict
-from ...widgets.baseplot import BasePlotCurveItem, BasePlot
+from pydm.widgets.baseplot import BasePlotCurveItem, BasePlot
 
 
 logger = logging.getLogger(__name__)

--- a/pydm/tests/widgets/test_byte.py
+++ b/pydm/tests/widgets/test_byte.py
@@ -1,6 +1,6 @@
 import pytest
 
-from ...widgets.byte import PyDMByteIndicator
+from pydm.widgets.byte import PyDMByteIndicator
 
 
 @pytest.mark.parametrize(

--- a/pydm/tests/widgets/test_channel.py
+++ b/pydm/tests/widgets/test_channel.py
@@ -1,9 +1,9 @@
 # Unit Tests for the Channel widget class
 import pytest
 
-from ...widgets.label import PyDMLabel
-from ...widgets.line_edit import PyDMLineEdit
-from ...widgets.channel import PyDMChannel
+from pydm.widgets.label import PyDMLabel
+from pydm.widgets.line_edit import PyDMLineEdit
+from pydm.widgets.channel import PyDMChannel
 from pydm.data_plugins import plugin_for_address
 
 

--- a/pydm/tests/widgets/test_checkbox.py
+++ b/pydm/tests/widgets/test_checkbox.py
@@ -1,7 +1,7 @@
 # Unit Tests for the PyDMCheckbox Widget
 
 import pytest
-from ...widgets.checkbox import PyDMCheckbox
+from pydm.widgets.checkbox import PyDMCheckbox
 
 
 # --------------------

--- a/pydm/tests/widgets/test_colormaps.py
+++ b/pydm/tests/widgets/test_colormaps.py
@@ -3,7 +3,7 @@
 
 import numpy as np
 
-from ...widgets.colormaps import (
+from pydm.widgets.colormaps import (
     PyDMColorMap,
     cmaps,
     magma,

--- a/pydm/tests/widgets/test_curve_editor.py
+++ b/pydm/tests/widgets/test_curve_editor.py
@@ -1,6 +1,6 @@
 from qtpy.QtWidgets import QTableView
-from ...widgets.baseplot import BasePlot
-from ...widgets.baseplot_curve_editor import (
+from pydm.widgets.baseplot import BasePlot
+from pydm.widgets.baseplot_curve_editor import (
     AxisColumnDelegate,
     ColorColumnDelegate,
     LineColumnDelegate,
@@ -8,14 +8,14 @@ from ...widgets.baseplot_curve_editor import (
     RedrawModeColumnDelegate,
     PlotStyleColumnDelegate,
 )
-from ...widgets import PyDMArchiverTimePlot
-from ...widgets.axis_table_model import BasePlotAxesModel
-from ...widgets.baseplot_table_model import BasePlotCurvesModel
-from ...widgets.archiver_time_plot_editor import PyDMArchiverTimePlotCurvesModel
-from ...widgets.scatterplot_curve_editor import ScatterPlotCurveEditorDialog
-from ...widgets.timeplot_curve_editor import TimePlotCurveEditorDialog
-from ...widgets.waveformplot import WaveformCurveItem
-from ...widgets.waveformplot_curve_editor import WaveformPlotCurveEditorDialog
+from pydm.widgets import PyDMArchiverTimePlot
+from pydm.widgets.axis_table_model import BasePlotAxesModel
+from pydm.widgets.baseplot_table_model import BasePlotCurvesModel
+from pydm.widgets.archiver_time_plot_editor import PyDMArchiverTimePlotCurvesModel
+from pydm.widgets.scatterplot_curve_editor import ScatterPlotCurveEditorDialog
+from pydm.widgets.timeplot_curve_editor import TimePlotCurveEditorDialog
+from pydm.widgets.waveformplot import WaveformCurveItem
+from pydm.widgets.waveformplot_curve_editor import WaveformPlotCurveEditorDialog
 
 
 def test_waveform_curve_editor(qtbot):

--- a/pydm/tests/widgets/test_drawing.py
+++ b/pydm/tests/widgets/test_drawing.py
@@ -9,8 +9,8 @@ from qtpy.QtWidgets import QApplication
 from qtpy.QtCore import Qt, QSize
 from qtpy.QtDesigner import QDesignerFormWindowInterface
 
-from ...widgets.base import PyDMWidget
-from ...widgets.drawing import (
+from pydm.widgets.base import PyDMWidget
+from pydm.widgets.drawing import (
     deg_to_qt,
     qt_to_deg,
     PyDMDrawing,
@@ -27,7 +27,7 @@ from ...widgets.drawing import (
     PyDMDrawingPolyline,
     PyDMDrawingIrregularPolygon,
 )
-from ...utilities import checkObjectProperties
+from pydm.utilities import checkObjectProperties
 
 
 # --------------------

--- a/pydm/tests/widgets/test_enum_button.py
+++ b/pydm/tests/widgets/test_enum_button.py
@@ -2,8 +2,8 @@ import pytest
 
 from qtpy.QtCore import Qt, QSize
 
-from ...widgets.enum_button import PyDMEnumButton, WidgetType, class_for_type
-from ... import data_plugins
+from pydm.widgets.enum_button import PyDMEnumButton, WidgetType, class_for_type
+from pydm import data_plugins
 
 
 def test_construct(qtbot):

--- a/pydm/tests/widgets/test_enum_combo_box.py
+++ b/pydm/tests/widgets/test_enum_combo_box.py
@@ -5,8 +5,8 @@ from logging import ERROR
 
 from qtpy.QtCore import Qt
 
-from ...widgets.enum_combo_box import PyDMEnumComboBox
-from ... import data_plugins
+from pydm.widgets.enum_combo_box import PyDMEnumComboBox
+from pydm import data_plugins
 
 
 # --------------------

--- a/pydm/tests/widgets/test_eventplot.py
+++ b/pydm/tests/widgets/test_eventplot.py
@@ -1,4 +1,4 @@
-from ...widgets.eventplot import PyDMEventPlot
+from pydm.widgets.eventplot import PyDMEventPlot
 
 
 def test_add_channel(qtbot):

--- a/pydm/tests/widgets/test_frame.py
+++ b/pydm/tests/widgets/test_frame.py
@@ -3,10 +3,10 @@
 
 import pytest
 
-from ...widgets.base import is_channel_valid
-from ... import data_plugins
-from ...widgets.base import PyDMWidget
-from ...widgets.frame import PyDMFrame
+from pydm.widgets.base import is_channel_valid
+from pydm import data_plugins
+from pydm.widgets.base import PyDMWidget
+from pydm.widgets.frame import PyDMFrame
 
 
 # --------------------

--- a/pydm/tests/widgets/test_label.py
+++ b/pydm/tests/widgets/test_label.py
@@ -5,11 +5,11 @@ import pytest
 import numpy as np
 import logging
 
-from ...utilities import is_pydm_app
-from ...widgets.label import PyDMLabel
-from ...widgets.base import PyDMWidget
-from ...widgets.display_format import parse_value_for_display, DisplayFormat
-from ...utilities import checkObjectProperties
+from pydm.utilities import is_pydm_app
+from pydm.widgets.label import PyDMLabel
+from pydm.widgets.base import PyDMWidget
+from pydm.widgets.display_format import parse_value_for_display, DisplayFormat
+from pydm.utilities import checkObjectProperties
 
 from qtpy.QtWidgets import QApplication, QStyleOption
 from qtpy.QtCore import Qt

--- a/pydm/tests/widgets/test_lineedit.py
+++ b/pydm/tests/widgets/test_lineedit.py
@@ -822,7 +822,7 @@ def test_apply_conversion_wrong_unit(qtbot, caplog, value, precision, initial_un
 
 
 @pytest.mark.parametrize(
-    "init_value, user_typed_value, display_format, precision, scale, unit," "show_units, expected_errors",
+    "init_value, user_typed_value, display_format, precision, scale, unit,show_units, expected_errors",
     [
         (123, 345.678, DisplayFormat.Default, 0, 1, "s", True, ("Error trying to set data ", "with type ", "int'>")),
     ],

--- a/pydm/tests/widgets/test_lineedit.py
+++ b/pydm/tests/widgets/test_lineedit.py
@@ -9,10 +9,10 @@ from logging import ERROR
 from qtpy.QtCore import QEvent, Qt
 from qtpy.QtGui import QFocusEvent
 from qtpy.QtWidgets import QMenu
-from ...widgets.line_edit import PyDMLineEdit
-from ...data_plugins import set_read_only
-from ...utilities import is_pydm_app, find_unit_options
-from ...widgets.display_format import DisplayFormat, parse_value_for_display
+from pydm.widgets.line_edit import PyDMLineEdit
+from pydm.data_plugins import set_read_only
+from pydm.utilities import is_pydm_app, find_unit_options
+from pydm.widgets.display_format import DisplayFormat, parse_value_for_display
 
 
 # --------------------

--- a/pydm/tests/widgets/test_multiaxis_plot.py
+++ b/pydm/tests/widgets/test_multiaxis_plot.py
@@ -3,7 +3,7 @@ from unittest import mock
 from unittest.mock import patch
 from pyqtgraph import AxisItem, PlotDataItem, ViewBox
 from qtpy.QtWidgets import QGraphicsScene
-from ...widgets.multi_axis_plot import MultiAxisPlot
+from pydm.widgets.multi_axis_plot import MultiAxisPlot
 
 
 @pytest.fixture

--- a/pydm/tests/widgets/test_multistate.py
+++ b/pydm/tests/widgets/test_multistate.py
@@ -2,7 +2,7 @@ import pytest
 
 from qtpy.QtGui import QColor
 from qtpy.QtCore import Qt
-from ...widgets.byte import PyDMMultiStateIndicator
+from pydm.widgets.byte import PyDMMultiStateIndicator
 
 
 @pytest.mark.parametrize(

--- a/pydm/tests/widgets/test_pushbutton.py
+++ b/pydm/tests/widgets/test_pushbutton.py
@@ -10,8 +10,8 @@ import logging
 from qtpy.QtCore import QSize, Qt
 from qtpy.QtGui import QColor
 from qtpy.QtWidgets import QInputDialog, QMessageBox
-from ...widgets.pushbutton import PyDMPushButton
-from ...utilities.iconfont import IconFont
+from pydm.widgets.pushbutton import PyDMPushButton
+from pydm.utilities.iconfont import IconFont
 
 
 # --------------------

--- a/pydm/tests/widgets/test_pushbutton.py
+++ b/pydm/tests/widgets/test_pushbutton.py
@@ -238,7 +238,7 @@ def test_set_password(qtbot, password_protected, plain_text_password):
 
 
 @pytest.mark.parametrize(
-    "is_widget_protected_with_password, plain_text_password, input_dialog_status," "expected_validation_status",
+    "is_widget_protected_with_password, plain_text_password, input_dialog_status,expected_validation_status",
     [
         (True, "$L4C_p4$$wd", True, True),
         (False, "$L4C_p4$$wd", True, True),

--- a/pydm/tests/widgets/test_related_display_button.py
+++ b/pydm/tests/widgets/test_related_display_button.py
@@ -4,9 +4,9 @@ import sys
 import warnings
 from qtpy.QtCore import Qt, QSize
 from qtpy.QtWidgets import QApplication
-from ...utilities.stylesheet import global_style
-from ...widgets.related_display_button import PyDMRelatedDisplayButton
-from ...utilities import IconFont, checkObjectProperties
+from pydm.utilities.stylesheet import global_style
+from pydm.widgets.related_display_button import PyDMRelatedDisplayButton
+from pydm.utilities import IconFont, checkObjectProperties
 
 test_ui_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "../test_data", "test.ui")
 test_ui_path_with_stylesheet = os.path.join(

--- a/pydm/tests/widgets/test_rules.py
+++ b/pydm/tests/widgets/test_rules.py
@@ -2,8 +2,8 @@ import logging
 import pytest
 import weakref
 
-from ...widgets.rules import RulesDispatcher
-from ...widgets.label import PyDMLabel
+from pydm.widgets.rules import RulesDispatcher
+from pydm.widgets.label import PyDMLabel
 
 
 def test_rules_dispatcher(qapp, caplog):

--- a/pydm/tests/widgets/test_rules_editor.py
+++ b/pydm/tests/widgets/test_rules_editor.py
@@ -7,8 +7,8 @@ import webbrowser
 from qtpy import QtCore
 from qtpy.QtWidgets import QMessageBox, QTableWidgetSelectionRange
 
-from ...widgets.base import PyDMPrimitiveWidget
-from ...widgets.rules_editor import RulesEditor
+from pydm.widgets.base import PyDMPrimitiveWidget
+from pydm.widgets.rules_editor import RulesEditor
 
 
 class DummyWidget:

--- a/pydm/tests/widgets/test_scatterplot.py
+++ b/pydm/tests/widgets/test_scatterplot.py
@@ -2,9 +2,9 @@ import pytest
 import logging
 import numpy as np
 from collections import OrderedDict
-from ...widgets.channel import PyDMChannel
-from ...widgets.scatterplot import ScatterPlotCurveItem, MINIMUM_BUFFER_SIZE, DEFAULT_BUFFER_SIZE
-from ...utilities import remove_protocol
+from pydm.widgets.channel import PyDMChannel
+from pydm.widgets.scatterplot import ScatterPlotCurveItem, MINIMUM_BUFFER_SIZE, DEFAULT_BUFFER_SIZE
+from pydm.utilities import remove_protocol
 
 logger = logging.getLogger(__name__)
 

--- a/pydm/tests/widgets/test_shell_command.py
+++ b/pydm/tests/widgets/test_shell_command.py
@@ -12,8 +12,8 @@ from qtpy import QtCore
 from qtpy.QtCore import QSize
 from qtpy.QtWidgets import QMenu, QAction
 
-from ...widgets.shell_command import PyDMShellCommand, TermOutputMode
-from ...utilities import IconFont
+from pydm.widgets.shell_command import PyDMShellCommand, TermOutputMode
+from pydm.utilities import IconFont
 
 
 # --------------------

--- a/pydm/tests/widgets/test_slider.py
+++ b/pydm/tests/widgets/test_slider.py
@@ -5,9 +5,9 @@ import numpy as np
 from qtpy.QtWidgets import QLabel, QVBoxLayout, QHBoxLayout, QSizePolicy, QApplication, QSlider
 from qtpy.QtCore import Qt, QMargins, QPoint, QEvent, QRect, QSize
 from qtpy.QtGui import QMouseEvent
-from ...widgets.slider import PyDMSlider, PyDMPrimitiveSlider
-from ...widgets.base import PyDMWidget
-from ...utilities import checkObjectProperties
+from pydm.widgets.slider import PyDMSlider, PyDMPrimitiveSlider
+from pydm.widgets.base import PyDMWidget
+from pydm.utilities import checkObjectProperties
 
 # Unit Tests for the PyDMPrimitiveSlider class
 

--- a/pydm/tests/widgets/test_spinbox.py
+++ b/pydm/tests/widgets/test_spinbox.py
@@ -7,8 +7,8 @@ from qtpy.QtWidgets import QApplication
 from qtpy.QtGui import QKeyEvent
 from qtpy.QtCore import QEvent, Qt
 
-from ...widgets.spinbox import PyDMSpinbox
-from ...tests.widgets.test_lineedit import find_action_from_menu
+from pydm.widgets.spinbox import PyDMSpinbox
+from pydm.tests.widgets.test_lineedit import find_action_from_menu
 
 
 # --------------------

--- a/pydm/tests/widgets/test_symbol_editor.py
+++ b/pydm/tests/widgets/test_symbol_editor.py
@@ -4,9 +4,9 @@ import copy
 from qtpy import QtCore
 from qtpy.QtWidgets import QMessageBox, QTableWidgetSelectionRange
 
-from ...widgets.symbol import PyDMSymbol
-from ...widgets.symbol_editor import SymbolEditor
-from ...utilities import checkObjectProperties
+from pydm.widgets.symbol import PyDMSymbol
+from pydm.widgets.symbol_editor import SymbolEditor
+from pydm.utilities import checkObjectProperties
 
 
 # additional props we expect to get added to PyDMSymbol class RULE_PROPERTIES

--- a/pydm/tests/widgets/test_template_repeater.py
+++ b/pydm/tests/widgets/test_template_repeater.py
@@ -1,5 +1,5 @@
 import os
-from ...widgets import PyDMSlider, PyDMTemplateRepeater
+from pydm.widgets import PyDMSlider, PyDMTemplateRepeater
 
 test_template_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "../test_data", "template.ui")
 

--- a/pydm/tests/widgets/test_timeplot.py
+++ b/pydm/tests/widgets/test_timeplot.py
@@ -4,9 +4,15 @@ import numpy as np
 from collections import OrderedDict
 from pyqtgraph import AxisItem, BarGraphItem
 from unittest import mock
-from ...widgets.channel import PyDMChannel
-from ...widgets.timeplot import TimePlotCurveItem, PyDMTimePlot, TimeAxisItem, MINIMUM_BUFFER_SIZE, DEFAULT_BUFFER_SIZE
-from ...utilities import remove_protocol
+from pydm.widgets.channel import PyDMChannel
+from pydm.widgets.timeplot import (
+    TimePlotCurveItem,
+    PyDMTimePlot,
+    TimeAxisItem,
+    MINIMUM_BUFFER_SIZE,
+    DEFAULT_BUFFER_SIZE,
+)
+from pydm.utilities import remove_protocol
 from qtpy.QtTest import QSignalSpy
 from unittest.mock import MagicMock
 

--- a/pydm/tests/widgets/test_waveform_plot.py
+++ b/pydm/tests/widgets/test_waveform_plot.py
@@ -2,7 +2,7 @@ import numpy as np
 from pyqtgraph import BarGraphItem
 from unittest import mock
 from unittest.mock import MagicMock, patch
-from ...widgets.waveformplot import PyDMWaveformPlot, WaveformCurveItem
+from pydm.widgets.waveformplot import PyDMWaveformPlot, WaveformCurveItem
 
 
 @mock.patch("pydm.widgets.waveformplot.WaveformCurveItem.setData")

--- a/pydm/tools/__init__.py
+++ b/pydm/tools/__init__.py
@@ -74,7 +74,7 @@ def install_external_tool(tool: Union[str, ExternalTool]) -> None:
 
     for tool_obj in objects:
         if not isinstance(tool_obj, ExternalTool):
-            raise ValueError(f"Invalid tool found: {tool}. String or ExternalTool " f"expected.")
+            raise ValueError(f"Invalid tool found: {tool}. String or ExternalTool expected.")
 
         if tool_obj.group is not None and tool_obj.group:
             if tool_obj.group not in ext_tools:
@@ -141,7 +141,7 @@ def assemble_tools_menu(
                         continue
                     if widget is not None and not t.is_compatible_with(widget):
                         logger.debug(
-                            "Skipping tool %s as it is incompatible with " "widget %s.",
+                            "Skipping tool %s as it is incompatible with widget %s.",
                             t.name,
                             widget,
                         )
@@ -174,7 +174,7 @@ def get_entrypoint_tools() -> Generator[ExternalTool, None, None]:
             continue
 
         if not _is_valid_external_tool_class(tool_cls):
-            logger.warning("Invalid external tool class specified in entrypoint " "%s: %s", entry.name, tool_cls)
+            logger.warning("Invalid external tool class specified in entrypoint %s: %s", entry.name, tool_cls)
             continue
 
         yield tool_cls()
@@ -185,7 +185,7 @@ def get_tools_from_path() -> Generator[ExternalTool, None, None]:
     tools_path = os.getenv("PYDM_TOOLS_PATH", None)
 
     if not tools_path:
-        logger.debug("External Tools not loaded from PYDM_TOOLS_PATH as no path " "was specified.")
+        logger.debug("External Tools not loaded from PYDM_TOOLS_PATH as no path was specified.")
         return
 
     logger.debug("Looking for external tools at: %s", tools_path)

--- a/pydm/tools/__init__.py
+++ b/pydm/tools/__init__.py
@@ -8,8 +8,8 @@ from typing import Any, Dict, Generator, List, Optional, Union
 import entrypoints
 from qtpy.QtWidgets import QMenu, QWidget
 
-from ..config import ENTRYPOINT_EXTERNAL_TOOL, EXTERNAL_TOOL_SUFFIX
-from ..utilities import import_module_by_filename, log_failures
+from pydm.config import ENTRYPOINT_EXTERNAL_TOOL, EXTERNAL_TOOL_SUFFIX
+from pydm.utilities import import_module_by_filename, log_failures
 from .tools import ExternalTool
 
 logger = logging.getLogger(__name__)

--- a/pydm/utilities/__init__.py
+++ b/pydm/utilities/__init__.py
@@ -110,7 +110,7 @@ def is_pydm_app(app=None):
     """
     from qtpy.QtWidgets import QApplication
 
-    from ..application import PyDMApplication
+    from pydm.application import PyDMApplication
 
     if app is None:
         app = QApplication.instance()
@@ -129,7 +129,7 @@ def is_qt_designer():
     bool
         True if inside Designer, False otherwise.
     """
-    from ..qtdesigner import DesignerHooks
+    from pydm.qtdesigner import DesignerHooks
 
     return DesignerHooks().form_editor is not None
 
@@ -147,7 +147,7 @@ def get_designer_current_path():
     if not is_qt_designer():
         return None
 
-    from ..qtdesigner import DesignerHooks
+    from pydm.qtdesigner import DesignerHooks
 
     form_editor = DesignerHooks().form_editor
     win_manager = form_editor.formWindowManager()

--- a/pydm/utilities/__init__.py
+++ b/pydm/utilities/__init__.py
@@ -567,9 +567,7 @@ def copy_to_clipboard(text: str, *, quiet: bool = False):
             app.sendEvent(clipboard, event)
 
     if not quiet:
-        logger.warning(
-            ("Copied text to clipboard:\n" "-------------------------\n" "%s\n" "-------------------------\n"), text
-        )
+        logger.warning(("Copied text to clipboard:\n-------------------------\n%s\n-------------------------\n"), text)
 
 
 def get_clipboard_text() -> str:

--- a/pydm/utilities/iconfont.py
+++ b/pydm/utilities/iconfont.py
@@ -3,6 +3,7 @@ iconfont provides a barebones system to get QIcons from icon fonts (like Font Aw
 The inspiration and methodology come from the 'QtAwesome' module, which does exactly this, but
 is a little too big, complicated, and flexible for PyDM's needs.
 """
+
 import json
 import os
 import sys

--- a/pydm/utilities/remove_protocol.py
+++ b/pydm/utilities/remove_protocol.py
@@ -1,6 +1,6 @@
 import re
 import urllib
-from .. import config
+from pydm import config
 
 
 def remove_protocol(addr):

--- a/pydm/utilities/stylesheet.py
+++ b/pydm/utilities/stylesheet.py
@@ -4,7 +4,7 @@ import logging
 
 from qtpy.QtWidgets import QApplication
 
-from ..config import STYLESHEET, STYLESHEET_INCLUDE_DEFAULT
+from pydm.config import STYLESHEET, STYLESHEET_INCLUDE_DEFAULT
 
 logger = logging.getLogger(__name__)
 

--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -317,7 +317,7 @@ class PyDMPrimitiveWidget(object):
 
         except Exception:
             logger.error(
-                "Error at Rule: %s. Could not execute method %s with " "value %s and type as %s.",
+                "Error at Rule: %s. Could not execute method %s with value %s and type as %s.",
                 name,
                 method_name,
                 value,

--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -12,9 +12,9 @@ from qtpy.QtWidgets import QApplication, QMenu, QGraphicsOpacityEffect, QToolTip
 from qtpy.QtGui import QCursor, QIcon
 from qtpy.QtCore import Qt, QEvent, Signal, Slot, Property
 from .channel import PyDMChannel
-from .. import data_plugins, tools, config
-from ..utilities import is_qt_designer, remove_protocol
-from ..display import Display
+from pydm import data_plugins, tools, config
+from pydm.utilities import is_qt_designer, remove_protocol
+from pydm.display import Display
 from .rules import RulesDispatcher
 from datetime import datetime
 from typing import Optional

--- a/pydm/widgets/baseplot.py
+++ b/pydm/widgets/baseplot.py
@@ -7,7 +7,7 @@ from abc import abstractmethod
 from qtpy.QtGui import QColor, QFont, QBrush
 from qtpy.QtCore import Signal, Slot, Property, QTimer, Qt, QEvent, QObject, QRect, QPointF
 from qtpy.QtWidgets import QToolTip, QWidget
-from .. import utilities
+from pydm import utilities
 from pyqtgraph import (
     AxisItem,
     PlotWidget,

--- a/pydm/widgets/baseplot_curve_editor.py
+++ b/pydm/widgets/baseplot_curve_editor.py
@@ -218,7 +218,6 @@ class ColorColumnDelegate(QStyledItemDelegate):
 
 
 class AxisColumnDelegate(QStyledItemDelegate):
-
     """
     AxisColumnDelegate draws a QComboBox with the allowed values for the axis orientation
     column value, which must map to the values expected by PyQtGraph. Helps ensure that the

--- a/pydm/widgets/channel.py
+++ b/pydm/widgets/channel.py
@@ -153,7 +153,7 @@ class PyDMChannel(object):
         try:
             pydm.data_plugins.establish_connection(self)
         except Exception:
-            logger.exception("Unable to make proper connection " "for %r", self)
+            logger.exception("Unable to make proper connection for %r", self)
 
     def disconnect(self, destroying=False):
         """
@@ -165,7 +165,7 @@ class PyDMChannel(object):
                 return
             plugin.remove_connection(self, destroying=destroying)
         except Exception:
-            logger.exception("Unable to remove connection " "for %r", self)
+            logger.exception("Unable to remove connection for %r", self)
 
     def __eq__(self, other):
         if isinstance(self, other.__class__):

--- a/pydm/widgets/channel.py
+++ b/pydm/widgets/channel.py
@@ -2,7 +2,7 @@ import logging
 
 import pydm.data_plugins
 
-from ..utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
+from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
 
 logger = logging.getLogger(__name__)
 

--- a/pydm/widgets/colormaps.py
+++ b/pydm/widgets/colormaps.py
@@ -14,7 +14,7 @@
 # work.  If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 
 import numpy as np
-from ..utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
+from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
 
 __all__ = ["magma", "inferno", "plasma", "viridis", "jet", "monochrome", "hot"]
 

--- a/pydm/widgets/datetime.py
+++ b/pydm/widgets/datetime.py
@@ -2,7 +2,7 @@ import logging
 from qtpy import QtWidgets, QtCore
 
 from .base import PyDMWritableWidget, PyDMWidget, PostParentClassInitSetup
-from ..utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
+from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
 
 logger = logging.getLogger(__name__)
 

--- a/pydm/widgets/designer_settings.py
+++ b/pydm/widgets/designer_settings.py
@@ -5,8 +5,8 @@ from typing import Any, List, Optional
 
 from qtpy import QtCore, QtDesigner, QtWidgets
 
-from ..utilities import copy_to_clipboard, get_clipboard_text
-from ..utilities.macro import parse_macro_string
+from pydm.utilities import copy_to_clipboard, get_clipboard_text
+from pydm.utilities.macro import parse_macro_string
 
 logger = logging.getLogger(__name__)
 

--- a/pydm/widgets/display_format.py
+++ b/pydm/widgets/display_format.py
@@ -107,8 +107,9 @@ def parse_value_for_display(
             r = fmt_string.format(value)
         except (ValueError, TypeError):
             logger.error(
-                "Could not display value '{0}' using displayFormat 'Exponential' at widget named "
-                "'{1}'.".format(value, widget_name)
+                "Could not display value '{0}' using displayFormat 'Exponential' at widget named '{1}'.".format(
+                    value, widget_name
+                )
             )
             r = value
         return r
@@ -117,8 +118,9 @@ def parse_value_for_display(
             r = hex(int(math.floor(value)))
         except (ValueError, TypeError):
             logger.error(
-                "Could not display value '{0}' using displayFormat 'Hex' at widget named "
-                "'{1}'.".format(value, widget_name)
+                "Could not display value '{0}' using displayFormat 'Hex' at widget named '{1}'.".format(
+                    value, widget_name
+                )
             )
             r = value
         return r
@@ -127,8 +129,9 @@ def parse_value_for_display(
             r = bin(int(math.floor(value)))
         except (ValueError, TypeError):
             logger.error(
-                "Could not display value '{0}' using displayFormat 'Binary' at widget named "
-                "'{1}'.".format(value, widget_name)
+                "Could not display value '{0}' using displayFormat 'Binary' at widget named '{1}'.".format(
+                    value, widget_name
+                )
             )
             r = value
         return r

--- a/pydm/widgets/display_format.py
+++ b/pydm/widgets/display_format.py
@@ -4,7 +4,7 @@ from typing import Any
 import logging
 import warnings
 
-from ..utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
+from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
 
 logger = logging.getLogger(__name__)
 

--- a/pydm/widgets/drawing.py
+++ b/pydm/widgets/drawing.py
@@ -8,7 +8,7 @@ from qtpy.QtGui import QColor, QPainter, QBrush, QPen, QPolygonF, QPixmap, QMovi
 from qtpy.QtCore import Property, Qt, QPoint, QPointF, QSize, Slot, QTimer, QRectF
 from qtpy.QtDesigner import QDesignerFormWindowInterface
 from .base import PyDMWidget, PostParentClassInitSetup
-from ..utilities import is_qt_designer, find_file
+from pydm.utilities import is_qt_designer, find_file
 from typing import List, Optional
 
 logger = logging.getLogger(__name__)

--- a/pydm/widgets/embedded_display.py
+++ b/pydm/widgets/embedded_display.py
@@ -7,7 +7,7 @@ import os.path
 import logging
 from .base import PyDMPrimitiveWidget
 from .baseplot import BasePlot
-from ..utilities import (
+from pydm.utilities import (
     is_pydm_app,
     establish_widget_connections,
     close_widget_connections,
@@ -15,7 +15,7 @@ from ..utilities import (
     is_qt_designer,
     find_file,
 )
-from ..display import load_file, ScreenTarget
+from pydm.display import load_file, ScreenTarget
 
 logger = logging.getLogger(__name__)
 

--- a/pydm/widgets/enum_button.py
+++ b/pydm/widgets/enum_button.py
@@ -14,8 +14,8 @@ from qtpy.QtWidgets import (
 )
 
 from .base import PyDMWritableWidget
-from .. import data_plugins
-from ..utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
+from pydm import data_plugins
+from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
 
 
 class WidgetType(object):

--- a/pydm/widgets/enum_combo_box.py
+++ b/pydm/widgets/enum_combo_box.py
@@ -176,7 +176,7 @@ class PyDMEnumComboBox(QComboBox, PyDMWritableWidget):
                 # findText return -1 when we can not find the text inside the
                 # QComboBox
                 if idx == -1:
-                    logger.error("Can not change value to %r. " "Not an option in PyDMComboBox", new_val)
+                    logger.error("Can not change value to %r. Not an option in PyDMComboBox", new_val)
                     return
             # Handle bool, float, and ndarray
             else:

--- a/pydm/widgets/enum_combo_box.py
+++ b/pydm/widgets/enum_combo_box.py
@@ -3,7 +3,7 @@ import six
 from qtpy.QtWidgets import QComboBox
 from qtpy.QtCore import Slot, Qt
 from .base import PyDMWritableWidget
-from .. import data_plugins
+from pydm import data_plugins
 
 logger = logging.getLogger(__name__)
 

--- a/pydm/widgets/image.py
+++ b/pydm/widgets/image.py
@@ -8,7 +8,7 @@ import logging
 from .channel import PyDMChannel
 from .colormaps import cmaps, cmap_names, PyDMColorMap
 from .base import PyDMWidget, PostParentClassInitSetup
-from ..utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
+from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
 
 logger = logging.getLogger(__name__)
 

--- a/pydm/widgets/line_edit.py
+++ b/pydm/widgets/line_edit.py
@@ -7,10 +7,10 @@ from functools import partial
 from qtpy.QtWidgets import QLineEdit, QMenu, QApplication
 from qtpy.QtCore import Property, Qt
 from qtpy.QtGui import QFocusEvent
-from .. import utilities
+from pydm import utilities
 from .base import PyDMWritableWidget, TextFormatter, str_types
 from .display_format import DisplayFormat, parse_value_for_display
-from ..utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
+from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
 
 logger = logging.getLogger(__name__)
 

--- a/pydm/widgets/logdisplay.py
+++ b/pydm/widgets/logdisplay.py
@@ -17,7 +17,7 @@ from qtpy.QtWidgets import (
 )
 from qtpy.QtGui import QPainter
 
-from ..utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
+from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
 
 logger = logging.getLogger(__name__)
 

--- a/pydm/widgets/multi_axis_plot.py
+++ b/pydm/widgets/multi_axis_plot.py
@@ -4,7 +4,7 @@ from typing import List, Optional
 from qtpy.QtCore import Qt, Signal
 from .multi_axis_viewbox import MultiAxisViewBox
 from .multi_axis_viewbox_menu import MultiAxisViewBoxMenu
-from ..utilities import is_qt_designer
+from pydm.utilities import is_qt_designer
 
 
 class MultiAxisPlot(PlotItem):

--- a/pydm/widgets/pushbutton.py
+++ b/pydm/widgets/pushbutton.py
@@ -5,7 +5,7 @@ from qtpy.QtWidgets import QPushButton, QMessageBox, QInputDialog, QLineEdit, QS
 from qtpy.QtCore import Slot, Property
 from qtpy import QtDesigner
 from .base import PyDMWritableWidget
-from ..utilities import IconFont
+from pydm.utilities import IconFont
 import logging
 
 logger = logging.getLogger(__name__)

--- a/pydm/widgets/qtplugin_base.py
+++ b/pydm/widgets/qtplugin_base.py
@@ -18,6 +18,7 @@ for each PyDMDesignerPlugin that Qt Designer tries to use. This will not
 affect any of your widgets, but it will be annoying.
 
 """
+
 import enum
 import inspect
 import logging
@@ -249,7 +250,7 @@ def create_designer_widget_from_widget(
         designer_kwargs = getattr(widget_cls, "_qt_designer_", None) or {}
         return qtplugin_factory(widget_cls, **designer_kwargs)
 
-    raise ValueError(f"Expected a PyDMDesignerPlugin or a QWidget subclass, " f"got a {type(widget_cls).__name__}")
+    raise ValueError(f"Expected a PyDMDesignerPlugin or a QWidget subclass, got a {type(widget_cls).__name__}")
 
 
 def get_widgets_from_entrypoints(key: str = config.ENTRYPOINT_WIDGET) -> Dict[str, Type[PyDMDesignerPlugin]]:
@@ -278,7 +279,7 @@ def get_widgets_from_entrypoints(key: str = config.ENTRYPOINT_WIDGET) -> Dict[st
         try:
             designer_widget = create_designer_widget_from_widget(plugin_cls)
         except Exception:
-            logger.warning("Invalid widget class specified in entrypoint " "%s: %s", entry.name, plugin_cls)
+            logger.warning("Invalid widget class specified in entrypoint %s: %s", entry.name, plugin_cls)
         else:
             widgets[entry.name] = designer_widget
 

--- a/pydm/widgets/qtplugin_base.py
+++ b/pydm/widgets/qtplugin_base.py
@@ -26,8 +26,8 @@ from typing import Dict, List, Optional, Type
 import entrypoints
 from qtpy import QtCore, QtDesigner, QtGui, QtWidgets
 
-from .. import config
-from ..qtdesigner import DesignerHooks
+from pydm import config
+from pydm.qtdesigner import DesignerHooks
 from .qtplugin_extensions import PyDMExtensionFactory
 
 logger = logging.getLogger(__name__)

--- a/pydm/widgets/qtplugin_extensions.py
+++ b/pydm/widgets/qtplugin_extensions.py
@@ -3,17 +3,17 @@ import logging
 from qtpy.QtDesigner import QExtensionFactory, QPyDesignerTaskMenuExtension
 from qtpy import QtWidgets
 
-from ..utilities import copy_to_clipboard, get_clipboard_text
-from ..widgets.base import PyDMPrimitiveWidget
+from pydm.utilities import copy_to_clipboard, get_clipboard_text
+from pydm.widgets.base import PyDMPrimitiveWidget
 
-from ..widgets.rules_editor import RulesEditor
-from ..widgets.designer_settings import BasicSettingsEditor
-from ..widgets.archiver_time_plot_editor import ArchiverTimePlotCurveEditorDialog
-from ..widgets.waveformplot_curve_editor import WaveformPlotCurveEditorDialog
-from ..widgets.timeplot_curve_editor import TimePlotCurveEditorDialog
-from ..widgets.scatterplot_curve_editor import ScatterPlotCurveEditorDialog
-from ..widgets.eventplot_curve_editor import EventPlotCurveEditorDialog
-from ..widgets.symbol_editor import SymbolEditor
+from pydm.widgets.rules_editor import RulesEditor
+from pydm.widgets.designer_settings import BasicSettingsEditor
+from pydm.widgets.archiver_time_plot_editor import ArchiverTimePlotCurveEditorDialog
+from pydm.widgets.waveformplot_curve_editor import WaveformPlotCurveEditorDialog
+from pydm.widgets.timeplot_curve_editor import TimePlotCurveEditorDialog
+from pydm.widgets.scatterplot_curve_editor import ScatterPlotCurveEditorDialog
+from pydm.widgets.eventplot_curve_editor import EventPlotCurveEditorDialog
+from pydm.widgets.symbol_editor import SymbolEditor
 
 
 logger = logging.getLogger(__name__)

--- a/pydm/widgets/qtplugins.py
+++ b/pydm/widgets/qtplugins.py
@@ -1,7 +1,7 @@
 import logging
 import os
 
-from ..utilities.iconfont import IconFont
+from pydm.utilities.iconfont import IconFont
 from .archiver_time_plot import PyDMArchiverTimePlot
 from .byte import PyDMByteIndicator
 from .byte import PyDMMultiStateIndicator

--- a/pydm/widgets/related_display_button.py
+++ b/pydm/widgets/related_display_button.py
@@ -9,10 +9,10 @@ from qtpy.QtGui import QCursor, QIcon, QMouseEvent, QColor
 from qtpy.QtCore import Slot, Property, Qt, QSize, QPoint
 from qtpy import QtDesigner
 from .base import PyDMWidget, only_if_channel_set, PostParentClassInitSetup
-from ..utilities import IconFont, find_file, is_pydm_app
-from ..utilities.macro import parse_macro_string
-from ..utilities.stylesheet import merge_widget_stylesheet
-from ..display import load_file, ScreenTarget
+from pydm.utilities import IconFont, find_file, is_pydm_app
+from pydm.utilities.macro import parse_macro_string
+from pydm.utilities.stylesheet import merge_widget_stylesheet
+from pydm.display import load_file, ScreenTarget
 from typing import Optional, List
 
 logger = logging.getLogger(__name__)

--- a/pydm/widgets/rules.py
+++ b/pydm/widgets/rules.py
@@ -372,7 +372,7 @@ class RulesEngine(QThread):
             self.emit_value(widget_ref, name, prop, val)
         except Exception:
             logger.exception(
-                f"Error while evaluating Rule with name: {name} and type: {prop} " f"and expression: {expression}"
+                f"Error while evaluating Rule with name: {name} and type: {prop} and expression: {expression}"
             )
 
     def emit_value(self, widget_ref, name, prop, val):

--- a/pydm/widgets/rules.py
+++ b/pydm/widgets/rules.py
@@ -6,7 +6,7 @@ import weakref
 from qtpy.QtCore import QThread, QMutex, Signal
 from qtpy.QtWidgets import QWidget, QApplication
 from qtpy.QtGui import QColor, QBrush
-from ..utilities import is_qt_designer
+from pydm.utilities import is_qt_designer
 from .channel import PyDMChannel
 
 import numpy as np

--- a/pydm/widgets/rules_editor.py
+++ b/pydm/widgets/rules_editor.py
@@ -5,7 +5,7 @@ import webbrowser
 
 from qtpy import QtWidgets, QtCore, QtDesigner
 from qtpy.QtCore import Qt
-from ..utilities.iconfont import IconFont
+from pydm.utilities.iconfont import IconFont
 
 
 class RulesEditor(QtWidgets.QDialog):

--- a/pydm/widgets/scatterplot.py
+++ b/pydm/widgets/scatterplot.py
@@ -6,7 +6,7 @@ from qtpy.QtGui import QColor
 from qtpy.QtCore import Slot, Property, Qt
 from .baseplot import BasePlot, NoDataError, BasePlotCurveItem
 from .channel import PyDMChannel
-from ..utilities import remove_protocol
+from pydm.utilities import remove_protocol
 
 
 DEFAULT_BUFFER_SIZE = 1200

--- a/pydm/widgets/shell_command.py
+++ b/pydm/widgets/shell_command.py
@@ -12,7 +12,7 @@ from qtpy.QtGui import QCursor, QIcon, QMouseEvent, QColor
 from qtpy.QtCore import Property, QSize, Qt, QTimer
 from qtpy import QtDesigner
 from .base import PyDMWidget, only_if_channel_set, PostParentClassInitSetup
-from ..utilities import IconFont, ACTIVE_QT_WRAPPER, QtWrapperTypes
+from pydm.utilities import IconFont, ACTIVE_QT_WRAPPER, QtWrapperTypes
 from typing import Optional, Union, List
 
 logger = logging.getLogger(__name__)

--- a/pydm/widgets/shell_command.py
+++ b/pydm/widgets/shell_command.py
@@ -649,7 +649,14 @@ class PyDMShellCommand(QPushButton, PyDMWidget):
             menu.addAction("Display Command", lambda: QMessageBox.information(self, "Shell Command", self.commands[0]))
             menu.addAction("Copy Command", lambda: QApplication.clipboard().setText(self.commands[0]))
         else:
-            menu.addAction("Display Commands", lambda: QMessageBox.information(self, "Shell Commands", "\n\n".join([f"{name}:\n{cmd}" for name, cmd in zip(self.titles, self.commands)])))
+            menu.addAction(
+                "Display Commands",
+                lambda: QMessageBox.information(
+                    self,
+                    "Shell Commands",
+                    "\n\n".join([f"{name}:\n{cmd}" for name, cmd in zip(self.titles, self.commands)]),
+                ),
+            )
 
         return menu
 

--- a/pydm/widgets/shell_command.py
+++ b/pydm/widgets/shell_command.py
@@ -504,7 +504,7 @@ class PyDMShellCommand(QPushButton, PyDMWidget):
         ----------
         value : str
         """
-        warnings.warn("'PyDMShellCommand.command' is deprecated, " "use 'PyDMShellCommand.commands' instead.")
+        warnings.warn("'PyDMShellCommand.command' is deprecated, use 'PyDMShellCommand.commands' instead.")
         if not self._commands:
             if value:
                 self.commands = [value]

--- a/pydm/widgets/symbol.py
+++ b/pydm/widgets/symbol.py
@@ -5,7 +5,7 @@ from qtpy.QtWidgets import QApplication, QWidget, QStyle, QStyleOption
 from qtpy.QtGui import QPainter, QPixmap
 from qtpy.QtCore import Property, Qt, QSize, QSizeF, QRectF, qInstallMessageHandler
 from qtpy.QtSvg import QSvgRenderer
-from ..utilities import find_file
+from pydm.utilities import find_file
 from .base import PyDMWidget, PostParentClassInitSetup
 
 logger = logging.getLogger(__name__)

--- a/pydm/widgets/symbol_editor.py
+++ b/pydm/widgets/symbol_editor.py
@@ -6,7 +6,7 @@ from qtpy.QtWidgets import QStyle, QStyleOption
 from qtpy.QtGui import QPainter, QPixmap
 from qtpy.QtCore import Qt, QSize, QSizeF, QRectF, qInstallMessageHandler
 from qtpy.QtSvg import QSvgRenderer
-from ..utilities import is_qt_designer, find_file
+from pydm.utilities import is_qt_designer, find_file
 
 
 class SymbolEditor(QtWidgets.QDialog):

--- a/pydm/widgets/tab_bar.py
+++ b/pydm/widgets/tab_bar.py
@@ -5,7 +5,7 @@ from .base import PyDMWidget, PostParentClassInitSetup
 from .channel import PyDMChannel
 from qtpy.QtCore import Property
 from functools import partial
-from ..utilities.iconfont import IconFont
+from pydm.utilities.iconfont import IconFont
 
 
 class PyDMTabBar(QTabBar, PyDMWidget):

--- a/pydm/widgets/template_repeater.py
+++ b/pydm/widgets/template_repeater.py
@@ -7,9 +7,9 @@ from qtpy.QtCore import Qt, QSize, QRect, Property, QPoint
 from .base import PyDMPrimitiveWidget
 from pydm.utilities import is_qt_designer
 import pydm.data_plugins
-from ..utilities import find_file
-from ..display import load_file
-from ..utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
+from pydm.utilities import find_file
+from pydm.display import load_file
+from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
 
 logger = logging.getLogger(__name__)
 

--- a/pydm/widgets/terminator.py
+++ b/pydm/widgets/terminator.py
@@ -5,7 +5,7 @@ from qtpy.QtGui import QIcon
 from qtpy.QtWidgets import QLabel, QMessageBox, QApplication
 
 from .base import PyDMPrimitiveWidget, get_icon_file
-from ..utilities import is_qt_designer
+from pydm.utilities import is_qt_designer
 
 logger = logging.getLogger(__name__)
 

--- a/pydm/widgets/timeplot.py
+++ b/pydm/widgets/timeplot.py
@@ -8,7 +8,7 @@ from qtpy.QtGui import QColor, QCursor
 from qtpy.QtCore import Signal, Slot, Property, QTimer
 from .baseplot import BasePlot, BasePlotCurveItem
 from .channel import PyDMChannel
-from ..utilities import remove_protocol, ACTIVE_QT_WRAPPER, QtWrapperTypes
+from pydm.utilities import remove_protocol, ACTIVE_QT_WRAPPER, QtWrapperTypes
 from datetime import datetime
 
 import logging

--- a/pydm/widgets/waveformplot.py
+++ b/pydm/widgets/waveformplot.py
@@ -7,7 +7,7 @@ from .channel import PyDMChannel
 import itertools
 import json
 from collections import OrderedDict
-from ..utilities import remove_protocol
+from pydm.utilities import remove_protocol
 
 
 class WaveformCurveItem(BasePlotCurveItem):


### PR DESCRIPTION
fix up precommit config, broken from recent patch and not running ruff. and apply ruff fixes from when it was not working.

also add unimportant, minor maintenance patch ive been sitting on for a bit.
pep8 recommends absolute imports, and i somehow always mess up the number of '.' to use when matching the current relative import style

just uses this rule from ruff as part of precommit https://docs.astral.sh/ruff/rules/#flake8-tidy-imports-tid

