### PR TITLE
TST: fix error during tests on pyside6 with c++ internal object deletion

### DIFF
--- a/pydm/tests/widgets/test_eventplot.py
+++ b/pydm/tests/widgets/test_eventplot.py
@@ -9,4 +9,8 @@ def test_add_channel(qtbot):
     curve = "TEST:EVENT:PLOT"
     event_plot.addChannel(curve)
 
+    # We need redrawPlot here to stop a specific pyside6 error where the internal C++ object for the plot gets
+    # deleted early. This only happens in the case of running all the tests together with pytest.
+    event_plot.redrawPlot()
+
     assert event_plot.curveAtIndex(0).channel.address == "TEST:EVENT:PLOT"


### PR DESCRIPTION
When running on pyside6, this error is not thrown on examples or when running test files individually. But only when running all the tests in sequence (with pytest cmd directly or run_tests.py), was getting following error:

```
Traceback (most recent call last):
  File "/home/nolan-work/repos/pydm/pydm/widgets/eventplot.py", line 403, in redrawPlot
    curve.redrawCurve()
  File "/home/nolan-work/repos/pydm/pydm/widgets/eventplot.py", line 195, in redrawCurve
    self.setData(
  File "/home/nolan-work/miniforge3/envs/pydm-environment-pyside6/lib/python3.10/site-packages/pyqtgraph/graphicsItems/PlotDataItem.py", line 833, in setData
    self.updateItems( styleUpdate = self.property('styleWasChanged') )
RuntimeError: Internal C++ object (EventPlotCurveItem) already deleted.
```

Calling a redraw of the eventplot seems to indicate to the pyside6 c++ bindings to not delete the object here while slots are still executing, and avoids this error.