### PR TITLE
TST: Fix macOS test runs

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -52,7 +52,7 @@ jobs:
         if [ "$RUNNER_OS" == "Windows" ]; then
           conda install -c conda-forge pydm pyqt=${{ matrix.pyqt-version }}
         elif [ "$RUNNER_OS" == "macOS" ]; then
-          mamba install -c conda-forge pydm pyqt=${{ matrix.pyqt-version }} git p4p=3.5.5 pyca
+          mamba install -c conda-forge pydm pyqt=${{ matrix.pyqt-version }} git pyca
         else
           mamba install -c conda-forge pydm pyqt=${{ matrix.pyqt-version }} pyca
         fi
@@ -83,7 +83,7 @@ jobs:
       timeout-minutes: 30 # timeout applies to single run of run_tests.py, not all os/python combos
       run: |
         if [ "$RUNNER_OS" == "macOS" ]; then
-          python run_tests.py --ignore=pydm/tests/widgets/test_slider.py # disable just for now, until fix intermittent issue
+          python run_tests.py --ignore=pydm/tests/data_plugins/test_p4p_plugin_component.py --ignore=pydm/tests/widgets/test_slider.py # disable just for now, until fix intermittent issue
         else 
           python run_tests.py
         fi

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -52,7 +52,7 @@ jobs:
         if [ "$RUNNER_OS" == "Windows" ]; then
           conda install -c conda-forge pydm pyqt=${{ matrix.pyqt-version }}
         elif [ "$RUNNER_OS" == "macOS" ]; then
-          mamba install -c conda-forge pydm pyqt=${{ matrix.pyqt-version }} git pyca
+          mamba install -c conda-forge pydm pyqt=${{ matrix.pyqt-version }} git p4p=3.5.5 pyca
         else
           mamba install -c conda-forge pydm pyqt=${{ matrix.pyqt-version }} pyca
         fi
@@ -60,10 +60,10 @@ jobs:
     - name: Install additional Python dependencies with pip
       shell: bash -el {0}
       run: |
-        if [ "$RUNNER_OS" == "Windows" ]; then
-          pip install .[test-no-optional]
-        else
+        if [ "$RUNNER_OS" == "Linux" ]; then
           pip install .[test]
+        else
+          pip install .[test-no-optional]
         fi
 
     - name: Install packages for testing a PyQt app on Linux

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -52,7 +52,7 @@ jobs:
         if [ "$RUNNER_OS" == "Windows" ]; then
           conda install -c conda-forge pydm pyqt=${{ matrix.pyqt-version }}
         elif [ "$RUNNER_OS" == "macOS" ]; then
-          mamba install -c conda-forge pydm pyqt=${{ matrix.pyqt-version }} git p4p pyca
+          mamba install -c conda-forge pydm pyqt=${{ matrix.pyqt-version }} git pyca
         else
           mamba install -c conda-forge pydm pyqt=${{ matrix.pyqt-version }} pyca
         fi
@@ -60,10 +60,10 @@ jobs:
     - name: Install additional Python dependencies with pip
       shell: bash -el {0}
       run: |
-        if [ "$RUNNER_OS" == "Linux" ]; then
-          pip install .[test]
-        else
+        if [ "$RUNNER_OS" == "Windows" ]; then
           pip install .[test-no-optional]
+        else
+          pip install .[test]
         fi
 
     - name: Install packages for testing a PyQt app on Linux


### PR DESCRIPTION
Removes the p4p data plugin test from macOS test runs.

The issue is that the a new version of p4p has been uploaded to conda-forge for the first time in a long while. This version seems to error out when installed alongside the conda-forge version of epicscorelibs.

Rather than attempt to work around it here (the pypi version causes the macOS runner to build epics from source which takes forever, the old 3.5.5 version of p4p doesn't work with python 3.12, carving out these very specific exceptions is just really ugly), it would be faster to fix it on the p4p side which I can do soon.

This just gets the tests passing again for now. And there should be no functional difference in the plugin code being tested between the different operating systems.