### PR TITLE
BUG: cleanup stylesheet readin code, also stops FileNotFoundError error when cancel out stylesheet selecting window

### DIFF
--- a/pydm/main_window.py
+++ b/pydm/main_window.py
@@ -377,10 +377,9 @@ class PyDMMainWindow(QMainWindow):
             self, "Change Stylesheet...", folder, "PyDM Stylesheets (*.qss *.css)"
         )
 
-        if ss_filename:
-            ss_filename = str(ss_filename)
-            self.ss_path = ss_filename.split("'")
-            style = open(self.ss_path[1], "r")
+        ss_path = str(ss_filename[0])
+        if ss_path:
+            style = open(ss_path, "r")
             style = style.read()
             self.setStyleSheet(style)
 


### PR DESCRIPTION
seems like b4 we were getting the filepath in a very roundabout way:
 - `QFileDialog.getOpenFileName()` returns a tuple where the 1st element is the full file-path
 - we were then converting tuple into string, splitting it on the ' char to get something like` ["'(','/home/nolan-work/repos/pydm/examples/label/style.qss', ', ', 'PyDMStylesheets (*.qss *.css)', ')'",]` and then just selecting the 2nd element of the split result.

we can instead just directly grab the first element of the output tuple of `QFileDialog.getOpenFileName()`. 

this fix also stops the `FileNotFoundError` caused by the `if ss_filename:` always being True b/c `ss_filename` was a tuple b4
(and when nothing selected ('','') got returned from `getOpenFileName()`, which is True in a conditional)