### PR TITLE
MNT/TST: add pyside6 testing runs to gh-actions automation 

### DIFF
--- a/.github/workflows/run-tests-pyqt5.yml
+++ b/.github/workflows/run-tests-pyqt5.yml
@@ -1,0 +1,89 @@
+# This workflow will install pydm dependencies and run the test suite using PyQt5 for all combinations
+# of operating systems and version numbers specified in the matrix
+
+name: PyQt5 Testing
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+permissions:
+  contents: read
+
+jobs:
+  build-pyqt5:
+    if: ${{ github.repository == 'slac/pydm' }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        # eventually we should just run 3.10 + pyqt 5.12.3 (or if fix designer issue, latest pyqt5 and latest python that works with it),
+        # and latest-python + latest-pyside6
+        python-version: ["3.10", "3.12"]
+        pyqt-version: ["5.12.3", "5.15.11"]  # we still use 5.12.3 since newer conda versions have designer plugin issues
+        exclude:
+          # don't run these
+          - python-version: "3.10"  # 5.15.11 is newest pyqt5, so use newest python (3.12) 
+            pyqt-version: "5.15.11" 
+          - python-version: "3.12"  # max python version for 5.12.3 is 3.10 (3.12 errors during conda env creation)
+            pyqt-version: "5.12.3" 
+    env:
+      DISPLAY: ':99.0'
+      QT_MAC_WANTS_LAYER: 1  # PyQT gui tests involving qtbot interaction on macOS will fail without this
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup conda
+      uses: conda-incubator/setup-miniconda@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+        miniforge-variant: Miniforge3
+        miniforge-version: latest
+        activate-environment: pydm-env
+        conda-remove-defaults: true
+        architecture: x64  # Ensure macOS finds PyQt 5.12.3 which isn't available with osx-arm64
+
+    - name: Install PyDM with PyQt5
+      shell: bash -el {0}
+      run: |
+        if [ "$RUNNER_OS" == "Windows" ]; then
+          conda install -c conda-forge pydm pyqt=${{ matrix.pyqt-version }}
+        elif [ "$RUNNER_OS" == "macOS" ]; then
+          mamba install -c conda-forge pydm pyqt=${{ matrix.pyqt-version }} git pyca
+        else
+          mamba install -c conda-forge pydm pyqt=${{ matrix.pyqt-version }} pyca
+        fi
+
+    - name: Install additional Python dependencies with pip
+      shell: bash -el {0}
+      run: |
+        if [ "$RUNNER_OS" == "Linux" ]; then
+          pip install .[test]
+        else
+          pip install .[test-no-optional]
+        fi
+
+    - name: Install packages for testing a PyQt/PySide app on Linux
+      shell: bash -el {0}
+      run: |
+        if [ "$RUNNER_OS" == "Linux" ]; then
+          sudo apt update
+          sudo apt install -y xvfb herbstluftwm libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 x11-utils
+          sudo /sbin/start-stop-daemon --start --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1024x768x24 -ac +extension GLX +render -noreset
+          sleep 3
+          sudo /sbin/start-stop-daemon --start --pidfile /tmp/custom_herbstluftwm_99.pid --make-pidfile --background --exec /usr/bin/herbstluftwm
+          sleep 1
+        fi
+
+    - name: Test with pytest
+      shell: bash -el {0}
+      timeout-minutes: 30 # timeout applies to single run of run_tests.py, not all os/python combos
+      run: |
+        if [ "$RUNNER_OS" == "macOS" ]; then
+          python run_tests.py --ignore=pydm/tests/data_plugins/test_p4p_plugin_component.py --ignore=pydm/tests/widgets/test_slider.py # disable just for now, until fix intermittent issue
+        else 
+          python run_tests.py
+        fi

--- a/.github/workflows/run-tests-pyside6.yml
+++ b/.github/workflows/run-tests-pyside6.yml
@@ -1,7 +1,7 @@
-# This workflow will install pydm dependencies and run the test suite for all combinations
+# This workflow will install pydm dependencies and run the test suite using PySide6 for all combinations
 # of operating systems and version numbers specified in the matrix
 
-name: Build Status
+name: PySide6 Testing
 
 on:
   push:
@@ -13,29 +13,23 @@ permissions:
   contents: read
 
 jobs:
-  build:
-    if: ${{ github.repository == 'slaclab/pydm' }}
+  build-pyside6:
+    if: ${{ github.repository == 'nstelter-slac/pydm' }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        # eventually we should just run 3.10 + pyqt 5.12.3 (or if fix designer issue, latest pyqt5 and latest python that works with it),
-        # and latest-python + latest-pyside6
-        python-version: ["3.10", "3.12"]
-        pyqt-version: ["5.12.3", "5.15.11"]  # we still use 5.12.3 since newer conda versions have designer plugin issues
-        exclude:
-          # don't run these
-          - python-version: "3.10"  # 5.15.11 is newest pyqt5, so use newest python (3.12) 
-            pyqt-version: "5.15.11" 
-          - python-version: "3.12"  # max python version for 5.12.3 is 3.10 (3.12 errors during conda env creation)
-            pyqt-version: "5.12.3" 
+        python-version: ["3.12"]
+
     env:
       DISPLAY: ':99.0'
-      QT_MAC_WANTS_LAYER: 1  # PyQT gui tests involving qtbot interaction on macOS will fail without this
+      QT_MAC_WANTS_LAYER: 1
+      QT_API: pyside6
 
     steps:
     - uses: actions/checkout@v4
+
     - name: Setup conda
       uses: conda-incubator/setup-miniconda@v3
       with:
@@ -44,17 +38,17 @@ jobs:
         miniforge-version: latest
         activate-environment: pydm-env
         conda-remove-defaults: true
-        architecture: x64  # Ensure macOS finds PyQt 5.12.3 which isn't available with osx-arm64
+        architecture: x64
 
-    - name: Install PyDM with Mamba
+    - name: Install PyDM with PySide6
       shell: bash -el {0}
       run: |
         if [ "$RUNNER_OS" == "Windows" ]; then
-          conda install -c conda-forge pydm pyqt=${{ matrix.pyqt-version }}
+          conda install -c conda-forge pydm pyside6
         elif [ "$RUNNER_OS" == "macOS" ]; then
-          mamba install -c conda-forge pydm pyqt=${{ matrix.pyqt-version }} git pyca
+          mamba install -c conda-forge pydm pyside6 git pyca
         else
-          mamba install -c conda-forge pydm pyqt=${{ matrix.pyqt-version }} pyca
+          mamba install -c conda-forge pydm pyside6 pyca
         fi
 
     - name: Install additional Python dependencies with pip
@@ -66,7 +60,7 @@ jobs:
           pip install .[test-no-optional]
         fi
 
-    - name: Install packages for testing a PyQt app on Linux
+    - name: Install packages for testing a PyQt/PySide app on Linux
       shell: bash -el {0}
       run: |
         if [ "$RUNNER_OS" == "Linux" ]; then
@@ -80,10 +74,10 @@ jobs:
 
     - name: Test with pytest
       shell: bash -el {0}
-      timeout-minutes: 30 # timeout applies to single run of run_tests.py, not all os/python combos
+      timeout-minutes: 30
       run: |
         if [ "$RUNNER_OS" == "macOS" ]; then
-          python run_tests.py --ignore=pydm/tests/data_plugins/test_p4p_plugin_component.py --ignore=pydm/tests/widgets/test_slider.py # disable just for now, until fix intermittent issue
+          python run_tests.py --ignore=pydm/tests/data_plugins/test_p4p_plugin_component.py --ignore=pydm/tests/widgets/test_slider.py  # disable just for now, until fix intermittent issue
         else 
           python run_tests.py
         fi

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-[![Build Status](https://github.com/slaclab/pydm/actions/workflows/run-tests.yml/badge.svg?branch=master)](https://github.com/slaclab/pydm/actions/workflows/run-tests.yml)
+[![Build Status: PySide6](https://github.com/slaclab/pydm/actions/workflows/run-tests-pyqt5.yml/badge.svg?branch=master)](https://github.com/slaclab/pydm/actions/workflows/run-tests-pyqt5.yml)
+[![Build Status: PyQt5](https://github.com/slaclab/pydm/actions/workflows/run-tests-pyside6.yml/badge.svg?branch=master)](https://github.com/slaclab/pydm/actions/workflows/run-tests-pyside6.yml)
 
 ![PyDM: Python Display Manager](pydm_banner_full.png)
 

--- a/run_tests.py
+++ b/run_tests.py
@@ -2,7 +2,6 @@
 import os
 import sys
 import pytest
-from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
 
 if __name__ == "__main__":
     # Show output results from every test function
@@ -23,10 +22,6 @@ if __name__ == "__main__":
     if os.name == "nt":
         args.append("--ignore=pydm/tests/data_plugins/test_p4p_plugin_component.py")
         args.append("--ignore=pydm/tests/data_plugins/test_psp_plugin_component.py")
-
-    if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
-        args.append("--ignore=pydm/tests/data_plugins")
-        args.append("--ignore=pydm/tests/widgets/test_baseplot.py")
 
     print("pytest arguments: {}".format(args))
 

--- a/run_tests.py
+++ b/run_tests.py
@@ -2,6 +2,7 @@
 import os
 import sys
 import pytest
+from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
 
 if __name__ == "__main__":
     # Show output results from every test function
@@ -22,6 +23,10 @@ if __name__ == "__main__":
     if os.name == "nt":
         args.append("--ignore=pydm/tests/data_plugins/test_p4p_plugin_component.py")
     args.append("--ignore=pydm/tests/data_plugins/test_psp_plugin_component.py")
+
+    if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
+        args.append("--ignore=pydm/tests/data_plugins")
+        args.append("--ignore=pydm/tests/widgets/test_baseplot.py")
 
     print("pytest arguments: {}".format(args))
 


### PR DESCRIPTION
for now just pass pyside6 tests regardless, use the result as reference on pyside6 status and not blocking for merge.

made a separate yaml file for pyside6 setup/running to avoid
complicating the pyqt5 yaml file any more.