### PR TITLE
ENH: make middle-click copy-to-clipboard feature on widgets copy also to the clipboard that pastes with 'Ctrl-v'

### DIFF
--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -237,12 +237,11 @@ class PyDMPrimitiveWidget(object):
 
         clipboard = QApplication.clipboard()
 
-        mode = clipboard.Clipboard
         if platform.system() == "Linux":
             # Mode Selection is only valid for X11.
-            mode = clipboard.Selection
+            clipboard.setText(clipboard_text, mode=clipboard.Selection)
 
-        clipboard.setText(clipboard_text, mode=mode)
+        clipboard.setText(clipboard_text, mode=clipboard.Clipboard)
         event = QEvent(QEvent.Clipboard)
         self.app.sendEvent(clipboard, event)
 


### PR DESCRIPTION
linux (x window system) has multiple clipboards, and we are currently just setting the 'Selection' clipboard which pastes by pressing middle-click.

while 'Selection' is only valid for linux, 'Clipboard' is still valid on linux also, so we can call 'setText' with it to enable pasting with 'Ctrl-V' on linux.