### PR TITLE
MNT/TST: only do necessary runs in github actions

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -20,8 +20,16 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.9', '3.10']
-        pyqt-version: [5.12.3, 5.15.9]
+        # eventually we should just run 3.10 + pyqt 5.12.3 (or if fix designer issue, latest pyqt5 and latest python that works with it),
+        # and latest-python + latest-pyside6
+        python-version: ["3.10", "3.12"]
+        pyqt-version: ["5.12.3", "5.15.11"]  # we still use 5.12.3 since newer conda versions have designer plugin issues
+        exclude:
+          # don't run these
+          - python-version: "3.10"  # 5.15.11 is newest pyqt5, so use newest python (3.12) 
+            pyqt-version: "5.15.11" 
+          - python-version: "3.12"  # max python version for 5.12.3 is 3.10 (3.12 errors during conda env creation)
+            pyqt-version: "5.12.3" 
     env:
       DISPLAY: ':99.0'
       QT_MAC_WANTS_LAYER: 1  # PyQT gui tests involving qtbot interaction on macOS will fail without this

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -63,7 +63,7 @@ Ready to contribute? Here's how to set up `pydm` for local development.
 
 3. Install your local copy into a new conda environment. Assuming you have conda installed, this is how you set up your fork for local development::
 
-    $ conda create -n pydm-environment python=3.8 pyqt=5.12.3 pip numpy scipy six psutil pyqtgraph -c conda-forge
+    $ conda create -n pydm-environment python=3.10 pyqt=5.12.3 pip numpy scipy six psutil pyqtgraph -c conda-forge
     $ cd pydm/
     $ pip install -e .
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,13 @@ as the abstraction layer for the Qt Python wrappers (PyQt5/PyQt4/PySide2/PySide)
 Python package requirements are listed in the requirements.txt file, which can
 be used to install all requirements from pip: 'pip install -r requirements.txt'
 
+# Getting Started
+For developers who wish to contribute to PyDM and modify the source code, please follow the "Getting Started!"
+instructions found here: https://github.com/slaclab/pydm/blob/master/CONTRIBUTING.rst#get-started.
+
+For users who want to just install and run PyDM, follow the "Installation"
+instructions found in the docs: https://slaclab.github.io/pydm/installation.html
+
 # Running the Tests
 In order to run the tests you will need to install some dependencies that are
 not part of the runtime dependencies of PyDM.

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -21,7 +21,7 @@ Installing PyDM and Prerequisites with Conda
     In order to use PyDM widgets in designer, please make sure to pin the PyQt version to 5.12.3 or lower
     until this is resolved.
 
-    $ conda create -n pydm-environment python=3.10 pyqt=5.12.3 pip numpy scipy six psutil pyqtgraph pydm -c conda-forge
+    $ conda create -n pydm-environment python=3.12 pyqt=5.12.3 pip numpy scipy six psutil pyqtgraph pydm -c conda-forge
 
 After installing Miniforge (see https://conda-forge.org/download/), create a new
 environment for PyDM::


### PR DESCRIPTION
run the following combos:
- 5.12.3 with latest python it supports (3.10) # this is latest pyqt5
  with working designer plugins
- 5.15.11 with latest python (3.12) # this is latest pyqt5

next we should add runs for latest pyside6 and python 3.12

also make dev setup instructions easier to find on main github page.