### PR TITLE
FIX: Backfill archive data correctly when adding a new curve to an archive plot

### DIFF
--- a/pydm/widgets/archiver_time_plot.py
+++ b/pydm/widgets/archiver_time_plot.py
@@ -1096,12 +1096,13 @@ class PyDMArchiverTimePlot(PyDMTimePlot):
            recorded yet, then defaults to the timestamp at which the plot was first rendered.
         """
         req_queued = False
+        requested_max = max_x
         if min_x is None:
             min_x = self._min_x
         for curve in self._curves:
             processing_command = ""
             if curve.use_archive_data:
-                if max_x is None:
+                if requested_max is None:  # If the caller didn't request a max, use the oldest data from the curve
                     max_x = curve.min_x()
                 if not self._cache_data:
                     max_x = min(max_x, self._max_x)


### PR DESCRIPTION
### Context

When adding a curve to an archive plot, it will only backfill with data up to the timestamp at which the plot was first rendered, not the timestamp at which the curve was added. This results in a line in which data is missing if the curve was added several minutes or more after the plot was first rendered.

Fix is just to ensure we use each individual curves minimum data point when deciding what timestamp parameters to call the archiver with. By doing this instead of using the same maximum timestamp for each curve on the plot, each individual curve will get the correct amount of data back.

Verified that backfilled data appears as expected after this change.