### PR TITLE
BUG: fix error when establishing plugin connections with protocols in all caps.

### DIFF
--- a/pydm/data_plugins/__init__.py
+++ b/pydm/data_plugins/__init__.py
@@ -91,7 +91,7 @@ def plugin_for_address(address: str) -> Optional[PyDMPlugin]:
     if protocol:
         initialize_plugins_if_needed()
         try:
-            return plugin_modules[str(protocol)]
+            return plugin_modules[(str(protocol)).lower()]
         except KeyError:
             logger.exception("Could not find protocol for %r", address)
     # Catch all in case of improper plugin specification

--- a/pydm/tests/widgets/test_channel.py
+++ b/pydm/tests/widgets/test_channel.py
@@ -84,9 +84,13 @@ def test_construct(qtbot):
     assert equal_result is False and not_equal_result is True
 
 
-def test_pydm_connection(test_plugin):
+@pytest.mark.parametrize("address", [
+    "tst://Tst:this3",
+    "TST://Tst:this3"
+])
+def test_pydm_connection(address, test_plugin):
     # Plugin, Channel and Registry
-    chan = PyDMChannel("tst://Tst:this3")
+    chan = PyDMChannel(address)
     plugin = plugin_for_address(chan.address)
     plugin_no = len(plugin.connections)
 


### PR DESCRIPTION
We only defined and only accept the protocol in channel addresses when its all lowercase. ('pva', 'calc', 'ca', etc) \
Used in an address, it looks like: 'ca://test:example'.

But sometimes we set the protocol to be uppercase, like in the testing when we use 'CA://MTEST'.

This fix just converts all protocols into lowercase to avoid an error, which imo is more user friendly than enforcing case-sensitive protocols

Found this issue when running tests on pyside6 since with it logger.error() calls are printed and fail the tests, but on pyqt5 we need to set 'log_cli=true' to get the same behavior. (which we currently don't do, but i'll set it in followup patch)

