### PR TITLE
FIX: use a regex to parse a given URI instead of urllib

### DIFF
--- a/pydm/tests/utilities/test_remove_protocol.py
+++ b/pydm/tests/utilities/test_remove_protocol.py
@@ -30,4 +30,25 @@ def test_parsed_address():
     assert out is None
 
     out = parsed_address("foo://bar")
-    assert out == ("foo", "bar", "", "", "", "")
+    assert out == ("foo", "bar", "", "")
+
+    out = parsed_address("foo://bar#baz")
+    assert out == ("foo", "bar#baz", "", "")
+
+    out = parsed_address("foo:///aj")
+    assert out == ("foo", "", "/aj", "")
+
+    out = parsed_address("foo://rd?question!")
+    assert out == ("foo", "rd", "", "question!")
+
+    out = parsed_address("alpha://beta/delta?gamma")
+    assert out.scheme == "alpha" and out.netloc == "beta" and out.path == "/delta" and out.query == "gamma"
+
+    out = parsed_address("foo://test:channel.{'f': {'lo':0, 'hi':10} }?and_query_too")
+    assert out == ("foo", "test:channel.{'f': {'lo':0, 'hi':10} }", "", "and_query_too")
+
+    out = parsed_address("foo://TEST:PV[3]")
+    assert out == ("foo", "TEST:PV[3]", "", "")
+
+    out = parsed_address("loc://my_variable_name?type=variable_type&init=initial_values")
+    assert out == ("loc", "my_variable_name", "", "type=variable_type&init=initial_values")

--- a/pydm/utilities/__init__.py
+++ b/pydm/utilities/__init__.py
@@ -31,6 +31,7 @@ __all__ = [
     "IconFont",
     "protocol_and_address",
     "remove_protocol",
+    "BasicURI",
     "parsed_address",
     "convert",
     "find_unit_options",

--- a/pydm/utilities/remove_protocol.py
+++ b/pydm/utilities/remove_protocol.py
@@ -1,5 +1,5 @@
+import collections
 import re
-import urllib
 from .. import config
 
 
@@ -46,9 +46,12 @@ def protocol_and_address(address):
     return protocol, addr
 
 
+BasicURI = collections.namedtuple("BasicURI", ["scheme", "netloc", "path", "query"])
+
+
 def parsed_address(address):
     """
-    Returns the given address parsed into a 6-tuple. The parsing is done by urllib.parse.urlparse
+    Returns the given address parsed into a BasicURI named tuple.
 
     Parameters
     ----------
@@ -63,11 +66,20 @@ def parsed_address(address):
         return None
 
     match = re.match(".*?://", address)
-    parsed_address = None
+    if not match:
+        if not config.DEFAULT_PROTOCOL:
+            return None
+        address = config.DEFAULT_PROTOCOL + "://" + address
 
-    if match:
-        parsed_address = urllib.parse.urlparse(address)
-    elif config.DEFAULT_PROTOCOL:
-        parsed_address = urllib.parse.urlparse(config.DEFAULT_PROTOCOL + "://" + address)
+    # scheme://netloc/path?query will decompose into "scheme", "netloc", "/path", "query"
+    # scheme is required. netloc, path, and query are each optional but have to appear in this order
+    components = re.match(r"(.*?)://([^/?]*)(?:(/[^?]*)?(?:\?(.*))?)?", address)
+    if not components:
+        return None
 
-    return parsed_address
+    return BasicURI(
+        scheme=(components.group(1) or ""),
+        netloc=(components.group(2) or ""),
+        path=(components.group(3) or ""),
+        query=(components.group(4) or ""),
+    )


### PR DESCRIPTION
Replaces `urllib.parse.urlparse` with a regex. The params and fragment values have been dropped from the returned tuple, as they were unused and could possibly break up valid channel names.

Closes #1118