### PR TITLE
BUG: reset data buffer after setting curve item address

### DIFF
--- a/pydm/widgets/timeplot.py
+++ b/pydm/widgets/timeplot.py
@@ -163,11 +163,7 @@ class TimePlotCurveItem(BasePlotCurveItem):
             severity_slot=self.severityChanged,
         )
         self.channel.connect()
-
-        # Clear the data from the previous channel and redraw the curve
-        if self.points_accumulated:
-            self.initialize_buffer()
-            self.redrawCurve()
+        QTimer.singleShot(10, self.initialize_buffer)  # removes live point receives upon connection
 
     @property
     def plotByTimeStamps(self):


### PR DESCRIPTION
## Description

## Motivation
Curve items should only receive live values when the value changes, but they also receive a value when initially connecting. This change resets the live data buffer to eliminate this extra point.

The reset is scheduled using a QTimer so that it occurs after the live value is received via signal-slot processing: if the reset is inside TimePlotCurveItem.address, it occurs before the value is received and the value is drawn on the plot. The delay is 10 milliseconds only because it was a low number that consistently worked; the delay may have to be revisited.

Closes slaclab/trace#232

## Screenshots
The PV shown updates at long intervals. The point at 10:25 is not an archived point, nor is it a regular update. It is the value polled when the channel connection is initially made, and so it should not be shown on the plot.

Before:
<img width="1009" height="633" alt="Screenshot 2026-03-11 at 10 25 08" src="https://github.com/user-attachments/assets/d5ffd427-87e5-424d-8b4b-a1d6e200db6a" />


After:
<img width="1007" height="632" alt="Screenshot 2026-03-11 at 10 24 27" src="https://github.com/user-attachments/assets/d1b5192c-e0b7-4688-b456-724ff8cf80e1" />
