### PR TITLE
FIX: Baseplot Crosshair Labels

### DIFF
--- a/pydm/widgets/archiver_time_plot.py
+++ b/pydm/widgets/archiver_time_plot.py
@@ -929,6 +929,7 @@ class FormulaCurveItem(BasePlotCurveItem):
     def channels(self):
         return [self.channel]
 
+
 class PyDMArchiverTimePlot(PyDMTimePlot):
     """
     PyDMArchiverTimePlot is a PyDMTimePlot with support for receiving data from


### PR DESCRIPTION
## Description 
This PR addresses a few bugs with the crosshair labels. The labels would persist after crosshairs were disabled. Labels would also be visible if the curve was made not visible. The X and Y values would only display 0.00 for very small numbers  