### PR TITLE
TST: Use America/New_York instead of US/Eastern in tests

### DIFF
--- a/pydm/tests/widgets/test_datetime_edit.py
+++ b/pydm/tests/widgets/test_datetime_edit.py
@@ -89,7 +89,7 @@ def test_value_changed(qtbot, signals, value, expected_value):
     if platform.system() == "Windows":
         return
 
-    os.environ["TZ"] = "US/Eastern"
+    os.environ["TZ"] = "America/New_York"
     time.tzset()
 
     pydm_datetimeedit = PyDMDateTimeEdit()

--- a/pydm/tests/widgets/test_datetime_label.py
+++ b/pydm/tests/widgets/test_datetime_label.py
@@ -80,7 +80,7 @@ def test_value_changed(qtbot, signals, value, text_format, expected_value):
     if platform.system() == "Windows":
         return
 
-    os.environ["TZ"] = "US/Eastern"
+    os.environ["TZ"] = "America/New_York"
     time.tzset()
 
     pydm_label = PyDMDateTimeLabel()


### PR DESCRIPTION
### Context

A few tests started failing locally for me. It was because the `US/Eastern` time zone was moved into `tzdata-legacy` by default in the most recent Debian release

https://www.debian.org/releases/trixie/release-notes/issues.html#timezones-split-off-into-tzdata-legacy-package

Installing the package works fine, but figured I'd just make a quick update here to use the preferred name instead.

### Testing

Tests still pass, and their functionality is unchanged. `US/Eastern` just linked to `America/New_York`