### PR TITLE
BLD: Ensure build job complete before running publish

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -38,6 +38,7 @@ jobs:
         retention-days: 1
 
   publish:
+    needs: build
     if: ${{ github.repository == 'slaclab/pydm' }}
     name: Publish release to PyPI
     runs-on: ubuntu-latest


### PR DESCRIPTION
A small fix to avoid the error here:

https://github.com/slaclab/pydm/actions/runs/21880220860/job/63160300053

where the second job is running before the built code has been uploaded.
