### PR TITLE
FIX: PyDMDateTime weirdness

### DIFF
--- a/examples/datetime/datetime.ui
+++ b/examples/datetime/datetime.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>208</width>
+    <width>240</width>
     <height>149</height>
    </rect>
   </property>

--- a/pydm/tests/widgets/test_datetime_edit.py
+++ b/pydm/tests/widgets/test_datetime_edit.py
@@ -1,0 +1,104 @@
+# Unit Tests for the PyDMLineEdit Widget
+
+import os
+import platform
+import pytest
+import time
+
+from ...widgets.datetime import PyDMDateTimeEdit, TimeBase
+from qtpy.QtCore import QDateTime
+
+
+# --------------------
+# POSITIVE TEST CASES
+# --------------------
+
+
+@pytest.mark.parametrize(
+    "init_channel",
+    [
+        "CA://MTEST",
+        "",
+        None,
+    ],
+)
+def test_construct(qtbot, init_channel):
+    """
+    Test the widget construct.
+    Expectations:
+    All parameters have the correct default value.
+
+    Parameters
+    ----------
+     qtbot : fixture
+        Window for widget testing
+    init_channel : str
+        The data channel to be used by the widget
+
+    """
+    pydm_datetimeedit = PyDMDateTimeEdit(init_channel=init_channel)
+    qtbot.addWidget(pydm_datetimeedit)
+
+    if init_channel:
+        assert pydm_datetimeedit.channel == str(init_channel)
+    else:
+        assert pydm_datetimeedit.channel is None
+
+    assert pydm_datetimeedit.blockPastDate == True
+    assert pydm_datetimeedit.relative == True
+    assert pydm_datetimeedit.timeBase == TimeBase.Milliseconds
+
+
+@pytest.mark.parametrize(
+    "value, expected_value",
+    [
+        # Assuming the time is localized to EST
+        (0,          "1969/12/31 19:00:00.000"),
+        (1000,       "1969/12/31 19:00:01.000"),
+        (60000,      "1969/12/31 19:01:00.000"),
+        (3600000,    "1969/12/31 20:00:00.000"),
+        (18000000,   "1970/01/01 00:00:00.000"),
+        (0.0,        "1969/12/31 19:00:00.000"),
+        (1000.0,     "1969/12/31 19:00:01.000"),
+        (60000.0,    "1969/12/31 19:01:00.000"),
+        (3600000.0,  "1969/12/31 20:00:00.000"),
+        (18000000.0, "1970/01/01 00:00:00.000"),
+    ],
+)
+def test_value_changed(qtbot, signals, value, expected_value):
+    """
+    Test the widget's handling of the value changed event.
+
+    Expectations:
+    The following settings are in place after the value changed signal is emitted:
+    1. The value displayed by the widget is the new value
+    2. The value format maintained by the widget the correct format for the new value
+
+    Parameters
+    ----------
+    qtbot : fixture
+        pytest-qt window for widget testing
+    signals : fixture
+        The signals fixture, which provides access signals to be bound to the appropriate slots
+    value : int, float
+        The value to be displayed by the widget
+    expected_value : str
+        The expected displayed value of the widget
+    """
+    # These tests will fail on Windows, we can't easily modify time
+    if platform.system() == 'Windows':
+        return
+
+    os.environ['TZ'] = 'US/Eastern'
+    time.tzset()
+
+    pydm_datetimeedit = PyDMDateTimeEdit()
+    pydm_datetimeedit.blockPastDate = False
+    pydm_datetimeedit.relative = False
+    pydm_datetimeedit.timeBase = TimeBase.Milliseconds
+    qtbot.addWidget(pydm_datetimeedit)
+
+    signals.new_value_signal[type(value)].connect(pydm_datetimeedit.channelValueChanged)
+    signals.new_value_signal[type(value)].emit(value)
+
+    assert pydm_datetimeedit.text() == expected_value

--- a/pydm/tests/widgets/test_datetime_label.py
+++ b/pydm/tests/widgets/test_datetime_label.py
@@ -1,0 +1,96 @@
+# Unit Tests for the PyDMLabel Widget
+
+
+import os
+import platform
+import pytest
+import time
+
+from ...widgets.datetime import PyDMDateTimeLabel, TimeBase
+
+# --------------------
+# POSITIVE TEST CASES
+# --------------------
+
+
+def test_construct(qtbot):
+    """
+    Test the basic instantiation of the widget.
+
+    Expectations:
+    The widget was created with the following default settings:
+    1. DisplayFormat is Default
+    2. String encoding is the same as that specified in the PyDM App, or UTF-8
+
+    Parameters
+    ----------
+    qtbot : fixture
+        Window for widget testing
+    """
+    pydm_label = PyDMDateTimeLabel()
+
+    qtbot.addWidget(pydm_label)
+
+    assert pydm_label.relative == True
+    assert pydm_label.timeBase == TimeBase.Milliseconds
+    assert pydm_label.textFormat == "yyyy/MM/dd hh:mm:ss.zzz"
+
+
+@pytest.mark.parametrize(
+    "value, text_format, expected_value",
+    [
+        # Assuming the time is localized to EST
+        (0,          "yyyy-MM-dd",              "1969-12-31"),
+        (0,          "yyyy-MM-dd-hh-mm-ss-zzz", "1969-12-31-19-00-00-000"),
+        (1000,       "yyyy-MM-dd-hh-mm-ss-zzz", "1969-12-31-19-00-01-000"),
+        (60000,      "yyyy-MM-dd-hh-mm-ss-zzz", "1969-12-31-19-01-00-000"),
+        (3600000,    "yyyy-MM-dd-hh-mm-ss-zzz", "1969-12-31-20-00-00-000"),
+        (18000000,   "yyyy-MM-dd-hh-mm-ss-zzz", "1970-01-01-00-00-00-000"),
+        (0.0,        "yyyy-MM-dd",              "1969-12-31"),
+        (0.0,        "yyyy-MM-dd-hh-mm-ss-zzz", "1969-12-31-19-00-00-000"),
+        (1000.0,     "yyyy-MM-dd-hh-mm-ss-zzz", "1969-12-31-19-00-01-000"),
+        (60000.0,    "yyyy-MM-dd-hh-mm-ss-zzz", "1969-12-31-19-01-00-000"),
+        (3600000.0,  "yyyy-MM-dd-hh-mm-ss-zzz", "1969-12-31-20-00-00-000"),
+        (18000000.0, "yyyy-MM-dd-hh-mm-ss-zzz", "1970-01-01-00-00-00-000"),
+    ],
+)
+def test_value_changed(qtbot, signals, value, text_format, expected_value):
+    """
+    Test the widget's handling of the value changed event.
+
+    Expectations:
+    The following settings are in place after the value changed signal is emitted:
+    1. The value displayed by the widget is the new value
+    2. The value format maintained by the widget the correct format for the new value
+
+    Parameters
+    ----------
+    qtbot : fixture
+        pytest-qt window for widget testing
+    signals : fixture
+        The signals fixture, which provides access signals to be bound to the appropriate slots
+    value : int, float
+        The value to be displayed by the widget
+    text_format : str
+        The format of the widget's displayed value
+    expected_value : str
+        The expected displayed value of the widget
+    """
+    # These tests will fail on Windows, we can't easily modify time
+    if platform.system() == 'Windows':
+        return
+
+    os.environ['TZ'] = 'US/Eastern'
+    time.tzset()
+
+    pydm_label = PyDMDateTimeLabel()
+    pydm_label.relative = False
+    pydm_label.timeBase = TimeBase.Milliseconds
+    pydm_label.textFormat = text_format
+    qtbot.addWidget(pydm_label)
+
+    signals.new_value_signal[type(value)].connect(pydm_label.channelValueChanged)
+    signals.new_value_signal[type(value)].emit(value)
+
+    assert pydm_label.textFormat == text_format
+    assert pydm_label.text() == expected_value

--- a/pydm/widgets/datetime.py
+++ b/pydm/widgets/datetime.py
@@ -24,16 +24,6 @@ if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
 
 
 class PyDMDateTimeEdit(QtWidgets.QDateTimeEdit, PyDMWritableWidget):
-    if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT5:
-        from PyQt5.QtCore import Q_ENUM
-
-        Q_ENUM(TimeBase)
-
-    # Make enum definitions known to this class
-    Milliseconds = TimeBase.Milliseconds
-    Seconds = TimeBase.Seconds
-
-    returnPressed = QtCore.Signal()
     """
     A QDateTimeEdit with support for setting the text via a PyDM Channel, or
     through the PyDM Rules system.
@@ -45,6 +35,17 @@ class PyDMDateTimeEdit(QtWidgets.QDateTimeEdit, PyDMWritableWidget):
     init_channel : str, optional
         The channel to be used by the widget.
     """
+
+    if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT5:
+        from PyQt5.QtCore import Q_ENUM
+
+        Q_ENUM(TimeBase)
+
+    # Make enum definitions known to this class
+    Milliseconds = TimeBase.Milliseconds
+    Seconds = TimeBase.Seconds
+
+    returnPressed = QtCore.Signal()
 
     def __init__(self, parent=None, init_channel=None):
         self._block_past_date = True
@@ -111,10 +112,11 @@ class PyDMDateTimeEdit(QtWidgets.QDateTimeEdit, PyDMWritableWidget):
 
         if self.timeBase == TimeBase.Seconds:
             new_value /= 1000.0
-        self.send_value_signal.emit(new_value)
+        self.send_value_signal[self.channeltype].emit(new_value)
 
     def value_changed(self, new_val):
         super().value_changed(new_val)
+        new_val = int(new_val)
 
         if self.timeBase == TimeBase.Seconds:
             new_val *= 1000
@@ -128,15 +130,6 @@ class PyDMDateTimeEdit(QtWidgets.QDateTimeEdit, PyDMWritableWidget):
 
 
 class PyDMDateTimeLabel(QtWidgets.QLabel, PyDMWidget):
-    if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT5:
-        from PyQt5.QtCore import Q_ENUM
-
-        Q_ENUM(TimeBase)
-
-    # Make enum definitions known to this class
-    Milliseconds = TimeBase.Milliseconds
-    Seconds = TimeBase.Seconds
-
     """
     A QLabel with support for setting the text via a PyDM Channel, or
     through the PyDM Rules system.
@@ -149,11 +142,19 @@ class PyDMDateTimeLabel(QtWidgets.QLabel, PyDMWidget):
         The channel to be used by the widget.
     """
 
+    if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT5:
+        from PyQt5.QtCore import Q_ENUM
+
+        Q_ENUM(TimeBase)
+
+    # Make enum definitions known to this class
+    Milliseconds = TimeBase.Milliseconds
+    Seconds = TimeBase.Seconds
+
     def __init__(self, parent=None, init_channel=None):
         QtWidgets.QLabel.__init__(self, parent=parent)
         PyDMWidget.__init__(self, init_channel=init_channel)
 
-        self._block_past_date = True
         self._relative = True
         self._time_base = TimeBase.Milliseconds
         self._text_format = "yyyy/MM/dd hh:mm:ss.zzz"
@@ -173,7 +174,8 @@ class PyDMDateTimeLabel(QtWidgets.QLabel, PyDMWidget):
     def textFormat(self, text_format):
         if self._text_format != text_format:
             self._text_format = text_format
-            self.value_changed(self.value)
+            if self.value is not None:
+                self.value_changed(self.value)
 
     @QtCore.Property(TimeBase)
     def timeBase(self):
@@ -200,6 +202,7 @@ class PyDMDateTimeLabel(QtWidgets.QLabel, PyDMWidget):
 
     def value_changed(self, new_val):
         super().value_changed(new_val)
+        new_val = int(new_val)
 
         if self.timeBase == TimeBase.Seconds:
             new_val *= 1000


### PR DESCRIPTION
- Fixed the `datetime` example erroring about implicit type conversion
- Fixed `PyDMDateTimeEdit` not being able to send the correct value in most cases (for dates further than approx. a week away it was breaking and/or sending negative values)
- Added barebones basic tests for both datetime widgets
  - Let me know if I should add more

Closes #1203