### PR TITLE
ENH: allow displays to be loaded from subdirectories of search paths

### DIFF
--- a/docs/source/tutorials/intro/launcher.rst
+++ b/docs/source/tutorials/intro/launcher.rst
@@ -38,6 +38,8 @@ Argument                     Description
 ============================ ================================================================================
 DISPLAY_FILE (positional)    | Loads a display from this file to show once PyDM has started.
 -h, --help                   | Show the PyDM help message and exit.
+-r, --recurse                | Recursively search for the provided DISPLAY_FILE in the current working
+                             | directory and subfolders.
 --homefile FILE              | Path to a PyDM file to return to when the home button is clicked in the
                              | navigation bar. This display remains loaded at all times, and is loaded
                              | even when a display file is specified separately. If the specified

--- a/pydm/application.py
+++ b/pydm/application.py
@@ -60,6 +60,10 @@ class PyDMApplication(QApplication):
     macros : dict, optional
         A dictionary of macro variables to be forwarded to the display class
         being loaded.
+    recursive_display_search : bool, optional
+        Whether or not to search for a provided display file recursively
+        in subfolders relative to the current working directory. Does not
+        apply to the homefile parameter.
     use_main_window : bool, optional
         If ui_file is note given, this parameter controls whether or not to
         create a PyDMMainWindow in the initialization (Default is True).
@@ -83,6 +87,7 @@ class PyDMApplication(QApplication):
         hide_status_bar=False,
         read_only=False,
         macros=None,
+        recursive_display_search=False,
         use_main_window=True,
         stylesheet_path=None,
         fullscreen=False,
@@ -116,6 +121,7 @@ class PyDMApplication(QApplication):
                 stylesheet_path=stylesheet_path,
                 home_file=self.home_file,
                 macros=macros,
+                recursive_display_search=recursive_display_search,
                 command_line_args=command_line_args,
             )
             if ui_file is not None and self.home_file is not None:
@@ -228,7 +234,7 @@ class PyDMApplication(QApplication):
             args.extend(command_line_args)
         subprocess.Popen(args, shell=False)
 
-    def make_main_window(self, stylesheet_path=None, home_file=None, macros=None, command_line_args=None):
+    def make_main_window(self, stylesheet_path=None, home_file=None, macros=None, recursive_display_search=False, command_line_args=None):
         """
         Instantiate a new PyDMMainWindow, add it to the application's
         list of windows. Typically, this function is only called as part
@@ -241,6 +247,7 @@ class PyDMApplication(QApplication):
             hide_status_bar=self.hide_status_bar,
             home_file=home_file,
             macros=macros,
+            recursive_display_search=recursive_display_search,
             command_line_args=command_line_args,
         )
 

--- a/pydm/main_window.py
+++ b/pydm/main_window.py
@@ -31,6 +31,7 @@ class PyDMMainWindow(QMainWindow):
         hide_status_bar=False,
         home_file=None,
         macros=None,
+        recursive_display_search=False,
         command_line_args=None,
     ):
         super().__init__(parent)
@@ -39,6 +40,7 @@ class PyDMMainWindow(QMainWindow):
         self.iconFont = IconFont()
         self._display_widget = None
         self._showing_file_path_in_title_bar = False
+        self._recursive_display_search = recursive_display_search
 
         # style sheet change flag
         self.isSS_Changed = False
@@ -388,7 +390,7 @@ class PyDMMainWindow(QMainWindow):
             curr_display = self.display_widget()
             if curr_display:
                 base_path = os.path.dirname(curr_display.loaded_file())
-            filename = find_file(filename, base_path=base_path, raise_if_not_found=True)
+            filename = find_file(filename, base_path=base_path, raise_if_not_found=True, subdir_scan_enabled=self._recursive_display_search, subdir_scan_base_path_only=False)
         new_widget = load_file(filename, macros=macros, args=args, target=target)
         if new_widget:
             if self.home_widget is None:

--- a/pydm/tests/utilities/test_utilities.py
+++ b/pydm/tests/utilities/test_utilities.py
@@ -37,7 +37,7 @@ def test_path_info():
 def test_find_display_in_path():
     temp, file_path = tempfile.mkstemp(suffix=".ui", prefix="display_")
     direc, fname, _ = path_info(file_path)
-    # Try to find the file as is... is should not find it.
+    # Try to find the file as is... it should not find it.
     assert find_display_in_path(fname) is None
 
     # Try to find the file passing the path

--- a/pydm/tests/utilities/test_utilities.py
+++ b/pydm/tests/utilities/test_utilities.py
@@ -5,7 +5,7 @@ import tempfile
 
 from qtpy import QtWidgets
 
-from ...utilities import find_display_in_path, is_pydm_app, is_qt_designer, log_failures, path_info, which
+from ...utilities import find_display_in_path, find_file, is_pydm_app, is_qt_designer, log_failures, path_info, which
 
 logger = logging.getLogger(__name__)
 
@@ -49,6 +49,27 @@ def test_find_display_in_path():
     expected = "{}{}{}".format(direc, os.sep, rel_name)
     disp_path = find_display_in_path(rel_name, mode=None, path=direc)
     assert disp_path == expected
+
+
+def test_find_file():
+    parent_lvl1 = tempfile.mkdtemp()
+    parent_lvl2 = tempfile.mkdtemp(dir=parent_lvl1)
+    temp, file_path = tempfile.mkstemp(suffix=".ui", prefix="display_", dir=parent_lvl2)
+    direc, fname, _ = path_info(file_path)
+    # Try to find the file as is... it should not find it.
+    assert find_file(fname) is None
+
+    # Try to find the file under base_path
+    disp_path = find_file(fname, base_path=direc)
+    assert disp_path == file_path
+
+    # Try to find the file under the parent folder without recursion (fail)
+    disp_path = find_file(fname, base_path=parent_lvl1)
+    assert disp_path == None
+
+    # Try to find the file under the parent folder with recursion (succeed)
+    disp_path = find_file(fname, base_path=parent_lvl1, subdir_scan_enabled=True)
+    assert disp_path == file_path
 
 
 def test_which():

--- a/pydm/utilities/__init__.py
+++ b/pydm/utilities/__init__.py
@@ -1,3 +1,4 @@
+import collections
 import functools
 import importlib
 import importlib.util
@@ -7,6 +8,7 @@ import os
 import platform
 import shlex
 import sys
+import time
 import types
 import uuid
 import errno
@@ -228,7 +230,7 @@ def _screen_file_extensions(preferred_extension):
     return extensions
 
 
-def find_file(fname, base_path=None, mode=None, extra_path=None, raise_if_not_found=False):
+def find_file(fname, base_path=None, mode=None, raise_if_not_found=False, subdir_scan_enabled=False, subdir_scan_base_path_only=True):
     """
     Look for files at the search paths common to PyDM.
 
@@ -238,7 +240,6 @@ def find_file(fname, base_path=None, mode=None, extra_path=None, raise_if_not_fo
     * Qt Designer Path - the path for the current form as reported by the
       designer
     * The current working directory
-    * Directories listed in ``extra_path``
     * Directories listed in the environment variable ``PYDM_DISPLAYS_PATH``
 
     Parameters
@@ -251,11 +252,15 @@ def find_file(fname, base_path=None, mode=None, extra_path=None, raise_if_not_fo
     mode : int
         The mode required for the file, defaults to os.F_OK | os.R_OK.
         Which ensure that the file exists and we can read it.
-    extra_path : list
-        Additional paths to look for file.
     raise_if_not_found : bool
         Flag which if False will add a check that raises a FileNotFoundError
         instead of returning None when the file is not found.
+    subdir_scan_enabled : bool
+        If the file cannot be found in the given directories, check
+        subdirectories. Defaults to False.
+    subdir_scan_base_path_only : bool
+        If it is necessary to scan subdirectories for the requested file,
+        only scan subdirectories of the base_path. Defaults to True.
 
     Returns
     -------
@@ -267,23 +272,19 @@ def find_file(fname, base_path=None, mode=None, extra_path=None, raise_if_not_fo
     if mode is None:
         mode = os.F_OK | os.R_OK
 
-    x_path = []
+    x_path = collections.deque()
 
     if base_path:
-        x_path.extend([os.path.abspath(base_path)])
+        base_path = os.path.abspath(base_path)
+        x_path.append(base_path)
 
     if is_qt_designer():
         designer_path = get_designer_current_path()
         if designer_path:
-            x_path.extend([designer_path])
+            x_path.append(designer_path)
 
     # Current working directory
-    x_path.extend([os.getcwd()])
-    if extra_path:
-        if not isinstance(extra_path, (list, tuple)):
-            extra_path = [extra_path]
-        extra_path = [os.path.expanduser(os.path.expandvars(x)) for x in extra_path]
-        x_path.extend(extra_path)
+    x_path.append(os.getcwd())
 
     pydm_search_path = os.getenv("PYDM_DISPLAYS_PATH", None)
     if pydm_search_path:
@@ -294,15 +295,43 @@ def find_file(fname, base_path=None, mode=None, extra_path=None, raise_if_not_fo
 
     root, ext = os.path.splitext(fname)
 
-    # loop through the possible screen file extensions
-    for e in _screen_file_extensions(ext):
-        file_path = which(str(root) + str(e), mode=mode, pathext=e, extra_path=x_path)
-        if file_path is not None:
-            break  # pick the first screen file found
+    # 3 seconds should be more than generous enough
+    SUBDIR_SCAN_TIME_LIMIT = 3
+    start_time = time.perf_counter()
 
-    if raise_if_not_found:
-        if not file_path:
-            raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), fname)
+    file_path = None
+    while file_path is None and len(x_path) > 0:
+        # Loop through the possible screen file extensions
+        for e in _screen_file_extensions(ext):
+            file_path = which(str(root) + str(e), mode=mode, pathext=e, extra_path=x_path)
+            if file_path is not None:
+                break  # pick the first screen file found
+
+        if not subdir_scan_enabled or time.perf_counter() - start_time >= SUBDIR_SCAN_TIME_LIMIT:
+            if not file_path and raise_if_not_found:
+                raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), fname)
+            break
+
+        # Only search recursively under base path
+        if subdir_scan_base_path_only:
+            if base_path is None or len(base_path) == 0:
+                break
+            x_path.clear()
+            x_path.append(os.path.expanduser(os.path.expandvars(base_path)))
+            # Prevent entering this block again
+            subdir_scan_base_path_only = False
+
+        # This might get large in some situations, but it's the easiest way to do BFS without
+        # changing too much of the existing logic, and ideally recursion isn't needed
+        path_count = len(x_path)
+        for _ in range(path_count):
+            for subdir in os.listdir(x_path[0]):
+                if subdir.startswith(".") or subdir.startswith("__pycache__"):
+                    continue
+                new_path = os.path.join(x_path[0], subdir)
+                if os.path.isdir(new_path):
+                    x_path.append(new_path)
+            x_path.popleft()
 
     return file_path
 
@@ -371,9 +400,6 @@ def which(cmd, mode=os.F_OK | os.X_OK, path=None, pathext=None, extra_path=None)
         return None
     path = path.split(os.pathsep)
 
-    if extra_path is not None:
-        path = extra_path + path
-
     if sys.platform == "win32":
         # The current directory takes precedence on Windows.
         if os.curdir not in path:
@@ -397,14 +423,17 @@ def which(cmd, mode=os.F_OK | os.X_OK, path=None, pathext=None, extra_path=None)
         files = [cmd]
 
     seen = set()
-    for dir_ in path:
-        normdir = os.path.normcase(dir_)
-        if normdir not in seen:
-            seen.add(normdir)
-            for thefile in files:
-                name = os.path.join(dir_, thefile)
-                if _access_check(name, mode):
-                    return name
+    for paths in extra_path, path:
+        if paths is None:
+            continue
+        for dir_ in paths:
+            normdir = os.path.normcase(dir_)
+            if normdir not in seen:
+                seen.add(normdir)
+                for thefile in files:
+                    name = os.path.join(dir_, thefile)
+                    if _access_check(name, mode):
+                        return name
     return None
 
 

--- a/pydm/widgets/drawing.py
+++ b/pydm/widgets/drawing.py
@@ -895,6 +895,7 @@ class PyDMDrawingImage(PyDMDrawing):
         self._pixmap.fill(self.null_color)
         self._aspect_ratio_mode = Qt.KeepAspectRatio
         self._movie = None
+        self._recursive_image_search = False
         self._file = None
         # Make sure we don't set a non-existent file
         if filename:
@@ -924,11 +925,37 @@ class PyDMDrawingImage(PyDMDrawing):
     def reload_image(self) -> None:
         self.filename = self._file
 
+    @Property(bool)
+    def recursiveImageSearch(self) -> bool:
+        """
+        Whether or not to search for a provided image file recursively
+        in subfolders relative to the location of this display.
+
+        Returns
+        -------
+        bool
+            If recursive search is enabled.
+        """
+        return self._recursive_image_search
+
+    @recursiveImageSearch.setter
+    def recursiveImageSearch(self, new_value) -> None:
+        """
+        Set whether or not to search for a provided image file recursively
+        in subfolders relative to the location of this image.
+
+        Parameters
+        ----------
+        new_value
+            If recursive search should be enabled.
+        """
+        self._recursive_image_search = new_value
+
     @Property(str)
     def filename(self) -> str:
         """
         The filename of the image to be displayed.
-        This can be an absolute or relative path to the display file.
+        This can be an absolute or relative path to the image file.
 
         Returns
         -------
@@ -961,7 +988,7 @@ class PyDMDrawingImage(PyDMDrawing):
             base_path = None
             if parent_display:
                 base_path = os.path.dirname(parent_display.loaded_file())
-            abs_path = find_file(abs_path, base_path=base_path)
+            abs_path = find_file(abs_path, base_path=base_path, subdir_scan_enabled=self._recursive_image_search)
             if not abs_path:
                 logger.error("Unable to find full filepath for %s", self._file)
                 return

--- a/pydm/widgets/embedded_display.py
+++ b/pydm/widgets/embedded_display.py
@@ -40,6 +40,7 @@ class PyDMEmbeddedDisplay(QFrame, PyDMPrimitiveWidget):
         PyDMPrimitiveWidget.__init__(self)
         self.app = QApplication.instance()
         self._filename = None
+        self._recursive_display_search = False
         self._macros = None
         self._embedded_widget = None
         self._disconnect_when_hidden = True
@@ -168,6 +169,32 @@ class PyDMEmbeddedDisplay(QFrame, PyDMPrimitiveWidget):
                 self.clear_error_text()
         self.load_if_needed()
 
+    @Property(bool)
+    def recursiveDisplaySearch(self) -> bool:
+        """
+        Whether or not to search for a provided display file recursively
+        in subfolders relative to the location of this display.
+
+        Returns
+        -------
+        bool
+            If recursive search is enabled.
+        """
+        return self._recursive_display_search
+
+    @recursiveDisplaySearch.setter
+    def recursiveDisplaySearch(self, new_value) -> None:
+        """
+        Set whether or not to search for a provided display file recursively
+        in subfolders relative to the location of this display.
+
+        Parameters
+        ----------
+        new_value
+            If recursive search should be enabled.
+        """
+        self._recursive_display_search = new_value
+
     def set_macros_and_filename(self, new_filename, new_macros):
         """
         A method to change both macros and the filename of an embedded display.
@@ -229,7 +256,7 @@ class PyDMEmbeddedDisplay(QFrame, PyDMPrimitiveWidget):
                     parent_file_path = os.path.realpath(parent_file_path)
                 base_path = os.path.dirname(parent_file_path)
 
-            fname = find_file(self.filename, base_path=base_path, raise_if_not_found=True)
+            fname = find_file(self.filename, base_path=base_path, raise_if_not_found=True, subdir_scan_enabled=self._recursive_display_search)
             w = load_file(fname, macros=self.parsed_macros(), target=None)
             self._needs_load = False
             self.clear_error_text()
@@ -420,7 +447,16 @@ class PyDMEmbeddedDisplay(QFrame, PyDMPrimitiveWidget):
         """Open the embedded display in a new window"""
         if not self.filename:
             return
-        file_path = find_file(self.filename, base_path="", raise_if_not_found=True)
+
+        parent_display = self.find_parent_display()
+        base_path = ""
+        if parent_display:
+            parent_file_path = parent_display.loaded_file()
+            if self._follow_symlinks:
+                parent_file_path = os.path.realpath(parent_file_path)
+            base_path = os.path.dirname(parent_file_path)
+
+        file_path = find_file(self.filename, base_path=base_path, raise_if_not_found=True, subdir_scan_enabled=self._recursive_display_search)
         macros = self.parsed_macros()
 
         if is_pydm_app():

--- a/pydm/widgets/related_display_button.py
+++ b/pydm/widgets/related_display_button.py
@@ -62,6 +62,7 @@ class PyDMRelatedDisplayButton(QPushButton, PyDMWidget):
         self.setCursor(QCursor(self._icon.pixmap(16, 16)))
         self._display_menu_items = None
         self._display_filename = ""
+        self._recursive_display_search = False
         self._macro_string = None
         self._open_in_new_window = False
         self.open_in_new_window_action = QAction("Open in New Window", self)
@@ -302,6 +303,32 @@ class PyDMRelatedDisplayButton(QPushButton, PyDMWidget):
             file_list = [value]
             self.filenames = self.filenames + file_list
         self._display_filename = ""
+
+    @Property(bool)
+    def recursiveDisplaySearch(self) -> bool:
+        """
+        Whether or not to search for a provided display file recursively
+        in subfolders relative to the location of this display.
+
+        Returns
+        -------
+        bool
+            If recursive search is enabled.
+        """
+        return self._recursive_display_search
+
+    @recursiveDisplaySearch.setter
+    def recursiveDisplaySearch(self, new_value) -> None:
+        """
+        Set whether or not to search for a provided display file recursively
+        in subfolders relative to the location of this display.
+
+        Parameters
+        ----------
+        new_value
+            If recursive search should be enabled.
+        """
+        self._recursive_display_search = new_value
 
     @Property("QStringList")
     def macros(self) -> List[str]:
@@ -582,7 +609,7 @@ class PyDMRelatedDisplayButton(QPushButton, PyDMWidget):
             base_path = os.path.dirname(parent_file_path)
             macros = copy.copy(parent_display.macros())
 
-        fname = find_file(filename, base_path=base_path, raise_if_not_found=True)
+        fname = find_file(filename, base_path=base_path, raise_if_not_found=True, subdir_scan_enabled=self._recursive_display_search)
         widget_macros = parse_macro_string(macro_string)
         macros.update(widget_macros)
 

--- a/pydm/widgets/template_repeater.py
+++ b/pydm/widgets/template_repeater.py
@@ -173,9 +173,11 @@ class PyDMTemplateRepeater(QFrame, PyDMPrimitiveWidget):
         QFrame.__init__(self, parent)
         PyDMPrimitiveWidget.__init__(self)
         self._template_filename = ""
+        self._recursive_template_search = False
         self._count_shown_in_designer = 1
         self._data_source = ""
         self._data = []
+        self._recursive_data_search = False
         self._cached_template = None
         self._parent_macros = None
         self._layout_type = LayoutType.Vertical
@@ -286,6 +288,32 @@ class PyDMTemplateRepeater(QFrame, PyDMPrimitiveWidget):
             else:
                 self.clear()
 
+    @Property(bool)
+    def recursiveTemplateSearch(self) -> bool:
+        """
+        Whether or not to search for a provided template file recursively
+        in subfolders relative to the location of this widget.
+
+        Returns
+        -------
+        bool
+            If recursive search is enabled.
+        """
+        return self._recursive_template_search
+
+    @recursiveTemplateSearch.setter
+    def recursiveTemplateSearch(self, new_value) -> None:
+        """
+        Set whether or not to search for a provided template file recursively
+        in subfolders relative to the location of this widget.
+
+        Parameters
+        ----------
+        new_value
+            If recursive search should be enabled.
+        """
+        self._recursive_template_search = new_value
+
     def _is_json(self, source):
         """
         Validate if the string source is a valid json.
@@ -349,7 +377,7 @@ class PyDMTemplateRepeater(QFrame, PyDMPrimitiveWidget):
                         base_path = None
                         if parent_display:
                             base_path = os.path.dirname(parent_display.loaded_file())
-                        fname = find_file(self._data_source, base_path=base_path, raise_if_not_found=True)
+                        fname = find_file(self._data_source, base_path=base_path, raise_if_not_found=True, subdir_scan_enabled=self._recursive_data_search)
 
                         if not fname:
                             if not is_qt_designer():
@@ -373,6 +401,32 @@ class PyDMTemplateRepeater(QFrame, PyDMPrimitiveWidget):
             else:
                 self.clear()
 
+    @Property(bool)
+    def recursiveDataSearch(self) -> bool:
+        """
+        Whether or not to search for a provided data file recursively
+        in subfolders relative to the location of this widget.
+
+        Returns
+        -------
+        bool
+            If recursive search is enabled.
+        """
+        return self._recursive_data_search
+
+    @recursiveDataSearch.setter
+    def recursiveDataSearch(self, new_value) -> None:
+        """
+        Set whether or not to search for a provided data file recursively
+        in subfolders relative to the location of this widget.
+
+        Parameters
+        ----------
+        new_value
+            If recursive search should be enabled.
+        """
+        self._recursive_data_search = new_value
+
     def open_template_file(self, variables=None):
         """
         Opens the widget specified in the templateFilename property.
@@ -393,7 +447,7 @@ class PyDMTemplateRepeater(QFrame, PyDMPrimitiveWidget):
         base_path = None
         if parent_display:
             base_path = os.path.dirname(parent_display.loaded_file())
-        fname = find_file(self.templateFilename, base_path=base_path, raise_if_not_found=True)
+        fname = find_file(self.templateFilename, base_path=base_path, raise_if_not_found=True, subdir_scan_enabled=self._recursive_template_search)
 
         if self._parent_macros is None:
             self._parent_macros = {}

--- a/pydm_launcher/main.py
+++ b/pydm_launcher/main.py
@@ -42,12 +42,18 @@ def main():
         default=None,
     )
     parser.add_argument(
+        "-r",
+        "--recurse",
+        action="store_true",
+        help="Recursively search for the provided displayfile in the current working directory and subfolders"
+    )
+    parser.add_argument(
         "--homefile", help="Path to a PyDM file to return to when the home button is clicked in the navigation bar"
     )
     parser.add_argument(
         "--perfmon",
         action="store_true",
-        help="Enable performance monitoring," + " and print CPU usage to the terminal.",
+        help="Enable performance monitoring, and print CPU usage to the terminal.",
     )
     parser.add_argument("--profile", action="store_true", help="Enable cProfile function profiling, printing on exit.")
     parser.add_argument("--faulthandler", action="store_true", help="Enable faulthandler to trace segmentation faults.")
@@ -121,6 +127,7 @@ def main():
         fullscreen=pydm_args.fullscreen,
         read_only=pydm_args.read_only,
         macros=macros,
+        recursive_display_search=pydm_args.recurse,
         stylesheet_path=pydm_args.stylesheet,
         home_file=pydm_args.homefile,
     )


### PR DESCRIPTION
Let me know if you would like any changes to the implementation, such as a command-line argument to enable this behavior. Possibly unknowingly changing existing behavior of a display, or having a collision between two displays with the same name worries me. I also disabled this behavior everywhere I found unrelated to loading displays, but maybe the parameter should be disabled by default and enabled in display loading code? Let me know your thoughts, I'm very new to this codebase.

Hopefully closes #1065