### PR TITLE
FIX: More Fixes to the FormulaCurveItem

### DIFF
--- a/pydm/widgets/archiver_time_plot.py
+++ b/pydm/widgets/archiver_time_plot.py
@@ -746,7 +746,7 @@ class FormulaCurveItem(BasePlotCurveItem):
             self.archive_points_accumulated = mid
             self.points_accumulated = ts.shape[0] - mid
             return
-        
+
         all_constants = all(isinstance(c, FormulaCurveItem) and not c.pvs for c in self.pvs.values())
         if not all_constants and not (self.connected or self.arch_connected):
             return

--- a/pydm/widgets/archiver_time_plot.py
+++ b/pydm/widgets/archiver_time_plot.py
@@ -315,7 +315,7 @@ class ArchivePlotCurveItem(TimePlotCurveItem):
                 idx = np.where(x == self.base_time)
                 y = np.delete(y, idx)
                 x = np.delete(x, idx)
-                
+
                 self.setData(y=y, x=x)
 
             except (ZeroDivisionError, OverflowError, TypeError):
@@ -1031,6 +1031,7 @@ class FormulaCurveItem(BasePlotCurveItem):
         for curve in self.pvs.keys():
             minx = max(self.pvs[curve].min_x(), minx)
         return minx
+
     def min_archiver_x(self):
         """
         Provide the the oldest valid timestamp from the archiver data buffer.
@@ -1094,6 +1095,7 @@ class FormulaCurveItem(BasePlotCurveItem):
     @units.setter
     def units(self, _value: str) -> None:
         pass
+
 
 class PyDMArchiverTimePlot(PyDMTimePlot):
     """
@@ -1285,7 +1287,7 @@ class PyDMArchiverTimePlot(PyDMTimePlot):
                 # Max amount of raw data to return before using optimized data
                 max_data_request = int(0.80 * self.getArchiveBufferSize())
                 if requested_seconds > max_data_request:
-                    if hasattr(curve, 'optimized_data_bins') and curve.optimized_data_bins:
+                    if hasattr(curve, "optimized_data_bins") and curve.optimized_data_bins:
                         optimized_data_bins = curve.optimized_data_bins
                     else:
                         optimized_data_bins = self.optimized_data_bins
@@ -1455,8 +1457,6 @@ class PyDMArchiverTimePlot(PyDMTimePlot):
         formula_curve = FormulaCurveItem(yAxisName=yAxisName, **kwargs)
 
         self._curves.append(formula_curve)
-
-        # self.plotItem.addItem(formula_curve)
         self.plotItem.linkDataToAxis(formula_curve, yAxisName)
 
         return formula_curve

--- a/pydm/widgets/archiver_time_plot.py
+++ b/pydm/widgets/archiver_time_plot.py
@@ -312,10 +312,6 @@ class ArchivePlotCurveItem(TimePlotCurveItem):
                     )
                 )
 
-                idx = np.where(x == self.base_time)
-                y = np.delete(y, idx)
-                x = np.delete(x, idx)
-
                 self.setData(y=y, x=x)
 
             except (ZeroDivisionError, OverflowError, TypeError):
@@ -591,7 +587,6 @@ class FormulaCurveItem(BasePlotCurveItem):
         self.pvs = pvs if pvs else {}
         self._liveData = liveData
         self.plot_style = plot_style
-        self.base_time = time.time()
         self.connected, self.arch_connected = None, None
         self.live_connections, self.arch_connections = {}, {}
 

--- a/pydm/widgets/timeplot.py
+++ b/pydm/widgets/timeplot.py
@@ -126,6 +126,8 @@ class TimePlotCurveItem(BasePlotCurveItem):
         super().__init__(**kws)
         self.address = channel_address
 
+        self.base_time = time.time()
+
     def to_dict(self):
         dic_ = OrderedDict([("channel", self.address), ("plot_style", self.plot_style)])
         dic_.update(super().to_dict())
@@ -320,7 +322,7 @@ class TimePlotCurveItem(BasePlotCurveItem):
         # If you don't specify dtype=float, you don't have enough
         # resolution for the timestamp data.
         self.data_buffer = np.zeros((2, self._bufferSize), order="f", dtype=float)
-        self.data_buffer[0].fill(time.time())
+        self.data_buffer[0].fill(self.base_time)
 
     def getBufferSize(self):
         return int(self._bufferSize)

--- a/pydm/widgets/timeplot.py
+++ b/pydm/widgets/timeplot.py
@@ -126,8 +126,6 @@ class TimePlotCurveItem(BasePlotCurveItem):
         super().__init__(**kws)
         self.address = channel_address
 
-        self.base_time = time.time()
-
     def to_dict(self):
         dic_ = OrderedDict([("channel", self.address), ("plot_style", self.plot_style)])
         dic_.update(super().to_dict())
@@ -322,7 +320,7 @@ class TimePlotCurveItem(BasePlotCurveItem):
         # If you don't specify dtype=float, you don't have enough
         # resolution for the timestamp data.
         self.data_buffer = np.zeros((2, self._bufferSize), order="f", dtype=float)
-        self.data_buffer[0].fill(self.base_time)
+        self.data_buffer[0].fill(time.time())
 
     def getBufferSize(self):
         return int(self._bufferSize)


### PR DESCRIPTION
## Description 
This PR is to address some persistent and new issues with the FormulaCurveItem. 

1. Small spelling mistake in remove_extension_line()
2. Fixes error in remove_error_bar and remove_extension_line leading to a `RuntimeError: Internal C++ object (MultiAxisViewBox) already deleted `
3. An issue with FormulaCurveItems not having 'optimized_data_bins'
4. Formula curves being duplicate on plot legends 
5. FormulaCurveItems not having Address and Units properties 
6. fix case where a formula is made up of constant formulas f://{f://1}+{f://2}