### PR TITLE
MNT: Syntax warning messages in python 3.12

### DIFF
--- a/pydm/tests/utilities/test_macro.py
+++ b/pydm/tests/utilities/test_macro.py
@@ -46,7 +46,7 @@ def test_substitute_in_file(text, macros, expected):
         ("A=$(other_macro),B=2,C=3", {"A": "$(other_macro)", "B": "2", "C": "3"}),
         ("A=$(other_macro=3)", {"A": "$(other_macro=3)"}),
         ("TITLE='1,2', B=2, C=3", {"TITLE": "1,2", "B": "2", "C": "3"}),
-        ("TITLE=1\,2,B=2,C=3", {"TITLE": "1,2", "B": "2", "C": "3"}),
+        (r"TITLE=1\,2,B=2,C=3", {"TITLE": "1,2", "B": "2", "C": "3"}),
         ('TITLE="e=mc^2",B=2,C=3', {"TITLE": "e=mc^2", "B": "2", "C": "3"}),
         ("", {}),
         (None, {}),

--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -1156,7 +1156,7 @@ class PyDMWidget(PyDMPrimitiveWidget):
             return new_tip
 
         if not self._tool_tip_substrings:
-            list_of_attributes = [substring.start() for substring in re.finditer("\$\(", new_tip)]
+            list_of_attributes = [substring.start() for substring in re.finditer(r"\$\(", new_tip)]
             tool_tip_substrings = []
 
             for index in list_of_attributes:


### PR DESCRIPTION
### Context

When running pydm using Python 3.12, these 2 places now print `SyntaxWarning` rather than the previous `DeprecationWarning`.

```
SyntaxWarning: invalid escape sequence '\$'
  list_of_attributes = [substring.start() for substring in re.finditer("\$\(", new_tip)]
```

 Uses raw strings now so that they aren't processed as escape sequences.

See here for more info: https://docs.python.org/3/whatsnew/3.12.html#other-language-changes

### Testing

Verified that tool tips still parse correctly after applying this change. Verified that the macro test case is still valid (removing the backslash character)
