### PR TITLE
FIX: Archive plots displaying a zero data point when no live data is present

### DIFF
--- a/pydm/widgets/archiver_time_plot.py
+++ b/pydm/widgets/archiver_time_plot.py
@@ -301,14 +301,18 @@ class ArchivePlotCurveItem(TimePlotCurveItem):
                 x = np.concatenate(
                     (
                         self.archive_data_buffer[0, -self.archive_points_accumulated :].astype(float),
-                        self.data_buffer[0, -self.points_accumulated :].astype(float),
+                        self.data_buffer[0, -self.points_accumulated :].astype(float)
+                        if self.points_accumulated > 0
+                        else np.empty(0, dtype=float),  # If there is no live data, just show the archive data only
                     )
                 )
 
                 y = np.concatenate(
                     (
                         self.archive_data_buffer[1, -self.archive_points_accumulated :].astype(float),
-                        self.data_buffer[1, -self.points_accumulated :].astype(float),
+                        self.data_buffer[1, -self.points_accumulated :].astype(float)
+                        if self.points_accumulated > 0
+                        else np.empty(0, dtype=float),
                     )
                 )
 


### PR DESCRIPTION
## Context

When there is no live data present, the archive plot will drop to zero because it is trying to plot a zero data point from the empty live buffer. This fixes it by ensuring nothing from the live data buffer is used if there are no live data points yet.

## Testing

Verified the plot curve no longer drops to zero when started without live data.
