### PR TITLE
ENH: Add PyDMWindow widget to configure hiding the nav bar, menu bar, and status bar components on first load

### DIFF
--- a/pydm/main_window.py
+++ b/pydm/main_window.py
@@ -39,6 +39,7 @@ class PyDMMainWindow(QMainWindow):
         self.iconFont = IconFont()
         self._display_widget = None
         self._showing_file_path_in_title_bar = False
+        self._display_widget_has_been_shown = False
 
         # style sheet change flag
         self.isSS_Changed = False
@@ -91,16 +92,8 @@ class PyDMMainWindow(QMainWindow):
         self.showMacros.triggered.connect(self.show_macro_window)
         self.ui.actionQuit.triggered.connect(self.quit_main_window)
 
-        if hide_nav_bar:
-            self.toggle_nav_bar(False)
-            self.ui.actionShow_Navigation_Bar.setChecked(False)
-        if hide_menu_bar:
-            # Toggle the menu bar via the QAction so that the menu item
-            # stays in sync with menu visibility.
-            self.ui.actionShow_Menu_Bar.activate(QAction.Trigger)
-        if hide_status_bar:
-            self.toggle_status_bar(False)
-            self.ui.actionShow_Status_Bar.setChecked(False)
+        self.hide_window_components(hide_nav_bar, hide_menu_bar, hide_status_bar)
+
         # Try to find the designer binary.
         self.ui.actionEdit_in_Designer.setEnabled(False)
 
@@ -138,6 +131,16 @@ class PyDMMainWindow(QMainWindow):
         self.enable_disable_navigation()
         self.update_window_title()
         self.add_menu_items()
+
+        # We want to respect the user's choices after the first display has loaded
+        if not self._display_widget_has_been_shown:
+            self.hide_window_components(
+                self._display_widget.property("hideNavBar"),
+                self._display_widget.property("hideMenuBar"),
+                self._display_widget.property("hideStatusBar"),
+            )
+        self._display_widget_has_been_shown = True
+
         # Resizing to the new widget's dimensions needs to be
         # done on the event loop for some reason - you can't
         # just do it here.
@@ -256,6 +259,18 @@ class PyDMMainWindow(QMainWindow):
         if data_plugins.is_read_only():
             title += " [Read Only Mode]"
         self.setWindowTitle(title)
+
+    def hide_window_components(self, hide_nav_bar, hide_menu_bar, hide_status_bar):
+        if hide_nav_bar:
+            self.toggle_nav_bar(False)
+            self.ui.actionShow_Navigation_Bar.setChecked(False)
+        if hide_menu_bar:
+            # Toggle the menu bar via the QAction so that the menu item
+            # stays in sync with menu visibility.
+            self.ui.actionShow_Menu_Bar.activate(QAction.Trigger)
+        if hide_status_bar:
+            self.toggle_status_bar(False)
+            self.ui.actionShow_Status_Bar.setChecked(False)
 
     @property
     def showing_file_path_in_title_bar(self):

--- a/pydm/tests/test_plugins_import.py
+++ b/pydm/tests/test_plugins_import.py
@@ -60,6 +60,13 @@ def test_import_frame_plugin():
     qtplugin_factory(PyDMFrame, is_container=True)
 
 
+def test_import_window_plugin():
+    # Window plugin
+    from ..widgets.window import PyDMWindow
+
+    qtplugin_factory(PyDMWindow, is_container=True)
+
+
 def test_import_enum_button_plugin():
     # Enum Button plugin
     from ..widgets.enum_button import PyDMEnumButton

--- a/pydm/tests/widgets/test_window.py
+++ b/pydm/tests/widgets/test_window.py
@@ -1,0 +1,28 @@
+# Unit Tests for the Window Widget
+
+from ...widgets.window import PyDMWindow
+
+
+# --------------------
+# POSITIVE TEST CASES
+# --------------------
+
+
+def test_construct(qtbot):
+    """
+    Test the construction of the widget.
+
+    Expectations:
+    The correct default values are assigned to the widget's attributes.
+
+    Parameters
+    ----------
+    qtbot : fixture
+        pytest-qt window for widget test
+    """
+    pydm_window = PyDMWindow()
+    qtbot.addWidget(pydm_window)
+
+    assert pydm_window._hide_menu_bar is False
+    assert pydm_window._hide_nav_bar is False
+    assert pydm_window._hide_status_bar is False

--- a/pydm/widgets/frame.py
+++ b/pydm/widgets/frame.py
@@ -11,7 +11,7 @@ class PyDMFrame(QFrame, PyDMWidget):
     Parameters
     ----------
     parent : QWidget
-        The parent widget for the Label
+        The parent widget for the Frame
     init_channel : str, optional
         The channel to be used by the widget.
     """

--- a/pydm/widgets/qtplugins.py
+++ b/pydm/widgets/qtplugins.py
@@ -25,6 +25,7 @@ from .embedded_display import PyDMEmbeddedDisplay
 from .enum_button import PyDMEnumButton
 from .enum_combo_box import PyDMEnumComboBox
 from .frame import PyDMFrame
+from .window import PyDMWindow
 from .image import PyDMImageView
 from .label import PyDMLabel
 from .line_edit import PyDMLineEdit
@@ -199,6 +200,11 @@ PyDMEnumComboBoxPlugin = qtplugin_factory(
 # Frame plugin
 PyDMFramePlugin = qtplugin_factory(
     PyDMFrame, group=WidgetCategory.CONTAINER, is_container=True, extensions=BASE_EXTENSIONS, icon=ifont.icon("expand")
+)
+
+# Window plugin
+PyDMWindowPlugin = qtplugin_factory(
+    PyDMWindow, group=WidgetCategory.CONTAINER, is_container=True, extensions=BASE_EXTENSIONS, icon=ifont.icon("expand")
 )
 
 # Image plugin

--- a/pydm/widgets/window.py
+++ b/pydm/widgets/window.py
@@ -1,0 +1,106 @@
+import warnings
+from qtpy.QtWidgets import QWidget
+from qtpy.QtCore import Property
+from typing import Optional
+from .base import is_qt_designer
+
+
+class PyDMWindow(QWidget):
+    """
+    QWidget with support for some custom PyDM properties. Right now it only
+    supports disabling the menu bar, nav bar, and status bar by default. This
+    widget will only function if it is at the root of the UI hierarchy.
+    This class inherits from QWidget. It is NOT a PyDMWidget.
+
+    Parameters
+    ----------
+    parent : QWidget
+        The parent widget for the Window. Should ideally be None
+    """
+
+    def __init__(self, parent: Optional[QWidget] = None):
+        if parent is not None and not is_qt_designer():
+            warnings.warn("PyDMWindow must be at the root of the UI hierarchy, or it will not function properly!")
+
+        super().__init__(parent)
+        self._hide_menu_bar = False
+        self._hide_nav_bar = False
+        self._hide_status_bar = False
+
+    @Property(bool)
+    def hideMenuBar(self):
+        """
+        Whether or not the widget should automatically disable the
+        menu bar when the display is loaded.
+
+        Returns
+        -------
+        hide_menu_bar : bool
+            The configured value
+        """
+        return self._hide_menu_bar
+
+    @hideMenuBar.setter
+    def hideMenuBar(self, new_val):
+        """
+        Whether or not the widget should automatically disable the
+        menu bar when the display is loaded.
+
+        Parameters
+        ----------
+        new_val : bool
+            The new configuration to use
+        """
+        self._hide_menu_bar = new_val
+
+    @Property(bool)
+    def hideNavBar(self):
+        """
+        Whether or not the widget should automatically disable the
+        nav bar when the display is loaded.
+
+        Returns
+        -------
+        hide_nav_bar : bool
+            The configured value
+        """
+        return self._hide_nav_bar
+
+    @hideNavBar.setter
+    def hideNavBar(self, new_val):
+        """
+        Whether or not the widget should automatically disable the
+        nav bar when the display is loaded.
+
+        Parameters
+        ----------
+        new_val : bool
+            The new configuration to use
+        """
+        self._hide_nav_bar = new_val
+
+    @Property(bool)
+    def hideStatusBar(self):
+        """
+        Whether or not the widget should automatically disable the
+        status bar when the display is loaded.
+
+        Returns
+        -------
+        hide_status_bar : bool
+            The configured value
+        """
+        return self._hide_status_bar
+
+    @hideStatusBar.setter
+    def hideStatusBar(self, new_val):
+        """
+        Whether or not the widget should automatically disable the
+        status bar when the display is loaded.
+
+        Parameters
+        ----------
+        new_val : bool
+            The new configuration to use
+        """
+        self._hide_status_bar = new_val


### PR DESCRIPTION
Command-line parameters exist to hide these components on startup, however these aren't possible to set in Qt Designer. This PR adds the `PyDMWindow` widget which can replace `QWidget` as the root of a display widget hierarchy, and it exposes the options to hide these components on first load as checkboxes in the properties section in Designer. When a display using this widget is loaded, it will apply the requested settings if it is the first display loaded in that instance of PyDM, similar to how the command-line parameters work.