### PR TITLE
BUG: make tabwidget call parent eventFilter() of correct parent class.

### DIFF
--- a/pydm/widgets/tab_bar.py
+++ b/pydm/widgets/tab_bar.py
@@ -33,7 +33,7 @@ class PyDMTabBar(QTabBar, PyDMWidget):
     # On pyside6, we need to expilcity call pydm's base class's eventFilter() call or events
     # will not propagate to the parent classes properly.
     def eventFilter(self, obj, event):
-        return PyDMWritableWidget.eventFilter(self, obj, event)
+        return PyDMWidget.eventFilter(self, obj, event)
 
     @Property(str)
     def currentTabAlarmChannel(self):


### PR DESCRIPTION
Stops the following error output when running a PyDMTabWidget widget:

```
Traceback (most recent call last):
  File "/home/nolan/repos/pydm/pydm/widgets/tab_bar.py", line 36, in eventFilter
    return PyDMWritableWidget.eventFilter(self, obj, event)
NameError: name 'PyDMWritableWidget' is not defined. Did you mean: 'PyDMTabWidget'?
```

We do these explicit parent eventFilter() calls in the first place so events to get events to be correctly on pyside6.

This bug got merged in b/c of lacking tests for the PyDMTabWidget, but tests for it and PyDMTerminator and PyDMNTTable will be added shortly.