### PR TITLE
FIX: Gets FormulaCurveItems working for pvs with archived or live connections 

### DIFF
--- a/pydm/widgets/archiver_time_plot.py
+++ b/pydm/widgets/archiver_time_plot.py
@@ -527,6 +527,7 @@ class FormulaCurveItem(BasePlotCurveItem):
         Additional parameters supported by pyqtgraph.PlotDataItem.
     """
 
+    _channels = ("channel",)
     archive_data_request_signal = Signal(float, float, str)
     archive_data_received_signal = Signal()
     live_channel_connection = Signal(bool)
@@ -667,7 +668,7 @@ class FormulaCurveItem(BasePlotCurveItem):
             self.data_buffer = np.array([[APPROX_SECONDS_300_YEARS], [eval(self._trueFormula)]])
             self.points_accumulated = self.archive_points_accumulated = 1
             return
-        if not (self.connected and self.arch_connected):
+        if not (self.connected or self.arch_connected):
             return
         pvArchiveData = dict()
         pvLiveData = dict()
@@ -924,6 +925,8 @@ class FormulaCurveItem(BasePlotCurveItem):
             maxx = min(self.pvs[curve].min_archiver_x(), maxx)
         return maxx
 
+    def channels(self):
+        return [self.channel]
 
 class PyDMArchiverTimePlot(PyDMTimePlot):
     """


### PR DESCRIPTION
## Details

A small fix which allows FormulaCurveItems to work when the PVs in the formula are connected by at least one option: archive or live. currently all PVs in a formula needs both a live and archived connection to evaluate.  