### PR TITLE
FIX: Don't attempt a disconnect on the value signal if the widget is being destroyed

### DIFF
--- a/pydm/data_plugins/plugin.py
+++ b/pydm/data_plugins/plugin.py
@@ -193,7 +193,7 @@ class PyDMConnection(QObject):
             except (KeyError, TypeError):
                 pass
 
-        if channel.value_signal is not None and hasattr(self, "put_value"):
+        if not destroying and channel.value_signal is not None and hasattr(self, "put_value"):
             for signal_type in (str, int, float, np.ndarray, dict):
                 try:
                     channel.value_signal[signal_type].disconnect(self.put_value)


### PR DESCRIPTION
## Context

A quick follow up to #1208. Sometimes will see `RuntimeError: wrapped C/C++ object of type Connection has been deleted` when closing a display.

This is because of a missed check that the widget isn't being destroyed before trying to disconnect `channel.value_signal`. If it is being destroyed, then Qt handles the signal/slot disconnection as expected and there's no need to attempt another time, otherwise can run into the error above since it's already gone by the time the second attempted disconnect happens.

Verified the error is gone after this fix. Verified that the issue #1208 fixed is still fixed.
