### PR TITLE
TST: Fix error during ubuntu test workflow

### DIFF
--- a/.github/workflows/run-tests-pyqt5.yml
+++ b/.github/workflows/run-tests-pyqt5.yml
@@ -54,7 +54,7 @@ jobs:
         elif [ "$RUNNER_OS" == "macOS" ]; then
           mamba install -c conda-forge pydm pyqt=${{ matrix.pyqt-version }} git pyca
         else
-          mamba install -c conda-forge pydm pyqt=${{ matrix.pyqt-version }} pyca
+          mamba install -c conda-forge pydm pyqt=${{ matrix.pyqt-version }}
         fi
 
     - name: Install additional Python dependencies with pip

--- a/.github/workflows/run-tests-pyside6.yml
+++ b/.github/workflows/run-tests-pyside6.yml
@@ -48,7 +48,7 @@ jobs:
         elif [ "$RUNNER_OS" == "macOS" ]; then
           mamba install -c conda-forge pydm pyside6 git pyca
         else
-          mamba install -c conda-forge pydm pyside6 pyca
+          mamba install -c conda-forge pydm pyside6
         fi
 
     - name: Install additional Python dependencies with pip

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,4 +4,5 @@ pytest-qt
 pytest-cov
 pytest-timeout
 p4p
+pyca-epics
 pre-commit


### PR DESCRIPTION
Installs pyca-epics from PyPI for the Ubuntu runner to avoid an epicscorelibs compatibility error seen during test runs


```
==================================== ERRORS ====================================
____ ERROR collecting pydm/tests/data_plugins/test_psp_plugin_component.py _____
ImportError while importing test module '/home/runner/work/pydm/pydm/pydm/tests/data_plugins/test_psp_plugin_component.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
../../../miniconda3/envs/pydm-env/lib/python3.10/site-packages/_pytest/python.py:507: in importtestmodule
    mod = import_path(
../../../miniconda3/envs/pydm-env/lib/python3.10/site-packages/_pytest/pathlib.py:587: in import_path
    importlib.import_module(module_name)
../../../miniconda3/envs/pydm-env/lib/python3.10/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
<frozen importlib._bootstrap>:1050: in _gcd_import
    ???
<frozen importlib._bootstrap>:1027: in _find_and_load
    ???
<frozen importlib._bootstrap>:1006: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:688: in _load_unlocked
    ???
../../../miniconda3/envs/pydm-env/lib/python3.10/site-packages/_pytest/assertion/rewrite.py:197: in exec_module
    exec(co, module.__dict__)
pydm/tests/data_plugins/test_psp_plugin_component.py:3: in <module>
    import pydm.data_plugins.epics_plugins.psp_plugin_component
pydm/data_plugins/epics_plugins/psp_plugin_component.py:7: in <module>
    import pyca
E   ImportError: libca.so.7.0.7.99.1: cannot open shared object file: No such file or directory
!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!
=============================== 1 error in 1.51s ===============================
Error: Process completed with exit code 2.

```
