### PR TITLE
ENH/MNT: convert all Qt Property declarations to use a way that works for both pyside6 and pyqt5. 

### DIFF
--- a/pydm/widgets/analog_indicator.py
+++ b/pydm/widgets/analog_indicator.py
@@ -1,8 +1,14 @@
 from .base import PyDMWidget
 from qtpy.QtGui import QColor, QPolygon, QPainter, QFontMetrics
 from qtpy.QtWidgets import QFrame, QSizePolicy
-from qtpy.QtCore import Qt, QPoint, Property, QSize
+from qtpy.QtCore import Qt, QPoint, QSize
 from .scale import QScale, PyDMScaleIndicator
+from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
+
+if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
+    from PySide6.QtCore import Property
+else:
+    from PyQt5.QtCore import pyqtProperty as Property
 
 
 class QScaleAlarmed(QScale):
@@ -472,8 +478,7 @@ class PyDMAnalogIndicator(PyDMScaleIndicator):
 
     # Reject barIndicator setter and getter
 
-    @Property(QColor)
-    def minorAlarmRegionColor(self):
+    def readMinorAlarmRegionColor(self) -> QColor:
         """
         The color of the scale background.
         Returns
@@ -482,8 +487,7 @@ class PyDMAnalogIndicator(PyDMScaleIndicator):
         """
         return self.scale_indicator.get_minor_alarm_region_color()
 
-    @minorAlarmRegionColor.setter
-    def minorAlarmRegionColor(self, color):
+    def setMinorAlarmRegionColor(self, color) -> None:
         """
         The color of the scale background.
         Parameters
@@ -492,8 +496,9 @@ class PyDMAnalogIndicator(PyDMScaleIndicator):
         """
         self.scale_indicator.set_minor_alarm_region_color(color)
 
-    @Property(QColor)
-    def minorAlarmColor(self):
+    minorAlarmRegionColor = Property(QColor, readMinorAlarmRegionColor, setMinorAlarmRegionColor)
+
+    def readMinorAlarmColor(self) -> QColor:
         """
         The color of the scale background.
         Returns
@@ -502,8 +507,7 @@ class PyDMAnalogIndicator(PyDMScaleIndicator):
         """
         return self.scale_indicator.get_minor_alarm_color()
 
-    @minorAlarmColor.setter
-    def minorAlarmColor(self, color):
+    def setMinorAlarmColor(self, color) -> None:
         """
         The color of the scale background.
         Parameters
@@ -512,8 +516,9 @@ class PyDMAnalogIndicator(PyDMScaleIndicator):
         """
         self.scale_indicator.set_minor_alarm_color(color)
 
-    @Property(QColor)
-    def majorAlarmRegionColor(self):
+    minorAlarmColor = Property(QColor, readMinorAlarmColor, setMinorAlarmColor)
+
+    def readMajorAlarmRegionColor(self) -> QColor:
         """
         The color of the scale background.
         Returns
@@ -522,8 +527,7 @@ class PyDMAnalogIndicator(PyDMScaleIndicator):
         """
         return self.scale_indicator.get_major_alarm_region_color()
 
-    @majorAlarmRegionColor.setter
-    def majorAlarmRegionColor(self, color):
+    def setMajorAlarmRegionColor(self, color) -> None:
         """
         The color of the scale background.
         Parameters
@@ -532,8 +536,9 @@ class PyDMAnalogIndicator(PyDMScaleIndicator):
         """
         self.scale_indicator.set_major_alarm_region_color(color)
 
-    @Property(QColor)
-    def majorAlarmColor(self):
+    majorAlarmRegionColor = Property(QColor, readMajorAlarmRegionColor, setMajorAlarmRegionColor)
+
+    def readMajorAlarmColor(self) -> QColor:
         """
         The color of the scale background.
         Returns
@@ -542,8 +547,7 @@ class PyDMAnalogIndicator(PyDMScaleIndicator):
         """
         return self.scale_indicator.get_major_alarm_color()
 
-    @majorAlarmColor.setter
-    def majorAlarmColor(self, color):
+    def setMajorAlarmColor(self, color) -> None:
         """
         The color of the scale background.
         Parameters
@@ -552,8 +556,9 @@ class PyDMAnalogIndicator(PyDMScaleIndicator):
         """
         self.scale_indicator.set_major_alarm_color(color)
 
-    @Property(bool)
-    def minorAlarmFromChannel(self):
+    majorAlarmColor = Property(QColor, readMajorAlarmColor, setMajorAlarmColor)
+
+    def readMinorAlarmFromChannel(self) -> bool:
         """
         Whether or not the scale indicator should use the minor alarm information
         from the channel.
@@ -563,8 +568,7 @@ class PyDMAnalogIndicator(PyDMScaleIndicator):
         """
         return self._minor_alarm_from_channel
 
-    @minorAlarmFromChannel.setter
-    def minorAlarmFromChannel(self, checked):
+    def setMinorAlarmFromChannel(self, checked) -> None:
         """
         Whether or not the scale indicator should use the minor alarm information
         from the channel.
@@ -586,8 +590,9 @@ class PyDMAnalogIndicator(PyDMScaleIndicator):
                 self.scale_indicator.set_upper_minor_alarm(self._user_upper_minor_alarm)
             self.update_labels()
 
-    @Property(float)
-    def userUpperMinorAlarm(self):
+    minorAlarmFromChannel = Property(bool, readMinorAlarmFromChannel, setMinorAlarmFromChannel)
+
+    def readUserUpperMinorAlarm(self) -> float:
         """
         The user-defined upper minor alarm for the scale.
         Returns
@@ -596,8 +601,7 @@ class PyDMAnalogIndicator(PyDMScaleIndicator):
         """
         return self._user_upper_minor_alarm
 
-    @userUpperMinorAlarm.setter
-    def userUpperMinorAlarm(self, value):
+    def setUserUpperMinorAlarm(self, value) -> None:
         """
         The user-defined upper minor alarm for the scale.
         Parameters
@@ -613,8 +617,9 @@ class PyDMAnalogIndicator(PyDMScaleIndicator):
         self.scale_indicator.set_upper_minor_alarm(self._user_upper_minor_alarm)
         self.update_labels()
 
-    @Property(float)
-    def userLowerMinorAlarm(self):
+    userUpperMinorAlarm = Property(float, readUserUpperMinorAlarm, setUserUpperMinorAlarm)
+
+    def readUserLowerMinorAlarm(self) -> float:
         """
         The user-defined lower minor alarm for the scale.
         Returns
@@ -623,8 +628,7 @@ class PyDMAnalogIndicator(PyDMScaleIndicator):
         """
         return self._user_lower_minor_alarm
 
-    @userLowerMinorAlarm.setter
-    def userLowerMinorAlarm(self, value):
+    def setUserLowerMinorAlarm(self, value) -> None:
         """
         The user-defined lower minor alarm for the scale.
         Parameters
@@ -640,8 +644,9 @@ class PyDMAnalogIndicator(PyDMScaleIndicator):
         self.scale_indicator.set_lower_minor_alarm(self._user_lower_minor_alarm)
         self.update_labels()
 
-    @Property(bool)
-    def majorAlarmFromChannel(self):
+    userLowerMinorAlarm = Property(float, readUserLowerMinorAlarm, setUserLowerMinorAlarm)
+
+    def readMajorAlarmFromChannel(self) -> bool:
         """
         Whether or not the scale indicator should use the major alarm information
         from the channel.
@@ -651,8 +656,7 @@ class PyDMAnalogIndicator(PyDMScaleIndicator):
         """
         return self._major_alarm_from_channel
 
-    @majorAlarmFromChannel.setter
-    def majorAlarmFromChannel(self, checked):
+    def setMajorAlarmFromChannel(self, checked) -> None:
         """
         Whether or not the scale indicator should use the minor alarm information
         from the channel.
@@ -678,8 +682,9 @@ class PyDMAnalogIndicator(PyDMScaleIndicator):
             self.scale_indicator.set_upper_major_alarm(self.upper_alarm_limit)
             self.update_labels()
 
-    @Property(float)
-    def userUpperMajorAlarm(self):
+    majorAlarmFromChannel = Property(bool, readMajorAlarmFromChannel, setMajorAlarmFromChannel)
+
+    def readUserUpperMajorAlarm(self) -> float:
         """
         The user-defined upper major alarm for the scale.
         Returns
@@ -688,8 +693,7 @@ class PyDMAnalogIndicator(PyDMScaleIndicator):
         """
         return self._user_upper_major_alarm
 
-    @userUpperMajorAlarm.setter
-    def userUpperMajorAlarm(self, value):
+    def setUserUpperMajorAlarm(self, value) -> None:
         """
         The user-defined upper major alarm for the scale.
         Parameters
@@ -704,8 +708,9 @@ class PyDMAnalogIndicator(PyDMScaleIndicator):
         self._user_upper_major_alarm = value
         self.scale_indicator.set_upper_major_alarm(self._user_upper_major_alarm)
 
-    @Property(float)
-    def userLowerMajorAlarm(self):
+    userUpperMajorAlarm = Property(float, readUserUpperMajorAlarm, setUserUpperMajorAlarm)
+
+    def readUserLowerMajorAlarm(self) -> float:
         """
         The user-defined lower major alarm for the scale.
         Returns
@@ -714,8 +719,7 @@ class PyDMAnalogIndicator(PyDMScaleIndicator):
         """
         return self._user_lower_major_alarm
 
-    @userLowerMajorAlarm.setter
-    def userLowerMajorAlarm(self, value):
+    def setUserLowerMajorAlarm(self, value) -> None:
         """
         The user-defined lower major alarm for the scale.
         Parameters
@@ -729,6 +733,8 @@ class PyDMAnalogIndicator(PyDMScaleIndicator):
 
         self._user_lower_major_alarm = value
         self.scale_indicator.set_lower_major_alarm(self._user_lower_major_alarm)
+
+    userLowerMajorAlarm = Property(float, readUserLowerMajorAlarm, setUserLowerMajorAlarm)
 
     # Two properties available on PyDMScaleIndicator we don't support for PyDMAnalogIndicator
     originAtZero = Property(bool, None, None, designable=False)

--- a/pydm/widgets/baseplot.py
+++ b/pydm/widgets/baseplot.py
@@ -5,7 +5,7 @@ import numpy as np
 import weakref
 from abc import abstractmethod
 from qtpy.QtGui import QColor, QFont, QBrush
-from qtpy.QtCore import Signal, Slot, Property, QTimer, Qt, QEvent, QObject, QRect, QPointF
+from qtpy.QtCore import Signal, Slot, QTimer, Qt, QEvent, QObject, QRect, QPointF
 from qtpy.QtWidgets import QToolTip, QWidget
 from pydm import utilities
 from pyqtgraph import (
@@ -23,6 +23,12 @@ from collections import OrderedDict
 from typing import Dict, List, Optional, Union, Any
 from .base import PyDMPrimitiveWidget, widget_destroyed
 from .multi_axis_plot import MultiAxisPlot
+from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
+
+if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
+    from PySide6.QtCore import Property
+else:
+    from PyQt5.QtCore import pyqtProperty as Property
 
 
 class NoDataError(Exception):
@@ -1409,8 +1415,7 @@ class BasePlot(PlotWidget, PyDMPrimitiveWidget):
         self._max_y = new_max_y_range
         self.plotItem.setYRange(self._min_y, self._max_y, padding=0)
 
-    @Property(bool)
-    def mouseEnabledX(self) -> bool:
+    def readMouseEnabledX(self) -> bool:
         """
         Whether or not mouse interactions are enabled for the X-axis.
 
@@ -1420,8 +1425,7 @@ class BasePlot(PlotWidget, PyDMPrimitiveWidget):
         """
         return self.plotItem.getViewBox().state["mouseEnabled"][0]
 
-    @mouseEnabledX.setter
-    def mouseEnabledX(self, x_enabled: bool) -> None:
+    def setMouseEnabledX(self, x_enabled: bool) -> None:
         """
         Whether or not mouse interactions are enabled for the X-axis.
 
@@ -1431,8 +1435,9 @@ class BasePlot(PlotWidget, PyDMPrimitiveWidget):
         """
         self.plotItem.setMouseEnabled(x=x_enabled)
 
-    @Property(bool)
-    def mouseEnabledY(self) -> bool:
+    mouseEnabledX = Property(bool, readMouseEnabledX, setMouseEnabledX)
+
+    def readMouseEnabledY(self) -> bool:
         """
         Whether or not mouse interactions are enabled for the Y-axis.
 
@@ -1442,8 +1447,7 @@ class BasePlot(PlotWidget, PyDMPrimitiveWidget):
         """
         return self.plotItem.getViewBox().state["mouseEnabled"][1]
 
-    @mouseEnabledY.setter
-    def mouseEnabledY(self, y_enabled: bool) -> None:
+    def setMouseEnabledY(self, y_enabled: bool) -> None:
         """
         Whether or not mouse interactions are enabled for the Y-axis.
 
@@ -1453,8 +1457,9 @@ class BasePlot(PlotWidget, PyDMPrimitiveWidget):
         """
         self.plotItem.setMouseEnabled(y=y_enabled)
 
-    @Property(int)
-    def maxRedrawRate(self) -> int:
+    mouseEnabledY = Property(bool, readMouseEnabledY, setMouseEnabledY)
+
+    def readMaxRedrawRate(self) -> int:
         """
         The maximum rate (in Hz) at which the plot will be redrawn.
         The plot will not be redrawn if there is not new data to draw.
@@ -1465,8 +1470,7 @@ class BasePlot(PlotWidget, PyDMPrimitiveWidget):
         """
         return self._redraw_rate
 
-    @maxRedrawRate.setter
-    def maxRedrawRate(self, redraw_rate: int) -> None:
+    def setMaxRedrawRate(self, redraw_rate: int) -> None:
         """
         The maximum rate (in Hz) at which the plot will be redrawn.
         The plot will not be redrawn if there is not new data to draw.
@@ -1477,6 +1481,8 @@ class BasePlot(PlotWidget, PyDMPrimitiveWidget):
         """
         self._redraw_rate = redraw_rate
         self.redraw_timer.setInterval(int((1.0 / self._redraw_rate) * 1000))
+
+    maxRedrawRate = Property(int, readMaxRedrawRate, setMaxRedrawRate)
 
     def pausePlotting(self) -> bool:
         (self.redraw_timer.stop() if self.redraw_timer.isActive() else self.redraw_timer.start())

--- a/pydm/widgets/byte.py
+++ b/pydm/widgets/byte.py
@@ -1,8 +1,14 @@
 from qtpy.QtWidgets import QWidget, QTabWidget, QGridLayout, QLabel, QStyle, QStyleOption
 from qtpy.QtGui import QColor, QPen, QFontMetrics, QPainter, QPaintEvent, QBrush
-from qtpy.QtCore import Property, Qt, QSize, QPoint
+from qtpy.QtCore import Qt, QSize, QPoint
 from typing import List, Optional
 from .base import PyDMWidget, PostParentClassInitSetup
+from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
+
+if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
+    from PySide6.QtCore import Property
+else:
+    from PyQt5.QtCore import pyqtProperty as Property
 
 
 class PyDMBitIndicator(QWidget):
@@ -224,8 +230,7 @@ class PyDMByteIndicator(QWidget, PyDMWidget):
                 c = self._disconnected_color
             indicator.setColor(c)
 
-    @Property(QColor)
-    def onColor(self) -> QColor:
+    def readOnColor(self) -> QColor:
         """
         The color for a bit in the 'on' state.
 
@@ -235,8 +240,7 @@ class PyDMByteIndicator(QWidget, PyDMWidget):
         """
         return self._on_color
 
-    @onColor.setter
-    def onColor(self, new_color: QColor) -> None:
+    def setOnColor(self, new_color: QColor) -> None:
         """
         The color for a bit in the 'on' state.
 
@@ -248,8 +252,9 @@ class PyDMByteIndicator(QWidget, PyDMWidget):
             self._on_color = new_color
             self.update_indicators()
 
-    @Property(QColor)
-    def offColor(self) -> QColor:
+    onColor = Property(QColor, readOnColor, setOnColor)
+
+    def readOffColor(self) -> QColor:
         """
         The color for a bit in the 'off' state.
 
@@ -259,8 +264,7 @@ class PyDMByteIndicator(QWidget, PyDMWidget):
         """
         return self._off_color
 
-    @offColor.setter
-    def offColor(self, new_color: QColor) -> None:
+    def setOffColor(self, new_color: QColor) -> None:
         """
         The color for a bit in the 'off' state.
 
@@ -272,8 +276,9 @@ class PyDMByteIndicator(QWidget, PyDMWidget):
             self._off_color = new_color
             self.update_indicators()
 
-    @Property(Qt.Orientation)
-    def orientation(self) -> Qt.Orientation:
+    offColor = Property(QColor, readOffColor, setOffColor)
+
+    def readOrientation(self) -> int | Qt.Orientation:
         """
         Whether to lay out the bit indicators vertically or horizontally.
 
@@ -283,8 +288,7 @@ class PyDMByteIndicator(QWidget, PyDMWidget):
         """
         return self._orientation
 
-    @orientation.setter
-    def orientation(self, new_orientation: Qt.Orientation) -> None:
+    def setOrientation(self, new_orientation: Qt.Orientation) -> None:
         """
         Whether to lay out the bit indicators vertically or horizontally.
 
@@ -295,6 +299,9 @@ class PyDMByteIndicator(QWidget, PyDMWidget):
         self._orientation = new_orientation
         self.set_spacing()
         self.rebuild_layout()
+
+    prop_type = int if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6 else Qt.Orientation
+    orientation = Property(prop_type, readOrientation, setOrientation)
 
     def set_spacing(self) -> None:
         """
@@ -315,8 +322,7 @@ class PyDMByteIndicator(QWidget, PyDMWidget):
             self.layout().setHorizontalSpacing(label_spacing)
             self.layout().setVerticalSpacing(indicator_spacing)
 
-    @Property(bool)
-    def showLabels(self) -> bool:
+    def readShowLabels(self) -> bool:
         """
         Whether or not to show labels next to each bit indicator.
 
@@ -326,8 +332,7 @@ class PyDMByteIndicator(QWidget, PyDMWidget):
         """
         return self._show_labels
 
-    @showLabels.setter
-    def showLabels(self, show: bool) -> None:
+    def setShowLabels(self, show: bool) -> None:
         """
         Whether or not to show labels next to each bit indicator.
 
@@ -340,8 +345,9 @@ class PyDMByteIndicator(QWidget, PyDMWidget):
         for label in self._labels:
             label.setVisible(show)
 
-    @Property(bool)
-    def bigEndian(self) -> bool:
+    showLabels = Property(bool, readShowLabels, setShowLabels)
+
+    def readBigEndian(self) -> bool:
         """
         Whether the most significant bit is at the start or end of the widget.
 
@@ -351,8 +357,7 @@ class PyDMByteIndicator(QWidget, PyDMWidget):
         """
         return self._big_endian
 
-    @bigEndian.setter
-    def bigEndian(self, is_big_endian: bool) -> None:
+    def setBigEndian(self, is_big_endian: bool) -> None:
         """
         Whether the most significant bit is at the start or end of the widget.
 
@@ -374,8 +379,9 @@ class PyDMByteIndicator(QWidget, PyDMWidget):
         self.layout().setOriginCorner(origin)
         self.rebuild_layout()
 
-    @Property(bool)
-    def circles(self) -> bool:
+    bigEndian = Property(bool, readBigEndian, setBigEndian)
+
+    def readCircles(self) -> bool:
         """
         Draw indicators as circles, rather than rectangles.
 
@@ -385,8 +391,7 @@ class PyDMByteIndicator(QWidget, PyDMWidget):
         """
         return self._circles
 
-    @circles.setter
-    def circles(self, draw_circles: bool) -> None:
+    def setCircles(self, draw_circles: bool) -> None:
         """
         Draw indicators as circles, rather than rectangles.
 
@@ -401,8 +406,9 @@ class PyDMByteIndicator(QWidget, PyDMWidget):
             indicator.circle = self._circles
         self.update_indicators()
 
-    @Property(QTabWidget.TabPosition)
-    def labelPosition(self) -> QTabWidget.TabPosition:
+    circles = Property(bool, readCircles, setCircles)
+
+    def readLabelPosition(self) -> QTabWidget.TabPosition:
         """
         The side of the widget to display labels on.
 
@@ -412,8 +418,7 @@ class PyDMByteIndicator(QWidget, PyDMWidget):
         """
         return self._label_position
 
-    @labelPosition.setter
-    def labelPosition(self, new_pos: QTabWidget.TabPosition) -> None:
+    def setLabelPosition(self, new_pos: QTabWidget.TabPosition) -> None:
         """
         The side of the widget to display labels on.
 
@@ -424,8 +429,9 @@ class PyDMByteIndicator(QWidget, PyDMWidget):
         self._label_position = new_pos
         self.rebuild_layout()
 
-    @Property(int)
-    def numBits(self) -> int:
+    labelPosition = Property(QTabWidget.TabPosition, readLabelPosition, setLabelPosition)
+
+    def readNumBits(self) -> int:
         """
         Number of bits to interpret.
 
@@ -435,8 +441,7 @@ class PyDMByteIndicator(QWidget, PyDMWidget):
         """
         return self._num_bits
 
-    @numBits.setter
-    def numBits(self, new_num_bits: int) -> None:
+    def setNumBits(self, new_num_bits: int) -> None:
         """
         Number of bits to interpret.
 
@@ -458,8 +463,9 @@ class PyDMByteIndicator(QWidget, PyDMWidget):
             new_labels[i] = old_label
         self.labels = new_labels
 
-    @Property(int)
-    def shift(self) -> int:
+    numBits = Property(int, readNumBits, setNumBits)
+
+    def readShift(self) -> int:
         """
         Bit shift.
 
@@ -469,8 +475,7 @@ class PyDMByteIndicator(QWidget, PyDMWidget):
         """
         return self._shift
 
-    @shift.setter
-    def shift(self, new_shift: int) -> None:
+    def setShift(self, new_shift: int) -> None:
         """
         Bit shift.
 
@@ -479,10 +484,10 @@ class PyDMByteIndicator(QWidget, PyDMWidget):
         new_shift : int
         """
         self._shift = new_shift
-        self.update_indicators()
 
-    @Property("QStringList")
-    def labels(self) -> List[str]:
+    shift = Property(int, readShift, setShift)
+
+    def readLabels(self) -> List[str]:
         """
         Labels for each bit.
 
@@ -492,8 +497,7 @@ class PyDMByteIndicator(QWidget, PyDMWidget):
         """
         return [str(currLabel.text()) for currLabel in self._labels]
 
-    @labels.setter
-    def labels(self, new_labels: List[str]) -> None:
+    def setLabels(self, new_labels: List[str]) -> None:
         """
         Labels for each bit.
 
@@ -508,6 +512,8 @@ class PyDMByteIndicator(QWidget, PyDMWidget):
         # Have to reset showLabels to hide or show all the new labels we just made.
         self.showLabels = self._show_labels
         self.rebuild_layout()
+
+    labels = Property("QStringList", readLabels, setLabels)
 
     def value_changed(self, new_val: int) -> None:
         """
@@ -601,14 +607,14 @@ class PyDMMultiStateIndicator(QWidget, PyDMWidget):
         return PyDMWidget.eventFilter(self, obj, event)
 
     # whether or not we render the widget as a circle (default) or a rectangle
-    @Property(bool)
-    def renderAsRectangle(self) -> bool:
+    def readRenderAsRectangle(self) -> bool:
         return self._render_as_rectangle
 
-    @renderAsRectangle.setter
-    def renderAsRectangle(self, new_val: bool) -> None:
+    def setRenderAsRectangle(self, new_val: bool) -> None:
         if new_val != self._render_as_rectangle:
             self._render_as_rectangle = new_val
+
+    renderAsRectangle = Property(bool, readRenderAsRectangle, setRenderAsRectangle)
 
     def value_changed(self, new_val: int) -> None:
         """
@@ -658,8 +664,7 @@ class PyDMMultiStateIndicator(QWidget, PyDMWidget):
         self._painter.end()
 
     # color state setters/getters
-    @Property(int)
-    def currentValue(self) -> int:
+    def readCurrentValue(self) -> int:
         """
         The color for when widget is in state 0
         Returns
@@ -668,8 +673,7 @@ class PyDMMultiStateIndicator(QWidget, PyDMWidget):
         """
         return self._curr_state
 
-    @currentValue.setter
-    def currentValue(self, new_state: int) -> None:
+    def setCurrentValue(self, new_state: int) -> None:
         """
         The color for when widget is in state 0
         Parameters
@@ -680,9 +684,10 @@ class PyDMMultiStateIndicator(QWidget, PyDMWidget):
             self._curr_state = new_state
             self.value_changed(new_state)
 
+    currentValue = Property(int, readCurrentValue, setCurrentValue)
+
     # color state setters/getters
-    @Property(QColor)
-    def state0Color(self) -> QColor:
+    def readState0Color(self) -> QColor:
         """
         The color for when widget is in state 0
         Returns
@@ -691,8 +696,7 @@ class PyDMMultiStateIndicator(QWidget, PyDMWidget):
         """
         return self._state_colors[0]
 
-    @state0Color.setter
-    def state0Color(self, state_color: QColor) -> None:
+    def setState0Color(self, state_color: QColor) -> None:
         """
         The color for when widget is in state 0
         Parameters
@@ -702,8 +706,9 @@ class PyDMMultiStateIndicator(QWidget, PyDMWidget):
         if state_color != self._state_colors[0]:
             self._state_colors[0] = state_color
 
-    @Property(QColor)
-    def state1Color(self) -> QColor:
+    state0Color = Property(QColor, readState0Color, setState0Color)
+
+    def readState1Color(self) -> QColor:
         """
         The color for when widget is in state 1
         Returns
@@ -712,8 +717,7 @@ class PyDMMultiStateIndicator(QWidget, PyDMWidget):
         """
         return self._state_colors[1]
 
-    @state1Color.setter
-    def state1Color(self, state_color: QColor) -> None:
+    def setState1Color(self, state_color: QColor) -> None:
         """
         The color for when widget is in state 1
         Parameters
@@ -723,8 +727,9 @@ class PyDMMultiStateIndicator(QWidget, PyDMWidget):
         if state_color != self._state_colors[1]:
             self._state_colors[1] = state_color
 
-    @Property(QColor)
-    def state2Color(self) -> QColor:
+    state1Color = Property(QColor, readState1Color, setState1Color)
+
+    def readState2Color(self) -> QColor:
         """
         The color for when widget is in state 2
         Returns
@@ -733,8 +738,7 @@ class PyDMMultiStateIndicator(QWidget, PyDMWidget):
         """
         return self._state_colors[2]
 
-    @state2Color.setter
-    def state2Color(self, new_color: QColor) -> None:
+    def setState2Color(self, new_color: QColor) -> None:
         """
         The color for when widget is in state 2
         Parameters
@@ -744,8 +748,9 @@ class PyDMMultiStateIndicator(QWidget, PyDMWidget):
         if new_color != self._state_colors[2]:
             self._state_colors[2] = new_color
 
-    @Property(QColor)
-    def state3Color(self) -> QColor:
+    state2Color = Property(QColor, readState2Color, setState2Color)
+
+    def readState3Color(self) -> QColor:
         """
         The color for when widget is in state 3
         Returns
@@ -754,8 +759,7 @@ class PyDMMultiStateIndicator(QWidget, PyDMWidget):
         """
         return self._state_colors[3]
 
-    @state3Color.setter
-    def state3Color(self, new_color: QColor) -> None:
+    def setState3Color(self, new_color: QColor) -> None:
         """
         The color for when widget is in state 3
         Parameters
@@ -765,8 +769,9 @@ class PyDMMultiStateIndicator(QWidget, PyDMWidget):
         if new_color != self._state_colors[3]:
             self._state_colors[3] = new_color
 
-    @Property(QColor)
-    def state4Color(self) -> QColor:
+    state3Color = Property(QColor, readState3Color, setState3Color)
+
+    def readState4Color(self) -> QColor:
         """
         The color for when widget is in state 4
         Returns
@@ -775,8 +780,7 @@ class PyDMMultiStateIndicator(QWidget, PyDMWidget):
         """
         return self._state_colors[4]
 
-    @state4Color.setter
-    def state4Color(self, new_color: QColor) -> None:
+    def setState4Color(self, new_color: QColor) -> None:
         """
         The color for when widget is in state 4
         Parameters
@@ -786,8 +790,9 @@ class PyDMMultiStateIndicator(QWidget, PyDMWidget):
         if new_color != self._state_colors[4]:
             self._state_colors[4] = new_color
 
-    @Property(QColor)
-    def state5Color(self) -> QColor:
+    state4Color = Property(QColor, readState4Color, setState4Color)
+
+    def readState5Color(self) -> QColor:
         """
         The color for when widget is in state 5
         Returns
@@ -796,8 +801,7 @@ class PyDMMultiStateIndicator(QWidget, PyDMWidget):
         """
         return self._state_colors[5]
 
-    @state5Color.setter
-    def state5Color(self, new_color: QColor) -> None:
+    def setState5Color(self, new_color: QColor) -> None:
         """
         The color for when widget is in state 5
         Parameters
@@ -807,8 +811,9 @@ class PyDMMultiStateIndicator(QWidget, PyDMWidget):
         if new_color != self._state_colors[5]:
             self._state_colors[5] = new_color
 
-    @Property(QColor)
-    def state6Color(self) -> QColor:
+    state5Color = Property(QColor, readState5Color, setState5Color)
+
+    def readState6Color(self) -> QColor:
         """
         The color for when widget is in state 6
         Returns
@@ -817,8 +822,7 @@ class PyDMMultiStateIndicator(QWidget, PyDMWidget):
         """
         return self._state_colors[6]
 
-    @state6Color.setter
-    def state6Color(self, new_color: QColor) -> None:
+    def setState6Color(self, new_color: QColor) -> None:
         """
         The color for when widget is in state 6
         Parameters
@@ -828,8 +832,9 @@ class PyDMMultiStateIndicator(QWidget, PyDMWidget):
         if new_color != self._state_colors[6]:
             self._state_colors[6] = new_color
 
-    @Property(QColor)
-    def state7Color(self) -> QColor:
+    state6Color = Property(QColor, readState6Color, setState6Color)
+
+    def readState7Color(self) -> QColor:
         """
         The color for when widget is in state 7
         Returns
@@ -838,8 +843,7 @@ class PyDMMultiStateIndicator(QWidget, PyDMWidget):
         """
         return self._state_colors[7]
 
-    @state7Color.setter
-    def state7Color(self, new_color: QColor) -> None:
+    def setState7Color(self, new_color: QColor) -> None:
         """
         The color for when widget is in state 7
         Parameters
@@ -849,8 +853,9 @@ class PyDMMultiStateIndicator(QWidget, PyDMWidget):
         if new_color != self._state_colors[7]:
             self._state_colors[7] = new_color
 
-    @Property(QColor)
-    def state8Color(self) -> QColor:
+    state7Color = Property(QColor, readState7Color, setState7Color)
+
+    def readState8Color(self) -> QColor:
         """
         The color for when widget is in state 8
         Returns
@@ -859,8 +864,7 @@ class PyDMMultiStateIndicator(QWidget, PyDMWidget):
         """
         return self._state_colors[8]
 
-    @state8Color.setter
-    def state8Color(self, new_color: QColor) -> None:
+    def setState8Color(self, new_color: QColor) -> None:
         """
         The color for when widget is in state 8
         Parameters
@@ -870,8 +874,9 @@ class PyDMMultiStateIndicator(QWidget, PyDMWidget):
         if new_color != self._state_colors[8]:
             self._state_colors[8] = new_color
 
-    @Property(QColor)
-    def state9Color(self) -> QColor:
+    state8Color = Property(QColor, readState8Color, setState8Color)
+
+    def readState9Color(self) -> QColor:
         """
         The color for when widget is in state 9
         Returns
@@ -880,8 +885,7 @@ class PyDMMultiStateIndicator(QWidget, PyDMWidget):
         """
         return self._state_colors[9]
 
-    @state9Color.setter
-    def state9Color(self, new_color: QColor) -> None:
+    def setState9Color(self, new_color: QColor) -> None:
         """
         The color for when widget is in state 9
         Parameters
@@ -891,8 +895,9 @@ class PyDMMultiStateIndicator(QWidget, PyDMWidget):
         if new_color != self._state_colors[9]:
             self._state_colors[9] = new_color
 
-    @Property(QColor)
-    def state10Color(self) -> QColor:
+    state9Color = Property(QColor, readState9Color, setState9Color)
+
+    def readState10Color(self) -> QColor:
         """
         The color for when widget is in state 10
         Returns
@@ -901,8 +906,7 @@ class PyDMMultiStateIndicator(QWidget, PyDMWidget):
         """
         return self._state_colors[10]
 
-    @state10Color.setter
-    def state10Color(self, new_color: QColor) -> None:
+    def setState10Color(self, new_color: QColor) -> None:
         """
         The color for when widget is in state 10
         Parameters
@@ -912,8 +916,9 @@ class PyDMMultiStateIndicator(QWidget, PyDMWidget):
         if new_color != self._state_colors[10]:
             self._state_colors[10] = new_color
 
-    @Property(QColor)
-    def state11Color(self) -> QColor:
+    state10Color = Property(QColor, readState10Color, setState10Color)
+
+    def readState11Color(self) -> QColor:
         """
         The color for when widget is in state 11
         Returns
@@ -922,8 +927,7 @@ class PyDMMultiStateIndicator(QWidget, PyDMWidget):
         """
         return self._state_colors[11]
 
-    @state11Color.setter
-    def state11Color(self, new_color: QColor) -> None:
+    def setState11Color(self, new_color: QColor) -> None:
         """
         The color for when widget is in state 11
         Parameters
@@ -933,8 +937,9 @@ class PyDMMultiStateIndicator(QWidget, PyDMWidget):
         if new_color != self._state_colors[11]:
             self._state_colors[11] = new_color
 
-    @Property(QColor)
-    def state12Color(self) -> QColor:
+    state11Color = Property(QColor, readState11Color, setState11Color)
+
+    def readState12Color(self) -> QColor:
         """
         The color for when widget is in state 12
         Returns
@@ -943,8 +948,7 @@ class PyDMMultiStateIndicator(QWidget, PyDMWidget):
         """
         return self._state_colors[12]
 
-    @state12Color.setter
-    def state12Color(self, new_color: QColor) -> None:
+    def setState12Color(self, new_color: QColor) -> None:
         """
         The color for when widget is in state 12
         Parameters
@@ -954,8 +958,9 @@ class PyDMMultiStateIndicator(QWidget, PyDMWidget):
         if new_color != self._state_colors[12]:
             self._state_colors[12] = new_color
 
-    @Property(QColor)
-    def state13Color(self) -> QColor:
+    state12Color = Property(QColor, readState12Color, setState12Color)
+
+    def readState13Color(self) -> QColor:
         """
         The color for when widget is in state 13
         Returns
@@ -964,8 +969,7 @@ class PyDMMultiStateIndicator(QWidget, PyDMWidget):
         """
         return self._state_colors[13]
 
-    @state13Color.setter
-    def state13Color(self, new_color: QColor) -> None:
+    def setState13Color(self, new_color: QColor) -> None:
         """
         The color for when widget is in state 13
         Parameters
@@ -975,8 +979,9 @@ class PyDMMultiStateIndicator(QWidget, PyDMWidget):
         if new_color != self._state_colors[13]:
             self._state_colors[13] = new_color
 
-    @Property(QColor)
-    def state14Color(self) -> QColor:
+    state13Color = Property(QColor, readState13Color, setState13Color)
+
+    def readState14Color(self) -> QColor:
         """
         The color for when widget is in state 14
         Returns
@@ -985,8 +990,7 @@ class PyDMMultiStateIndicator(QWidget, PyDMWidget):
         """
         return self._state_colors[14]
 
-    @state14Color.setter
-    def state14Color(self, new_color: QColor) -> None:
+    def setState14Color(self, new_color: QColor) -> None:
         """
         The color for when widget is in state 14
         Parameters
@@ -996,8 +1000,9 @@ class PyDMMultiStateIndicator(QWidget, PyDMWidget):
         if new_color != self._state_colors[14]:
             self._state_colors[14] = new_color
 
-    @Property(QColor)
-    def state15Color(self) -> QColor:
+    state14Color = Property(QColor, readState14Color, setState14Color)
+
+    def readState15Color(self) -> QColor:
         """
         The color for when widget is in state 15
         Returns
@@ -1006,8 +1011,7 @@ class PyDMMultiStateIndicator(QWidget, PyDMWidget):
         """
         return self._state_colors[15]
 
-    @state15Color.setter
-    def state15Color(self, state_color: QColor) -> None:
+    def setState15Color(self, state_color: QColor) -> None:
         """
         The color for when widget is in state 15
         Parameters
@@ -1016,3 +1020,5 @@ class PyDMMultiStateIndicator(QWidget, PyDMWidget):
         """
         if state_color != self._state_colors[15]:
             self._state_colors[15] = state_color
+
+    state15Color = Property(QColor, readState15Color, setState15Color)

--- a/pydm/widgets/datetime.py
+++ b/pydm/widgets/datetime.py
@@ -4,6 +4,11 @@ from qtpy import QtWidgets, QtCore
 from .base import PyDMWritableWidget, PyDMWidget, PostParentClassInitSetup
 from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
 
+if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
+    from PySide6.QtCore import Property
+else:
+    from PyQt5.QtCore import pyqtProperty as Property
+
 logger = logging.getLogger(__name__)
 
 
@@ -68,38 +73,38 @@ class PyDMDateTimeEdit(QtWidgets.QDateTimeEdit, PyDMWritableWidget):
     def eventFilter(self, obj, event):
         return PyDMWritableWidget.eventFilter(self, obj, event)
 
-    @QtCore.Property(TimeBase)
-    def timeBase(self):
+    def readTimeBase(self) -> TimeBase:
         """Whether to use milliseconds or seconds as time base for the widget"""
         return self._time_base
 
-    @timeBase.setter
-    def timeBase(self, base):
+    def setTimeBase(self, base) -> None:
         if self._time_base != base:
             self._time_base = base
 
-    @QtCore.Property(bool)
-    def relative(self):
+    timeBase = Property(TimeBase, readTimeBase, setTimeBase)
+
+    def readRelative(self) -> bool:
         """
         Whether the value in milliseconds is relative to current date or if it
         is milliseconds since epoch.
         """
         return self._relative
 
-    @relative.setter
-    def relative(self, checked):
+    def setRelative(self, checked) -> None:
         if self._relative != checked:
             self._relative = checked
 
-    @QtCore.Property(bool)
-    def blockPastDate(self):
+    relative = Property(bool, readRelative, setRelative)
+
+    def readBlockPastDate(self) -> bool:
         """Error out if user tries to set value to a date older than current."""
         return self._block_past_date
 
-    @blockPastDate.setter
-    def blockPastDate(self, block):
+    def setBlockPastDate(self, block) -> None:
         if block != self._block_past_date:
             self._block_past_date = block
+
+    blockPastDate = Property(bool, readBlockPastDate, setBlockPastDate)
 
     def keyPressEvent(self, key_event):
         ret = super().keyPressEvent(key_event)
@@ -180,40 +185,40 @@ class PyDMDateTimeLabel(QtWidgets.QLabel, PyDMWidget):
     def eventFilter(self, obj, event):
         return PyDMWidget.eventFilter(self, obj, event)
 
-    @QtCore.Property(str)
-    def textFormat(self):
+    def readTextFormat(self) -> str:
         """The format to use when displaying the date/time values."""
         return self._text_format
 
-    @textFormat.setter
-    def textFormat(self, text_format):
+    def setTextFormat(self, text_format) -> None:
         if self._text_format != text_format:
             self._text_format = text_format
             if self.value is not None:
                 self.value_changed(self.value)
 
-    @QtCore.Property(TimeBase)
-    def timeBase(self):
+    textFormat = Property(str, readTextFormat, setTextFormat)
+
+    def readTimeBase(self) -> TimeBase:
         """Whether to use milliseconds or seconds as time base for the widget"""
         return self._time_base
 
-    @timeBase.setter
-    def timeBase(self, base):
+    def setTimeBase(self, base) -> None:
         if self._time_base != base:
             self._time_base = base
 
-    @QtCore.Property(bool)
-    def relative(self):
+    timeBase = Property(TimeBase, readTimeBase, setTimeBase)
+
+    def readRelative(self) -> None:
         """
         Whether the value in milliseconds is relative to current date or if it
         is milliseconds since epoch.
         """
         return self._relative
 
-    @relative.setter
-    def relative(self, checked):
+    def setRelative(self, checked) -> None:
         if self._relative != checked:
             self._relative = checked
+
+    relative = Property(bool, readRelative, setRelative)
 
     def value_changed(self, new_val):
         super().value_changed(new_val)

--- a/pydm/widgets/drawing.py
+++ b/pydm/widgets/drawing.py
@@ -6,10 +6,10 @@ import logging
 from qtpy.QtWidgets import QWidget, QStyle, QStyleOption
 from qtpy.QtGui import QColor, QPainter, QBrush, QPen, QPolygonF, QPixmap, QMovie
 from qtpy.QtCore import Qt, QPoint, QPointF, QSize, Slot, QTimer, QRectF
-from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
 from qtpy.QtDesigner import QDesignerFormWindowInterface
 from .base import PyDMWidget, PostParentClassInitSetup
 from pydm.utilities import is_qt_designer, find_file
+from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
 
 if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
     from PySide6.QtCore import Property
@@ -269,8 +269,7 @@ class PyDMDrawing(QWidget, PyDMWidget):
             h = w0 * c
         return w, h
 
-    @Property(QBrush)
-    def brush(self):
+    def readBrush(self) -> QBrush:
         """
         PyQT Property for the brush object to be used when coloring the
         drawing
@@ -281,8 +280,7 @@ class PyDMDrawing(QWidget, PyDMWidget):
         """
         return self._brush
 
-    @brush.setter
-    def brush(self, new_brush):
+    def setBrush(self, new_brush) -> None:
         """
         PyQT Property for the brush object to be used when coloring the
         drawing
@@ -297,7 +295,9 @@ class PyDMDrawing(QWidget, PyDMWidget):
             self._brush = new_brush
             self.update()
 
-    def readPenStyle(self):
+    brush = Property(QBrush, readBrush, setBrush)
+
+    def readPenStyle(self) -> int | Qt.PenStyle:
         """
         Property for the pen style to be used when drawing the border
 
@@ -308,13 +308,13 @@ class PyDMDrawing(QWidget, PyDMWidget):
         """
         return self._pen_style
 
-    def setPenStyle(self, new_style):
+    def setPenStyle(self, new_style) -> None:
         """
         Property for the pen style to be used when drawing the border
 
         Parameters
         ----------
-        new_style : Qt.PenStyle
+        new_style : Qt.PenStyle or int
             Index at Qt.PenStyle enum
         """
         # pyside6 enums are more strict and will error if passed int
@@ -327,10 +327,10 @@ class PyDMDrawing(QWidget, PyDMWidget):
             self._pen.setStyle(new_style)
             self.update()
 
-    penStyle = Property(int, readPenStyle, setPenStyle)
+    prop_type = int if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6 else Qt.PenStyle
+    penStyle = Property(prop_type, readPenStyle, setPenStyle)
 
-    @Property(Qt.PenCapStyle)
-    def penCapStyle(self):
+    def readPenCapStyle(self) -> int | Qt.PenCapStyle:
         """
         PyQT Property for the pen cap to be used when drawing the border
 
@@ -341,23 +341,27 @@ class PyDMDrawing(QWidget, PyDMWidget):
         """
         return self._pen_cap_style
 
-    @penCapStyle.setter
-    def penCapStyle(self, new_style):
+    def setPenCapStyle(self, new_style) -> None:
         """
         PyQT Property for the pen cap style to be used when drawing the border
 
         Parameters
         ----------
         new_style : int
-            Index at Qt.PenStyle enum
+            Index at Qt.PenStyle enum or int
         """
+        # pyside6 enums are more strict and will error if passed int
+        # if isinstance(new_style, int):
+        #    new_style = Qt.PenStyle(new_style)
         if new_style != self._pen_cap_style:
             self._pen_cap_style = new_style
             self._pen.setCapStyle(new_style)
             self.update()
 
-    @Property(Qt.PenJoinStyle)
-    def penJoinStyle(self):
+    prop_type = int if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6 else Qt.PenCapStyle
+    penCapStyle = Property(prop_type, readPenCapStyle, setPenCapStyle)
+
+    def readPenJoinStyle(self) -> int | Qt.PenJoinStyle:
         """
         PyQT Property for the pen join style to be used when drawing the border
 
@@ -368,23 +372,24 @@ class PyDMDrawing(QWidget, PyDMWidget):
         """
         return self._pen_join_style
 
-    @penJoinStyle.setter
-    def penJoinStyle(self, new_style):
+    def setPenJoinStyle(self, new_style) -> None:
         """
         PyQT Property for the pen join style to be used when drawing the border
 
         Parameters
         ----------
         new_style : int
-            Index at Qt.PenStyle enum
+            Index at Qt.PenStyle enum or int
         """
         if new_style != self._pen_join_style:
             self._pen_join_style = new_style
             self._pen.setJoinStyle(new_style)
             self.update()
 
-    @Property(QColor)
-    def penColor(self):
+    prop_type = int if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6 else Qt.PenJoinStyle
+    penJoinStyle = Property(prop_type, readPenJoinStyle, setPenJoinStyle)
+
+    def readPenColor(self) -> QColor:
         """
         PyQT Property for the pen color to be used when drawing the border
 
@@ -394,8 +399,7 @@ class PyDMDrawing(QWidget, PyDMWidget):
         """
         return self._pen_color
 
-    @penColor.setter
-    def penColor(self, new_color):
+    def setPenColor(self, new_color) -> None:
         """
         PyQT Property for the pen color to be used when drawing the border
 
@@ -411,8 +415,9 @@ class PyDMDrawing(QWidget, PyDMWidget):
             self._pen.setColor(new_color)
             self.update()
 
-    @Property(float)
-    def penWidth(self):
+    penColor = Property(QColor, readPenColor, setPenColor)
+
+    def readPenWidth(self) -> float:
         """
         PyQT Property for the pen width to be used when drawing the border
 
@@ -422,8 +427,7 @@ class PyDMDrawing(QWidget, PyDMWidget):
         """
         return self._pen_width
 
-    @penWidth.setter
-    def penWidth(self, new_width):
+    def setPenWidth(self, new_width) -> None:
         """
         PyQT Property for the pen width to be used when drawing the border
 
@@ -438,8 +442,9 @@ class PyDMDrawing(QWidget, PyDMWidget):
             self._pen.setWidthF(float(self._pen_width))
             self.update()
 
-    @Property(float)
-    def rotation(self):
+    penWidth = Property(float, readPenWidth, setPenWidth)
+
+    def readRotation(self) -> float:
         """
         PyQT Property for the counter-clockwise rotation in degrees
         to be applied to the drawing.
@@ -450,8 +455,7 @@ class PyDMDrawing(QWidget, PyDMWidget):
         """
         return self._rotation
 
-    @rotation.setter
-    def rotation(self, new_angle):
+    def setRotation(self, new_angle) -> None:
         """
         PyQT Property for the counter-clockwise rotation in degrees
         to be applied to the drawing.
@@ -463,6 +467,8 @@ class PyDMDrawing(QWidget, PyDMWidget):
         if new_angle != self._rotation:
             self._rotation = new_angle
             self.update()
+
+    rotation = Property(float, readRotation, setRotation)
 
     def alarm_severity_changed(self, new_alarm_severity):
         PyDMWidget.alarm_severity_changed(self, new_alarm_severity)
@@ -498,8 +504,7 @@ class PyDMDrawingLineBase(PyDMDrawing):
         self._arrow_mid_point_selection = False
         self._arrow_mid_point_flipped = False
 
-    @Property(int)
-    def arrowSize(self) -> int:
+    def readArrowSize(self) -> int:
         """
         Size to render line arrows.
 
@@ -509,8 +514,7 @@ class PyDMDrawingLineBase(PyDMDrawing):
         """
         return self._arrow_size
 
-    @arrowSize.setter
-    def arrowSize(self, new_size) -> None:
+    def setArrowSize(self, new_size) -> None:
         """
         Size to render line arrows.
 
@@ -522,8 +526,9 @@ class PyDMDrawingLineBase(PyDMDrawing):
             self._arrow_size = new_size
             self.update()
 
-    @Property(bool)
-    def arrowEndPoint(self) -> bool:
+    arrowSize = Property(int, readArrowSize, setArrowSize)
+
+    def readArrowEndPoint(self) -> bool:
         """
         If True, an arrow will be drawn at the end of the line.
 
@@ -533,8 +538,7 @@ class PyDMDrawingLineBase(PyDMDrawing):
         """
         return self._arrow_end_point_selection
 
-    @arrowEndPoint.setter
-    def arrowEndPoint(self, new_selection) -> None:
+    def setArrowEndPoint(self, new_selection) -> None:
         """
         If True, an arrow will be drawn at the end of the line.
 
@@ -546,8 +550,9 @@ class PyDMDrawingLineBase(PyDMDrawing):
             self._arrow_end_point_selection = new_selection
             self.update()
 
-    @Property(bool)
-    def arrowStartPoint(self) -> bool:
+    arrowEndPoint = Property(bool, readArrowEndPoint, setArrowEndPoint)
+
+    def readArrowStartPoint(self) -> bool:
         """
         If True, an arrow will be drawn at the start of the line.
 
@@ -557,8 +562,7 @@ class PyDMDrawingLineBase(PyDMDrawing):
         """
         return self._arrow_start_point_selection
 
-    @arrowStartPoint.setter
-    def arrowStartPoint(self, new_selection) -> None:
+    def setArrowStartPoint(self, new_selection) -> None:
         """
         If True, an arrow will be drawn at the start of the line.
 
@@ -570,8 +574,9 @@ class PyDMDrawingLineBase(PyDMDrawing):
             self._arrow_start_point_selection = new_selection
             self.update()
 
-    @Property(bool)
-    def arrowMidPoint(self) -> bool:
+    arrowStartPoint = Property(bool, readArrowStartPoint, setArrowStartPoint)
+
+    def readArrowMidPoint(self) -> bool:
         """
         If True, an arrow will be drawn at the midpoint of the line.
         Returns
@@ -580,8 +585,7 @@ class PyDMDrawingLineBase(PyDMDrawing):
         """
         return self._arrow_mid_point_selection
 
-    @arrowMidPoint.setter
-    def arrowMidPoint(self, new_selection) -> None:
+    def setArrowMidPoint(self, new_selection) -> None:
         """
         If True, an arrow will be drawn at the midpoint of the line.
         Parameters
@@ -592,8 +596,9 @@ class PyDMDrawingLineBase(PyDMDrawing):
             self._arrow_mid_point_selection = new_selection
             self.update()
 
-    @Property(bool)
-    def flipMidPointArrow(self) -> bool:
+    arrowMidPoint = Property(bool, readArrowMidPoint, setArrowMidPoint)
+
+    def readFlipMidPointArrow(self) -> bool:
         """
         Flips the direction of the midpoint arrow.
 
@@ -603,8 +608,7 @@ class PyDMDrawingLineBase(PyDMDrawing):
         """
         return self._arrow_mid_point_flipped
 
-    @flipMidPointArrow.setter
-    def flipMidPointArrow(self, new_selection) -> None:
+    def setFlipMidPointArrow(self, new_selection) -> None:
         """
         Flips the direction of the midpoint arrow.
 
@@ -615,6 +619,8 @@ class PyDMDrawingLineBase(PyDMDrawing):
         if self._arrow_mid_point_flipped != new_selection:
             self._arrow_mid_point_flipped = new_selection
             self.update()
+
+    flipMidPointArrow = Property(bool, readFlipMidPointArrow, setFlipMidPointArrow)
 
     @staticmethod
     def _arrow_points(startpoint, endpoint, height, width) -> QPolygonF:
@@ -939,8 +945,7 @@ class PyDMDrawingImage(PyDMDrawing):
     def reload_image(self) -> None:
         self.filename = self._file
 
-    @Property(bool)
-    def recursiveImageSearch(self) -> bool:
+    def readRecursiveImageSearch(self) -> bool:
         """
         Whether or not to search for a provided image file recursively
         in subfolders relative to the location of this display.
@@ -952,8 +957,7 @@ class PyDMDrawingImage(PyDMDrawing):
         """
         return self._recursive_image_search
 
-    @recursiveImageSearch.setter
-    def recursiveImageSearch(self, new_value) -> None:
+    def setRecursiveImageSearch(self, new_value) -> None:
         """
         Set whether or not to search for a provided image file recursively
         in subfolders relative to the location of this image.
@@ -965,8 +969,9 @@ class PyDMDrawingImage(PyDMDrawing):
         """
         self._recursive_image_search = new_value
 
-    @Property(str)
-    def filename(self) -> str:
+    recursiveImageSearch = Property(bool, readRecursiveImageSearch, setRecursiveImageSearch)
+
+    def readFilename(self) -> str:
         """
         The filename of the image to be displayed.
         This can be an absolute or relative path to the image file.
@@ -978,8 +983,7 @@ class PyDMDrawingImage(PyDMDrawing):
         """
         return self._file
 
-    @filename.setter
-    def filename(self, new_file) -> None:
+    def setFilename(self, new_file) -> None:
         """
         The filename of the image to be displayed.
 
@@ -1036,13 +1040,14 @@ class PyDMDrawingImage(PyDMDrawing):
             self._pixmap = pixmap
             self.update()
 
+    filename = Property(str, readFilename, setFilename)
+
     def sizeHint(self):
         if self._pixmap.size().isEmpty():
             return super().sizeHint()
         return self._pixmap.size()
 
-    @Property(Qt.AspectRatioMode)
-    def aspectRatioMode(self):
+    def readAspectRatioMode(self) -> int | Qt.AspectRatioMode:
         """
         PyQT Property for aspect ratio mode to be used when rendering
         the image
@@ -1054,8 +1059,7 @@ class PyDMDrawingImage(PyDMDrawing):
         """
         return self._aspect_ratio_mode
 
-    @aspectRatioMode.setter
-    def aspectRatioMode(self, new_mode):
+    def setAspectRatioMode(self, new_mode) -> None:
         """
         PyQT Property for aspect ratio mode to be used when rendering
         the image
@@ -1068,6 +1072,9 @@ class PyDMDrawingImage(PyDMDrawing):
         if new_mode != self._aspect_ratio_mode:
             self._aspect_ratio_mode = new_mode
             self.update()
+
+    prop_type = int if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6 else Qt.AspectRatioMode
+    aspectRatioMode = Property(prop_type, readAspectRatioMode, setAspectRatioMode)
 
     def draw_item(self, painter):
         """
@@ -1257,8 +1264,7 @@ class PyDMDrawingArc(PyDMDrawing):
         self._start_angle = 0
         self._span_angle = deg_to_qt(90)
 
-    @Property(float)
-    def startAngle(self):
+    def readStartAngle(self) -> None:
         """
         PyQT Property for the start angle in degrees
 
@@ -1269,8 +1275,7 @@ class PyDMDrawingArc(PyDMDrawing):
         """
         return qt_to_deg(self._start_angle)
 
-    @startAngle.setter
-    def startAngle(self, new_angle):
+    def setStartAngle(self, new_angle) -> None:
         """
         PyQT Property for the start angle in degrees
 
@@ -1283,8 +1288,9 @@ class PyDMDrawingArc(PyDMDrawing):
             self._start_angle = deg_to_qt(new_angle)
             self.update()
 
-    @Property(float)
-    def spanAngle(self):
+    startAngle = Property(float, readStartAngle, setStartAngle)
+
+    def readSpanAngle(self) -> float:
         """
         PyQT Property for the span angle in degrees
 
@@ -1295,8 +1301,7 @@ class PyDMDrawingArc(PyDMDrawing):
         """
         return qt_to_deg(self._span_angle)
 
-    @spanAngle.setter
-    def spanAngle(self, new_angle):
+    def setSpanAngle(self, new_angle) -> None:
         """
         PyQT Property for the span angle in degrees
 
@@ -1308,6 +1313,8 @@ class PyDMDrawingArc(PyDMDrawing):
         if deg_to_qt(new_angle) != self._span_angle:
             self._span_angle = deg_to_qt(new_angle)
             self.update()
+
+    spanAngle = Property(float, readSpanAngle, setSpanAngle)
 
     def draw_item(self, painter):
         """
@@ -1391,8 +1398,7 @@ class PyDMDrawingPolygon(PyDMDrawing):
         super().__init__(parent, init_channel)
         self._num_points = 3
 
-    @Property(int)
-    def numberOfPoints(self):
+    def readNumberOfPoints(self) -> int:
         """
         PyQT Property for the number of points
 
@@ -1403,11 +1409,12 @@ class PyDMDrawingPolygon(PyDMDrawing):
         """
         return self._num_points
 
-    @numberOfPoints.setter
-    def numberOfPoints(self, points):
+    def setNumberOfPoints(self, points) -> None:
         if points >= 3 and points != self._num_points:
             self._num_points = points
             self.update()
+
+    numberOfPoints = Property(int, readNumberOfPoints, setNumberOfPoints)
 
     def _calculate_drawing_points(self, x, y, w, h):
         # (x + r*cos(theta), y + r*sin(theta))

--- a/pydm/widgets/embedded_display.py
+++ b/pydm/widgets/embedded_display.py
@@ -1,6 +1,6 @@
 from pyqtgraph.GraphicsScene.mouseEvents import MouseClickEvent
 from qtpy.QtWidgets import QAction, QFrame, QApplication, QLabel, QMenu, QVBoxLayout
-from qtpy.QtCore import QPoint, Qt, QSize, Property, QTimer
+from qtpy.QtCore import QPoint, Qt, QSize, QTimer
 
 import copy
 import os.path
@@ -16,6 +16,12 @@ from pydm.utilities import (
     find_file,
 )
 from pydm.display import load_file, ScreenTarget
+from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
+
+if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
+    from PySide6.QtCore import Property
+else:
+    from PyQt5.QtCore import pyqtProperty as Property
 
 logger = logging.getLogger(__name__)
 
@@ -102,8 +108,7 @@ class PyDMEmbeddedDisplay(QFrame, PyDMPrimitiveWidget):
         # This is totally arbitrary, I just want *some* visible nonzero size
         return QSize(100, 100)
 
-    @Property(str)
-    def macros(self):
+    def readMacros(self) -> str:
         """
         JSON-formatted string containing macro variables to pass to the embedded file.
 
@@ -115,8 +120,7 @@ class PyDMEmbeddedDisplay(QFrame, PyDMPrimitiveWidget):
             return ""
         return self._macros
 
-    @macros.setter
-    def macros(self, new_macros):
+    def setMacros(self, new_macros) -> None:
         """
         JSON-formatted string containing macro variables to pass to the embedded file.
 
@@ -135,8 +139,9 @@ class PyDMEmbeddedDisplay(QFrame, PyDMPrimitiveWidget):
             self._needs_load = True
         self.load_if_needed()
 
-    @Property(str)
-    def filename(self):
+    macros = Property(str, readMacros, setMacros)
+
+    def readFilename(self) -> str:
         """
         Filename of the display to embed.
 
@@ -148,8 +153,7 @@ class PyDMEmbeddedDisplay(QFrame, PyDMPrimitiveWidget):
             return ""
         return self._filename
 
-    @filename.setter
-    def filename(self, filename):
+    def setFilename(self, filename) -> None:
         """
         Filename of the display to embed.
 
@@ -169,8 +173,9 @@ class PyDMEmbeddedDisplay(QFrame, PyDMPrimitiveWidget):
                 self.clear_error_text()
         self.load_if_needed()
 
-    @Property(bool)
-    def recursiveDisplaySearch(self) -> bool:
+    filename = Property(str, readFilename, setFilename)
+
+    def readRecursiveDisplaySearch(self) -> bool:
         """
         Whether or not to search for a provided display file recursively
         in subfolders relative to the location of this display.
@@ -182,8 +187,7 @@ class PyDMEmbeddedDisplay(QFrame, PyDMPrimitiveWidget):
         """
         return self._recursive_display_search
 
-    @recursiveDisplaySearch.setter
-    def recursiveDisplaySearch(self, new_value) -> None:
+    def setRecursiveDisplaySearch(self, new_value) -> None:
         """
         Set whether or not to search for a provided display file recursively
         in subfolders relative to the location of this display.
@@ -194,6 +198,8 @@ class PyDMEmbeddedDisplay(QFrame, PyDMPrimitiveWidget):
             If recursive search should be enabled.
         """
         self._recursive_display_search = new_value
+
+    recursiveDisplaySearch = Property(bool, readRecursiveDisplaySearch, setRecursiveDisplaySearch)
 
     def set_macros_and_filename(self, new_filename, new_macros):
         """
@@ -341,8 +347,7 @@ class PyDMEmbeddedDisplay(QFrame, PyDMPrimitiveWidget):
         close_widget_connections(self.embedded_widget)
         self._is_connected = False
 
-    @Property(bool)
-    def loadWhenShown(self):
+    def readLoadWhenShown(self) -> bool:
         """
         If True, only load and display the file once the
         PyDMEmbeddedDisplayWidget is visible on screen.  This is very useful
@@ -359,13 +364,13 @@ class PyDMEmbeddedDisplay(QFrame, PyDMPrimitiveWidget):
         """
         return self._only_load_when_shown
 
-    @loadWhenShown.setter
-    def loadWhenShown(self, val):
+    def setLoadWhenShown(self, val) -> None:
         self._only_load_when_shown = val
         self.load_if_needed()
 
-    @Property(bool)
-    def disconnectWhenHidden(self):
+    loadWhenShown = Property(bool, readLoadWhenShown, setLoadWhenShown)
+
+    def readDisconnectWhenHidden(self) -> bool:
         """
         Disconnect from PVs when this widget is not visible.
 
@@ -375,8 +380,7 @@ class PyDMEmbeddedDisplay(QFrame, PyDMPrimitiveWidget):
         """
         return self._disconnect_when_hidden
 
-    @disconnectWhenHidden.setter
-    def disconnectWhenHidden(self, disconnect_when_hidden):
+    def setDisconnectWhenHidden(self, disconnect_when_hidden) -> None:
         """
         Disconnect from PVs when this widget is not visible.
 
@@ -386,8 +390,9 @@ class PyDMEmbeddedDisplay(QFrame, PyDMPrimitiveWidget):
         """
         self._disconnect_when_hidden = disconnect_when_hidden
 
-    @Property(bool)
-    def followSymlinks(self) -> bool:
+    disconnectWhenHidden = Property(bool, readDisconnectWhenHidden, setDisconnectWhenHidden)
+
+    def readFollowSymlinks(self) -> bool:
         """
         If True, any symlinks in the path to filename (including the base path of the parent display)
         will be followed, so that it will always use the canonical path. If False (default),
@@ -401,8 +406,7 @@ class PyDMEmbeddedDisplay(QFrame, PyDMPrimitiveWidget):
         """
         return self._follow_symlinks
 
-    @followSymlinks.setter
-    def followSymlinks(self, follow_symlinks: bool) -> None:
+    def setFollowSymlinks(self, follow_symlinks: bool) -> None:
         """
         If True, any symlinks in the path to filename (including the base path of the parent display)
         will be followed, so that it will always use the canonical path.
@@ -415,6 +419,8 @@ class PyDMEmbeddedDisplay(QFrame, PyDMPrimitiveWidget):
         follow_symlinks : bool
         """
         self._follow_symlinks = follow_symlinks
+
+    followSymlinks = Property(bool, readFollowSymlinks, setFollowSymlinks)
 
     def showEvent(self, e):
         """

--- a/pydm/widgets/enum_button.py
+++ b/pydm/widgets/enum_button.py
@@ -1,6 +1,7 @@
 import logging
+from typing import List
 
-from qtpy.QtCore import Qt, QSize, Property, Slot, QMargins
+from qtpy.QtCore import Qt, QSize, Slot, QMargins
 from qtpy.QtGui import QPainter
 from qtpy.QtWidgets import (
     QWidget,
@@ -16,6 +17,11 @@ from qtpy.QtWidgets import (
 from .base import PyDMWritableWidget, PostParentClassInitSetup
 from pydm import data_plugins
 from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
+
+if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
+    from PySide6.QtCore import Property
+else:
+    from PyQt5.QtCore import pyqtProperty as Property
 
 
 class WidgetType(object):
@@ -109,8 +115,7 @@ class PyDMEnumButton(QWidget, PyDMWritableWidget):
         # This is totally arbitrary, I just want *some* visible nonzero size
         return QSize(50, 100)
 
-    @Property("QStringList")
-    def items(self):
+    def readItems(self) -> List[str]:
         """
         Items to be displayed in the button group.
 
@@ -123,12 +128,12 @@ class PyDMEnumButton(QWidget, PyDMWritableWidget):
         """
         return self.enum_strings or []
 
-    @items.setter
-    def items(self, value):
+    def setItems(self, value) -> None:
         self.enum_strings_changed(value)
 
-    @Property(bool)
-    def useCustomOrder(self):
+    items = Property("QStringList", readItems, setItems)
+
+    def readUseCustomOrder(self) -> bool:
         """
         Whether or not to use custom order for the button group.
 
@@ -138,14 +143,14 @@ class PyDMEnumButton(QWidget, PyDMWritableWidget):
         """
         return self._use_custom_order
 
-    @useCustomOrder.setter
-    def useCustomOrder(self, value):
+    def setUseCustomOrder(self, value) -> None:
         if value != self._use_custom_order:
             self._use_custom_order = value
             self.rebuild_layout()
 
-    @Property(bool)
-    def invertOrder(self):
+    useCustomOrder = Property(bool, readUseCustomOrder, setUseCustomOrder)
+
+    def readInvertOrder(self) -> bool:
         """
         Whether or not to invert the order for the button group.
 
@@ -155,15 +160,15 @@ class PyDMEnumButton(QWidget, PyDMWritableWidget):
         """
         return self._invert_order
 
-    @invertOrder.setter
-    def invertOrder(self, value):
+    def setInvertOrder(self, value) -> None:
         if value != self._invert_order:
             self._invert_order = value
             if self._has_enums:
                 self.rebuild_layout()
 
-    @Property("QStringList")
-    def customOrder(self):
+    invertOrder = Property(bool, readInvertOrder, setInvertOrder)
+
+    def readCustomOrder(self) -> List[str]:
         """
         Index list in which items are to be displayed in the button group.
 
@@ -173,8 +178,7 @@ class PyDMEnumButton(QWidget, PyDMWritableWidget):
         """
         return self._custom_order
 
-    @customOrder.setter
-    def customOrder(self, value):
+    def setCustomOOrder(self, value) -> None:
         if value != self._custom_order:
             try:
                 [int(v) for v in value]
@@ -185,8 +189,9 @@ class PyDMEnumButton(QWidget, PyDMWritableWidget):
             if self.useCustomOrder and self._has_enums:
                 self.rebuild_layout()
 
-    @Property(WidgetType)
-    def widgetType(self):
+    customOrder = Property("QStringList", readCustomOrder, setCustomOOrder)
+
+    def readWidgetType(self) -> WidgetType:
         """
         The widget type to be used when composing the group.
 
@@ -196,8 +201,7 @@ class PyDMEnumButton(QWidget, PyDMWritableWidget):
         """
         return self._widget_type
 
-    @widgetType.setter
-    def widgetType(self, new_type):
+    def setWidgetType(self, new_type) -> None:
         """
         The widget type to be used when composing the group.
 
@@ -209,8 +213,9 @@ class PyDMEnumButton(QWidget, PyDMWritableWidget):
             self._widget_type = new_type
             self.rebuild_widgets()
 
-    @Property(Qt.Orientation)
-    def orientation(self):
+    widgetType = Property(WidgetType, readWidgetType, setWidgetType)
+
+    def readOrientation(self) -> int | Qt.Orientation:
         """
         Whether to lay out the bit indicators vertically or horizontally.
 
@@ -220,8 +225,7 @@ class PyDMEnumButton(QWidget, PyDMWritableWidget):
         """
         return self._orientation
 
-    @orientation.setter
-    def orientation(self, new_orientation):
+    def setOrientation(self, new_orientation) -> None:
         """
         Whether to lay out the bit indicators vertically or horizontally.
 
@@ -233,8 +237,10 @@ class PyDMEnumButton(QWidget, PyDMWritableWidget):
             self._orientation = new_orientation
             self.rebuild_layout()
 
-    @Property(int)
-    def marginTop(self):
+    prop_type = int if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6 else Qt.Orientation
+    orientation = Property(prop_type, readOrientation, setOrientation)
+
+    def readMarginTop(self) -> int:
         """
         The top margin of the QGridLayout of buttons.
 
@@ -244,8 +250,7 @@ class PyDMEnumButton(QWidget, PyDMWritableWidget):
         """
         return self._layout_margins.top()
 
-    @marginTop.setter
-    def marginTop(self, new_margin):
+    def setMarginTop(self, new_margin) -> None:
         """
         Set the top margin of the QGridLayout of buttons.
 
@@ -257,8 +262,9 @@ class PyDMEnumButton(QWidget, PyDMWritableWidget):
         self._layout_margins.setTop(new_margin)
         self.layout().setContentsMargins(self._layout_margins)
 
-    @Property(int)
-    def marginBottom(self):
+    marginTop = Property(int, readMarginTop, setMarginTop)
+
+    def readMarginBottom(self) -> int:
         """
         The bottom margin of the QGridLayout of buttons.
 
@@ -268,8 +274,7 @@ class PyDMEnumButton(QWidget, PyDMWritableWidget):
         """
         return self._layout_margins.bottom()
 
-    @marginBottom.setter
-    def marginBottom(self, new_margin):
+    def setMarginBottom(self, new_margin) -> None:
         """
         Set the bottom margin of the QGridLayout of buttons.
 
@@ -281,8 +286,9 @@ class PyDMEnumButton(QWidget, PyDMWritableWidget):
         self._layout_margins.setBottom(new_margin)
         self.layout().setContentsMargins(self._layout_margins)
 
-    @Property(int)
-    def marginLeft(self):
+    marginBottom = Property(int, readMarginBottom, setMarginBottom)
+
+    def readMarginLeft(self) -> int:
         """
         The left margin of the QGridLayout of buttons.
 
@@ -292,8 +298,7 @@ class PyDMEnumButton(QWidget, PyDMWritableWidget):
         """
         return self._layout_margins.left()
 
-    @marginLeft.setter
-    def marginLeft(self, new_margin):
+    def setMarginLeft(self, new_margin) -> None:
         """
         Set the left margin of the QGridLayout of buttons.
 
@@ -305,8 +310,9 @@ class PyDMEnumButton(QWidget, PyDMWritableWidget):
         self._layout_margins.setLeft(new_margin)
         self.layout().setContentsMargins(self._layout_margins)
 
-    @Property(int)
-    def marginRight(self):
+    marginLeft = Property(int, readMarginLeft, setMarginLeft)
+
+    def readMarginRight(self) -> int:
         """
         The right margin of the QGridLayout of buttons.
 
@@ -316,8 +322,7 @@ class PyDMEnumButton(QWidget, PyDMWritableWidget):
         """
         return self._layout_margins.right()
 
-    @marginRight.setter
-    def marginRight(self, new_margin):
+    def setMarginRight(self, new_margin) -> None:
         """
         Set the right margin of the QGridLayout of buttons.
 
@@ -329,8 +334,9 @@ class PyDMEnumButton(QWidget, PyDMWritableWidget):
         self._layout_margins.setRight(new_margin)
         self.layout().setContentsMargins(self._layout_margins)
 
-    @Property(int)
-    def horizontalSpacing(self):
+    marginRight = Property(int, readMarginRight, setMarginRight)
+
+    def readHorizontalSpacing(self) -> int:
         """
         The horizontal gap of the QGridLayout containing the QButtonGroup.
 
@@ -340,8 +346,7 @@ class PyDMEnumButton(QWidget, PyDMWritableWidget):
         """
         return self._layout_spacing_horizontal
 
-    @horizontalSpacing.setter
-    def horizontalSpacing(self, new_spacing):
+    def setHorizontalSpacing(self, new_spacing) -> None:
         """
         Set the layout horizontal gap between buttons.
 
@@ -354,8 +359,9 @@ class PyDMEnumButton(QWidget, PyDMWritableWidget):
             self._layout_spacing_horizontal = new_spacing
             self.layout().setHorizontalSpacing(new_spacing)
 
-    @Property(int)
-    def verticalSpacing(self):
+    horizontalSpacing = Property(int, readHorizontalSpacing, setHorizontalSpacing)
+
+    def readVerticalSpacing(self) -> int:
         """
         The vertical gap of the QGridLayout containing the QButtonGroup.
 
@@ -365,8 +371,7 @@ class PyDMEnumButton(QWidget, PyDMWritableWidget):
         """
         return self._layout_spacing_vertical
 
-    @verticalSpacing.setter
-    def verticalSpacing(self, new_spacing):
+    def setVerticalSpacing(self, new_spacing) -> None:
         """
         Set the layout vertical gap between buttons.
 
@@ -379,8 +384,9 @@ class PyDMEnumButton(QWidget, PyDMWritableWidget):
             self._layout_spacing_vertical = new_spacing
             self.layout().setVerticalSpacing(new_spacing)
 
-    @Property(bool)
-    def checkable(self):
+    verticalSpacing = Property(int, readVerticalSpacing, setVerticalSpacing)
+
+    def readCheckable(self) -> bool:
         """
         Whether or not the button should be checkable.
 
@@ -390,12 +396,13 @@ class PyDMEnumButton(QWidget, PyDMWritableWidget):
         """
         return self._checkable
 
-    @checkable.setter
-    def checkable(self, value):
+    def setCheckable(self, value) -> None:
         if value != self._checkable:
             self._checkable = value
             for widget in self._widgets:
                 widget.setCheckable(value)
+
+    checkable = Property(bool, readCheckable, setCheckable)
 
     @Slot(QAbstractButton)
     def handle_button_clicked(self, button):

--- a/pydm/widgets/frame.py
+++ b/pydm/widgets/frame.py
@@ -1,6 +1,11 @@
 from qtpy.QtWidgets import QFrame
-from qtpy.QtCore import Property
 from .base import PyDMWidget, PostParentClassInitSetup
+from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
+
+if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
+    from PySide6.QtCore import Property
+else:
+    from PyQt5.QtCore import pyqtProperty as Property
 
 
 class PyDMFrame(QFrame, PyDMWidget):
@@ -33,8 +38,7 @@ class PyDMFrame(QFrame, PyDMWidget):
     def eventFilter(self, obj, event):
         return PyDMWidget.eventFilter(self, obj, event)
 
-    @Property(bool)
-    def disableOnDisconnect(self):
+    def readDisableOnDisconnect(self) -> bool:
         """
         Whether or not the PyDMFrame should be disabled in case the
         channel is disconnected.
@@ -46,8 +50,7 @@ class PyDMFrame(QFrame, PyDMWidget):
         """
         return self._disable_on_disconnect
 
-    @disableOnDisconnect.setter
-    def disableOnDisconnect(self, new_val):
+    def setDisableOnDisconnect(self, new_val) -> None:
         """
         Whether or not the PyDMFrame should be disabled in case the
         channel is disconnected.
@@ -60,6 +63,8 @@ class PyDMFrame(QFrame, PyDMWidget):
         if self._disable_on_disconnect != bool(new_val):
             self._disable_on_disconnect = new_val
             self.check_enable_state()
+
+    disableOnDisconnect = Property(bool, readDisableOnDisconnect, setDisableOnDisconnect)
 
     def check_enable_state(self):
         """

--- a/pydm/widgets/image.py
+++ b/pydm/widgets/image.py
@@ -1,5 +1,5 @@
 from qtpy.QtWidgets import QActionGroup
-from qtpy.QtCore import Signal, Slot, Property, QTimer, QThread
+from qtpy.QtCore import Signal, Slot, QTimer, QThread
 from pyqtgraph import ImageView, PlotItem
 from pyqtgraph import ColorMap
 from pyqtgraph.graphicsItems.ViewBox.ViewBoxMenu import ViewBoxMenu
@@ -9,6 +9,12 @@ from .channel import PyDMChannel
 from .colormaps import cmaps, cmap_names, PyDMColorMap
 from .base import PyDMWidget, PostParentClassInitSetup
 from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
+from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
+
+if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
+    from PySide6.QtCore import Property
+else:
+    from PyQt5.QtCore import pyqtProperty as Property
 
 logger = logging.getLogger(__name__)
 
@@ -242,16 +248,16 @@ class PyDMImageView(ImageView, PyDMWidget):
     def eventFilter(self, obj, event):
         return PyDMWidget.eventFilter(self, obj, event)
 
-    @Property(str, designable=False)
-    def channel(self):
+    def readChannel(self) -> None:
         return
 
-    @channel.setter
-    def channel(self, ch):
+    def setChannel(self, ch) -> None:
         if not ch:
             return
         logger.info("Use the imageChannel property with the ImageView widget.")
         return
+
+    channel = Property(str, readChannel, setChannel, designable=False)
 
     def widget_ctx_menu(self):
         """
@@ -284,8 +290,7 @@ class PyDMImageView(ImageView, PyDMWidget):
         """
         self.colorMap = self.cmap_for_action[action]
 
-    @Property(float)
-    def colorMapMin(self):
+    def readColorMapMin(self) -> float:
         """
         Minimum value for the colormap.
 
@@ -295,9 +300,8 @@ class PyDMImageView(ImageView, PyDMWidget):
         """
         return self.cm_min
 
-    @colorMapMin.setter
     @Slot(float)
-    def colorMapMin(self, new_min):
+    def setColorMapMin(self, new_min) -> None:
         """
         Set the minimum value for the colormap.
 
@@ -310,8 +314,9 @@ class PyDMImageView(ImageView, PyDMWidget):
             if self.cm_min > self.cm_max:
                 self.cm_max = self.cm_min
 
-    @Property(float)
-    def colorMapMax(self):
+    colorMapMin = Property(float, readColorMapMin, setColorMapMin)
+
+    def readColorMapMax(self) -> float:
         """
         Maximum value for the colormap.
 
@@ -321,9 +326,8 @@ class PyDMImageView(ImageView, PyDMWidget):
         """
         return self.cm_max
 
-    @colorMapMax.setter
     @Slot(float)
-    def colorMapMax(self, new_max):
+    def setColorMapMax(self, new_max) -> None:
         """
         Set the maximum value for the colormap.
 
@@ -335,6 +339,8 @@ class PyDMImageView(ImageView, PyDMWidget):
             self.cm_max = new_max
             if self.cm_max < self.cm_min:
                 self.cm_min = self.cm_max
+
+    colorMapMax = Property(float, readColorMapMax, setColorMapMax)
 
     def setColorMapLimits(self, mn, mx):
         """
@@ -352,8 +358,7 @@ class PyDMImageView(ImageView, PyDMWidget):
         self.cm_max = mx
         self.cm_min = mn
 
-    @Property(PyDMColorMap)
-    def colorMap(self):
+    def readColorMap(self) -> PyDMColorMap:
         """
         Return the color map used by the ImageView.
 
@@ -363,8 +368,7 @@ class PyDMImageView(ImageView, PyDMWidget):
         """
         return self._colormap
 
-    @colorMap.setter
-    def colorMap(self, new_cmap):
+    def setColorMap(self, new_cmap) -> None:
         """
         Set the color map used by the ImageView.
 
@@ -380,6 +384,8 @@ class PyDMImageView(ImageView, PyDMWidget):
                 action.setChecked(True)
             else:
                 action.setChecked(False)
+
+    colorMap = Property(PyDMColorMap, readColorMap, setColorMap)
 
     def setColorMap(self, cmap=None):
         """
@@ -506,8 +512,7 @@ class PyDMImageView(ImageView, PyDMWidget):
         self.getImageItem().setLevels([mini, maxi])
         self.getImageItem().setImage(img, autoLevels=False, autoDownsample=self.autoDownsample)
 
-    @Property(bool)
-    def autoDownsample(self):
+    def readAutoDownsample(self) -> bool:
         """
         Return if we should or not apply the
         autoDownsample option to PyQtGraph.
@@ -518,8 +523,7 @@ class PyDMImageView(ImageView, PyDMWidget):
         """
         return self._auto_downsample
 
-    @autoDownsample.setter
-    def autoDownsample(self, new_value):
+    def setAutoDownsample(self, new_value) -> None:
         """
         Whether we should or not apply the
         autoDownsample option to PyQtGraph.
@@ -531,8 +535,9 @@ class PyDMImageView(ImageView, PyDMWidget):
         if new_value != self._auto_downsample:
             self._auto_downsample = new_value
 
-    @Property(int)
-    def imageWidth(self):
+    autoDownsample = Property(bool, readAutoDownsample, setAutoDownsample)
+
+    def readImageWidth(self) -> int:
         """
         Return the width of the image.
 
@@ -542,8 +547,7 @@ class PyDMImageView(ImageView, PyDMWidget):
         """
         return self._image_width
 
-    @imageWidth.setter
-    def imageWidth(self, new_width):
+    def setImageWidth(self, new_width) -> None:
         """
         Set the width of the image.
 
@@ -556,8 +560,9 @@ class PyDMImageView(ImageView, PyDMWidget):
         if self._image_width != int(new_width) and (self._widthchannel is None or self._widthchannel == ""):
             self._image_width = int(new_width)
 
-    @Property(bool)
-    def normalizeData(self):
+    imageWidth = Property(int, readImageWidth, setImageWidth)
+
+    def readNormalizeData(self) -> bool:
         """
         Return True if the colors are relative to data maximum and minimum.
 
@@ -567,9 +572,8 @@ class PyDMImageView(ImageView, PyDMWidget):
         """
         return self._normalize_data
 
-    @normalizeData.setter
     @Slot(bool)
-    def normalizeData(self, new_norm):
+    def setNormalizeData(self, new_norm) -> None:
         """
         Define if the colors are relative to minimum and maximum of the data.
 
@@ -580,8 +584,9 @@ class PyDMImageView(ImageView, PyDMWidget):
         if self._normalize_data != new_norm:
             self._normalize_data = new_norm
 
-    @Property(ReadingOrder)
-    def readingOrder(self):
+    normalizeData = Property(bool, readNormalizeData, setNormalizeData)
+
+    def readReadingOrder(self) -> ReadingOrder:
         """
         Return the reading order of the :attr:`imageChannel` array.
 
@@ -591,8 +596,7 @@ class PyDMImageView(ImageView, PyDMWidget):
         """
         return self._reading_order
 
-    @readingOrder.setter
-    def readingOrder(self, new_order):
+    def setReadingOrder(self, new_order) -> None:
         """
         Set reading order of the :attr:`imageChannel` array.
 
@@ -603,8 +607,9 @@ class PyDMImageView(ImageView, PyDMWidget):
         if self._reading_order != new_order:
             self._reading_order = new_order
 
-    @Property(DimensionOrder)
-    def dimensionOrder(self):
+    readingOrder = Property(ReadingOrder, readReadingOrder, setReadingOrder)
+
+    def readDimensionOrder(self) -> DimensionOrder:
         """
         Return the dimension order of the :attr:`imageChannel` array.
         (for more info see DimensionOrder class definition)
@@ -615,8 +620,7 @@ class PyDMImageView(ImageView, PyDMWidget):
         """
         return self._dimension_order
 
-    @dimensionOrder.setter
-    def dimensionOrder(self, new_order):
+    def setDimensionOrder(self, new_order) -> None:
         """
         Set dimension order of the :attr:`imageChannel` array.
 
@@ -627,12 +631,13 @@ class PyDMImageView(ImageView, PyDMWidget):
         if self._dimension_order != new_order:
             self._dimension_order = new_order
 
+    dimensionOrder = Property(DimensionOrder, readDimensionOrder, setDimensionOrder)
+
     def keyPressEvent(self, ev):
         """Handle keypress events."""
         return
 
-    @Property(str)
-    def imageChannel(self):
+    def readImageChannel(self) -> str:
         """
         The channel address in use for the image data .
 
@@ -646,8 +651,7 @@ class PyDMImageView(ImageView, PyDMWidget):
         else:
             return ""
 
-    @imageChannel.setter
-    def imageChannel(self, value):
+    def setImageChannel(self, value) -> None:
         """
         The channel address in use for the image data .
 
@@ -670,8 +674,9 @@ class PyDMImageView(ImageView, PyDMWidget):
             self._channels[0] = self._imagechannel
             self._imagechannel.connect()
 
-    @Property(str)
-    def widthChannel(self):
+    imageChannel = Property(str, readImageChannel, setImageChannel)
+
+    def readWidthChannel(self) -> str:
         """
         The channel address in use for the image width .
 
@@ -685,8 +690,7 @@ class PyDMImageView(ImageView, PyDMWidget):
         else:
             return ""
 
-    @widthChannel.setter
-    def widthChannel(self, value):
+    def setWidthChannel(self, value) -> None:
         """
         The channel address in use for the image width .
 
@@ -709,6 +713,8 @@ class PyDMImageView(ImageView, PyDMWidget):
             self._channels[1] = self._widthchannel
             self._widthchannel.connect()
 
+    widthChannel = Property(str, readWidthChannel, setWidthChannel)
+
     def channels(self):
         """
         Return the channels being used for this Widget.
@@ -724,8 +730,7 @@ class PyDMImageView(ImageView, PyDMWidget):
         """Return channels for tools."""
         return [self._imagechannel]
 
-    @Property(int)
-    def maxRedrawRate(self):
+    def readMaxRedrawRate(self) -> int:
         """
         The maximum rate (in Hz) at which the plot will be redrawn.
 
@@ -737,8 +742,7 @@ class PyDMImageView(ImageView, PyDMWidget):
         """
         return self._redraw_rate
 
-    @maxRedrawRate.setter
-    def maxRedrawRate(self, redraw_rate):
+    def setMaxRedrawRate(self, redraw_rate) -> None:
         """
         The maximum rate (in Hz) at which the plot will be redrawn.
 
@@ -751,21 +755,22 @@ class PyDMImageView(ImageView, PyDMWidget):
         self._redraw_rate = redraw_rate
         self.redraw_timer.setInterval(int((1.0 / self._redraw_rate) * 1000))
 
-    @Property(bool)
-    def showAxes(self):
+    maxRedrawRate = Property(int, readMaxRedrawRate, setMaxRedrawRate)
+
+    def readShowAxes(self) -> bool:
         """
         Whether or not axes should be shown on the widget.
         """
         return self._show_axes
 
-    @showAxes.setter
-    def showAxes(self, show):
+    def setShowAxes(self, show) -> None:
         self._show_axes = show
         self.getView().showAxis("left", show=show)
         self.getView().showAxis("bottom", show=show)
 
-    @Property(float)
-    def scaleXAxis(self):
+    showAxes = Property(bool, readShowAxes, setShowAxes)
+
+    def readScaleXAxis(self) -> float:
         """
         Sets the scale for the X Axis.
 
@@ -777,12 +782,12 @@ class PyDMImageView(ImageView, PyDMWidget):
             return self.getView().getAxis("bottom").scale
         return None
 
-    @scaleXAxis.setter
-    def scaleXAxis(self, new_scale):
+    def setScaleXAxis(self, new_scale) -> None:
         self.getView().getAxis("bottom").setScale(new_scale)
 
-    @Property(float)
-    def scaleYAxis(self):
+    scaleXAxis = Property(float, readScaleXAxis, setScaleXAxis)
+
+    def readScaleYAxis(self) -> float:
         """
         Sets the scale for the Y Axis.
 
@@ -794,6 +799,7 @@ class PyDMImageView(ImageView, PyDMWidget):
             return self.getView().getAxis("left").scale
         return None
 
-    @scaleYAxis.setter
-    def scaleYAxis(self, new_scale):
+    def setScaleYAxis(self, new_scale) -> None:
         self.getView().getAxis("left").setScale(new_scale)
+
+    scaleYAxis = Property(float, readScaleYAxis, setScaleYAxis)

--- a/pydm/widgets/label.py
+++ b/pydm/widgets/label.py
@@ -1,10 +1,16 @@
 from .base import PyDMWidget, TextFormatter, str_types, PostParentClassInitSetup
 from qtpy.QtWidgets import QLabel, QApplication
-from qtpy.QtCore import Qt, Property
+from qtpy.QtCore import Qt
 from .display_format import DisplayFormat, parse_value_for_display
 from pydm.utilities import is_pydm_app, is_qt_designer, ACTIVE_QT_WRAPPER, QtWrapperTypes
 from pydm import config
 from pydm.widgets.base import only_if_channel_set
+from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
+
+if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
+    from PySide6.QtCore import Property
+else:
+    from PyQt5.QtCore import pyqtProperty as Property
 
 _labelRuleProperties = {"Text": ["value_changed", str]}
 
@@ -66,12 +72,10 @@ class PyDMLabel(QLabel, TextFormatter, PyDMWidget):
     def eventFilter(self, obj, event):
         return PyDMWidget.eventFilter(self, obj, event)
 
-    @Property(bool)
-    def enableRichText(self):
+    def readEnableRichText(self):
         return self._enable_rich_text
 
-    @enableRichText.setter
-    def enableRichText(self, new_value):
+    def setEnableRichText(self, new_value):
         if self._enable_rich_text == new_value:
             return
         self._enable_rich_text = new_value
@@ -81,8 +85,9 @@ class PyDMLabel(QLabel, TextFormatter, PyDMWidget):
         else:
             self.setTextFormat(Qt.PlainText)
 
-    @Property(DisplayFormat)
-    def displayFormat(self):
+    enableRichText = Property(bool, readEnableRichText, setEnableRichText)
+
+    def readDisplayFormat(self):
         """
         displayFormat property.
 
@@ -92,14 +97,15 @@ class PyDMLabel(QLabel, TextFormatter, PyDMWidget):
         """
         return self._display_format_type
 
-    @displayFormat.setter
-    def displayFormat(self, new_type):
+    def setDisplayFormat(self, new_type):
         if self._display_format_type == new_type:
             return
         self._display_format_type = new_type
         if not is_qt_designer() or config.DESIGNER_ONLINE:
             # Trigger the update of display format
             self.value_changed(self.value)
+
+    displayFormat = Property(DisplayFormat, readDisplayFormat, setDisplayFormat)
 
     def value_changed(self, new_value):
         """

--- a/pydm/widgets/line_edit.py
+++ b/pydm/widgets/line_edit.py
@@ -5,12 +5,17 @@ import shlex
 import logging
 from functools import partial
 from qtpy.QtWidgets import QLineEdit, QMenu, QApplication
-from qtpy.QtCore import Property, Qt
+from qtpy.QtCore import Qt
 from qtpy.QtGui import QFocusEvent
 from .base import PyDMWritableWidget, TextFormatter, str_types, PostParentClassInitSetup
 from pydm import utilities
 from .display_format import DisplayFormat, parse_value_for_display
 from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
+
+if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
+    from PySide6.QtCore import Property
+else:
+    from PyQt5.QtCore import pyqtProperty as Property
 
 logger = logging.getLogger(__name__)
 
@@ -69,16 +74,16 @@ class PyDMLineEdit(QLineEdit, TextFormatter, PyDMWritableWidget):
     def eventFilter(self, obj, event):
         return PyDMWritableWidget.eventFilter(self, obj, event)
 
-    @Property(DisplayFormat)
-    def displayFormat(self):
+    def readDisplayFormat(self) -> DisplayFormat:
         return self._display_format_type
 
-    @displayFormat.setter
-    def displayFormat(self, new_type):
+    def setDisplayFormat(self, new_type) -> None:
         if self._display_format_type != new_type:
             self._display_format_type = new_type
             # Trigger the update of display format
             self.value_changed(self.value)
+
+    displayFormat = Property(DisplayFormat, readDisplayFormat, setDisplayFormat)
 
     def value_changed(self, new_val):
         """

--- a/pydm/widgets/nt_table.py
+++ b/pydm/widgets/nt_table.py
@@ -3,6 +3,12 @@ import numpy as np
 from operator import itemgetter
 from pydm.widgets.base import PyDMWidget, PyDMWritableWidget
 from qtpy import QtCore, QtWidgets
+from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
+
+if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
+    from PySide6.QtCore import Property
+else:
+    from PyQt5.QtCore import pyqtProperty as Property
 
 logger = logging.getLogger(__name__)
 
@@ -200,14 +206,14 @@ class PyDMNTTable(QtWidgets.QWidget, PyDMWritableWidget):
     def eventFilter(self, obj, event):
         return PyDMWritableWidget.eventFilter(self, obj, event)
 
-    @QtCore.Property(bool)
-    def readOnly(self):
+    def readReadOnly(self) -> bool:
         return self._read_only
 
-    @readOnly.setter
-    def readOnly(self, value):
+    def setReadOnly(self, value) -> None:
         if self._read_only != value:
             self._read_only = value
+
+    readOnly = Property(bool, readReadOnly, setReadOnly)
 
     def check_enable_state(self):
         """

--- a/pydm/widgets/pushbutton.py
+++ b/pydm/widgets/pushbutton.py
@@ -2,11 +2,18 @@ import hashlib
 
 from qtpy.QtGui import QColor
 from qtpy.QtWidgets import QPushButton, QMessageBox, QInputDialog, QLineEdit, QStyle
-from qtpy.QtCore import Slot, Property
+from qtpy.QtCore import Slot
 from qtpy import QtDesigner
 from .base import PyDMWritableWidget, PostParentClassInitSetup
 from pydm.utilities import IconFont
 import logging
+from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
+
+if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
+    from PySide6.QtCore import Property
+else:
+    from PyQt5.QtCore import pyqtProperty as Property
+
 
 logger = logging.getLogger(__name__)
 
@@ -92,8 +99,7 @@ class PyDMPushButton(QPushButton, PyDMWritableWidget):
     def eventFilter(self, obj, event):
         return PyDMWritableWidget.eventFilter(self, obj, event)
 
-    @Property(str)
-    def PyDMIcon(self) -> str:
+    def readPyDMIcon(self) -> str:
         """
         Name of icon to be set from Qt provided standard icons or from the fontawesome icon-set.
         See "enum QStyle::StandardPixmap" in Qt's QStyle documentation for full list of usable standard icons.
@@ -105,8 +111,7 @@ class PyDMPushButton(QPushButton, PyDMWritableWidget):
         """
         return self._pydm_icon_name
 
-    @PyDMIcon.setter
-    def PyDMIcon(self, value: str) -> None:
+    def setPyDMIcon(self, value: str) -> None:
         """
         Name of icon to be set from Qt provided standard icons or from the "Font Awesome" icon-set.
         See "enum QStyle::StandardPixmap" in Qt's QStyle documentation for full list of usable standard icons.
@@ -132,8 +137,9 @@ class PyDMPushButton(QPushButton, PyDMWritableWidget):
 
         self._pydm_icon_name = value
 
-    @Property(QColor)
-    def PyDMIconColor(self) -> QColor:
+    PyDMIcon = Property(str, readPyDMIcon, setPyDMIcon)
+
+    def readPyDMIconColor(self) -> QColor:
         """
         The color of the icon (color is only applied if using icon from the "Font Awesome" set)
         Returns
@@ -142,8 +148,7 @@ class PyDMPushButton(QPushButton, PyDMWritableWidget):
         """
         return self._pydm_icon_color
 
-    @PyDMIconColor.setter
-    def PyDMIconColor(self, state_color: QColor) -> None:
+    def setPyDMIconColor(self, state_color: QColor) -> None:
         """
         The color of the icon (color is only applied if using icon from the "Font Awesome" set)
         Parameters
@@ -160,8 +165,9 @@ class PyDMPushButton(QPushButton, PyDMWritableWidget):
             except Exception:
                 return
 
-    @Property(bool)
-    def passwordProtected(self):
+    PyDMIconColor = Property(QColor, readPyDMIconColor, setPyDMIconColor)
+
+    def readPasswordProtected(self):
         """
         Whether or not this button is password protected.
 
@@ -171,8 +177,7 @@ class PyDMPushButton(QPushButton, PyDMWritableWidget):
         """
         return self._password_protected
 
-    @passwordProtected.setter
-    def passwordProtected(self, value):
+    def setPasswordProtected(self, value):
         """
         Whether or not this button is password protected.
 
@@ -183,8 +188,9 @@ class PyDMPushButton(QPushButton, PyDMWritableWidget):
         if self._password_protected != value:
             self._password_protected = value
 
-    @Property(str)
-    def password(self):
+    passwordProtected = Property(bool, readPasswordProtected, setPasswordProtected)
+
+    def readPassword(self) -> str:
         """
         Password to be encrypted using SHA256.
 
@@ -198,8 +204,7 @@ class PyDMPushButton(QPushButton, PyDMWritableWidget):
         """
         return ""
 
-    @password.setter
-    def password(self, value):
+    def setPassword(self, value) -> None:
         """
         Password to be encrypted using SHA256.
 
@@ -220,8 +225,9 @@ class PyDMPushButton(QPushButton, PyDMWritableWidget):
             if formWindow:
                 formWindow.cursor().setProperty("protectedPassword", self.protectedPassword)
 
-    @Property(str)
-    def protectedPassword(self):
+    password = Property(str, readPassword, setPassword)
+
+    def readProtectedPassword(self) -> str:
         """
         The encrypted password.
 
@@ -231,13 +237,13 @@ class PyDMPushButton(QPushButton, PyDMWritableWidget):
         """
         return self._protected_password
 
-    @protectedPassword.setter
-    def protectedPassword(self, value):
+    def setProtectedPassword(self, value) -> None:
         if self._protected_password != value:
             self._protected_password = value
 
-    @Property(bool)
-    def showConfirmDialog(self):
+    protectedPassword = Property(str, readProtectedPassword, setProtectedPassword)
+
+    def readShowConfirmDialog(self) -> bool:
         """
         Whether or not to display a confirmation dialog.
 
@@ -247,8 +253,7 @@ class PyDMPushButton(QPushButton, PyDMWritableWidget):
         """
         return self._show_confirm_dialog
 
-    @showConfirmDialog.setter
-    def showConfirmDialog(self, value):
+    def setShowConfirmDialog(self, value) -> None:
         """
         Whether or not to display a confirmation dialog.
 
@@ -259,8 +264,9 @@ class PyDMPushButton(QPushButton, PyDMWritableWidget):
         if self._show_confirm_dialog != value:
             self._show_confirm_dialog = value
 
-    @Property(str)
-    def confirmMessage(self):
+    showConfirmDialog = Property(bool, readShowConfirmDialog, setShowConfirmDialog)
+
+    def readConfirmMessage(self) -> str:
         """
         Message to be displayed at the Confirmation dialog.
 
@@ -270,8 +276,7 @@ class PyDMPushButton(QPushButton, PyDMWritableWidget):
         """
         return self._confirm_message
 
-    @confirmMessage.setter
-    def confirmMessage(self, value):
+    def setConfirmMessage(self, value) -> None:
         """
         Message to be displayed at the Confirmation dialog.
 
@@ -282,8 +287,9 @@ class PyDMPushButton(QPushButton, PyDMWritableWidget):
         if self._confirm_message != value:
             self._confirm_message = value
 
-    @Property(str)
-    def pressValue(self):
+    confirmMessage = Property(str, readConfirmMessage, setConfirmMessage)
+
+    def readPressValue(self) -> str:
         """
         This property holds the value to send back through the channel.
 
@@ -297,8 +303,7 @@ class PyDMPushButton(QPushButton, PyDMWritableWidget):
         """
         return str(self._pressValue)
 
-    @pressValue.setter
-    def pressValue(self, value):
+    def setPressValue(self, value) -> None:
         """
         This property holds the value to send back through the channel.
 
@@ -313,8 +318,9 @@ class PyDMPushButton(QPushButton, PyDMWritableWidget):
         if str(value) != self._pressValue:
             self._pressValue = str(value)
 
-    @Property(str)
-    def releaseValue(self):
+    pressValue = Property(str, readPressValue, setPressValue)
+
+    def readReleaseValue(self) -> str:
         """
         This property holds the value to send back through the channel.
 
@@ -328,8 +334,7 @@ class PyDMPushButton(QPushButton, PyDMWritableWidget):
         """
         return str(self._releaseValue)
 
-    @releaseValue.setter
-    def releaseValue(self, value):
+    def setReleaseValue(self, value) -> None:
         """
         This property holds the value to send back through the channel.
 
@@ -344,8 +349,9 @@ class PyDMPushButton(QPushButton, PyDMWritableWidget):
         if str(value) != self._releaseValue:
             self._releaseValue = str(value)
 
-    @Property(bool)
-    def relativeChange(self):
+    releaseValue = Property(str, readReleaseValue, setReleaseValue)
+
+    def readRelativeChange(self) -> bool:
         """
         The mode of operation of the PyDMPushButton.
 
@@ -364,8 +370,7 @@ class PyDMPushButton(QPushButton, PyDMWritableWidget):
         """
         return self._relative
 
-    @relativeChange.setter
-    def relativeChange(self, choice):
+    def setRelativeChange(self, choice) -> None:
         """
         The mode of operation of the PyDMPushButton.
 
@@ -384,6 +389,8 @@ class PyDMPushButton(QPushButton, PyDMWritableWidget):
         """
         if self._relative != choice:
             self._relative = choice
+
+    relativeChange = Property(bool, readRelativeChange, setRelativeChange)
 
     def confirm_dialog(self, is_release=False):
         """
@@ -572,8 +579,7 @@ class PyDMPushButton(QPushButton, PyDMWritableWidget):
         except (ValueError, TypeError):
             logger.error("'{0}' is not a valid pressValue for '{1}'.".format(value, self.channel))
 
-    @Property(bool)
-    def writeWhenRelease(self):
+    def readWriteWhenRelease(self) -> bool:
         """
         Whether or not to write releaseValue on release
 
@@ -583,8 +589,7 @@ class PyDMPushButton(QPushButton, PyDMWritableWidget):
         """
         return self._write_when_release
 
-    @writeWhenRelease.setter
-    def writeWhenRelease(self, value):
+    def setWriteWhenRelease(self, value) -> None:
         """
         Whether or not to write releaseValue on release
 
@@ -600,6 +605,8 @@ class PyDMPushButton(QPushButton, PyDMWritableWidget):
             self.clicked.disconnect()
             self.pressed.connect(self.sendValue)
             self.released.connect(self.sendReleaseValue)
+
+    writeWhenRelease = Property(bool, readWriteWhenRelease, setWriteWhenRelease)
 
     @Slot(int)
     @Slot(float)

--- a/pydm/widgets/scale.py
+++ b/pydm/widgets/scale.py
@@ -1,8 +1,14 @@
 from .base import PyDMWidget, TextFormatter, PostParentClassInitSetup
 from qtpy.QtGui import QColor, QPolygon, QPen, QPainter, QPaintEvent
 from qtpy.QtWidgets import QFrame, QVBoxLayout, QHBoxLayout, QLabel, QSizePolicy, QWidget, QGridLayout
-from qtpy.QtCore import Qt, QPoint, Property
+from qtpy.QtCore import Qt, QPoint
 from typing import Optional
+from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
+
+if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
+    from PySide6.QtCore import Property
+else:
+    from PyQt5.QtCore import pyqtProperty as Property
 
 
 class QScale(QFrame):
@@ -621,8 +627,7 @@ class PyDMScaleIndicator(QFrame, TextFormatter, PyDMWidget):
         self.widget_layout.setContentsMargins(1, 1, 1, 1)
         self.setLayout(self.widget_layout)
 
-    @Property(bool)
-    def showValue(self) -> bool:
+    def readShowValue(self) -> bool:
         """
         Whether or not the current value should be displayed on the scale.
 
@@ -632,8 +637,7 @@ class PyDMScaleIndicator(QFrame, TextFormatter, PyDMWidget):
         """
         return self._show_value
 
-    @showValue.setter
-    def showValue(self, checked: bool) -> None:
+    def setShowValue(self, checked: bool) -> None:
         """
         Whether or not the current value should be displayed on the scale.
 
@@ -648,8 +652,9 @@ class PyDMScaleIndicator(QFrame, TextFormatter, PyDMWidget):
         else:
             self.value_label.hide()
 
-    @Property(bool)
-    def showLimits(self) -> bool:
+    showValue = Property(bool, readShowValue, setShowValue)
+
+    def readShowLimits(self) -> bool:
         """
         Whether or not the high and low limits should be displayed on the scale.
 
@@ -659,8 +664,7 @@ class PyDMScaleIndicator(QFrame, TextFormatter, PyDMWidget):
         """
         return self._show_limits
 
-    @showLimits.setter
-    def showLimits(self, checked: bool) -> None:
+    def setShowLimits(self, checked: bool) -> None:
         """
         Whether or not the high and low limits should be displayed on the scale.
 
@@ -677,8 +681,9 @@ class PyDMScaleIndicator(QFrame, TextFormatter, PyDMWidget):
             self.lower_label.hide()
             self.upper_label.hide()
 
-    @Property(bool)
-    def showTicks(self) -> bool:
+    showLimits = Property(bool, readShowLimits, setShowLimits)
+
+    def readShowTicks(self) -> bool:
         """
         Whether or not the tick marks should be displayed on the scale.
 
@@ -688,8 +693,7 @@ class PyDMScaleIndicator(QFrame, TextFormatter, PyDMWidget):
         """
         return self.scale_indicator.get_show_ticks()
 
-    @showTicks.setter
-    def showTicks(self, checked: bool) -> None:
+    def setShowTicks(self, checked: bool) -> None:
         """
         Whether or not the tick marks should be displayed on the scale.
 
@@ -699,8 +703,9 @@ class PyDMScaleIndicator(QFrame, TextFormatter, PyDMWidget):
         """
         self.scale_indicator.set_show_ticks(checked)
 
-    @Property(Qt.Orientation)
-    def orientation(self) -> Qt.Orientation:
+    showTicks = Property(bool, readShowTicks, setShowTicks)
+
+    def readOrientation(self) -> int | Qt.Orientation:
         """
         The scale orientation (Horizontal or Vertical)
 
@@ -711,8 +716,7 @@ class PyDMScaleIndicator(QFrame, TextFormatter, PyDMWidget):
         """
         return self.scale_indicator.get_orientation()
 
-    @orientation.setter
-    def orientation(self, orientation: Qt.Orientation) -> None:
+    def setOrientation(self, orientation: Qt.Orientation) -> None:
         """
         The scale orientation (Horizontal or Vertical)
 
@@ -724,8 +728,10 @@ class PyDMScaleIndicator(QFrame, TextFormatter, PyDMWidget):
         self.scale_indicator.set_orientation(orientation)
         self.setup_widgets_for_orientation(orientation, self.flipScale, self.invertedAppearance, self._value_position)
 
-    @Property(bool)
-    def flipScale(self) -> bool:
+    prop_type = int if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6 else Qt.Orientation
+    orientation = Property(prop_type, readOrientation, setOrientation)
+
+    def readFlipScale(self) -> bool:
         """
         Whether or not the scale should be flipped.
 
@@ -735,8 +741,7 @@ class PyDMScaleIndicator(QFrame, TextFormatter, PyDMWidget):
         """
         return self.scale_indicator.get_flip_scale()
 
-    @flipScale.setter
-    def flipScale(self, checked: bool) -> None:
+    def setFlipScale(self, checked: bool) -> None:
         """
         Whether or not the scale should be flipped.
 
@@ -747,8 +752,9 @@ class PyDMScaleIndicator(QFrame, TextFormatter, PyDMWidget):
         self.scale_indicator.set_flip_scale(checked)
         self.setup_widgets_for_orientation(self.orientation, checked, self.invertedAppearance, self._value_position)
 
-    @Property(bool)
-    def invertedAppearance(self) -> bool:
+    flipScale = Property(bool, readFlipScale, setFlipScale)
+
+    def readInvertedAppearance(self) -> bool:
         """
         Whether or not the scale appearance should be inverted.
 
@@ -758,8 +764,7 @@ class PyDMScaleIndicator(QFrame, TextFormatter, PyDMWidget):
         """
         return self.scale_indicator.get_inverted_appearance()
 
-    @invertedAppearance.setter
-    def invertedAppearance(self, inverted: bool) -> None:
+    def setInvertedAppearance(self, inverted: bool) -> None:
         """
         Whether or not the scale appearance should be inverted.
 
@@ -770,8 +775,9 @@ class PyDMScaleIndicator(QFrame, TextFormatter, PyDMWidget):
         self.scale_indicator.set_inverted_appearance(inverted)
         self.setup_widgets_for_orientation(self.orientation, self.flipScale, inverted, self._value_position)
 
-    @Property(bool)
-    def barIndicator(self) -> bool:
+    invertedAppearance = Property(bool, readInvertedAppearance, setInvertedAppearance)
+
+    def readBarIndicator(self) -> bool:
         """
         Whether or not the scale indicator should be a bar instead of a pointer.
 
@@ -781,8 +787,7 @@ class PyDMScaleIndicator(QFrame, TextFormatter, PyDMWidget):
         """
         return self.scale_indicator.get_bar_indicator()
 
-    @barIndicator.setter
-    def barIndicator(self, checked: bool) -> None:
+    def setBarIndicator(self, checked: bool) -> None:
         """
         Whether or not the scale indicator should be a bar instead of a pointer.
 
@@ -792,8 +797,9 @@ class PyDMScaleIndicator(QFrame, TextFormatter, PyDMWidget):
         """
         self.scale_indicator.set_bar_indicator(checked)
 
-    @Property(QColor)
-    def backgroundColor(self) -> QColor:
+    barIndicator = Property(bool, readBarIndicator, setBarIndicator)
+
+    def getBackgroundColor(self) -> QColor:
         """
         The color of the scale background.
 
@@ -803,8 +809,7 @@ class PyDMScaleIndicator(QFrame, TextFormatter, PyDMWidget):
         """
         return self.scale_indicator.get_background_color()
 
-    @backgroundColor.setter
-    def backgroundColor(self, color: QColor) -> None:
+    def setBackgroundColor(self, color: QColor) -> None:
         """
         The color of the scale background.
 
@@ -814,8 +819,9 @@ class PyDMScaleIndicator(QFrame, TextFormatter, PyDMWidget):
         """
         self.scale_indicator.set_background_color(color)
 
-    @Property(QColor)
-    def indicatorColor(self) -> QColor:
+    backgroundColor = Property(QColor, getBackgroundColor, setBackgroundColor)
+
+    def readIndicatorColor(self) -> QColor:
         """
         The color of the scale indicator.
 
@@ -825,8 +831,7 @@ class PyDMScaleIndicator(QFrame, TextFormatter, PyDMWidget):
         """
         return self.scale_indicator.get_indicator_color()
 
-    @indicatorColor.setter
-    def indicatorColor(self, color: QColor) -> None:
+    def setIndicatorColor(self, color: QColor) -> None:
         """
         The color of the scale indicator.
 
@@ -836,8 +841,9 @@ class PyDMScaleIndicator(QFrame, TextFormatter, PyDMWidget):
         """
         self.scale_indicator.set_indicator_color(color)
 
-    @Property(QColor)
-    def tickColor(self) -> QColor:
+    indicatorColor = Property(QColor, readIndicatorColor, setIndicatorColor)
+
+    def readTickColor(self) -> QColor:
         """
         The color of the scale tick marks.
 
@@ -847,8 +853,7 @@ class PyDMScaleIndicator(QFrame, TextFormatter, PyDMWidget):
         """
         return self.scale_indicator.get_tick_color()
 
-    @tickColor.setter
-    def tickColor(self, color: QColor) -> None:
+    def setTickColor(self, color: QColor) -> None:
         """
         The color of the scale tick marks.
 
@@ -858,8 +863,9 @@ class PyDMScaleIndicator(QFrame, TextFormatter, PyDMWidget):
         """
         self.scale_indicator.set_tick_color(color)
 
-    @Property(float)
-    def backgroundSizeRate(self) -> float:
+    tickColor = Property(QColor, readTickColor, setTickColor)
+
+    def getBackgroundSizeRate(self) -> float:
         """
         The rate of background height size (from top to bottom).
 
@@ -869,8 +875,7 @@ class PyDMScaleIndicator(QFrame, TextFormatter, PyDMWidget):
         """
         return self.scale_indicator.get_background_size_rate()
 
-    @backgroundSizeRate.setter
-    def backgroundSizeRate(self, rate: float) -> None:
+    def setBackgroundSizeRate(self, rate: float) -> None:
         """
         The rate of background height size (from top to bottom).
 
@@ -881,8 +886,9 @@ class PyDMScaleIndicator(QFrame, TextFormatter, PyDMWidget):
         """
         self.scale_indicator.set_background_size_rate(rate)
 
-    @Property(float)
-    def tickSizeRate(self) -> float:
+    backgroundSizeRate = Property(float, getBackgroundSizeRate, setBackgroundSizeRate)
+
+    def readTickSizeRate(self) -> float:
         """
         The rate of tick marks height size (from bottom to top).
 
@@ -892,8 +898,7 @@ class PyDMScaleIndicator(QFrame, TextFormatter, PyDMWidget):
         """
         return self.scale_indicator.get_tick_size_rate()
 
-    @tickSizeRate.setter
-    def tickSizeRate(self, rate: float) -> None:
+    def setTickSizeRate(self, rate: float) -> None:
         """
         The rate of tick marks height size (from bottom to top).
 
@@ -904,8 +909,9 @@ class PyDMScaleIndicator(QFrame, TextFormatter, PyDMWidget):
         """
         self.scale_indicator.set_tick_size_rate(rate)
 
-    @Property(int)
-    def numDivisions(self) -> int:
+    tickSizeRate = Property(float, readTickSizeRate, setTickSizeRate)
+
+    def readNumDivisions(self) -> int:
         """
         The number in which the scale is divided.
 
@@ -915,8 +921,7 @@ class PyDMScaleIndicator(QFrame, TextFormatter, PyDMWidget):
         """
         return self.scale_indicator.get_num_divisions()
 
-    @numDivisions.setter
-    def numDivisions(self, divisions: int) -> None:
+    def setNumDivisions(self, divisions: int) -> None:
         """
         The number in which the scale is divided.
 
@@ -927,8 +932,9 @@ class PyDMScaleIndicator(QFrame, TextFormatter, PyDMWidget):
         """
         self.scale_indicator.set_num_divisions(divisions)
 
-    @Property(int)
-    def scaleHeight(self) -> int:
+    numDivisions = Property(int, readNumDivisions, setNumDivisions)
+
+    def readScaleHeight(self) -> int:
         """
         The scale height, fixed so it do not wiggle when value label resizes.
 
@@ -938,8 +944,7 @@ class PyDMScaleIndicator(QFrame, TextFormatter, PyDMWidget):
         """
         return self.scale_indicator.get_scale_height()
 
-    @scaleHeight.setter
-    def scaleHeight(self, value: int) -> None:
+    def setScaleHeight(self, value: int) -> None:
         """
         The scale height, fixed so it do not wiggle when value label resizes.
 
@@ -950,8 +955,9 @@ class PyDMScaleIndicator(QFrame, TextFormatter, PyDMWidget):
         """
         self.scale_indicator.set_scale_height(value)
 
-    @Property(Qt.Edge)
-    def valuePosition(self) -> Qt.Edge:
+    scaleHeight = Property(int, readScaleHeight, setScaleHeight)
+
+    def readValuePosition(self) -> Qt.Edge:
         """
         The position of the value label (Top, Bottom, Left or Right).
 
@@ -962,8 +968,7 @@ class PyDMScaleIndicator(QFrame, TextFormatter, PyDMWidget):
         """
         return self._value_position
 
-    @valuePosition.setter
-    def valuePosition(self, position: Qt.Edge) -> None:
+    def setValuePosition(self, position: Qt.Edge) -> None:
         """
         The position of the value label (Top, Bottom, Left or Right).
 
@@ -975,8 +980,10 @@ class PyDMScaleIndicator(QFrame, TextFormatter, PyDMWidget):
         self._value_position = position
         self.setup_widgets_for_orientation(self.orientation, self.flipScale, self.invertedAppearance, position)
 
-    @Property(bool)
-    def originAtZero(self) -> bool:
+    prop_type = int if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6 else Qt.Edge
+    valuePosition = Property(prop_type, readValuePosition, setValuePosition)
+
+    def readOriginAtZero(self) -> bool:
         """
         Whether or not the scale indicator should start at zero value.
         Applies only for bar indicator.
@@ -987,8 +994,7 @@ class PyDMScaleIndicator(QFrame, TextFormatter, PyDMWidget):
         """
         return self.scale_indicator.get_origin_at_zero()
 
-    @originAtZero.setter
-    def originAtZero(self, checked: bool) -> None:
+    def setOriginAtZero(self, checked: bool) -> None:
         """
         Whether or not the scale indicator should start at zero value.
         Applies only for bar indicator.
@@ -999,8 +1005,9 @@ class PyDMScaleIndicator(QFrame, TextFormatter, PyDMWidget):
         """
         self.scale_indicator.set_origin_at_zero(checked)
 
-    @Property(bool)
-    def limitsFromChannel(self) -> bool:
+    originAtZero = Property(bool, readOriginAtZero, setOriginAtZero)
+
+    def readLimitsFromChannel(self) -> bool:
         """
         Whether or not the scale indicator should use the limits information
         from the channel.
@@ -1011,8 +1018,7 @@ class PyDMScaleIndicator(QFrame, TextFormatter, PyDMWidget):
         """
         return self._limits_from_channel
 
-    @limitsFromChannel.setter
-    def limitsFromChannel(self, checked: bool) -> None:
+    def setLimitsFromChannel(self, checked: bool) -> None:
         """
         Whether or not the scale indicator should use the limits information
         from the channel.
@@ -1035,8 +1041,9 @@ class PyDMScaleIndicator(QFrame, TextFormatter, PyDMWidget):
                 self.scale_indicator.set_upper_limit(self._user_upper_limit)
             self.update_labels()
 
-    @Property(float)
-    def userLowerLimit(self) -> float:
+    limitsFromChannel = Property(bool, readLimitsFromChannel, setLimitsFromChannel)
+
+    def readUserLowerLimit(self) -> float:
         """
         The user-defined lower limit for the scale.
 
@@ -1046,8 +1053,7 @@ class PyDMScaleIndicator(QFrame, TextFormatter, PyDMWidget):
         """
         return self._user_lower_limit
 
-    @userLowerLimit.setter
-    def userLowerLimit(self, value: float) -> None:
+    def setUserLowerLimit(self, value: float) -> None:
         """
         The user-defined lower limit for the scale.
 
@@ -1062,8 +1068,9 @@ class PyDMScaleIndicator(QFrame, TextFormatter, PyDMWidget):
         self.scale_indicator.set_lower_limit(self._user_lower_limit)
         self.update_labels()
 
-    @Property(float)
-    def userUpperLimit(self) -> float:
+    userLowerLimit = Property(float, readUserLowerLimit, setUserLowerLimit)
+
+    def readUserUpperLimit(self) -> float:
         """
         The user-defined upper limit for the scale.
 
@@ -1073,8 +1080,7 @@ class PyDMScaleIndicator(QFrame, TextFormatter, PyDMWidget):
         """
         return self._user_upper_limit
 
-    @userUpperLimit.setter
-    def userUpperLimit(self, value: float) -> None:
+    def setUserUpperLimit(self, value: float) -> None:
         """
         The user-defined upper limit for the scale.
 
@@ -1088,3 +1094,5 @@ class PyDMScaleIndicator(QFrame, TextFormatter, PyDMWidget):
         self._user_upper_limit = value
         self.scale_indicator.set_upper_limit(self._user_upper_limit)
         self.update_labels()
+
+    userUpperLimit = Property(float, readUserUpperLimit, setUserUpperLimit)

--- a/pydm/widgets/shell_command.py
+++ b/pydm/widgets/shell_command.py
@@ -9,11 +9,17 @@ import hashlib
 from ast import literal_eval
 from qtpy.QtWidgets import QApplication, QPushButton, QMenu, QMessageBox, QInputDialog, QLineEdit, QWidget, QStyle
 from qtpy.QtGui import QCursor, QIcon, QMouseEvent, QColor
-from qtpy.QtCore import Property, QSize, Qt, QTimer, Signal
+from qtpy.QtCore import QSize, Qt, QTimer, Signal
 from qtpy import QtDesigner
 from .base import PyDMWidget, only_if_channel_set, PostParentClassInitSetup
 from pydm.utilities import IconFont, ACTIVE_QT_WRAPPER, QtWrapperTypes
 from typing import Optional, Union, List
+from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
+
+if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
+    from PySide6.QtCore import Property
+else:
+    from PyQt5.QtCore import pyqtProperty as Property
 
 logger = logging.getLogger(__name__)
 
@@ -161,8 +167,7 @@ class PyDMShellCommand(QPushButton, PyDMWidget):
 
         return True
 
-    @Property(str)
-    def PyDMIcon(self) -> str:
+    def readPyDMIcon(self) -> str:
         """
         Name of icon to be set from Qt provided standard icons or from the fontawesome icon-set.
         See "enum QStyle::StandardPixmap" in Qt's QStyle documentation for full list of usable standard icons.
@@ -174,8 +179,7 @@ class PyDMShellCommand(QPushButton, PyDMWidget):
         """
         return self._pydm_icon_name
 
-    @PyDMIcon.setter
-    def PyDMIcon(self, value: str) -> None:
+    def setPyDMIcon(self, value: str) -> None:
         """
         Name of icon to be set from Qt provided standard icons or from the "Font Awesome" icon-set.
         See "enum QStyle::StandardPixmap" in Qt's QStyle documentation for full list of usable standard icons.
@@ -201,8 +205,9 @@ class PyDMShellCommand(QPushButton, PyDMWidget):
 
         self._pydm_icon_name = value
 
-    @Property(QColor)
-    def PyDMIconColor(self) -> QColor:
+    PyDMIcon = Property(str, readPyDMIcon, setPyDMIcon)
+
+    def readPyDMIconColor(self) -> QColor:
         """
         The color of the icon (color is only applied if using icon from the "Font Awesome" set)
         Returns
@@ -211,8 +216,7 @@ class PyDMShellCommand(QPushButton, PyDMWidget):
         """
         return self._pydm_icon_color
 
-    @PyDMIconColor.setter
-    def PyDMIconColor(self, state_color: QColor) -> None:
+    def setPyDMIconColor(self, state_color: QColor) -> None:
         """
         The color of the icon (color is only applied if using icon from the "Font Awesome" set)
         Parameters
@@ -229,8 +233,9 @@ class PyDMShellCommand(QPushButton, PyDMWidget):
             except Exception:
                 return
 
-    @Property(bool)
-    def showConfirmDialog(self) -> bool:
+    PyDMIconColor = Property(QColor, readPyDMIconColor, setPyDMIconColor)
+
+    def readShowConfirmDialog(self) -> bool:
         """
         Whether or not to display a confirmation dialog.
 
@@ -240,8 +245,7 @@ class PyDMShellCommand(QPushButton, PyDMWidget):
         """
         return self._show_confirm_dialog
 
-    @showConfirmDialog.setter
-    def showConfirmDialog(self, value: bool) -> None:
+    def setShowConfirmDialog(self, value: bool) -> None:
         """
         Whether or not to display a confirmation dialog.
 
@@ -252,8 +256,9 @@ class PyDMShellCommand(QPushButton, PyDMWidget):
         if self._show_confirm_dialog != value:
             self._show_confirm_dialog = value
 
-    @Property(bool)
-    def runCommandsInFullShell(self) -> bool:
+    showConfirmDialog = Property(bool, readShowConfirmDialog, setShowConfirmDialog)
+
+    def readRunCommandsInFullShell(self) -> bool:
         """
         Whether or not to run cmds with Popen's option for running them through a shell subprocess.
 
@@ -263,8 +268,7 @@ class PyDMShellCommand(QPushButton, PyDMWidget):
         """
         return self._run_commands_in_full_shell
 
-    @runCommandsInFullShell.setter
-    def runCommandsInFullShell(self, value: bool) -> None:
+    def setRunCommandsInFullShell(self, value: bool) -> None:
         """
         Whether or not to run cmds with Popen's option for running them through a shell subprocess.
 
@@ -275,8 +279,9 @@ class PyDMShellCommand(QPushButton, PyDMWidget):
         if self._run_commands_in_full_shell != value:
             self._run_commands_in_full_shell = value
 
-    @Property(str)
-    def confirmMessage(self) -> str:
+    runCommandsInFullShell = Property(bool, readRunCommandsInFullShell, setRunCommandsInFullShell)
+
+    def readConfirmMessage(self) -> str:
         """
         Message to be displayed at the Confirmation dialog.
 
@@ -286,8 +291,7 @@ class PyDMShellCommand(QPushButton, PyDMWidget):
         """
         return self._confirm_message
 
-    @confirmMessage.setter
-    def confirmMessage(self, value: str) -> None:
+    def setConfirmMessage(self, value: str) -> None:
         """
         Message to be displayed at the Confirmation dialog.
 
@@ -297,6 +301,8 @@ class PyDMShellCommand(QPushButton, PyDMWidget):
         """
         if self._confirm_message != value:
             self._confirm_message = value
+
+    confirmMessage = Property(str, readConfirmMessage, setConfirmMessage)
 
     @only_if_channel_set
     def check_enable_state(self) -> None:
@@ -315,8 +321,7 @@ class PyDMShellCommand(QPushButton, PyDMWidget):
 
         self.setToolTip(tooltip)
 
-    @Property(str)
-    def environmentVariables(self) -> str:
+    def readEnvironmentVariables(self) -> str:
         """
         Return the environment variables which would be set along with the shell command.
 
@@ -326,8 +331,7 @@ class PyDMShellCommand(QPushButton, PyDMWidget):
         """
         return self.env_var
 
-    @environmentVariables.setter
-    def environmentVariables(self, new_dict: str) -> None:
+    def setEnvironmentVariables(self, new_dict: str) -> None:
         """
         Set environment variables which would be set along with the shell command.
 
@@ -338,8 +342,9 @@ class PyDMShellCommand(QPushButton, PyDMWidget):
         if self.env_var != new_dict:
             self.env_var = new_dict
 
-    @Property(bool)
-    def showIcon(self) -> bool:
+    environmentVariables = Property(str, readEnvironmentVariables, setEnvironmentVariables)
+
+    def readShowIcon(self) -> bool:
         """
         Whether or not we should show the selected Icon.
 
@@ -349,8 +354,7 @@ class PyDMShellCommand(QPushButton, PyDMWidget):
         """
         return self._show_icon
 
-    @showIcon.setter
-    def showIcon(self, value: bool) -> None:
+    def setShowIcon(self, value: bool) -> None:
         """
         Whether or not we should show the selected Icon.
 
@@ -367,8 +371,9 @@ class PyDMShellCommand(QPushButton, PyDMWidget):
                 self._icon = self.icon()
                 self.setIcon(QIcon())
 
-    @Property(bool, designable=False)
-    def redirectCommandOutput(self) -> bool:
+    showIcon = Property(bool, readShowIcon, setShowIcon)
+
+    def readRedirectCommandOutput(self) -> bool:
         """
         Whether or not we should redirect the output of command to the shell.
 
@@ -382,8 +387,7 @@ class PyDMShellCommand(QPushButton, PyDMWidget):
         """
         return self._stdout == TermOutputMode.SHOW
 
-    @redirectCommandOutput.setter
-    def redirectCommandOutput(self, value: bool) -> None:
+    def setRedirectCommandOutput(self, value: bool) -> None:
         if self._uses_stdout_intf:
             logger.warning(
                 f"In PydmShellCommand named {self.objectName()}, "
@@ -396,8 +400,9 @@ class PyDMShellCommand(QPushButton, PyDMWidget):
         else:
             self._stdout = TermOutputMode.HIDE
 
-    @Property(TermOutputMode)
-    def stdout(self) -> TermOutputMode:
+    redirectCommandOutput = Property(bool, readRedirectCommandOutput, setRedirectCommandOutput, designable=False)
+
+    def readStdout(self) -> TermOutputMode:
         """
         The behavior of the subprocess's standard output stream.
 
@@ -415,13 +420,13 @@ class PyDMShellCommand(QPushButton, PyDMWidget):
         """
         return self._stdout
 
-    @stdout.setter
-    def stdout(self, value: TermOutputMode) -> None:
+    def setStdout(self, value: TermOutputMode) -> None:
         self._uses_stdout_intf = True
         self._stdout = value
 
-    @Property(TermOutputMode)
-    def stderr(self) -> TermOutputMode:
+    stdout = Property(TermOutputMode, readStdout, setStdout)
+
+    def readStderr(self) -> TermOutputMode:
         """
         The behavior of the subprocess's standard error stream.
 
@@ -433,12 +438,12 @@ class PyDMShellCommand(QPushButton, PyDMWidget):
         """
         return self._stderr
 
-    @stderr.setter
-    def stderr(self, value: TermOutputMode) -> None:
+    def setStderr(self, value: TermOutputMode) -> None:
         self._stderr = value
 
-    @Property(bool)
-    def allowMultipleExecutions(self) -> bool:
+    stderr = Property(TermOutputMode, readStderr, setStderr)
+
+    def readAllowMultipleExecutions(self) -> bool:
         """
         Whether or not we should allow the same command
         to be executed even if it is still running.
@@ -449,8 +454,7 @@ class PyDMShellCommand(QPushButton, PyDMWidget):
         """
         return self._allow_multiple
 
-    @allowMultipleExecutions.setter
-    def allowMultipleExecutions(self, value: bool) -> None:
+    def setAllowMultipleExecutions(self, value: bool) -> None:
         """
         Whether or not we should allow the same command
         to be executed even if it is still running.
@@ -462,29 +466,30 @@ class PyDMShellCommand(QPushButton, PyDMWidget):
         if self._allow_multiple != value:
             self._allow_multiple = value
 
-    @Property("QStringList")
-    def titles(self) -> List[str]:
+    allowMultipleExecutions = Property(bool, readAllowMultipleExecutions, setAllowMultipleExecutions)
+
+    def readTitles(self) -> List[str]:
         return self._titles
 
-    @titles.setter
-    def titles(self, val: List[str]) -> None:
+    def setTitles(self, val: List[str]) -> None:
         self._titles = val
         self._menu_needs_rebuild = True
 
-    @Property("QStringList")
-    def commands(self) -> List[str]:
+    titles = Property("QStringList", readTitles, setTitles)
+
+    def readCommands(self) -> List[str]:
         return self._commands
 
-    @commands.setter
-    def commands(self, val: List[str]) -> None:
+    def setCommands(self, val: List[str]) -> None:
         if not val:
             self._commands = []
         else:
             self._commands = val
         self._menu_needs_rebuild = True
 
-    @Property(str, designable=False)
-    def command(self) -> str:
+    commands = Property("QStringList", readCommands, setCommands)
+
+    def readCommand(self) -> str:
         """
         DEPRECATED: use the 'commands' property.
         This property simply returns the first command from the 'commands'
@@ -499,8 +504,7 @@ class PyDMShellCommand(QPushButton, PyDMWidget):
             return ""
         return self.commands[0]
 
-    @command.setter
-    def command(self, value: str) -> None:
+    def setCommand(self, value: str) -> None:
         """
         DEPRECATED: Use the 'commands' property instead.
         This property only has an effect if the 'commands' property is empty.
@@ -518,8 +522,9 @@ class PyDMShellCommand(QPushButton, PyDMWidget):
             else:
                 self.commands = []
 
-    @Property(bool)
-    def passwordProtected(self) -> bool:
+    command = Property(str, readCommand, setCommand, designable=False)
+
+    def readPasswordProtected(self) -> bool:
         """
         Whether or not this button is password protected.
 
@@ -530,8 +535,7 @@ class PyDMShellCommand(QPushButton, PyDMWidget):
         """
         return self._password_protected
 
-    @passwordProtected.setter
-    def passwordProtected(self, value: bool) -> None:
+    def setPasswordProtected(self, value: bool) -> None:
         """
         Whether or not this button is password protected.
 
@@ -542,8 +546,9 @@ class PyDMShellCommand(QPushButton, PyDMWidget):
         if self._password_protected != value:
             self._password_protected = value
 
-    @Property(str)
-    def password(self) -> str:
+    passwordProtected = Property(bool, readPasswordProtected, setPasswordProtected)
+
+    def readPassword(self) -> str:
         """
         Password to be encrypted using SHA256.
 
@@ -556,8 +561,7 @@ class PyDMShellCommand(QPushButton, PyDMWidget):
         """
         return ""
 
-    @password.setter
-    def password(self, value: str) -> None:
+    def setPassword(self, value: str) -> None:
         """
         Password to be encrypted using SHA256.
 
@@ -578,8 +582,9 @@ class PyDMShellCommand(QPushButton, PyDMWidget):
             if formWindow:
                 formWindow.cursor().setProperty("protectedPassword", self.protectedPassword)
 
-    @Property(str)
-    def protectedPassword(self) -> str:
+    password = Property(str, readPassword, setPassword)
+
+    def readProtectedPassword(self) -> str:
         """
         The encrypted password.
 
@@ -589,8 +594,7 @@ class PyDMShellCommand(QPushButton, PyDMWidget):
         """
         return self._protected_password
 
-    @protectedPassword.setter
-    def protectedPassword(self, value: str) -> None:
+    def setProtectedPassword(self, value: str) -> None:
         """
         Setter for the encrypted password.
 
@@ -601,8 +605,9 @@ class PyDMShellCommand(QPushButton, PyDMWidget):
         if self._protected_password != value:
             self._protected_password = value
 
-    @Property(bool)
-    def showCurrentlyRunningIndication(self) -> bool:
+    protectedPassword = Property(str, readProtectedPassword, setProtectedPassword)
+
+    def readShowCurrentlyRunningIndication(self) -> bool:
         """
         Whether or not to have a button's visuals change to indicate when the command is running.
         It's nice to enable this when you know your button's command runs long.
@@ -613,8 +618,7 @@ class PyDMShellCommand(QPushButton, PyDMWidget):
         """
         return self._show_currently_running_indication
 
-    @showCurrentlyRunningIndication.setter
-    def showCurrentlyRunningIndication(self, value: bool) -> None:
+    def setShowCurrentlyRunningIndication(self, value: bool) -> None:
         """
         Whether or not to have a button's visuals change to indicate when the command is running.
         It's nice to enable this when you know your button's command runs long.
@@ -625,6 +629,10 @@ class PyDMShellCommand(QPushButton, PyDMWidget):
         """
         if self._show_currently_running_indication != value:
             self._show_currently_running_indication = value
+
+    showCurrentlyRunningIndication = Property(
+        bool, readShowCurrentlyRunningIndication, setShowCurrentlyRunningIndication
+    )
 
     def _rebuild_menu(self) -> None:
         if not any(self._commands):

--- a/pydm/widgets/slider.py
+++ b/pydm/widgets/slider.py
@@ -1,7 +1,7 @@
 import logging
 import numpy as np
 from decimal import Decimal
-from qtpy.QtCore import Qt, Signal, Slot, Property, QRect, QPoint, QSize
+from qtpy.QtCore import Qt, Signal, Slot, QRect, QPoint, QSize
 from qtpy.QtWidgets import (
     QFrame,
     QLabel,
@@ -18,6 +18,12 @@ from qtpy.QtWidgets import (
 from pydm.widgets import PyDMLabel
 from .base import PyDMWritableWidget, TextFormatter, is_channel_valid
 from .channel import PyDMChannel
+from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
+
+if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
+    from PySide6.QtCore import Property
+else:
+    from PyQt5.QtCore import pyqtProperty as Property
 
 logger = logging.getLogger(__name__)
 _step_size_properties = {
@@ -501,8 +507,7 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget):
         """
         self.value = 0.0
 
-    @Property(Qt.Orientation)
-    def orientation(self):
+    def readOrientation(self) -> int | Qt.Orientation:
         """
         The slider orientation (Horizontal or Vertical)
 
@@ -513,8 +518,7 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget):
         """
         return self._orientation
 
-    @orientation.setter
-    def orientation(self, new_orientation):
+    def setOrientation(self, new_orientation) -> None:
         """
         The slider orientation (Horizontal or Vertical)
 
@@ -525,6 +529,9 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget):
         """
         self._orientation = new_orientation
         self.setup_widgets_for_orientation(new_orientation)
+
+    prop_type = int if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6 else Qt.Orientation
+    orientation = Property(prop_type, readOrientation, setOrientation)
 
     def setup_widgets_for_orientation(self, new_orientation):
         """
@@ -922,8 +929,7 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget):
             except IndexError:
                 pass
 
-    @Property(bool)
-    def tracking(self):
+    def readTracking(self) -> bool:
         """
         If tracking is enabled (the default), the slider emits new values
         while the slider is being dragged.  If tracking is disabled, it will
@@ -935,9 +941,10 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget):
         """
         return self._slider.hasTracking()
 
-    @tracking.setter
-    def tracking(self, checked):
+    def setTracking(self, checked) -> None:
         self._slider.setTracking(checked)
+
+    tracking = Property(bool, readTracking, setTracking)
 
     def hasTracking(self):
         """
@@ -953,8 +960,7 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget):
         """
         self.tracking = checked
 
-    @Property(bool)
-    def ignoreMouseWheel(self):
+    def readIgnoreMouseWheel(self) -> bool:
         """
         If true, the mouse wheel will not change the value of the slider.
         This is useful if you want to put sliders inside a scroll view, and
@@ -962,16 +968,16 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget):
         """
         return self._ignore_mouse_wheel
 
-    @ignoreMouseWheel.setter
-    def ignoreMouseWheel(self, checked):
+    def setIgnoreMouseWheel(self, checked) -> None:
         self._ignore_mouse_wheel = checked
         if checked:
             self._slider.wheelEvent = self.wheelEvent
         else:
             self._slider.wheelEvent = self._orig_wheel_event
 
-    @Property(bool)
-    def showLimitLabels(self):
+    ignoreMouseWheel = Property(bool, readIgnoreMouseWheel, setIgnoreMouseWheel)
+
+    def readShowLimitLabels(self) -> bool:
         """
         Whether or not the high and low limits should be displayed on the slider.
 
@@ -981,8 +987,7 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget):
         """
         return self._show_limit_labels
 
-    @showLimitLabels.setter
-    def showLimitLabels(self, checked):
+    def setShowLimitLabels(self, checked) -> None:
         """
         Whether or not the high and low limits should be displayed on the slider.
 
@@ -998,8 +1003,9 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget):
             self.low_lim_label.hide()
             self.high_lim_label.hide()
 
-    @Property(bool)
-    def showValueLabel(self):
+    showLimitLabels = Property(bool, readShowLimitLabels, setShowLimitLabels)
+
+    def readShowValueLabel(self) -> bool:
         """
         Whether or not the current value should be displayed on the slider.
 
@@ -1009,8 +1015,7 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget):
         """
         return self._show_value_label
 
-    @showValueLabel.setter
-    def showValueLabel(self, checked):
+    def setShowValueLabel(self, checked) -> None:
         """
         Whether or not the current value should be displayed on the slider.
 
@@ -1024,8 +1029,9 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget):
         else:
             self.value_label.hide()
 
-    @Property(QSlider.TickPosition)
-    def tickPosition(self):
+    showValueLabel = Property(bool, readShowValueLabel, setShowValueLabel)
+
+    def readTickPosition(self) -> QSlider.TickPosition:
         """
         Where to draw tick marks for the slider.
 
@@ -1035,8 +1041,7 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget):
         """
         return self._slider.tickPosition()
 
-    @tickPosition.setter
-    def tickPosition(self, position):
+    def setTickPosition(self, position) -> None:
         """
         Where to draw tick marks for the slider.
 
@@ -1046,8 +1051,9 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget):
         """
         self._slider.setTickPosition(position)
 
-    @Property(bool)
-    def userDefinedLimits(self):
+    tickPosition = Property(QSlider.TickPosition, readTickPosition, setTickPosition)
+
+    def readUserDefinedLimits(self) -> bool:
         """
         Whether or not to use limits defined by the user and not from the
         channel
@@ -1058,8 +1064,7 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget):
         """
         return self._user_defined_limits
 
-    @userDefinedLimits.setter
-    def userDefinedLimits(self, user_defined_limits):
+    def setUserDefinedLimits(self, user_defined_limits) -> None:
         """
         Whether or not to use limits defined by the user and not from the
         channel
@@ -1071,8 +1076,9 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget):
         self._user_defined_limits = user_defined_limits
         self.reset_slider_limits()
 
-    @Property(float)
-    def userMinimum(self):
+    userDefinedLimits = Property(bool, readUserDefinedLimits, setUserDefinedLimits)
+
+    def readUserMinimum(self) -> float:
         """
         Lower user defined limit value
 
@@ -1082,8 +1088,7 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget):
         """
         return self._user_minimum
 
-    @userMinimum.setter
-    def userMinimum(self, new_min):
+    def setUserMinimum(self, new_min) -> None:
         """
         Lower user defined limit value
 
@@ -1095,8 +1100,9 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget):
         if self.userDefinedLimits:
             self.reset_slider_limits()
 
-    @Property(float)
-    def userMaximum(self):
+    userMinimum = Property(float, readUserMinimum, setUserMinimum)
+
+    def readUserMaximum(self) -> float:
         """
         Upper user defined limit value
 
@@ -1106,8 +1112,7 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget):
         """
         return self._user_maximum
 
-    @userMaximum.setter
-    def userMaximum(self, new_max):
+    def setUserMaximum(self, new_max) -> None:
         """
         Upper user defined limit value
 
@@ -1118,6 +1123,8 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget):
         self._user_maximum = float(new_max) if new_max is not None else None
         if self.userDefinedLimits:
             self.reset_slider_limits()
+
+    userMaximum = Property(float, readUserMaximum, setUserMaximum)
 
     @property
     def minimum(self):
@@ -1145,8 +1152,7 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget):
             return self._user_maximum
         return self._upper_ctrl_limit
 
-    @Property(int)
-    def num_steps(self):
+    def read_num_steps(self) -> int:
         """
         The number of steps on the slider
 
@@ -1156,8 +1162,7 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget):
         """
         return self._num_steps
 
-    @num_steps.setter
-    def num_steps(self, new_steps):
+    def set_num_steps(self, new_steps) -> None:
         """
         The number of steps on the slider
 
@@ -1169,8 +1174,9 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget):
         self._num_steps = int(new_steps)
         self.reset_slider_limits()
 
-    @Property(float)
-    def step_size(self):
+    num_steps = Property(int, read_num_steps, set_num_steps)
+
+    def read_step_size(self) -> int:
         """
         The number of steps on the slider
 
@@ -1181,8 +1187,7 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget):
 
         return self._step_size
 
-    @step_size.setter
-    def step_size(self, new_step_size):
+    def set_step_size(self, new_step_size) -> None:
         """
         The number of steps on the slider
 
@@ -1202,6 +1207,8 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget):
 
         return True
 
+    step_size = Property(float, read_step_size, set_step_size)
+
     @Slot(str)
     @Slot(float)
     def step_size_changed(self, new_val):
@@ -1218,16 +1225,16 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget):
         except ValueError:
             logger.debug("cannot cast PV value as float")
 
-    @Property(str)
-    def step_size_channel(self):
+    def read_step_size_channel(self) -> None:
         """
         String to connect to pydm channel after initialization
         """
         return self._step_size_channel
 
-    @step_size_channel.setter
-    def step_size_channel(self, step_size_channel):
+    def set_step_size_channel(self, step_size_channel):
         self._step_size_channel = step_size_channel
+
+    step_size_channel = Property(str, read_step_size_channel, set_step_size_channel)
 
     @property
     def value(self):

--- a/pydm/widgets/spinbox.py
+++ b/pydm/widgets/spinbox.py
@@ -1,6 +1,12 @@
 from qtpy.QtWidgets import QDoubleSpinBox, QApplication, QLineEdit
-from qtpy.QtCore import Property, Qt
+from qtpy.QtCore import Qt
 from .base import PyDMWritableWidget, TextFormatter, PostParentClassInitSetup
+from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
+
+if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
+    from PySide6.QtCore import Property
+else:
+    from PyQt5.QtCore import pyqtProperty as Property
 
 
 class PyDMSpinbox(QDoubleSpinBox, TextFormatter, PyDMWritableWidget):
@@ -168,8 +174,7 @@ class PyDMSpinbox(QDoubleSpinBox, TextFormatter, PyDMWritableWidget):
         if not self.valueBeingSet:
             self.send_value_signal[float].emit(value)
 
-    @Property(bool)
-    def userDefinedLimits(self) -> bool:
+    def readUserDefinedLimits(self) -> bool:
         """
         True if the range of the spinbox should be set based on user-defined limits, False if
         it should be set based on the limits received from the channel
@@ -180,8 +185,7 @@ class PyDMSpinbox(QDoubleSpinBox, TextFormatter, PyDMWritableWidget):
         """
         return self._user_defined_limits
 
-    @userDefinedLimits.setter
-    def userDefinedLimits(self, user_defined_limits: bool) -> None:
+    def setUserDefinedLimits(self, user_defined_limits: bool) -> None:
         """
         Whether or not to set the range of the spinbox based on user-defined limits. Will also reset
         the range of the spinbox in case this is called while the application is running to ensure it matches
@@ -194,8 +198,9 @@ class PyDMSpinbox(QDoubleSpinBox, TextFormatter, PyDMWritableWidget):
         self._user_defined_limits = user_defined_limits
         self.reset_limits()
 
-    @Property(float)
-    def userMinimum(self) -> float:
+    userDefinedLimits = Property(bool, readUserDefinedLimits, setUserDefinedLimits)
+
+    def readUserMinimum(self) -> float:
         """
         Lower user-defined limit value
 
@@ -205,8 +210,7 @@ class PyDMSpinbox(QDoubleSpinBox, TextFormatter, PyDMWritableWidget):
         """
         return self._user_minimum
 
-    @userMinimum.setter
-    def userMinimum(self, new_min: float) -> None:
+    def setUserMinimum(self, new_min: float) -> None:
         """
         Set the Lower user-defined limit value, updates the range of the spinbox if needed
 
@@ -217,8 +221,9 @@ class PyDMSpinbox(QDoubleSpinBox, TextFormatter, PyDMWritableWidget):
         self._user_minimum = new_min
         self.reset_limits()
 
-    @Property(float)
-    def userMaximum(self) -> float:
+    userMinimum = Property(float, readUserMinimum, setUserMinimum)
+
+    def readUserMaximum(self) -> float:
         """
         Upper user-defined limit value
 
@@ -228,8 +233,7 @@ class PyDMSpinbox(QDoubleSpinBox, TextFormatter, PyDMWritableWidget):
         """
         return self._user_maximum
 
-    @userMaximum.setter
-    def userMaximum(self, new_max: float) -> None:
+    def setUserMaximum(self, new_max: float) -> None:
         """
         Set the upper user-defined limit value, updates the range of the spinbox if needed
 
@@ -239,6 +243,8 @@ class PyDMSpinbox(QDoubleSpinBox, TextFormatter, PyDMWritableWidget):
         """
         self._user_maximum = new_max
         self.reset_limits()
+
+    userMaximum = Property(float, readUserMaximum, setUserMaximum)
 
     def reset_limits(self) -> None:
         """
@@ -290,15 +296,13 @@ class PyDMSpinbox(QDoubleSpinBox, TextFormatter, PyDMWritableWidget):
         super().precision_changed(new_precision)
         self.setDecimals(self.precision)
 
-    @Property(int)
-    def precision(self):
+    def readPrecision(self) -> int:
         if self.precisionFromPV:
             return self._prec
         else:
             return self._user_prec
 
-    @precision.setter
-    def precision(self, new_prec):
+    def setPrecision(self, new_prec) -> None:
         if self.precisionFromPV:
             return
         if new_prec and self._user_prec != int(new_prec) and new_prec >= 0:
@@ -306,8 +310,9 @@ class PyDMSpinbox(QDoubleSpinBox, TextFormatter, PyDMWritableWidget):
             self.value_changed(self.value)
             self.setDecimals(new_prec)
 
-    @Property(bool)
-    def showStepExponent(self):
+    precision = Property(int, readPrecision, setPrecision)
+
+    def readShowStepExponent(self) -> bool:
         """
         Whether to show or not the step exponent
 
@@ -317,8 +322,7 @@ class PyDMSpinbox(QDoubleSpinBox, TextFormatter, PyDMWritableWidget):
         """
         return self._show_step_exponent
 
-    @showStepExponent.setter
-    def showStepExponent(self, val):
+    def setShowStepExponent(self, val) -> None:
         """
         Whether to show or not the step exponent
 
@@ -329,8 +333,9 @@ class PyDMSpinbox(QDoubleSpinBox, TextFormatter, PyDMWritableWidget):
         self._show_step_exponent = val
         self.update_format_string()
 
-    @Property(bool)
-    def writeOnPress(self):
+    showStepExponent = Property(bool, readShowStepExponent, setShowStepExponent)
+
+    def readWriteOnPress(self) -> bool:
         """
         Whether to write value on key press
 
@@ -340,8 +345,7 @@ class PyDMSpinbox(QDoubleSpinBox, TextFormatter, PyDMWritableWidget):
         """
         return self._write_on_press
 
-    @writeOnPress.setter
-    def writeOnPress(self, val):
+    def setWriteOnPress(self, val) -> None:
         """
         Whether value to write on key press.
 
@@ -350,3 +354,5 @@ class PyDMSpinbox(QDoubleSpinBox, TextFormatter, PyDMWritableWidget):
         val : bool
         """
         self._write_on_press = val
+
+    writeOnPress = Property(bool, readWriteOnPress, setWriteOnPress)

--- a/pydm/widgets/tab_bar.py
+++ b/pydm/widgets/tab_bar.py
@@ -3,9 +3,14 @@ from qtpy.QtGui import QIcon, QColor
 from qtpy.QtCore import QByteArray
 from .base import PyDMWidget, PostParentClassInitSetup
 from .channel import PyDMChannel
-from qtpy.QtCore import Property
 from functools import partial
 from pydm.utilities.iconfont import IconFont
+from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
+
+if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
+    from PySide6.QtCore import Property
+else:
+    from PyQt5.QtCore import pyqtProperty as Property
 
 
 class PyDMTabBar(QTabBar, PyDMWidget):
@@ -35,8 +40,7 @@ class PyDMTabBar(QTabBar, PyDMWidget):
     def eventFilter(self, obj, event):
         return PyDMWidget.eventFilter(self, obj, event)
 
-    @Property(str)
-    def currentTabAlarmChannel(self):
+    def readCurrentTabAlarmChannel(self) -> str:
         """A channel to use for this tab's alarm indicator."""
         if self.currentIndex() < 0:
             return
@@ -45,11 +49,12 @@ class PyDMTabBar(QTabBar, PyDMWidget):
         except KeyError:
             return ""
 
-    @currentTabAlarmChannel.setter
-    def currentTabAlarmChannel(self, new_alarm_channel):
+    def setCurrentTabAlarmChannel(self, new_alarm_channel) -> None:
         if self.currentIndex() < 0:
             return
         self.set_channel_for_tab(self.currentIndex(), new_alarm_channel)
+
+    currentTabAlarmChannel = Property(str, readCurrentTabAlarmChannel, setCurrentTabAlarmChannel)
 
     def set_channel_for_tab(self, index, channel):
         idx = self.tab_channels.get(index)
@@ -119,55 +124,55 @@ class PyDMTabBar(QTabBar, PyDMWidget):
             self.tab_channels[index] = {"address": ""}
         self.set_initial_icon_for_tab(index)
 
-    @Property(QColor)
-    def noAlarmIconColor(self):
+    def readNoAlarmIconColor(self) -> QColor:
         return self._no_alarm_icon_color
 
-    @noAlarmIconColor.setter
-    def noAlarmIconColor(self, new_color):
+    def setNoAlarmIconColor(self, new_color) -> None:
         if self._no_alarm_icon_color != new_color:
             self._no_alarm_icon_color = new_color
             self.generate_alarm_icons()
 
-    @Property(QColor)
-    def minorAlarmIconColor(self):
+    noAlarmIconColor = Property(QColor, readNoAlarmIconColor, setNoAlarmIconColor)
+
+    def readMinorAlarmIconColor(self) -> QColor:
         return self._minor_alarm_icon_color
 
-    @minorAlarmIconColor.setter
-    def minorAlarmIconColor(self, new_color):
+    def setMinorAlarmIconColor(self, new_color) -> None:
         if self._minor_alarm_icon_color != new_color:
             self._minor_alarm_icon_color = new_color
             self.generate_alarm_icons()
 
-    @Property(QColor)
-    def majorAlarmIconColor(self):
+    minorAlarmIconColor = Property(QColor, readMinorAlarmIconColor, setMinorAlarmIconColor)
+
+    def readMajorAlarmIconColor(self) -> QColor:
         return self._major_alarm_icon_color
 
-    @majorAlarmIconColor.setter
-    def majorAlarmIconColor(self, new_color):
+    def setMajorAlarmIconColor(self, new_color) -> None:
         if self._major_alarm_icon_color != new_color:
             self._major_alarm_icon_color = new_color
             self.generate_alarm_icons()
 
-    @Property(QColor)
-    def invalidAlarmIconColor(self):
+    majorAlarmIconColor = Property(QColor, readMajorAlarmIconColor, setMajorAlarmIconColor)
+
+    def readInvalidAlarmIconColor(self) -> QColor:
         return self._invalid_alarm_icon_color
 
-    @invalidAlarmIconColor.setter
-    def invalidAlarmIconColor(self, new_color):
+    def setInvalidAlarmIconColor(self, new_color) -> None:
         if self._invalid_alarm_icon_color != new_color:
             self._invalid_alarm_icon_color = new_color
             self.generate_alarm_icons()
 
-    @Property(QColor)
-    def disconnectedAlarmIconColor(self):
+    invalidAlarmIconColor = Property(QColor, readInvalidAlarmIconColor, setInvalidAlarmIconColor)
+
+    def readDisconnectedAlarmIconColor(self) -> QColor:
         return self._disconnected_alarm_icon_color
 
-    @disconnectedAlarmIconColor.setter
-    def disconnectedAlarmIconColor(self, new_color):
+    def setDisconnectedAlarmIconColor(self, new_color) -> None:
         if self._disconnected_alarm_icon_color != new_color:
             self._disconnected_alarm_icon_color = new_color
             self.generate_alarm_icons()
+
+    disconnectedAlarmIconColor = Property(QColor, readDisconnectedAlarmIconColor, setDisconnectedAlarmIconColor)
 
     def generate_alarm_icons(self):
         self.alarm_icons = (
@@ -198,8 +203,7 @@ class PyDMTabWidget(QTabWidget):
         self.tb = PyDMTabBar(parent=self)
         self.setTabBar(self.tb)
 
-    @Property(QByteArray)
-    def currentTabAlarmChannel(self):
+    def readCurrentTabAlarmChannel(self) -> QByteArray:
         """
         A channel to use for the current tab's alarm indicator.
 
@@ -212,9 +216,10 @@ class PyDMTabWidget(QTabWidget):
         else:
             return bytearray()
 
-    @currentTabAlarmChannel.setter
-    def currentTabAlarmChannel(self, new_alarm_channel):
+    def setCurrentTabAlarmChannel(self, new_alarm_channel) -> None:
         self.tabBar().currentTabAlarmChannel = bytes(new_alarm_channel).decode()
+
+    currentTabAlarmChannel = Property(QByteArray, readCurrentTabAlarmChannel, setCurrentTabAlarmChannel)
 
     def channels(self):
         """
@@ -240,8 +245,7 @@ class PyDMTabWidget(QTabWidget):
         """
         self.tabBar().setAlarmChannels(new_alarm_channels)
 
-    @Property(QColor)
-    def noAlarmIconColor(self):
+    def readNoAlarmIconColor(self) -> QColor:
         """
         A color to use for alarm-sensitive tabs that have PyDMWidget.ALARM_NONE severity level.
         This property can be defined in a stylesheet by using 'qproperty-noAlarmIconColor'.
@@ -252,14 +256,14 @@ class PyDMTabWidget(QTabWidget):
         """
         return self.tabBar().noAlarmIconColor
 
-    @noAlarmIconColor.setter
-    def noAlarmIconColor(self, new_color):
+    def setNoAlarmIconColor(self, new_color) -> None:
         if self.tabBar().noAlarmIconColor != new_color:
             self.tabBar().noAlarmIconColor = new_color
             self.tabBar().generate_alarm_icons()
 
-    @Property(QColor)
-    def minorAlarmIconColor(self):
+    noAlarmIconColor = Property(QColor, readNoAlarmIconColor, setNoAlarmIconColor)
+
+    def readMinorAlarmIconColor(self) -> QColor:
         """
         A color to use for alarm-sensitive tabs that have PyDMWidget.ALARM_MINOR severity level.
         This property can be defined in a stylesheet by using 'qproperty-minorAlarmIconColor'.
@@ -270,12 +274,12 @@ class PyDMTabWidget(QTabWidget):
         """
         return self.tabBar().minorAlarmIconColor
 
-    @minorAlarmIconColor.setter
-    def minorAlarmIconColor(self, new_color):
+    def setMinorAlarmIconColor(self, new_color) -> None:
         self.tabBar().minorAlarmIconColor = new_color
 
-    @Property(QColor)
-    def majorAlarmIconColor(self):
+    minorAlarmIconColor = Property(QColor, readMinorAlarmIconColor, setMinorAlarmIconColor)
+
+    def readMajorAlarmIconColor(self) -> QColor:
         """
         A color to use for alarm-sensitive tabs that have PyDMWidget.ALARM_MAJOR severity level.
         This property can be defined in a stylesheet by using 'qproperty-majorAlarmIconColor'.
@@ -286,12 +290,12 @@ class PyDMTabWidget(QTabWidget):
         """
         return self.tabBar().majorAlarmIconColor
 
-    @majorAlarmIconColor.setter
-    def majorAlarmIconColor(self, new_color):
+    def setMajorAlarmIconColor(self, new_color) -> None:
         self.tabBar().majorAlarmIconColor = new_color
 
-    @Property(QColor)
-    def invalidAlarmIconColor(self):
+    majorAlarmIconColor = Property(QColor, readMajorAlarmIconColor, setMajorAlarmIconColor)
+
+    def readInvalidAlarmIconColor(self) -> QColor:
         """
         A color to use for alarm-sensitive tabs that have PyDMWidget.ALARM_INVALID severity level.
         This property can be defined in a stylesheet by using 'qproperty-majorAlarmIconColor'.
@@ -302,12 +306,12 @@ class PyDMTabWidget(QTabWidget):
         """
         return self.tabBar().invalidAlarmIconColor
 
-    @invalidAlarmIconColor.setter
-    def invalidAlarmIconColor(self, new_color):
+    def setInvalidAlarmIconColor(self, new_color) -> None:
         self.tabBar().invalidAlarmIconColor = new_color
 
-    @Property(QColor)
-    def disconnectedAlarmIconColor(self):
+    invalidAlarmIconColor = Property(QColor, readInvalidAlarmIconColor, setInvalidAlarmIconColor)
+
+    def readDisconnectedAlarmIconColor(self) -> QColor:
         """
         A color to use for alarm-sensitive tabs that have PyDMWidget.ALARM_DISCONNECTED severity level.
         This property can be defined in a stylesheet by using 'qproperty-disconnectedAlarmIconColor'.
@@ -318,9 +322,10 @@ class PyDMTabWidget(QTabWidget):
         """
         return self.tabBar().disconnectedAlarmIconColor
 
-    @disconnectedAlarmIconColor.setter
-    def disconnectedAlarmIconColor(self, new_color):
+    def setDisconnectedAlarmIconColor(self, new_color) -> None:
         self.tabBar().disconnectedAlarmIconColor = new_color
+
+    disconnectedAlarmIconColor = Property(QColor, readDisconnectedAlarmIconColor, setDisconnectedAlarmIconColor)
 
     alarmChannels = Property("QStringList", getAlarmChannels, setAlarmChannels, designable=False)
 

--- a/pydm/widgets/template_repeater.py
+++ b/pydm/widgets/template_repeater.py
@@ -3,13 +3,19 @@ import json
 import copy
 import logging
 from qtpy.QtWidgets import QFrame, QApplication, QLabel, QVBoxLayout, QHBoxLayout, QWidget, QStyle, QSizePolicy, QLayout
-from qtpy.QtCore import Qt, QSize, QRect, Property, QPoint
+from qtpy.QtCore import Qt, QSize, QRect, QPoint
 from .base import PyDMPrimitiveWidget
 from pydm.utilities import is_qt_designer
 import pydm.data_plugins
 from pydm.utilities import find_file
 from pydm.display import load_file
 from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
+from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
+
+if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
+    from PySide6.QtCore import Property
+else:
+    from PyQt5.QtCore import pyqtProperty as Property
 
 logger = logging.getLogger(__name__)
 
@@ -185,8 +191,7 @@ class PyDMTemplateRepeater(QFrame, PyDMPrimitiveWidget):
         self.app = QApplication.instance()
         self.rebuild()
 
-    @Property(LayoutType)
-    def layoutType(self):
+    def readLayoutType(self) -> LayoutType:
         """
         The layout type to use.
 
@@ -196,8 +201,7 @@ class PyDMTemplateRepeater(QFrame, PyDMPrimitiveWidget):
         """
         return self._layout_type
 
-    @layoutType.setter
-    def layoutType(self, new_type):
+    def setLayoutType(self, new_type) -> None:
         """
         The layout type to use.
         Options are:
@@ -214,20 +218,21 @@ class PyDMTemplateRepeater(QFrame, PyDMPrimitiveWidget):
             self._layout_type = new_type
             self.rebuild()
 
-    @Property(int)
-    def layoutSpacing(self):
+    layoutType = Property(LayoutType, readLayoutType, setLayoutType)
+
+    def readLayoutSpacing(self) -> int:
         if self.layout():
             return self.layout().spacing()
         return self._temp_layout_spacing
 
-    @layoutSpacing.setter
-    def layoutSpacing(self, new_spacing):
+    def setLayoutSpacing(self, new_spacing) -> None:
         self._temp_layout_spacing = new_spacing
         if self.layout():
             self.layout().setSpacing(new_spacing)
 
-    @Property(int)
-    def countShownInDesigner(self):
+    layoutSpacing = Property(int, readLayoutSpacing, setLayoutSpacing)
+
+    def readCountShownInDesigner(self) -> int:
         """
         The number of instances to show in Qt Designer.  This property has no
         effect outside of Designer.
@@ -238,8 +243,7 @@ class PyDMTemplateRepeater(QFrame, PyDMPrimitiveWidget):
         """
         return self._count_shown_in_designer
 
-    @countShownInDesigner.setter
-    def countShownInDesigner(self, new_count):
+    def setCountShownInDesigner(self, new_count) -> None:
         """
         The number of instances to show in Qt Designer.  This property has no
         effect outside of Designer.
@@ -260,8 +264,9 @@ class PyDMTemplateRepeater(QFrame, PyDMPrimitiveWidget):
             self._count_shown_in_designer = new_count
             self.rebuild()
 
-    @Property(str)
-    def templateFilename(self):
+    countShownInDesigner = Property(int, readCountShownInDesigner, setCountShownInDesigner)
+
+    def readTemplateFilename(self) -> str:
         """
         The path to the .ui file to use as a template.
 
@@ -271,8 +276,7 @@ class PyDMTemplateRepeater(QFrame, PyDMPrimitiveWidget):
         """
         return self._template_filename
 
-    @templateFilename.setter
-    def templateFilename(self, new_filename):
+    def setTemplateFilename(self, new_filename) -> None:
         """
         The path to the .ui file to use as a template.
 
@@ -288,8 +292,9 @@ class PyDMTemplateRepeater(QFrame, PyDMPrimitiveWidget):
             else:
                 self.clear()
 
-    @Property(bool)
-    def recursiveTemplateSearch(self) -> bool:
+    templateFilename = Property(str, readTemplateFilename, setTemplateFilename)
+
+    def readRecursiveTemplateSearch(self) -> bool:
         """
         Whether or not to search for a provided template file recursively
         in subfolders relative to the location of this widget.
@@ -301,8 +306,7 @@ class PyDMTemplateRepeater(QFrame, PyDMPrimitiveWidget):
         """
         return self._recursive_template_search
 
-    @recursiveTemplateSearch.setter
-    def recursiveTemplateSearch(self, new_value) -> None:
+    def setRecursiveTemplateSearch(self, new_value) -> None:
         """
         Set whether or not to search for a provided template file recursively
         in subfolders relative to the location of this widget.
@@ -313,6 +317,8 @@ class PyDMTemplateRepeater(QFrame, PyDMPrimitiveWidget):
             If recursive search should be enabled.
         """
         self._recursive_template_search = new_value
+
+    recursiveTemplateSearch = Property(bool, readRecursiveTemplateSearch, setRecursiveTemplateSearch)
 
     def _is_json(self, source):
         """
@@ -335,8 +341,7 @@ class PyDMTemplateRepeater(QFrame, PyDMPrimitiveWidget):
         except Exception as ex:
             return False, ex
 
-    @Property(str)
-    def dataSource(self):
+    def readDataSource(self) -> str:
         """
         The path to the JSON file or a valid JSON string to fill in each
         instance of the template.
@@ -347,8 +352,7 @@ class PyDMTemplateRepeater(QFrame, PyDMPrimitiveWidget):
         """
         return self._data_source
 
-    @dataSource.setter
-    def dataSource(self, data_source):
+    def setDataSource(self, data_source) -> None:
         """
         Sets the path to the JSON file or a valid JSON string to fill in each
         instance of the template.
@@ -406,8 +410,9 @@ class PyDMTemplateRepeater(QFrame, PyDMPrimitiveWidget):
             else:
                 self.clear()
 
-    @Property(bool)
-    def recursiveDataSearch(self) -> bool:
+    dataSource = Property(str, readDataSource, setDataSource)
+
+    def readRecursiveDataSearch(self) -> bool:
         """
         Whether or not to search for a provided data file recursively
         in subfolders relative to the location of this widget.
@@ -419,8 +424,7 @@ class PyDMTemplateRepeater(QFrame, PyDMPrimitiveWidget):
         """
         return self._recursive_data_search
 
-    @recursiveDataSearch.setter
-    def recursiveDataSearch(self, new_value) -> None:
+    def setRecursiveDataSearch(self, new_value) -> None:
         """
         Set whether or not to search for a provided data file recursively
         in subfolders relative to the location of this widget.
@@ -431,6 +435,8 @@ class PyDMTemplateRepeater(QFrame, PyDMPrimitiveWidget):
             If recursive search should be enabled.
         """
         self._recursive_data_search = new_value
+
+    recursiveDataSearch = Property(bool, readRecursiveDataSearch, setRecursiveDataSearch)
 
     def open_template_file(self, variables=None):
         """

--- a/pydm/widgets/terminator.py
+++ b/pydm/widgets/terminator.py
@@ -1,11 +1,18 @@
 import math
 import logging
-from qtpy.QtCore import QTimer, Property, QEvent
+from qtpy.QtCore import QTimer, QEvent
 from qtpy.QtGui import QIcon
 from qtpy.QtWidgets import QLabel, QMessageBox, QApplication
 
 from .base import PyDMPrimitiveWidget, get_icon_file
 from pydm.utilities import is_qt_designer
+from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
+
+if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
+    from PySide6.QtCore import Property
+else:
+    from PyQt5.QtCore import pyqtProperty as Property
+
 
 logger = logging.getLogger(__name__)
 
@@ -154,8 +161,7 @@ class PyDMTerminator(QLabel, PyDMPrimitiveWidget):
         text = self._get_time_text(rem_time_s)
         self.setText("This screen will close in {}.".format(text))
 
-    @Property(int)
-    def timeout(self):
+    def readTimeout(self) -> int:
         """
         Timeout in seconds.
 
@@ -165,12 +171,13 @@ class PyDMTerminator(QLabel, PyDMPrimitiveWidget):
         """
         return self._timeout
 
-    @timeout.setter
-    def timeout(self, seconds):
+    def setTimeout(self, seconds) -> None:
         self.stop()
         if seconds and seconds > 0:
             self._timeout = seconds
             self.reset()
+
+    timeout = Property(int, readTimeout, setTimeout)
 
     def handle_timeout(self):
         """

--- a/pydm/widgets/timeplot.py
+++ b/pydm/widgets/timeplot.py
@@ -5,11 +5,17 @@ from typing import Optional
 from pyqtgraph import BarGraphItem, ViewBox, AxisItem
 import numpy as np
 from qtpy.QtGui import QColor, QCursor
-from qtpy.QtCore import Signal, Slot, Property, QTimer
+from qtpy.QtCore import Signal, Slot, QTimer
 from .baseplot import BasePlot, BasePlotCurveItem
 from .channel import PyDMChannel
 from pydm.utilities import remove_protocol, ACTIVE_QT_WRAPPER, QtWrapperTypes
 from datetime import datetime
+from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
+
+if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
+    from PySide6.QtCore import Property
+else:
+    from PyQt5.QtCore import pyqtProperty as Property
 
 import logging
 
@@ -1009,8 +1015,7 @@ class PyDMTimePlot(BasePlot):
         "bool", getUpdatesAsynchronously, setUpdatesAsynchronously, resetUpdatesAsynchronously, designable=False
     )
 
-    @Property(updateMode)
-    def updateMode(self):
+    def readUpdateMode(self) -> updateMode:
         """
         The updateMode to be used as property to set plot update mode.
 
@@ -1020,8 +1025,7 @@ class PyDMTimePlot(BasePlot):
         """
         return self._updateMode
 
-    @updateMode.setter
-    def updateMode(self, new_type):
+    def setUpdateMode(self, new_type) -> None:
         """
         The updateMode to be used as property to set plot update mode.
 
@@ -1032,6 +1036,8 @@ class PyDMTimePlot(BasePlot):
         if new_type != self._updateMode:
             self._updateMode = new_type
             self.setUpdatesAsynchronously(self._updateMode)
+
+    updateMode = Property(updateMode, readUpdateMode, setUpdateMode)
 
     def getTimeSpan(self):
         """

--- a/pydm/widgets/waveformtable.py
+++ b/pydm/widgets/waveformtable.py
@@ -1,8 +1,14 @@
 from qtpy.QtWidgets import QTableWidget, QTableWidgetItem, QApplication
 from qtpy.QtGui import QCursor
-from qtpy.QtCore import Slot, Property, Qt, QEvent
+from qtpy.QtCore import Slot, Qt, QEvent
 import numpy as np
 from .base import PyDMWritableWidget, PostParentClassInitSetup
+from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
+
+if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
+    from PySide6.QtCore import Property
+else:
+    from PyQt5.QtCore import pyqtProperty as Property
 
 
 class PyDMWaveformTable(QTableWidget, PyDMWritableWidget):
@@ -114,19 +120,17 @@ class PyDMWaveformTable(QTableWidget, PyDMWritableWidget):
             QApplication.setOverrideCursor(QCursor(Qt.ForbiddenCursor))
         return False
 
-    @Property("QStringList")
-    def columnHeaderLabels(self):
+    def readColumnHeaderLabels(self) -> list[str]:
         """
         Return the list of labels for the columns of the Table.
 
         Returns
         -------
-        list of strings
+        list[str]
         """
         return self._columnHeaders
 
-    @columnHeaderLabels.setter
-    def columnHeaderLabels(self, new_labels):
+    def setColumnHeaderLabels(self, new_labels) -> None:
         """
         Set the list of labels for the columns of the Table.
 
@@ -141,19 +145,19 @@ class PyDMWaveformTable(QTableWidget, PyDMWritableWidget):
         self._columnHeaders = new_labels
         self.setHorizontalHeaderLabels(self._columnHeaders)
 
-    @Property("QStringList")
-    def rowHeaderLabels(self):
+    columnHeaderLabels = Property("QStringList", readColumnHeaderLabels, setColumnHeaderLabels)
+
+    def readRowHeaderLabels(self) -> list[str]:
         """
         Return the list of labels for the rows of the Table.
 
         Returns
         -------
-        list of strings
+        list[str]
         """
         return self._rowHeaders
 
-    @rowHeaderLabels.setter
-    def rowHeaderLabels(self, new_labels):
+    def setRowHeaderLabels(self, new_labels) -> None:
         """
         Set the list of labels for the rows of the Table.
 
@@ -167,3 +171,5 @@ class PyDMWaveformTable(QTableWidget, PyDMWritableWidget):
             new_labels += (self.rowCount() - len(new_labels)) * [""]
         self._rowHeaders = new_labels
         self.setVerticalHeaderLabels(self._rowHeaders)
+
+    rowHeaderLabels = Property("QStringList", readRowHeaderLabels, setRowHeaderLabels)

--- a/run_tests.py
+++ b/run_tests.py
@@ -21,7 +21,7 @@ if __name__ == "__main__":
     # and a Windows PyCA build exists
     if os.name == "nt":
         args.append("--ignore=pydm/tests/data_plugins/test_p4p_plugin_component.py")
-        args.append("--ignore=pydm/tests/data_plugins/test_psp_plugin_component.py")
+    args.append("--ignore=pydm/tests/data_plugins/test_psp_plugin_component.py")
 
     print("pytest arguments: {}".format(args))
 


### PR DESCRIPTION
the current way we use the `@Property` function-decorator doesn't work with pyside6.

the docs for how to declare Properties in pyside6 are
here: https://doc.qt.io/qtforpython-6/PySide6/QtCore/Property.html.

the docs claim that `@Property` should work if you import it from
`PySide6.QtCore`, but from my testing it does not.

what does work is the `Property()` function, which has an equivalent
in pyqt5 `pyqtProperty()`. So the idea of this patch is to switch all
instances of `@Property` to the instead use the function calls, and
conditionally import them depending on the current API.