### PR TITLE
DOC: add basic info and install instructions for pyside6 usage to the docs

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -64,7 +64,16 @@ Ready to contribute? Here's how to set up `pydm` for local development.
 3. Install your local copy into a new conda environment. Assuming you have conda installed, this is how you set up your fork for local development::
 
     $ conda create -n pydm-environment python=3.10 pyqt=5.12.3 pip numpy scipy six psutil pyqtgraph -c conda-forge
+    $ conda activate pydm-environment
     $ cd pydm/
+    $ pip install -e .
+
+   PyDM also supports running on PySide6 (current functionality should be the same using PyQt5 or PySide6)::
+
+    $ conda create -n pydm-environment-pyside6 python=3.12 pip numpy scipy six psutil pyqtgraph -c conda-forge # or use same environment as PyQt5.
+    $ conda activate pydm-environment-pyside6
+    $ pip install pyside6 # for now, we suggest installing PySide6 with pip to avoid some weirdness with QtDesigner in the PySide6 conda package.
+    $ cd pydm
     $ pip install -e .
 
 4. Install additional packages only needed for development and building the docs::
@@ -72,33 +81,39 @@ Ready to contribute? Here's how to set up `pydm` for local development.
     $ pip install -r dev-requirements.txt
     $ pip install -r docs-requirements.txt
 
-5. Create a branch for local development::
+5: Now you should be able to launch pydm as follows:
+
+    $ export QT_API=pyqt5 # or `export QT_AP=pyside6`, this determines which python wrapper pydm will use (chosen wrapper must be installed in the curr conda env).
+    $ pydm # launches an empty main-window
+    $ pydm example.ui # launches PyDM screen
+
+6. Create a branch for local development::
 
     $ git checkout -b name-of-your-bugfix-or-feature
 
    Now you can make your changes locally.
 
-6. Install and enable ``pre-commit`` for this repository::
+7. Install and enable ``pre-commit`` for this repository::
 
     $ pip install pre-commit
     $ pre-commit install
 
-7. Add new tests for any additional functionality or bugs you may have discovered.  And of course, be sure that all previous tests still pass by running::
+8. Add new tests for any additional functionality or bugs you may have discovered.  And of course, be sure that all previous tests still pass by running::
 
     $ python run_tests.py
 
-8. Add documentation for any new features and algorithms into the .rst files of the /docs directory. Create a local build of the docs by running::
+9. Add documentation for any new features and algorithms into the .rst files of the /docs directory. Create a local build of the docs by running::
 
     $ cd docs
     $ make html
 
-8. Commit your changes and push your branch to GitHub::
+10. Commit your changes and push your branch to GitHub::
 
     $ git add .
     $ git commit -m "Your detailed description of your changes."
     $ git push origin name-of-your-bugfix-or-feature
 
-9. Submit a pull request through the GitHub website.
+11. Submit a pull request through the GitHub website.
 
 Pull Request Guidelines
 -----------------------
@@ -128,9 +143,9 @@ Commit messages should be clear and follow a few basic rules. Example:
     characters.  If the commit is related to a ticket, indicate that with
     "See #3456", "See ticket 3456", "Closes #3456" or similar.
 
-Describing the motivation for a change, the nature of a bug for bug fixes 
-or some details on what an enhancement does are also good to include in a 
-commit message. Messages should be understandable without looking at the code 
+Describing the motivation for a change, the nature of a bug for bug fixes
+or some details on what an enhancement does are also good to include in a
+commit message. Messages should be understandable without looking at the code
 changes. 
 
 Standard acronyms to start the commit message with are:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 </p>
 
 <p align="left">
-  PyDM is a PyQt-based framework for building user interfaces for control systems.
+  PyDM is a Python-Qt based framework for building user interfaces for control systems.
   The goal is to provide a no-code, drag-and-drop system to make simple screens,
   as well as a straightforward Python framework to build complex applications.
   <br>
@@ -32,18 +32,18 @@
 
 # Python Qt Wrapper
 PyDM project uses the [qtpy](https://github.com/spyder-ide/qtpy)
-as the abstraction layer for the Qt Python wrappers (PyQt5/PyQt4/PySide2/PySide).
+as the abstraction layer for the Qt Python wrappers (PyQt5/PyQt4/PySide2/PySide6).
 **All tests are performed with PyQt5**.
 
 # Prerequisites
-* Python 3.10+
+* Python >= 3.10, <= 3.12
 * Qt 5.6 or higher
 * qtpy
-* PyQt5 >= 5.7 or any other Qt Python wrapper.
+* PyQt5 >= 5.7 or PySide6 >= 6.9.2
 > **Note:**
 > If you'd like to use Qt Designer (drag-and-drop tool to build interfaces) you'll
-> need to make sure you have the PyQt plugin for Designer installed.  This usually
-> happens automatically when you install PyQt from source, but if you install it
+> need to make sure you have the PyQt5/PySide6 plugin for Designer installed.  This usually
+> happens automatically when you install PyQt5/PySide6 from source, but if you install it
 > from a package manager, it may be left out.
 
 Python package requirements are listed in the requirements.txt file, which can
@@ -110,10 +110,12 @@ Documentation is available at http://slaclab.github.io/pydm/.  Documentation is
 somewhat sparse right now, unfortunately.
 
 # Widget Designer Plugins
-pydm widgets are written in Python, and are loaded into Qt Designer via the PyQt
+PyDM widgets are written in Python, and are loaded into Qt Designer via the PyQt5/PySide6 Qt
 Designer Plugin.
-If you want to use the pydm widgets in Qt Designer, add the pydm directory
-(which holds designer_plugin.py) to your PYQTDESIGNERPATH environment variable.
+
+For PyQt5, if you want to use the pydm widgets in Qt Designer, add the pydm directory
+(which holds `register_pydm_designer_plugin.py`) to your `PYQTDESIGNERPATH` environment variable.
+For PySide6, add the pydm directory to your `PYSIDE_DESIGNER_PLUGINS` environment variable instead.
 Eventually, this will happen automatically in some kind of setup script.
 
 # Easy Installing PyDM

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -44,7 +44,7 @@ about:
   license_file: LICENSE.md
   summary: 'Python Display Manager'
   description: |
-    PyDM is a PyQt-based framework for building user interfaces for control systems.
+    PyDM is a Python-Qt based framework for building user interfaces for control systems.
     The goal is to provide a no-code, drag-and-drop system to make simple screens,
     as well as a straightforward Python framework to build complex applications.
   doc_url: https://slaclab.github.io/pydm/

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,7 +1,7 @@
 PyDM - Python Display Manager
 =============================
 
-PyDM is a PyQt-based framework for building user interfaces for control systems.
+PyDM is a Python-Qt based framework for building user interfaces for control systems.
 
 The goal is to provide a no-code, drag-and-drop system to make simple screens,
 as well as a straightforward python framework to build complex applications.

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -25,7 +25,7 @@ Installing PyDM and Prerequisites with Conda
 
 After installing Miniforge (see https://conda-forge.org/download/), create a new
 environment for PyDM::
-  
+
   $ conda create -n pydm-environment python=3.10 pyqt=5 pip numpy scipy six psutil pyqtgraph pydm -c conda-forge
   $ source activate pydm-environment
 
@@ -48,7 +48,7 @@ Now, you can use 'open' to open Designer.app::
 
     $ export QT_MAC_WANTS_LAYER=1
 
-Installing Manually, Without Anaconda
+Installing Manually, Without Anaconda (PyQt5)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 This alternate installation method is only recommended for large 'site' installations that want to avoid using Anaconda.
 
@@ -78,14 +78,18 @@ and extract the archive.  Follow `the provided instructions <http://pyqt.sourcef
 build and install it.  Note that you may need to manually set the '--qmake' option to point to the
 qmake binary you created when you built Qt5.
 
+Installing Manually, Without Anaconda (PySide6)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Instructions coming soon...
+
 Installing PyDM with PIP
 ++++++++++++++++++++++++
 
 PyDM is part of the Python Package Index (PyPI), so you can install it with pip:
 
   $ pip install pydm
-  
-This will download and install all the necessary python dependencies, then will install 
+
+This will download and install all the necessary python dependencies, then will install
 PyDM.  (You'll still need the Qt and PyQt install from above).
 
 Setting Environment Variables

--- a/docs/source/tutorials/action/intro_python.rst
+++ b/docs/source/tutorials/action/intro_python.rst
@@ -28,8 +28,8 @@ widgets later in your code.
 Writing The Code For Your Display
 ---------------------------------
 
-Python-based displays in PyDM are mostly just PyQt widgets with a few extra features
-on top.  This guide expects that you have a basic familiarity with PyQt and Qt itself.
+Python-based displays in PyDM are mostly just Qt widgets with a few extra features
+on top.  This guide expects that you have a basic familiarity with PyQt or PySide and Qt itself.
 Good resources for these topics are available online.  The Qt documentation, especially,
 is very thorough, and will come in handy as you build your display.
 
@@ -38,7 +38,7 @@ is very thorough, and will come in handy as you build your display.
 Subclassing Display
 ^^^^^^^^^^^^^^^^^^^
 
-Python-based displays are just PyQt widgets, based on PyDM's 'Display' class.
+Python-based displays are just Qt widgets, based on PyDM's 'Display' class.
 Your display must subclass Display, and implement a few required methods::
 
   from os import path
@@ -128,7 +128,7 @@ from some other source of data, like a file or database.  As mentioned in
 `Handling Command Line Arguments`_, you can read in command line arguments to help
 get data into your display.
 
-Once you have a source of data, you can use PyQt to make new widgets, and add them
+Once you have a source of data, you can use Qt to make new widgets, and add them
 to your display.  For example, if you get a list of devices from somewhere, you can
 make widgets for each device, and add them to a layout you defined in the .ui file::
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pydm"
-description = "A PyQt-based framework for building user interfaces for control systems"
+description = "A Python-Qt based framework for building user interfaces for control systems"
 readme = "README.md"
 authors = [ {name = "SLAC National Accelerator Laboratory"} ]
 classifiers = [


### PR DESCRIPTION
appears that running with python 3.14 caues issues with pyside6,
and > 3.12 hits an issue with shiboken6?

so lets limit to python <= 3.12 for now.