### PR TITLE
FIX: Plot view boxes were being garbage collected too soon with pyside6

### DIFF
--- a/pydm/widgets/multi_axis_plot.py
+++ b/pydm/widgets/multi_axis_plot.py
@@ -1,4 +1,3 @@
-import weakref
 from pyqtgraph import AxisItem, PlotDataItem, PlotItem, ViewBox
 from typing import List, Optional
 from qtpy.QtCore import Qt, Signal
@@ -36,7 +35,7 @@ class MultiAxisPlot(PlotItem):
         # A set containing view boxes which are stacked underneath the top level view. These views will be needed
         # in order to support multiple axes on the same plot. This set will remain empty if the plot has only
         # one set of axes
-        self.stackedViews = weakref.WeakSet()
+        self.stackedViews = set()
         viewBox.sigResized.connect(self.updateStackedViews, Qt.QueuedConnection)
 
         # Signals that will be emitted when mouse wheel or mouse drag events happen

--- a/pydm/widgets/multi_axis_viewbox_menu.py
+++ b/pydm/widgets/multi_axis_viewbox_menu.py
@@ -45,6 +45,7 @@ class MultiAxisViewBoxMenu(ViewBoxMenu):
         self.insertAction(self.viewAll, self.restoreRangesAction)
         self.removeAction(self.viewAll)
         self.insertAction(self.restoreRangesAction, self.viewAll)
+        self.viewAll.triggered.connect(self.autoRange)
 
     def set3ButtonMode(self):
         """Change the mouse left-click functionality to pan the plot"""


### PR DESCRIPTION
Fixes #1269 

### Context

As mentioned in that issue, PySide 6.9.1 will not work due to https://bugreports.qt.io/browse/PYSIDE-3115, but there was also a second issue to fix on the pydm side.

When running PyDM with any pyside6 version, plots using multiple axes would error out because the view boxes associated with those axes were being garbage collected right away unlike in PyQt5.

Fix is just to store the viewboxes in a set so there are strong references to them as along as the main plot containing them is still around. This change is fine, they didn't need to be weak refs in the first place, they are cleaned up correctly if their associated axes go away.

Also includes a fix to ensure the "View All" option in the right-click context menu continues to function properly by setting the plot to auto-range mode (which will auto-update the axes to show all data).

### Testing

Verified plots now render correctly when using pyside6 and pyqt5. Verified interactive functionality and menu options still work as well.

