### PR TITLE
MNT: on pyside6, ensure events get filtered properly into pydm's base classes.

### DIFF
--- a/pydm/widgets/byte.py
+++ b/pydm/widgets/byte.py
@@ -119,6 +119,11 @@ class PyDMByteIndicator(QWidget, PyDMWidget):
         # (so we can avoid pyside6 throwing an error, see func def for more info)
         PostParentClassInitSetup(self)
 
+    # On pyside6, we need to expilcity call pydm's base class's eventFilter() call or events
+    # will not propagate to the parent classes properly.
+    def eventFilter(self, obj, event):
+        return PyDMWidget.eventFilter(self, obj, event)
+
     def init_for_designer(self) -> None:
         """
         Method called after the constructor to tweak configurations for
@@ -589,6 +594,11 @@ class PyDMMultiStateIndicator(QWidget, PyDMWidget):
         # and after it's parent __init__ calls have completed.
         # (so we can avoid pyside6 throwing an error, see func def for more info)
         PostParentClassInitSetup(self)
+
+    # On pyside6, we need to expilcity call pydm's base class's eventFilter() call or events
+    # will not propagate to the parent classes properly.
+    def eventFilter(self, obj, event):
+        return PyDMWidget.eventFilter(self, obj, event)
 
     # whether or not we render the widget as a circle (default) or a rectangle
     @Property(bool)

--- a/pydm/widgets/checkbox.py
+++ b/pydm/widgets/checkbox.py
@@ -20,6 +20,11 @@ class PyDMCheckbox(QCheckBox, PyDMWritableWidget):
         PyDMWritableWidget.__init__(self, init_channel=init_channel)
         self.clicked.connect(self.send_value)
 
+    # On pyside6, we need to expilcity call pydm's base class's eventFilter() call or events
+    # will not propagate to the parent classes properly.
+    def eventFilter(self, obj, event):
+        return PyDMWritableWidget.eventFilter(self, obj, event)
+
     def value_changed(self, new_val):
         """
         Callback invoked when the Channel value is changed.

--- a/pydm/widgets/datetime.py
+++ b/pydm/widgets/datetime.py
@@ -58,6 +58,11 @@ class PyDMDateTimeEdit(QtWidgets.QDateTimeEdit, PyDMWritableWidget):
         self.setCalendarPopup(True)
         self.returnPressed.connect(self.send_value)
 
+    # On pyside6, we need to expilcity call pydm's base class's eventFilter() call or events
+    # will not propagate to the parent classes properly.
+    def eventFilter(self, obj, event):
+        return PyDMWritableWidget.eventFilter(self, obj, event)
+
     @QtCore.Property(TimeBase)
     def timeBase(self):
         """Whether to use milliseconds or seconds as time base for the widget"""
@@ -163,6 +168,11 @@ class PyDMDateTimeLabel(QtWidgets.QLabel, PyDMWidget):
         # and after it's parent __init__ calls have completed.
         # (so we can avoid pyside6 throwing an error, see func def for more info)
         PostParentClassInitSetup(self)
+
+    # On pyside6, we need to expilcity call pydm's base class's eventFilter() call or events
+    # will not propagate to the parent classes properly.
+    def eventFilter(self, obj, event):
+        return PyDMWidget.eventFilter(self, obj, event)
 
     @QtCore.Property(str)
     def textFormat(self):

--- a/pydm/widgets/drawing.py
+++ b/pydm/widgets/drawing.py
@@ -101,7 +101,7 @@ class PyDMDrawing(QWidget, PyDMWidget):
     # will not propagate to the parent classes properly.
     def eventFilter(self, obj, event):
         return PyDMWidget.eventFilter(self, obj, event)
-        
+
     def sizeHint(self):
         return QSize(100, 100)
 

--- a/pydm/widgets/drawing.py
+++ b/pydm/widgets/drawing.py
@@ -97,6 +97,11 @@ class PyDMDrawing(QWidget, PyDMWidget):
         # (so we can avoid pyside6 throwing an error, see func def for more info)
         PostParentClassInitSetup(self)
 
+    # On pyside6, we need to expilcity call pydm's base class's eventFilter() call or events
+    # will not propagate to the parent classes properly.
+    def eventFilter(self, obj, event):
+        return PyDMWidget.eventFilter(self, obj, event)
+        
     def sizeHint(self):
         return QSize(100, 100)
 

--- a/pydm/widgets/enum_button.py
+++ b/pydm/widgets/enum_button.py
@@ -89,6 +89,11 @@ class PyDMEnumButton(QWidget, PyDMWritableWidget):
         self._widgets = []
         self.rebuild_widgets()
 
+    # On pyside6, we need to expilcity call pydm's base class's eventFilter() call or events
+    # will not propagate to the parent classes properly.
+    def eventFilter(self, obj, event):
+        return PyDMWritableWidget.eventFilter(self, obj, event)
+
     def minimumSizeHint(self):
         """
         This property holds the recommended minimum size for the widget.

--- a/pydm/widgets/enum_combo_box.py
+++ b/pydm/widgets/enum_combo_box.py
@@ -45,6 +45,11 @@ class PyDMEnumComboBox(QComboBox, PyDMWritableWidget):
         # This flag helps tracking title change followed immediately after adding a new item.
         self._new_item_added = False
 
+    # On pyside6, we need to expilcity call pydm's base class's eventFilter() call or events
+    # will not propagate to the parent classes properly.
+    def eventFilter(self, obj, event):
+        return PyDMWritableWidget.eventFilter(self, obj, event)
+
     def wheelEvent(self, e):
         # To ignore mouse wheel events
         e.ignore()

--- a/pydm/widgets/frame.py
+++ b/pydm/widgets/frame.py
@@ -28,6 +28,11 @@ class PyDMFrame(QFrame, PyDMWidget):
         # (so we can avoid pyside6 throwing an error, see func def for more info)
         PostParentClassInitSetup(self)
 
+    # On pyside6, we need to expilcity call pydm's base class's eventFilter() call or events
+    # will not propagate to the parent classes properly.
+    def eventFilter(self, obj, event):
+        return PyDMWidget.eventFilter(self, obj, event)
+
     @Property(bool)
     def disableOnDisconnect(self):
         """

--- a/pydm/widgets/image.py
+++ b/pydm/widgets/image.py
@@ -237,6 +237,11 @@ class PyDMImageView(ImageView, PyDMWidget):
         # (so we can avoid pyside6 throwing an error, see func def for more info)
         PostParentClassInitSetup(self)
 
+    # On pyside6, we need to expilcity call pydm's base class's eventFilter() call or events
+    # will not propagate to the parent classes properly.
+    def eventFilter(self, obj, event):
+        return PyDMWidget.eventFilter(self, obj, event)
+
     @Property(str, designable=False)
     def channel(self):
         return

--- a/pydm/widgets/label.py
+++ b/pydm/widgets/label.py
@@ -61,6 +61,11 @@ class PyDMLabel(QLabel, TextFormatter, PyDMWidget):
         # (so we can avoid pyside6 throwing an error, see func def for more info)
         PostParentClassInitSetup(self)
 
+    # On pyside6, we need to expilcity call pydm's base class's eventFilter() call or events
+    # will not propagate to the parent classes properly.
+    def eventFilter(self, obj, event):
+        return PyDMWidget.eventFilter(self, obj, event)
+
     @Property(bool)
     def enableRichText(self):
         return self._enable_rich_text

--- a/pydm/widgets/line_edit.py
+++ b/pydm/widgets/line_edit.py
@@ -60,6 +60,11 @@ class PyDMLineEdit(QLineEdit, TextFormatter, PyDMWritableWidget):
         if utilities.is_pydm_app():
             self._string_encoding = self.app.get_string_encoding()
 
+    # On pyside6, we need to expilcity call pydm's base class's eventFilter() call or events
+    # will not propagate to the parent classes properly.
+    def eventFilter(self, obj, event):
+        return PyDMWritableWidget.eventFilter(self, obj, event)
+
     @Property(DisplayFormat)
     def displayFormat(self):
         return self._display_format_type

--- a/pydm/widgets/nt_table.py
+++ b/pydm/widgets/nt_table.py
@@ -195,6 +195,11 @@ class PyDMNTTable(QtWidgets.QWidget, PyDMWritableWidget):
         self._table_values = []
         self.edit_method = None
 
+    # On pyside6, we need to expilcity call pydm's base class's eventFilter() call or events
+    # will not propagate to the parent classes properly.
+    def eventFilter(self, obj, event):
+        return PyDMWritableWidget.eventFilter(self, obj, event)
+
     @QtCore.Property(bool)
     def readOnly(self):
         return self._read_only

--- a/pydm/widgets/pushbutton.py
+++ b/pydm/widgets/pushbutton.py
@@ -83,6 +83,11 @@ class PyDMPushButton(QPushButton, PyDMWritableWidget):
         # but standard icons are already colored and can not be set.
         self._pydm_icon_color = QColor(90, 90, 90)
 
+    # On pyside6, we need to expilcity call pydm's base class's eventFilter() call or events
+    # will not propagate to the parent classes properly.
+    def eventFilter(self, obj, event):
+        return PyDMWritableWidget.eventFilter(self, obj, event)
+ 
     @Property(str)
     def PyDMIcon(self) -> str:
         """

--- a/pydm/widgets/pushbutton.py
+++ b/pydm/widgets/pushbutton.py
@@ -87,7 +87,7 @@ class PyDMPushButton(QPushButton, PyDMWritableWidget):
     # will not propagate to the parent classes properly.
     def eventFilter(self, obj, event):
         return PyDMWritableWidget.eventFilter(self, obj, event)
- 
+
     @Property(str)
     def PyDMIcon(self) -> str:
         """

--- a/pydm/widgets/related_display_button.py
+++ b/pydm/widgets/related_display_button.py
@@ -92,6 +92,11 @@ class PyDMRelatedDisplayButton(QPushButton, PyDMWidget):
         # (so we can avoid pyside6 throwing an error, see func def for more info)
         PostParentClassInitSetup(self)
 
+    # On pyside6, we need to expilcity call pydm's base class's eventFilter() call or events
+    # will not propagate to the parent classes properly.
+    def eventFilter(self, obj, event):
+        return PyDMWidget.eventFilter(self, obj, event)
+ 
     @only_if_channel_set
     def check_enable_state(self) -> None:
         """

--- a/pydm/widgets/related_display_button.py
+++ b/pydm/widgets/related_display_button.py
@@ -97,7 +97,7 @@ class PyDMRelatedDisplayButton(QPushButton, PyDMWidget):
     # will not propagate to the parent classes properly.
     def eventFilter(self, obj, event):
         return PyDMWidget.eventFilter(self, obj, event)
- 
+
     @only_if_channel_set
     def check_enable_state(self) -> None:
         """

--- a/pydm/widgets/scale.py
+++ b/pydm/widgets/scale.py
@@ -412,6 +412,11 @@ class PyDMScaleIndicator(QFrame, TextFormatter, PyDMWidget):
         # (so we can avoid pyside6 throwing an error, see func def for more info)
         PostParentClassInitSetup(self)
 
+    # On pyside6, we need to expilcity call pydm's base class's eventFilter() call or events
+    # will not propagate to the parent classes properly.
+    def eventFilter(self, obj, event):
+        return PyDMWidget.eventFilter(self, obj, event)
+
     def update_labels(self) -> None:
         """
         Update the limits and value labels with the correct values.

--- a/pydm/widgets/shell_command.py
+++ b/pydm/widgets/shell_command.py
@@ -128,6 +128,11 @@ class PyDMShellCommand(QPushButton, PyDMWidget):
         # (so we can avoid pyside6 throwing an error, see func def for more info)
         PostParentClassInitSetup(self)
 
+    # On pyside6, we need to expilcity call pydm's base class's eventFilter() call or events
+    # will not propagate to the parent classes properly.
+    def eventFilter(self, obj, event):
+        return PyDMWidget.eventFilter(self, obj, event)
+
     def confirmDialog(self) -> bool:
         """
         Show the confirmation dialog with the proper message in case

--- a/pydm/widgets/slider.py
+++ b/pydm/widgets/slider.py
@@ -318,6 +318,11 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget):
         self._step_size_channel = None
         self.step_size_channel_pv = None
 
+    # On pyside6, we need to expilcity call pydm's base class's eventFilter() call or events
+    # will not propagate to the parent classes properly.
+    def eventFilter(self, obj, event):
+        return PyDMWritableWidget.eventFilter(self, obj, event)
+
     def wheelEvent(self, e):
         """
         Method to specifically ignore mouse wheel events.

--- a/pydm/widgets/spinbox.py
+++ b/pydm/widgets/spinbox.py
@@ -36,6 +36,11 @@ class PyDMSpinbox(QDoubleSpinBox, TextFormatter, PyDMWritableWidget):
         child = self.findChild(QLineEdit)
         child.installEventFilter(self)
 
+    # On pyside6, we need to expilcity call pydm's base class's eventFilter() call or events
+    # will not propagate to the parent classes properly.
+    def eventFilter(self, obj, event):
+        return PyDMWritableWidget.eventFilter(self, obj, event)
+
     def stepBy(self, step):
         """
         Method triggered whenever user triggers a step. If the writeOnPress property

--- a/pydm/widgets/symbol.py
+++ b/pydm/widgets/symbol.py
@@ -43,6 +43,11 @@ class PyDMSymbol(QWidget, PyDMWidget):
         # (so we can avoid pyside6 throwing an error, see func def for more info)
         PostParentClassInitSetup(self)
 
+    # On pyside6, we need to expilcity call pydm's base class's eventFilter() call or events
+    # will not propagate to the parent classes properly.
+    def eventFilter(self, obj, event):
+        return PyDMWidget.eventFilter(self, obj, event)
+
     def init_for_designer(self):
         """
         Method called after the constructor to tweak configurations for

--- a/pydm/widgets/tab_bar.py
+++ b/pydm/widgets/tab_bar.py
@@ -30,6 +30,11 @@ class PyDMTabBar(QTabBar, PyDMWidget):
         # (so we can avoid pyside6 throwing an error, see func def for more info)
         PostParentClassInitSetup(self)
 
+    # On pyside6, we need to expilcity call pydm's base class's eventFilter() call or events
+    # will not propagate to the parent classes properly.
+    def eventFilter(self, obj, event):
+        return PyDMWritableWidget.eventFilter(self, obj, event)
+
     @Property(str)
     def currentTabAlarmChannel(self):
         """A channel to use for this tab's alarm indicator."""

--- a/pydm/widgets/waveformtable.py
+++ b/pydm/widgets/waveformtable.py
@@ -32,6 +32,11 @@ class PyDMWaveformTable(QTableWidget, PyDMWritableWidget):
         self.setColumnCount(1)
         self.cellChanged.connect(self.send_waveform)
 
+    # On pyside6, we need to expilcity call pydm's base class's eventFilter() call or events
+    # will not propagate to the parent classes properly.
+    def eventFilter(self, obj, event):
+        return PyDMWritableWidget.eventFilter(self, obj, event)
+
     def value_changed(self, new_waveform):
         """
         Callback invoked when the Channel value is changed.


### PR DESCRIPTION
Some more pyside6 weirdness was that events such as middle-click's were not getting propated from child classes of PyDMWidget/PyDMWritableWidget to their parent's eventFilter() funcs.

This is even after an earlier fix for event-handling, which made pyqt5's events work again but not pyside6's.

The problem seems to be that pyside6 is unsure of which parent class to propagate the events to, and explicity declaring this in the eventFilter() func of the child classes fixes the issue.