### PR TITLE
BLD: Install pyca from PyPI

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -44,9 +44,9 @@ jobs:
         if [ "$RUNNER_OS" == "Windows" ]; then
           conda install -c conda-forge pydm pyqt=${{ matrix.pyqt-version }}
         elif [ "$RUNNER_OS" == "macOS" ]; then
-          mamba install -c conda-forge pydm pyqt=${{ matrix.pyqt-version }} git p4p pyca
+          mamba install -c conda-forge pydm pyqt=${{ matrix.pyqt-version }} p4p
         else
-          mamba install -c conda-forge pydm pyqt=${{ matrix.pyqt-version }} pyca
+          mamba install -c conda-forge pydm pyqt=${{ matrix.pyqt-version }}
         fi
 
     - name: Install additional Python dependencies with pip

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,3 +5,4 @@ pytest-cov
 pytest-timeout
 p4p
 pre-commit
+pyca-epics


### PR DESCRIPTION
### Context

With pyca available on PyPI now here:

https://pypi.org/project/pyca-epics/

This just reverts the temporary change from #1211 and adds it back as a PyPI installable package in both the `dev-requirements.txt` file and our testing workflow.
