### PR TITLE
BUG: properly remove error bars in time plot's clearCurves

### DIFF
--- a/pydm/widgets/archiver_time_plot.py
+++ b/pydm/widgets/archiver_time_plot.py
@@ -1041,8 +1041,7 @@ class PyDMArchiverTimePlot(PyDMTimePlot):
             # Need to clear out any bars from optimized data; only applicable to ArchivePlotCurveItems
             if not isinstance(curve, ArchivePlotCurveItem):
                 continue
-            vb = curve.error_bar.getViewBox()
-            vb.removeItem(curve.error_bar)
+            curve.remove_error_bar()
 
         # reset _min_x to let updateXAxis make requests anew
         self._min_x = self._starting_timestamp


### PR DESCRIPTION
PyDMArchiverTimePlot.clearCurves tries to remove the error bars from its curves before removing the curves themselves, which is throwing an AttributeError if an error bar doesn't have a view box.  This situation can occur when first setting curves in a model, when no curves or error bars have been set up.

This commit fixes the error by delegating error bar removal to the curve itself via ArchivePlotCurveItem.remove_error_bar