### PR TITLE
FIX: Eliminate error when setting the color map for an image view

### DIFF
--- a/pydm/widgets/image.py
+++ b/pydm/widgets/image.py
@@ -1,4 +1,3 @@
-from enum import Enum
 from qtpy.QtWidgets import QActionGroup
 from qtpy.QtCore import Signal, Slot, QTimer, QThread
 from pyqtgraph import ImageView, PlotItem
@@ -9,7 +8,6 @@ import logging
 from .channel import PyDMChannel
 from .colormaps import cmaps, cmap_names, PyDMColorMap
 from .base import PyDMWidget, PostParentClassInitSetup
-from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
 from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
 
 if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:


### PR DESCRIPTION
### Context

Fixes #1311 

In #1280 the setter was renamed to `setColorMap` which should have been fine, except another method in the class was already named `setColorMap`. The second definition was then mistakenly called by the property setter, resulting in the error seen. This just ensures the property setter gets called again as expected, without affecting any code that wanted to call the method that was already named `setColorMap`.

### Testing

Verified the `colorMap` property can be set correctly in designer again.