### PR TITLE
MNT: change any min python version references to 3.10

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: conda-incubator/setup-miniconda@v2
         with:
-          python-version: 3.9
+          python-version: 3.10
           mamba-version: "*"
           channels: conda-forge
           activate-environment: pydm-docs

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ as the abstraction layer for the Qt Python wrappers (PyQt5/PyQt4/PySide2/PySide)
 **All tests are performed with PyQt5**.
 
 # Prerequisites
-* Python 3.9+
+* Python 3.10+
 * Qt 5.6 or higher
 * qtpy
 * PyQt5 >= 5.7 or any other Qt Python wrapper.

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -16,14 +16,14 @@ build:
 
 requirements:
   host:
-    - python >=3.9
+    - python >=3.10
     - pip
     - setuptools
     - setuptools_scm
     - pyqt =5
     - qtpy >=2.2.0
   run:
-    - python >=3.9
+    - python >=3.10
     - six
     - numpy
     - scipy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Operating System :: OS Independent"
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dynamic = ["version", "dependencies", "optional-dependencies"]
 
 [project.scripts]


### PR DESCRIPTION
min supported python for pydm is now 3.10 (bumped from 3.9)