### PR TITLE
MNT: stop passing parent=parent to prevent error on pyside6 with __init__() calls

### DIFF
--- a/pydm/display.py
+++ b/pydm/display.py
@@ -331,7 +331,7 @@ _extension_to_loader = {
 
 class Display(QWidget):
     def __init__(self, parent=None, args=None, macros=None, ui_filename=None):
-        super().__init__(parent=parent)
+        super().__init__(parent)
         self.ui = None
         self.help_window = None
         self._ui_filename = ui_filename

--- a/pydm/tests/test_display.py
+++ b/pydm/tests/test_display.py
@@ -2,7 +2,7 @@ import os
 import pytest
 from pydm import Display
 from pydm.display import load_file, load_py_file, _compile_ui_file, _load_compiled_ui_into_display, ScreenTarget
-from qtpy.QtWidgets import QLabel
+from qtpy.QtWidgets import QLabel, QWidget
 from ..utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
 
 # The path to the .ui file used in these tests
@@ -22,9 +22,19 @@ valid_display_test_py_path = os.path.join(
 
 def test_ui_filename_arg(qtbot):
     """If you supply a valid filename argument, you shouldn't get any exceptions."""
-    my_display = Display(parent=None, ui_filename=test_ui_path)
+    parent = QWidget()
+    qtbot.addWidget(parent)
+    
+    my_display = Display(parent=parent, ui_filename=test_ui_path)
     qtbot.addWidget(my_display)
 
+    assert my_display.parent() == parent
+
+    # This prevents pyside6 from deleting the internal c++ object 
+    # ("Internal C++ object (PyDMDateTimeLabel) already deleted")
+    parent.deleteLater()
+    my_display.deleteLater()
+    
 
 def test_reimplemented_ui_filename(qtbot):
     """If you reimplement ui_filename and return a valid filename, you

--- a/pydm/tests/widgets/test_baseplot.py
+++ b/pydm/tests/widgets/test_baseplot.py
@@ -7,6 +7,7 @@ from pydm.widgets.timeplot import PyDMTimePlot
 from pydm.widgets.waveformplot import PyDMWaveformPlot, WaveformCurveItem
 from qtpy.QtGui import QColor, QFont
 from qtpy.QtCore import QTimer, Qt, QPointF
+from qtpy.QtWidgets import QWidget
 
 from collections import OrderedDict
 from ...widgets.baseplot import BasePlotCurveItem, BasePlot
@@ -142,8 +143,13 @@ def test_baseplot_multiple_y_axes(qtbot):
 
 def test_baseplot_no_added_y_axes(qtbot):
     """Confirm that if the user does not name or create any new y-axes, the plot will still work just fine"""
-    base_plot = BasePlot()
+    parent = QWidget()
+    qtbot.addWidget(parent)
+    
+    base_plot = BasePlot(parent)
     base_plot.clear()
+
+    assert base_plot.parent() == parent
 
     # Add 3 curves to our plot, but don't bother to use any of the y-axis parameters
     # in addCurve() leaving them to their default of None
@@ -170,6 +176,10 @@ def test_baseplot_no_added_y_axes(qtbot):
     assert base_plot.plotItem.axes["top"]["item"].orientation == "top"
     assert base_plot.plotItem.axes["right"]["item"].orientation == "right"
 
+    # This prevents pyside6 from deleting the internal c++ object 
+    # ("Internal C++ object (PyDMDateTimeLabel) already deleted")
+    parent.deleteLater()
+    base_plot.deleteLater()
 
 def test_timeplot_add_multiple_axes(qtbot):
     """Similar to the multiple y axes test above, but this one creates the new axes first, and invokes the setters

--- a/pydm/tests/widgets/test_checkbox.py
+++ b/pydm/tests/widgets/test_checkbox.py
@@ -1,6 +1,7 @@
 # Unit Tests for the PyDMCheckbox Widget
 
 import pytest
+from qtpy.QtWidgets import QWidget
 from ...widgets.checkbox import PyDMCheckbox
 
 
@@ -31,11 +32,19 @@ def test_construct(qtbot, init_channel):
     init_channel : str
         The data channel to be used by the widget
     """
-    pydm_checkbox = PyDMCheckbox(init_channel=init_channel)
+    parent = QWidget()
+    qtbot.addWidget(parent)
+    
+    pydm_checkbox = PyDMCheckbox(parent=parent, init_channel=init_channel)
     qtbot.addWidget(pydm_checkbox)
 
     assert not pydm_checkbox.isChecked()
+    assert pydm_checkbox.parent() == parent
 
+    # This prevents pyside6 from deleting the internal c++ object 
+    # ("Internal C++ object (PyDMDateTimeLabel) already deleted")
+    parent.deleteLater()
+    pydm_checkbox.deleteLater()
 
 @pytest.mark.parametrize(
     "init_checked_status, new_value",

--- a/pydm/tests/widgets/test_datetime_edit.py
+++ b/pydm/tests/widgets/test_datetime_edit.py
@@ -5,7 +5,7 @@ import platform
 import pytest
 import time
 
-from ...widgets.datetime import PyDMDateTimeEdit, TimeBase
+from pydm.widgets.datetime import PyDMDateTimeEdit, TimeBase
 from qtpy.QtCore import QDateTime
 
 
@@ -53,15 +53,15 @@ def test_construct(qtbot, init_channel):
     "value, expected_value",
     [
         # Assuming the time is localized to EST
-        (0,          "1969/12/31 19:00:00.000"),
-        (1000,       "1969/12/31 19:00:01.000"),
-        (60000,      "1969/12/31 19:01:00.000"),
-        (3600000,    "1969/12/31 20:00:00.000"),
-        (18000000,   "1970/01/01 00:00:00.000"),
-        (0.0,        "1969/12/31 19:00:00.000"),
-        (1000.0,     "1969/12/31 19:00:01.000"),
-        (60000.0,    "1969/12/31 19:01:00.000"),
-        (3600000.0,  "1969/12/31 20:00:00.000"),
+        (0, "1969/12/31 19:00:00.000"),
+        (1000, "1969/12/31 19:00:01.000"),
+        (60000, "1969/12/31 19:01:00.000"),
+        (3600000, "1969/12/31 20:00:00.000"),
+        (18000000, "1970/01/01 00:00:00.000"),
+        (0.0, "1969/12/31 19:00:00.000"),
+        (1000.0, "1969/12/31 19:00:01.000"),
+        (60000.0, "1969/12/31 19:01:00.000"),
+        (3600000.0, "1969/12/31 20:00:00.000"),
         (18000000.0, "1970/01/01 00:00:00.000"),
     ],
 )
@@ -86,10 +86,10 @@ def test_value_changed(qtbot, signals, value, expected_value):
         The expected displayed value of the widget
     """
     # These tests will fail on Windows, we can't easily modify time
-    if platform.system() == 'Windows':
+    if platform.system() == "Windows":
         return
 
-    os.environ['TZ'] = 'US/Eastern'
+    os.environ["TZ"] = "US/Eastern"
     time.tzset()
 
     pydm_datetimeedit = PyDMDateTimeEdit()

--- a/pydm/tests/widgets/test_datetime_label.py
+++ b/pydm/tests/widgets/test_datetime_label.py
@@ -6,7 +6,7 @@ import platform
 import pytest
 import time
 
-from ...widgets.datetime import PyDMDateTimeLabel, TimeBase
+from pydm.widgets.datetime import PyDMDateTimeLabel, TimeBase
 
 # --------------------
 # POSITIVE TEST CASES
@@ -40,17 +40,17 @@ def test_construct(qtbot):
     "value, text_format, expected_value",
     [
         # Assuming the time is localized to EST
-        (0,          "yyyy-MM-dd",              "1969-12-31"),
-        (0,          "yyyy-MM-dd-hh-mm-ss-zzz", "1969-12-31-19-00-00-000"),
-        (1000,       "yyyy-MM-dd-hh-mm-ss-zzz", "1969-12-31-19-00-01-000"),
-        (60000,      "yyyy-MM-dd-hh-mm-ss-zzz", "1969-12-31-19-01-00-000"),
-        (3600000,    "yyyy-MM-dd-hh-mm-ss-zzz", "1969-12-31-20-00-00-000"),
-        (18000000,   "yyyy-MM-dd-hh-mm-ss-zzz", "1970-01-01-00-00-00-000"),
-        (0.0,        "yyyy-MM-dd",              "1969-12-31"),
-        (0.0,        "yyyy-MM-dd-hh-mm-ss-zzz", "1969-12-31-19-00-00-000"),
-        (1000.0,     "yyyy-MM-dd-hh-mm-ss-zzz", "1969-12-31-19-00-01-000"),
-        (60000.0,    "yyyy-MM-dd-hh-mm-ss-zzz", "1969-12-31-19-01-00-000"),
-        (3600000.0,  "yyyy-MM-dd-hh-mm-ss-zzz", "1969-12-31-20-00-00-000"),
+        (0, "yyyy-MM-dd", "1969-12-31"),
+        (0, "yyyy-MM-dd-hh-mm-ss-zzz", "1969-12-31-19-00-00-000"),
+        (1000, "yyyy-MM-dd-hh-mm-ss-zzz", "1969-12-31-19-00-01-000"),
+        (60000, "yyyy-MM-dd-hh-mm-ss-zzz", "1969-12-31-19-01-00-000"),
+        (3600000, "yyyy-MM-dd-hh-mm-ss-zzz", "1969-12-31-20-00-00-000"),
+        (18000000, "yyyy-MM-dd-hh-mm-ss-zzz", "1970-01-01-00-00-00-000"),
+        (0.0, "yyyy-MM-dd", "1969-12-31"),
+        (0.0, "yyyy-MM-dd-hh-mm-ss-zzz", "1969-12-31-19-00-00-000"),
+        (1000.0, "yyyy-MM-dd-hh-mm-ss-zzz", "1969-12-31-19-00-01-000"),
+        (60000.0, "yyyy-MM-dd-hh-mm-ss-zzz", "1969-12-31-19-01-00-000"),
+        (3600000.0, "yyyy-MM-dd-hh-mm-ss-zzz", "1969-12-31-20-00-00-000"),
         (18000000.0, "yyyy-MM-dd-hh-mm-ss-zzz", "1970-01-01-00-00-00-000"),
     ],
 )
@@ -77,10 +77,10 @@ def test_value_changed(qtbot, signals, value, text_format, expected_value):
         The expected displayed value of the widget
     """
     # These tests will fail on Windows, we can't easily modify time
-    if platform.system() == 'Windows':
+    if platform.system() == "Windows":
         return
 
-    os.environ['TZ'] = 'US/Eastern'
+    os.environ["TZ"] = "US/Eastern"
     time.tzset()
 
     pydm_label = PyDMDateTimeLabel()

--- a/pydm/tests/widgets/test_enum_button.py
+++ b/pydm/tests/widgets/test_enum_button.py
@@ -1,6 +1,7 @@
 import pytest
 
 from qtpy.QtCore import Qt, QSize
+from qtpy.QtWidgets import QWidget
 
 from ...widgets.enum_button import PyDMEnumButton, WidgetType, class_for_type
 from ... import data_plugins
@@ -18,14 +19,22 @@ def test_construct(qtbot):
     qtbot : fixture
         pytest-qt window for widget test
     """
-    widget = PyDMEnumButton()
+    parent = QWidget()
+    qtbot.addWidget(parent)
+
+    widget = PyDMEnumButton(parent)
     qtbot.addWidget(widget)
 
     assert widget._has_enums is False
     assert widget.orientation == Qt.Vertical
     assert widget.widgetType == WidgetType.PushButton
     assert widget.minimumSizeHint() == QSize(50, 100)
+    assert widget.parent() == parent
 
+    # This prevents pyside6 from deleting the internal c++ object 
+    # ("Internal C++ object (PyDMDateTimeLabel) already deleted")
+    parent.deleteLater()
+    widget.deleteLater()
 
 @pytest.mark.parametrize("widget_type", [WidgetType.PushButton, WidgetType.RadioButton])
 def test_widget_type(qtbot, widget_type):

--- a/pydm/tests/widgets/test_enum_combo_box.py
+++ b/pydm/tests/widgets/test_enum_combo_box.py
@@ -4,6 +4,7 @@ import pytest
 from logging import ERROR
 
 from qtpy.QtCore import Qt
+from qtpy.QtWidgets import QWidget
 
 from ...widgets.enum_combo_box import PyDMEnumComboBox
 from ... import data_plugins
@@ -26,13 +27,21 @@ def test_construct(qtbot):
     qtbot : fixture
         pytest-qt window for widget test
     """
-    pydm_enumcombobox = PyDMEnumComboBox()
+    parent = QWidget()
+    qtbot.addWidget(parent)
+
+    pydm_enumcombobox = PyDMEnumComboBox(parent)
     qtbot.addWidget(pydm_enumcombobox)
 
     assert pydm_enumcombobox._has_enums is False
     assert pydm_enumcombobox.contextMenuPolicy() == Qt.DefaultContextMenu
     assert pydm_enumcombobox.contextMenuEvent == pydm_enumcombobox.open_context_menu
+    assert pydm_enumcombobox.parent() == parent
 
+    # This prevents pyside6 from deleting the internal c++ object 
+    # ("Internal C++ object (PyDMDateTimeLabel) already deleted")
+    parent.deleteLater()
+    pydm_enumcombobox.deleteLater()
 
 @pytest.mark.parametrize(
     "enums",

--- a/pydm/tests/widgets/test_frame.py
+++ b/pydm/tests/widgets/test_frame.py
@@ -2,6 +2,7 @@
 
 
 import pytest
+from qtpy.QtWidgets import QWidget
 
 from ...widgets.base import is_channel_valid
 from ... import data_plugins
@@ -26,12 +27,20 @@ def test_construct(qtbot):
     qtbot : fixture
         pytest-qt window for widget test
     """
-    pydm_frame = PyDMFrame()
+    parent = QWidget()
+    qtbot.addWidget(parent)
+
+    pydm_frame = PyDMFrame(parent)
     qtbot.addWidget(pydm_frame)
 
     assert pydm_frame._disable_on_disconnect is False
     assert pydm_frame.alarmSensitiveBorder is False
+    assert pydm_frame.parent() == parent
 
+    # This prevents pyside6 from deleting the internal c++ object 
+    # ("Internal C++ object (PyDMDateTimeLabel) already deleted")
+    parent.deleteLater()
+    pydm_frame.deleteLater()
 
 @pytest.mark.parametrize("init_value, new_value", [(False, True), (True, False), (False, False), (True, True)])
 def test_disable_on_disconnect(qtbot, init_value, new_value):

--- a/pydm/tests/widgets/test_label.py
+++ b/pydm/tests/widgets/test_label.py
@@ -11,7 +11,7 @@ from ...widgets.base import PyDMWidget
 from ...widgets.display_format import parse_value_for_display, DisplayFormat
 from ...utilities import checkObjectProperties
 
-from qtpy.QtWidgets import QApplication, QStyleOption
+from qtpy.QtWidgets import QApplication, QStyleOption, QWidget
 from qtpy.QtCore import Qt
 
 # --------------------
@@ -37,7 +37,10 @@ def test_construct(qtbot):
     qtbot : fixture
         Window for widget testing
     """
-    pydm_label = PyDMLabel()
+    parent = QWidget()
+    qtbot.addWidget(parent)
+    
+    pydm_label = PyDMLabel(parent)
     assert checkObjectProperties(pydm_label, expected_label_properties) is True
 
     qtbot.addWidget(pydm_label)
@@ -45,7 +48,12 @@ def test_construct(qtbot):
     display_format_type = pydm_label.displayFormat
     assert display_format_type == pydm_label.DisplayFormat.Default
     assert pydm_label._string_encoding == pydm_label.app.get_string_encoding() if is_pydm_app() else "utf_8"
+    assert pydm_label.parent() == parent
 
+    # This prevents pyside6 from deleting the internal c++ object 
+    # ("Internal C++ object (PyDMDateTimeLabel) already deleted")
+    parent.deleteLater()
+    pydm_label.deleteLater()
 
 def test_enable_rich_text(qtbot):
     """

--- a/pydm/tests/widgets/test_lineedit.py
+++ b/pydm/tests/widgets/test_lineedit.py
@@ -9,6 +9,8 @@ from logging import ERROR
 from qtpy.QtCore import QEvent, Qt
 from qtpy.QtGui import QFocusEvent
 from qtpy.QtWidgets import QMenu
+from qtpy.QtWidgets import QWidget
+
 from ...widgets.line_edit import PyDMLineEdit
 from ...data_plugins import set_read_only
 from ...utilities import is_pydm_app, find_unit_options
@@ -42,7 +44,10 @@ def test_construct(qtbot, init_channel):
         The data channel to be used by the widget
 
     """
-    pydm_lineedit = PyDMLineEdit(init_channel=init_channel)
+    parent = QWidget()
+    qtbot.addWidget(parent)
+
+    pydm_lineedit = PyDMLineEdit(parent=parent, init_channel=init_channel)
     qtbot.addWidget(pydm_lineedit)
 
     if init_channel:
@@ -53,6 +58,7 @@ def test_construct(qtbot, init_channel):
     assert pydm_lineedit._scale == 1
     assert pydm_lineedit._prec == 0
     assert pydm_lineedit.showUnits is False
+    assert pydm_lineedit.parent() == parent
 
     assert pydm_lineedit.unitMenu is None
     pydm_lineedit.widget_ctx_menu()
@@ -63,6 +69,10 @@ def test_construct(qtbot, init_channel):
 
     assert find_action_from_menu(pydm_lineedit.unitMenu, "No Unit Conversions found")
 
+    # This prevents pyside6 from deleting the internal c++ object 
+    # ("Internal C++ object (PyDMDateTimeLabel) already deleted")
+    parent.deleteLater()
+    pydm_lineedit.deleteLater()
 
 @pytest.mark.parametrize(
     "display_format",

--- a/pydm/tests/widgets/test_logdisplay.py
+++ b/pydm/tests/widgets/test_logdisplay.py
@@ -1,6 +1,7 @@
 import pytest
 import logging
 
+from qtpy.QtWidgets import QApplication, QWidget
 from pydm.widgets.logdisplay import PyDMLogDisplay
 
 
@@ -11,11 +12,16 @@ def log():
 
 
 def test_write(qtbot, log):
-    logd = PyDMLogDisplay(parent=None, logname=log.name, level=logging.INFO)
+    parent = QWidget()
+    qtbot.addWidget(parent)
+    
+    logd = PyDMLogDisplay(parent=parent, logname=log.name, level=logging.INFO)
     qtbot.addWidget(logd)
     logd.show()
     assert logd.logLevel == logging.INFO
     assert logd.logName == log.name
+    assert logd.parent() == parent
+
     # Watch our error message show up in the log
     err_msg = "This is a test of the emergency broadcast system"
     log.error(err_msg)
@@ -38,7 +44,9 @@ def test_write(qtbot, log):
     logd.clear()
     assert logd.text.toPlainText() == ""
 
-
+    # Calling .deleteLater() here on pyside6 causes weird behavior with the underlying c++ object in next testcase,
+    # maybe since the logger is associated with the previous logd instance when it gets deleted? 
+    
 def test_handler_cleanup(qtbot, log):
     logd = PyDMLogDisplay(logname=log.name, level=logging.DEBUG)
     qtbot.addWidget(logd)

--- a/pydm/tests/widgets/test_logdisplay.py
+++ b/pydm/tests/widgets/test_logdisplay.py
@@ -14,7 +14,7 @@ def log():
 def test_write(qtbot, log):
     parent = QWidget()
     qtbot.addWidget(parent)
-    
+
     logd = PyDMLogDisplay(parent=parent, logname=log.name, level=logging.INFO)
     qtbot.addWidget(logd)
     logd.show()
@@ -45,8 +45,9 @@ def test_write(qtbot, log):
     assert logd.text.toPlainText() == ""
 
     # Calling .deleteLater() here on pyside6 causes weird behavior with the underlying c++ object in next testcase,
-    # maybe since the logger is associated with the previous logd instance when it gets deleted? 
-    
+    # maybe since the logger is associated with the previous logd instance when it gets deleted?
+
+
 def test_handler_cleanup(qtbot, log):
     logd = PyDMLogDisplay(logname=log.name, level=logging.DEBUG)
     qtbot.addWidget(logd)

--- a/pydm/tests/widgets/test_pushbutton.py
+++ b/pydm/tests/widgets/test_pushbutton.py
@@ -9,7 +9,8 @@ import logging
 
 from qtpy.QtCore import QSize, Qt
 from qtpy.QtGui import QColor
-from qtpy.QtWidgets import QInputDialog, QMessageBox
+from qtpy.QtWidgets import QInputDialog, QMessageBox, QWidget
+
 from ...widgets.pushbutton import PyDMPushButton
 from ...utilities.iconfont import IconFont
 
@@ -78,8 +79,11 @@ def test_construct(qtbot, label, press_value, relative, init_channel, icon_font_
     if icon_font_name:
         icon = IconFont().icon(icon_font_name, icon_color)
 
+    parent = QWidget()
+    qtbot.addWidget(parent)
+
     pydm_pushbutton = PyDMPushButton(
-        label=label, pressValue=press_value, relative=relative, init_channel=init_channel, icon=icon
+        parent=parent, label=label, pressValue=press_value, relative=relative, init_channel=init_channel, icon=icon
     )
     qtbot.addWidget(pydm_pushbutton)
 
@@ -129,7 +133,12 @@ def test_construct(qtbot, label, press_value, relative, init_channel, icon_font_
     assert pydm_pushbutton.passwordProtected is False
     assert pydm_pushbutton.password == ""
     assert pydm_pushbutton.protectedPassword == ""
+    assert pydm_pushbutton.parent() == parent
 
+    # This prevents pyside6 from deleting the internal c++ object 
+    # ("Internal C++ object (PyDMDateTimeLabel) already deleted")
+    parent.deleteLater()
+    pydm_pushbutton.deleteLater()
 
 @pytest.mark.parametrize(
     "password_is_protected",

--- a/pydm/tests/widgets/test_shell_command.py
+++ b/pydm/tests/widgets/test_shell_command.py
@@ -10,7 +10,7 @@ from logging import ERROR
 
 from qtpy import QtCore
 from qtpy.QtCore import QSize
-from qtpy.QtWidgets import QMenu, QAction
+from qtpy.QtWidgets import QMenu, QAction, QWidget
 
 from ...widgets.shell_command import PyDMShellCommand, TermOutputMode
 from ...utilities import IconFont
@@ -49,7 +49,10 @@ def test_construct(qtbot, command, title):
         len(commands) > 1
 
     """
-    pydm_shell_command = PyDMShellCommand(command=command, title=title)
+    parent = QWidget()
+    qtbot.addWidget(parent)
+
+    pydm_shell_command = PyDMShellCommand(parent=parent, command=command, title=title)
     qtbot.addWidget(pydm_shell_command)
     if command and isinstance(command, str):
         assert pydm_shell_command._commands == [command]
@@ -96,6 +99,12 @@ def test_construct(qtbot, command, title):
     shell_cmd_icon_image = shell_cmd_icon.pixmap(DEFAULT_ICON_SIZE).toImage()
 
     assert test_icon_image == shell_cmd_icon_image
+    assert pydm_shell_command.parent() == parent
+
+    # This prevents pyside6 from deleting the internal c++ object 
+    # ("Internal C++ object (PyDMDateTimeLabel) already deleted")
+    parent.deleteLater()
+    pydm_shell_command.deleteLater()
 
 
 @pytest.mark.filterwarnings("ignore:'PyDMShellCommand.command' is deprecated")

--- a/pydm/tests/widgets/test_slider.py
+++ b/pydm/tests/widgets/test_slider.py
@@ -2,7 +2,7 @@ import pytest
 from logging import ERROR
 import numpy as np
 
-from qtpy.QtWidgets import QLabel, QVBoxLayout, QHBoxLayout, QSizePolicy, QApplication, QSlider
+from qtpy.QtWidgets import QLabel, QVBoxLayout, QHBoxLayout, QSizePolicy, QApplication, QSlider, QWidget
 from qtpy.QtCore import Qt, QMargins, QPoint, QEvent, QRect, QSize
 from qtpy.QtGui import QMouseEvent
 from ...widgets.slider import PyDMSlider, PyDMPrimitiveSlider
@@ -216,7 +216,10 @@ def test_construct(qtbot):
     qtbot : fixture
         Window for widget testing
     """
-    pydm_slider = PyDMSlider()
+    parent = QWidget()
+    qtbot.addWidget(parent)
+
+    pydm_slider = PyDMSlider(parent)
     assert checkObjectProperties(pydm_slider, expected_slider_properties) is True
     qtbot.addWidget(pydm_slider)
 
@@ -250,6 +253,13 @@ def test_construct(qtbot):
     assert pydm_slider._slider_position_to_value_map is None
     assert pydm_slider._mute_internal_slider_changes is False
     assert pydm_slider._orientation == Qt.Horizontal
+    assert pydm_slider.parent() == parent
+
+    # This prevents pyside6 from deleting the internal c++ object 
+    # ("Internal C++ object (PyDMDateTimeLabel) already deleted")
+    parent.deleteLater()
+    pydm_slider.deleteLater()
+
 
 
 def test_init_for_designer(qtbot):

--- a/pydm/tests/widgets/test_spinbox.py
+++ b/pydm/tests/widgets/test_spinbox.py
@@ -3,7 +3,7 @@
 
 import pytest
 
-from qtpy.QtWidgets import QApplication
+from qtpy.QtWidgets import QApplication, QWidget
 from qtpy.QtGui import QKeyEvent
 from qtpy.QtCore import QEvent, Qt
 
@@ -28,7 +28,10 @@ def test_construct(qtbot):
     qtbot : fixture
         Window for widget testing
     """
-    pydm_spinbox = PyDMSpinbox()
+    parent = QWidget()
+    qtbot.addWidget(parent)
+
+    pydm_spinbox = PyDMSpinbox(parent)
     qtbot.addWidget(pydm_spinbox)
 
     assert pydm_spinbox.valueBeingSet is False
@@ -39,6 +42,12 @@ def test_construct(qtbot):
     assert pydm_spinbox.app == QApplication.instance()
     assert pydm_spinbox.isAccelerated() is True
     assert pydm_spinbox._write_on_press is False
+    assert pydm_spinbox.parent() == parent
+
+    # This prevents pyside6 from deleting the internal c++ object 
+    # ("Internal C++ object (PyDMDateTimeLabel) already deleted")
+    parent.deleteLater()
+    pydm_spinbox.deleteLater()
 
 
 @pytest.mark.parametrize(

--- a/pydm/widgets/datetime.py
+++ b/pydm/widgets/datetime.py
@@ -51,7 +51,7 @@ class PyDMDateTimeEdit(QtWidgets.QDateTimeEdit, PyDMWritableWidget):
         self._relative = True
         self._time_base = TimeBase.Milliseconds
 
-        QtWidgets.QDateTimeEdit.__init__(self, parent=parent)
+        QtWidgets.QDateTimeEdit.__init__(self, parent)
         PyDMWritableWidget.__init__(self, init_channel=init_channel)
         self.setDisplayFormat("yyyy/MM/dd hh:mm:ss.zzz")
         self.setDateTime(QtCore.QDateTime.currentDateTime())
@@ -150,10 +150,11 @@ class PyDMDateTimeLabel(QtWidgets.QLabel, PyDMWidget):
     """
 
     def __init__(self, parent=None, init_channel=None):
-        QtWidgets.QLabel.__init__(self, parent=parent)
+        QtWidgets.QLabel.__init__(self, parent)
         PyDMWidget.__init__(self, init_channel=init_channel)
 
         self._block_past_date = True
+
         self._relative = True
         self._time_base = TimeBase.Milliseconds
         self._text_format = "yyyy/MM/dd hh:mm:ss.zzz"

--- a/pydm/widgets/logdisplay.py
+++ b/pydm/widgets/logdisplay.py
@@ -67,7 +67,7 @@ class GuiHandler(QObject, logging.Handler):
 
     def __init__(self, level=logging.NOTSET, parent=None):
         logging.Handler.__init__(self, level=level)
-        QObject.__init__(self, parent=parent)
+        QObject.__init__(self, parent)
 
     def emit(self, record):
         """Emit formatted log messages when received but only if level is set."""
@@ -173,7 +173,7 @@ class PyDMLogDisplay(QWidget):
     default_level = logging.INFO
 
     def __init__(self, parent=None, logname=None, level=logging.NOTSET):
-        QWidget.__init__(self, parent=parent)
+        QWidget.__init__(self, parent)
         # Create Widgets
         self.label = QLabel("Minimum displayed log level: ", parent=self)
         self.combo = QComboBox(parent=self)
@@ -192,7 +192,7 @@ class PyDMLogDisplay(QWidget):
         # Allow QCombobox to control log level
         for log_level, value in LogLevels.as_dict().items():
             self.combo.addItem(log_level, value)
-        self.combo.currentIndexChanged[str].connect(self.setLevel)
+        self.combo.currentTextChanged.connect(self.setLevel)
         # Allow QPushButton to clear log text
         self.clear_btn.clicked.connect(self.clear)
         # Create a handler with the default format

--- a/pydm/widgets/nt_table.py
+++ b/pydm/widgets/nt_table.py
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 
 class PythonTableModel(QtCore.QAbstractTableModel):
     def __init__(self, column_names, initial_list=None, parent=None, edit_method=None, can_edit_method=None):
-        super().__init__(parent=parent)
+        super().__init__(parent)
         self.parent = parent
         self._list = None
         self._column_names = column_names
@@ -185,7 +185,7 @@ class PyDMNTTable(QtWidgets.QWidget, PyDMWritableWidget):
     def __init__(self, parent=None, init_channel=None):
         self._read_only = True
 
-        super().__init__(parent=parent)
+        super().__init__(parent)
         PyDMWidget.__init__(self, init_channel=init_channel)
         self.setLayout(QtWidgets.QVBoxLayout())
         self._table = QtWidgets.QTableView(self)

--- a/pydm/widgets/tab_bar.py
+++ b/pydm/widgets/tab_bar.py
@@ -12,7 +12,7 @@ class PyDMTabBar(QTabBar, PyDMWidget):
     """PyDMTabBar is used internally by PyDMTabWidget, and shouldn't be directly used on its own."""
 
     def __init__(self, parent=None):
-        super().__init__(parent=parent)
+        super().__init__(parent)
         self.tab_channels = {}
         self.tab_connection_status = {}
         self.tab_alarm_severity = {}
@@ -189,7 +189,7 @@ class PyDMTabWidget(QTabWidget):
     """
 
     def __init__(self, parent=None):
-        super().__init__(parent=parent)
+        super().__init__(parent)
         self.tb = PyDMTabBar(parent=self)
         self.setTabBar(self.tb)
 

--- a/pydm/widgets/terminator.py
+++ b/pydm/widgets/terminator.py
@@ -20,7 +20,7 @@ class PyDMTerminator(QLabel, PyDMPrimitiveWidget):
     """
 
     def __init__(self, parent=None, timeout=60, *args, **kwargs):
-        super().__init__(parent=parent, *args, **kwargs)
+        super().__init__(parent, *args, **kwargs)
         self.setText("")
         self._hook_setup = False
         self._timeout = 60


### PR DESCRIPTION
For some widgets that call "\_\_init\_\_(parent=parent)" using the named arg to pass in 'parent'
on pyside6 it was throwing the error "\_\_init\_\_() got an unexpected keyword argument 'parent'"

Most widgets already use the positional arg for passing 'parent':
"\_\_init\_\_(parent)", so this patch switches over those throwing error on
pyside6 to use positional arg.

(note: some plot related widgets still pass a named 'parent' arg to
\_\_init\_\_ and don't cause error, this seems to be related to their diff
class hierarchy and sublcassing of pyqtgraph classes)

Also add checks to tests for if parent gets set properly in widgets.

Also update to use correct signal type for the combobox text change in logdisplay.