### PR TITLE
BUG: ensure all PyDMWritableWidget and PyDMWidget subclasses get init'd correctly.

### DIFF
--- a/pydm/widgets/__init__.py
+++ b/pydm/widgets/__init__.py
@@ -1,6 +1,7 @@
 __all__ = [
     "PyDMChannel",
     "PyDMByteIndicator",
+    "PyDMMultiStateIndicator"
     "PyDMCheckbox",
     "PyDMDrawingLine",
     "PyDMDrawingRectangle",
@@ -16,6 +17,7 @@ __all__ = [
     "PyDMDrawingIrregularPolygon",
     "PyDMEmbeddedDisplay",
     "PyDMEnumComboBox",
+    "PyDMEnumButton"
     "PyDMImageView",
     "PyDMLabel",
     "PyDMLineEdit",
@@ -35,12 +37,18 @@ __all__ = [
     "PyDMTabWidget",
     "PyDMTemplateRepeater",
     "PyDMNTTable",
+    "PyDMDateTimeEdit",
+    "PyDMDateTimeLabel",
+    "PyDMDrawing",
+    "PyDMFrame"
 ]
 
 from .channel import PyDMChannel
 from .byte import PyDMByteIndicator
+from .byte import PyDMMultiStateIndicator
 from .checkbox import PyDMCheckbox
 from .drawing import (
+    PyDMDrawing,
     PyDMDrawingLine,
     PyDMDrawingRectangle,
     PyDMDrawingTriangle,
@@ -56,6 +64,7 @@ from .drawing import (
 )
 from .embedded_display import PyDMEmbeddedDisplay
 from .enum_combo_box import PyDMEnumComboBox
+from .enum_button import PyDMEnumButton
 from .image import PyDMImageView
 from .label import PyDMLabel
 from .line_edit import PyDMLineEdit
@@ -75,3 +84,6 @@ from .eventplot import PyDMEventPlot
 from .tab_bar import PyDMTabWidget
 from .template_repeater import PyDMTemplateRepeater
 from .nt_table import PyDMNTTable
+from .datetime import PyDMDateTimeEdit
+from .datetime import PyDMDateTimeLabel
+from .frame import PyDMFrame

--- a/pydm/widgets/__init__.py
+++ b/pydm/widgets/__init__.py
@@ -1,7 +1,7 @@
 __all__ = [
     "PyDMChannel",
     "PyDMByteIndicator",
-    "PyDMMultiStateIndicator"
+    "PyDMMultiStateIndicator",
     "PyDMCheckbox",
     "PyDMDrawingLine",
     "PyDMDrawingRectangle",
@@ -17,7 +17,7 @@ __all__ = [
     "PyDMDrawingIrregularPolygon",
     "PyDMEmbeddedDisplay",
     "PyDMEnumComboBox",
-    "PyDMEnumButton"
+    "PyDMEnumButton",
     "PyDMImageView",
     "PyDMLabel",
     "PyDMLineEdit",
@@ -40,7 +40,7 @@ __all__ = [
     "PyDMDateTimeEdit",
     "PyDMDateTimeLabel",
     "PyDMDrawing",
-    "PyDMFrame"
+    "PyDMFrame",
 ]
 
 from .channel import PyDMChannel

--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -223,6 +223,8 @@ class PyDMPrimitiveWidget(object):
         addrs = []
         no_proto_addrs = []
         for ch in channels:
+            if not ch:
+                continue
             addr = ch.address
             if not addr:
                 continue

--- a/pydm/widgets/checkbox.py
+++ b/pydm/widgets/checkbox.py
@@ -1,5 +1,5 @@
 from qtpy.QtWidgets import QCheckBox
-from .base import PyDMWritableWidget
+from .base import PyDMWritableWidget, PostParentClassInitSetup
 
 
 class PyDMCheckbox(QCheckBox, PyDMWritableWidget):
@@ -19,6 +19,10 @@ class PyDMCheckbox(QCheckBox, PyDMWritableWidget):
         QCheckBox.__init__(self, parent)
         PyDMWritableWidget.__init__(self, init_channel=init_channel)
         self.clicked.connect(self.send_value)
+        # Execute setup calls that must be done here in the widget class's __init__,
+        # and after it's parent __init__ calls have completed.
+        # (so we can avoid pyside6 throwing an error, see func def for more info)
+        PostParentClassInitSetup(self)
 
     def value_changed(self, new_val):
         """

--- a/pydm/widgets/datetime.py
+++ b/pydm/widgets/datetime.py
@@ -57,6 +57,10 @@ class PyDMDateTimeEdit(QtWidgets.QDateTimeEdit, PyDMWritableWidget):
         self.setDateTime(QtCore.QDateTime.currentDateTime())
         self.setCalendarPopup(True)
         self.returnPressed.connect(self.send_value)
+        # Execute setup calls that must be done here in the widget class's __init__,
+        # and after it's parent __init__ calls have completed.
+        # (so we can avoid pyside6 throwing an error, see func def for more info)
+        PostParentClassInitSetup(self)
 
     @QtCore.Property(TimeBase)
     def timeBase(self):

--- a/pydm/widgets/enum_button.py
+++ b/pydm/widgets/enum_button.py
@@ -13,7 +13,7 @@ from qtpy.QtWidgets import (
     QAbstractButton,
 )
 
-from .base import PyDMWritableWidget
+from .base import PyDMWritableWidget, PostParentClassInitSetup
 from .. import data_plugins
 from ..utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
 
@@ -88,6 +88,10 @@ class PyDMEnumButton(QWidget, PyDMWritableWidget):
         self._orientation = Qt.Vertical
         self._widgets = []
         self.rebuild_widgets()
+        # Execute setup calls that must be done here in the widget class's __init__,
+        # and after it's parent __init__ calls have completed.
+        # (so we can avoid pyside6 throwing an error, see func def for more info)
+        PostParentClassInitSetup(self)
 
     def minimumSizeHint(self):
         """

--- a/pydm/widgets/enum_combo_box.py
+++ b/pydm/widgets/enum_combo_box.py
@@ -2,7 +2,7 @@ import logging
 import six
 from qtpy.QtWidgets import QComboBox
 from qtpy.QtCore import Slot, Qt
-from .base import PyDMWritableWidget
+from .base import PyDMWritableWidget, PostParentClassInitSetup
 from .. import data_plugins
 
 logger = logging.getLogger(__name__)
@@ -44,6 +44,10 @@ class PyDMEnumComboBox(QComboBox, PyDMWritableWidget):
         # and then resetting that title to the actual text), we can't distinguish it from the regular title change.
         # This flag helps tracking title change followed immediately after adding a new item.
         self._new_item_added = False
+        # Execute setup calls that must be done here in the widget class's __init__,
+        # and after it's parent __init__ calls have completed.
+        # (so we can avoid pyside6 throwing an error, see func def for more info)
+        PostParentClassInitSetup(self)
 
     def wheelEvent(self, e):
         # To ignore mouse wheel events

--- a/pydm/widgets/line_edit.py
+++ b/pydm/widgets/line_edit.py
@@ -8,7 +8,7 @@ from qtpy.QtWidgets import QLineEdit, QMenu, QApplication
 from qtpy.QtCore import Property, Qt
 from qtpy.QtGui import QFocusEvent
 from .. import utilities
-from .base import PyDMWritableWidget, TextFormatter, str_types
+from .base import PyDMWritableWidget, TextFormatter, str_types, PostParentClassInitSetup
 from .display_format import DisplayFormat, parse_value_for_display
 from ..utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
 
@@ -59,6 +59,10 @@ class PyDMLineEdit(QLineEdit, TextFormatter, PyDMWritableWidget):
         self._user_set_read_only = False  # Are we *really* read only?
         if utilities.is_pydm_app():
             self._string_encoding = self.app.get_string_encoding()
+        # Execute setup calls that must be done here in the widget class's __init__,
+        # and after it's parent __init__ calls have completed.
+        # (so we can avoid pyside6 throwing an error, see func def for more info)
+        PostParentClassInitSetup(self)
 
     @Property(DisplayFormat)
     def displayFormat(self):

--- a/pydm/widgets/pushbutton.py
+++ b/pydm/widgets/pushbutton.py
@@ -4,7 +4,7 @@ from qtpy.QtGui import QColor
 from qtpy.QtWidgets import QPushButton, QMessageBox, QInputDialog, QLineEdit, QStyle
 from qtpy.QtCore import Slot, Property
 from qtpy import QtDesigner
-from .base import PyDMWritableWidget
+from .base import PyDMWritableWidget, PostParentClassInitSetup
 from ..utilities import IconFont
 import logging
 
@@ -82,6 +82,10 @@ class PyDMPushButton(QPushButton, PyDMWritableWidget):
         # The color of "Font Awesome" icons can be set,
         # but standard icons are already colored and can not be set.
         self._pydm_icon_color = QColor(90, 90, 90)
+        # Execute setup calls that must be done here in the widget class's __init__,
+        # and after it's parent __init__ calls have completed.
+        # (so we can avoid pyside6 throwing an error, see func def for more info)
+        PostParentClassInitSetup(self)
 
     @Property(str)
     def PyDMIcon(self) -> str:

--- a/pydm/widgets/spinbox.py
+++ b/pydm/widgets/spinbox.py
@@ -1,6 +1,6 @@
 from qtpy.QtWidgets import QDoubleSpinBox, QApplication, QLineEdit
 from qtpy.QtCore import Property, Qt
-from .base import PyDMWritableWidget, TextFormatter
+from .base import PyDMWritableWidget, TextFormatter, PostParentClassInitSetup
 
 
 class PyDMSpinbox(QDoubleSpinBox, TextFormatter, PyDMWritableWidget):
@@ -35,6 +35,11 @@ class PyDMSpinbox(QDoubleSpinBox, TextFormatter, PyDMWritableWidget):
         # in order to catch the click events
         child = self.findChild(QLineEdit)
         child.installEventFilter(self)
+
+        # Execute setup calls that must be done here in the widget class's __init__,
+        # and after it's parent __init__ calls have completed.
+        # (so we can avoid pyside6 throwing an error, see func def for more info)
+        PostParentClassInitSetup(self)
 
     def stepBy(self, step):
         """

--- a/pydm/widgets/waveformtable.py
+++ b/pydm/widgets/waveformtable.py
@@ -2,7 +2,7 @@ from qtpy.QtWidgets import QTableWidget, QTableWidgetItem, QApplication
 from qtpy.QtGui import QCursor
 from qtpy.QtCore import Slot, Property, Qt, QEvent
 import numpy as np
-from .base import PyDMWritableWidget
+from .base import PyDMWritableWidget, PostParentClassInitSetup
 
 
 class PyDMWaveformTable(QTableWidget, PyDMWritableWidget):
@@ -31,6 +31,10 @@ class PyDMWaveformTable(QTableWidget, PyDMWritableWidget):
         self._valueBeingSet = False
         self.setColumnCount(1)
         self.cellChanged.connect(self.send_waveform)
+        # Execute setup calls that must be done here in the widget class's __init__,
+        # and after it's parent __init__ calls have completed.
+        # (so we can avoid pyside6 throwing an error, see func def for more info)
+        PostParentClassInitSetup(self)
 
     def value_changed(self, new_waveform):
         """


### PR DESCRIPTION
This fixes middle-click functionality issues on some widgets (like
PyDMPushButton)

In https://github.com/slaclab/pydm/pull/1181
(https://github.com/nstelter-slac/pydm/commit/c949c0272565f89add821b1116e0793881bc09af), we moved some calls from
the base widgets into the subclasses to appease pyside6 warnings.

These calls should have been added to all child classes of PyDMWritableWidget and PyDMWidget.
(note this setup is not intended to be done for widgets that subclass
PyDMPrimitiveWidget directly)

And expand testcase to check if this setup is getting done by checking
all the relevant widget class's middle-click functionality.
(this is still quite fast (~ 1 sec) even when checking all the classes)

Also add missing classes to be exported from module as part of \_\_all\_\_.