### PR TITLE
Fix PySide6 scoped enum comparison failures across widget classes

### DIFF
--- a/pydm/widgets/analog_indicator.py
+++ b/pydm/widgets/analog_indicator.py
@@ -64,7 +64,7 @@ class QScaleAlarmed(QScale):
         # We originally used QWIDGETSIZE_MAX here but the macro is only defined in PyQt and not PySide.
         # Instead we use it's direct value from the docs: https://doc.qt.io/qt-6/qwidget.html#QWIDGETSIZE_MAX
         self.setMaximumSize(16777215, 16777215)  # Unset fixed size
-        if self._orientation == Qt.Horizontal:
+        if self._orientation == Qt.Horizontal or self._orientation == 1:
             self._widget_width = self.width()
             self._widget_height = self.height()
             self._painter_translation_y = 0
@@ -72,7 +72,7 @@ class QScaleAlarmed(QScale):
             # expands scale in horizontal position
             self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
             self.setFixedHeight(self._scale_height)
-        elif self._orientation == Qt.Vertical:
+        elif self._orientation == Qt.Vertical or self._orientation == 2:
             # Invert dimensions for paintEvent()
             self._widget_width = self.height()
             self._widget_height = self.width()

--- a/pydm/widgets/baseplot.py
+++ b/pydm/widgets/baseplot.py
@@ -310,7 +310,10 @@ class BasePlotCurveItem(PlotDataItem):
         -------
         new_style: Qt.PenStyle
         """
-        if new_style in self.lines.values():
+        valid_styles = set(self.lines.values())
+        if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6 and isinstance(new_style, int):
+            new_style = Qt.PenStyle(new_style)
+        if new_style in valid_styles:
             self._pen.setStyle(new_style)
             self.setPen(self._pen)
 

--- a/pydm/widgets/byte.py
+++ b/pydm/widgets/byte.py
@@ -210,7 +210,8 @@ class PyDMByteIndicator(QWidget, PyDMWidget):
         # This is a horrendous mess of if statements
         # for every possible case.  Ugh.
         # There is probably a more clever way to do this.
-        if self.orientation == Qt.Vertical:
+        orient = self.orientation
+        if orient == Qt.Vertical or orient == 2:
             for i, (label, indicator) in enumerate(pairs):
                 if self.labelPosition == QTabWidget.East:
                     self.layout().addWidget(indicator, i, 0)
@@ -224,7 +225,7 @@ class PyDMByteIndicator(QWidget, PyDMWidget):
                     self.layout().addWidget(indicator, i, 0)
                     # Invalid combo of orientation and label position,
                     # so we don't reset label visibility here.
-        elif self.orientation == Qt.Horizontal:
+        elif orient == Qt.Horizontal or orient == 1:
             for i, (label, indicator) in enumerate(pairs):
                 if self.labelPosition == QTabWidget.North:
                     self.layout().addWidget(label, 0, i, 1, 1, Qt.AlignHCenter)
@@ -533,10 +534,10 @@ class PyDMByteIndicator(QWidget, PyDMWidget):
 
         self.layout().setContentsMargins(0, 0, 0, 0)
 
-        if self._orientation == Qt.Horizontal:
+        if self._orientation == Qt.Horizontal or self._orientation == 1:
             self.layout().setHorizontalSpacing(indicator_spacing)
             self.layout().setVerticalSpacing(label_spacing)
-        elif self._orientation == Qt.Vertical:
+        elif self._orientation == Qt.Vertical or self._orientation == 2:
             self.layout().setHorizontalSpacing(label_spacing)
             self.layout().setVerticalSpacing(indicator_spacing)
 
@@ -586,14 +587,11 @@ class PyDMByteIndicator(QWidget, PyDMWidget):
         """
         self._big_endian = is_big_endian
 
-        origin_map = {
-            (Qt.Vertical, True): Qt.BottomLeftCorner,
-            (Qt.Vertical, False): Qt.TopLeftCorner,
-            (Qt.Horizontal, True): Qt.TopRightCorner,
-            (Qt.Horizontal, False): Qt.TopLeftCorner,
-        }
-
-        origin = origin_map[(self.orientation, self.bigEndian)]
+        orient = self.orientation
+        if orient == Qt.Vertical or orient == 2:
+            origin = Qt.BottomLeftCorner if self.bigEndian else Qt.TopLeftCorner
+        else:
+            origin = Qt.TopRightCorner if self.bigEndian else Qt.TopLeftCorner
         self.layout().setOriginCorner(origin)
         self.rebuild_layout()
 

--- a/pydm/widgets/drawing.py
+++ b/pydm/widgets/drawing.py
@@ -351,8 +351,8 @@ class PyDMDrawing(QWidget, PyDMWidget):
             Index at Qt.PenStyle enum or int
         """
         # pyside6 enums are more strict and will error if passed int
-        # if isinstance(new_style, int):
-        #    new_style = Qt.PenStyle(new_style)
+        if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6 and isinstance(new_style, int):
+            new_style = Qt.PenCapStyle(new_style)
         if new_style != self._pen_cap_style:
             self._pen_cap_style = new_style
             self._pen.setCapStyle(new_style)
@@ -381,6 +381,9 @@ class PyDMDrawing(QWidget, PyDMWidget):
         new_style : int
             Index at Qt.PenStyle enum or int
         """
+        # pyside6 enums are more strict and will error if passed int
+        if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6 and isinstance(new_style, int):
+            new_style = Qt.PenJoinStyle(new_style)
         if new_style != self._pen_join_style:
             self._pen_join_style = new_style
             self._pen.setJoinStyle(new_style)

--- a/pydm/widgets/enum_button.py
+++ b/pydm/widgets/enum_button.py
@@ -487,9 +487,13 @@ class PyDMEnumButton(QWidget, PyDMWritableWidget):
                         len(self._widgets) - 1,
                     )
                 continue
-            if self.orientation == Qt.Vertical:
+            # Compare with both enum and int values because PySide6 scoped
+            # enums don't compare equal to plain ints, and .ui loading via
+            # pyside6-uic passes raw int values through setProperty().
+            orient = self.orientation
+            if orient == Qt.Vertical or orient == 2:
                 self.layout().addWidget(widget, i, 0)
-            elif self.orientation == Qt.Horizontal:
+            elif orient == Qt.Horizontal or orient == 1:
                 self.layout().addWidget(widget, 0, i)
 
     def check_enable_state(self):

--- a/pydm/widgets/nt_table.py
+++ b/pydm/widgets/nt_table.py
@@ -101,7 +101,7 @@ class PythonTableModel(QtCore.QAbstractTableModel):
 
     def sort(self, col, order=QtCore.Qt.AscendingOrder):
         self.layoutAboutToBeChanged.emit()
-        sort_reversed = order == QtCore.Qt.AscendingOrder
+        sort_reversed = order == QtCore.Qt.AscendingOrder or order == 0
         self._list.sort(key=itemgetter(col), reverse=sort_reversed)
         self.layoutChanged.emit()
 

--- a/pydm/widgets/scale.py
+++ b/pydm/widgets/scale.py
@@ -73,14 +73,14 @@ class QScale(QFrame):
         # We originally used QWIDGETSIZE_MAX here but the macro is only defined in PyQt and not PySide.
         # Instead we use it's direct value from the docs: https://doc.qt.io/qt-6/qwidget.html#QWIDGETSIZE_MAX
         self.setMaximumSize(16777215, 16777215)  # Unset fixed size
-        if self._orientation == Qt.Horizontal:
+        if self._orientation == Qt.Horizontal or self._orientation == 1:
             self._widget_width = self.width()
             self._widget_height = self.height()
             self._painter_translation_y = 0
             self._painter_rotation = 0
             self.setSizePolicy(QSizePolicy.Preferred, QSizePolicy.Fixed)
             self.setFixedHeight(self._scale_height)
-        elif self._orientation == Qt.Vertical:
+        elif self._orientation == Qt.Vertical or self._orientation == 2:
             # Invert dimensions for paintEvent()
             self._widget_width = self.height()
             self._widget_height = self.width()
@@ -491,7 +491,7 @@ class PyDMScaleIndicator(QFrame, TextFormatter, PyDMWidget):
         """
         self.limits_layout = None
         self.widget_layout = None
-        if new_orientation == Qt.Horizontal:
+        if new_orientation == Qt.Horizontal or new_orientation == 1:
             self.limits_layout = QHBoxLayout()
             if not inverted:
                 self.limits_layout.addWidget(self.lower_label)
@@ -550,7 +550,7 @@ class PyDMScaleIndicator(QFrame, TextFormatter, PyDMWidget):
                     self.lower_label.setAlignment(Qt.AlignBottom | Qt.AlignRight)
                     self.upper_label.setAlignment(Qt.AlignBottom | Qt.AlignLeft)
 
-        elif new_orientation == Qt.Vertical:
+        elif new_orientation == Qt.Vertical or new_orientation == 2:
             self.limits_layout = QVBoxLayout()
             if (value_position == Qt.RightEdge and not flipped) or (value_position == Qt.LeftEdge and flipped):
                 add_value_between_limits = True

--- a/pydm/widgets/slider.py
+++ b/pydm/widgets/slider.py
@@ -542,12 +542,12 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget):
         new_orientation : Qt.Orientation
             Qt.Horizontal or Qt.Vertical
         """
-        if new_orientation not in (Qt.Horizontal, Qt.Vertical):
+        if new_orientation not in (Qt.Horizontal, Qt.Vertical, 1, 2):
             logger.error("Invalid orientation '{0}'. The existing layout will not change.".format(new_orientation))
             return
 
         layout = None
-        if new_orientation == Qt.Horizontal:
+        if new_orientation == Qt.Horizontal or new_orientation == 1:
             layout = QVBoxLayout()
             layout.setContentsMargins(4, 0, 4, 4)
             label_layout = QHBoxLayout()
@@ -559,7 +559,7 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget):
             layout.addLayout(label_layout)
             self._slider.setOrientation(new_orientation)
             layout.addWidget(self._slider)
-        elif new_orientation == Qt.Vertical:
+        elif new_orientation == Qt.Vertical or new_orientation == 2:
             layout = QHBoxLayout()
             layout.setContentsMargins(0, 4, 4, 4)
             label_layout = QVBoxLayout()


### PR DESCRIPTION
PySide6 scoped enums don't compare equal to plain ints, but pyside6-uic passes raw int values via setProperty() when loading .ui files. This causes orientation, widgetType, penStyle and other enum-based comparisons to silently fail.

- enum_button: orientation and widgetType comparisons, class_for_type lookup
- drawing: PenCapStyle/PenJoinStyle int-to-enum conversion (PySide6 only)
- byte: rebuild_layout orientation, set_spacing, origin_map dict lookup
- slider: orientation guard and layout comparisons
- scale: QScale.adjust_transformation, setup_widgets_for_orientation
- analog_indicator: QScaleAlarmed.adjust_transformation
- baseplot: lineStyle setter int-to-enum conversion
- nt_table: sort order comparison