### PR TITLE
FIX: datetime edits broken in some cases

### DIFF
--- a/pydm/tests/widgets/test_datetime_edit.py
+++ b/pydm/tests/widgets/test_datetime_edit.py
@@ -44,7 +44,7 @@ def test_construct(qtbot, init_channel):
     assert pydm_datetimeedit.timeBase == TimeBase.Milliseconds
 
 
-@pytest.mark.xfailif(
+@pytest.mark.xfail(
     platform.system() == "Windows",
     reason="These tests will fail on Windows, we can't easily modify time",
 )

--- a/pydm/tests/widgets/test_datetime_edit.py
+++ b/pydm/tests/widgets/test_datetime_edit.py
@@ -9,11 +9,6 @@ from pydm.widgets.datetime import PyDMDateTimeEdit, TimeBase
 from qtpy.QtCore import QDateTime
 
 
-# --------------------
-# POSITIVE TEST CASES
-# --------------------
-
-
 @pytest.mark.parametrize(
     "init_channel",
     [
@@ -44,11 +39,15 @@ def test_construct(qtbot, init_channel):
     else:
         assert pydm_datetimeedit.channel is None
 
-    assert pydm_datetimeedit.blockPastDate == True
-    assert pydm_datetimeedit.relative == True
+    assert pydm_datetimeedit.blockPastDate
+    assert pydm_datetimeedit.relative
     assert pydm_datetimeedit.timeBase == TimeBase.Milliseconds
 
 
+@pytest.mark.xfailif(
+    platform.system() == "Windows",
+    reason="These tests will fail on Windows, we can't easily modify time",
+)
 @pytest.mark.parametrize(
     "value, expected_value",
     [
@@ -102,3 +101,84 @@ def test_value_changed(qtbot, signals, value, expected_value):
     signals.new_value_signal[type(value)].emit(value)
 
     assert pydm_datetimeedit.text() == expected_value
+
+
+@pytest.mark.xfail(
+    platform.system() == "Windows",
+    reason="These tests will fail on Windows, we can't easily modify time",
+)
+@pytest.mark.parametrize(
+    "value, time_base",
+    [
+        (0, TimeBase.Milliseconds),
+        (1000, TimeBase.Milliseconds),
+        (60000, TimeBase.Milliseconds),
+        (3600000, TimeBase.Milliseconds),
+        (18000000, TimeBase.Milliseconds),
+        (0.0, TimeBase.Milliseconds),
+        (1000.0, TimeBase.Milliseconds),
+        (60000.0, TimeBase.Milliseconds),
+        (3600000.0, TimeBase.Milliseconds),
+        (18000000.0, TimeBase.Milliseconds),
+        (0, TimeBase.Seconds),
+        (1000, TimeBase.Seconds),
+        (60000, TimeBase.Seconds),
+        (3600000, TimeBase.Seconds),
+        (18000000, TimeBase.Seconds),
+        (0.0, TimeBase.Seconds),
+        (1000.0, TimeBase.Seconds),
+        (60000.0, TimeBase.Seconds),
+        (3600000.0, TimeBase.Seconds),
+        (18000000.0, TimeBase.Seconds),
+    ],
+)
+def test_value_round_trip(qtbot, value, time_base):
+    """
+    Test that using the widget as a setpoint is self-consistent.
+
+    Parameters
+    ----------
+    qtbot : fixture
+        pytest-qt window for widget testing
+    value : int, float
+        The milliseconds from the epoch, whose type can vary
+        depending on what widget we're hooked up to
+    time_base : TimeBase
+        Whether we're storing the time in seconds or milliseconds
+    """
+    os.environ["TZ"] = "America/New_York"
+    time.tzset()
+
+    pydm_datetimeedit = PyDMDateTimeEdit()
+    pydm_datetimeedit.blockPastDate = False
+    pydm_datetimeedit.relative = False
+    pydm_datetimeedit.timeBase = time_base
+    qtbot.addWidget(pydm_datetimeedit)
+
+    last_value = None
+
+    def collect_value(new_value):
+        nonlocal last_value
+        last_value = new_value
+
+    goal_type = type(value)
+
+    pydm_datetimeedit.channeltype = goal_type
+    pydm_datetimeedit.send_value_signal[goal_type].connect(collect_value)
+
+    dt = QDateTime()
+    if time_base == TimeBase.Milliseconds:
+        set_value = value
+    elif time_base == TimeBase.Seconds:
+        set_value = goal_type(value * 1000)
+    else:
+        raise RuntimeError(f"Please add new test branch for {time_base}")
+
+    dt.setMSecsSinceEpoch(int(set_value))
+
+    pydm_datetimeedit.setDateTime(dt)
+
+    with qtbot.waitSignal(pydm_datetimeedit.send_value_signal[goal_type], timeout=1000):
+        pydm_datetimeedit.send_value()
+
+    assert last_value == value

--- a/pydm/tests/widgets/test_datetime_edit.py
+++ b/pydm/tests/widgets/test_datetime_edit.py
@@ -84,10 +84,6 @@ def test_value_changed(qtbot, signals, value, expected_value):
     expected_value : str
         The expected displayed value of the widget
     """
-    # These tests will fail on Windows, we can't easily modify time
-    if platform.system() == "Windows":
-        return
-
     os.environ["TZ"] = "America/New_York"
     time.tzset()
 

--- a/pydm/widgets/datetime.py
+++ b/pydm/widgets/datetime.py
@@ -126,6 +126,9 @@ class PyDMDateTimeEdit(QtWidgets.QDateTimeEdit, PyDMWritableWidget):
 
         if self.timeBase == TimeBase.Seconds:
             new_value /= 1000.0
+
+        # Force to the same base type as the data source, else qt can cast the pointer wrong
+        new_value = self.channeltype(new_value)
         self.send_value_signal[self.channeltype].emit(new_value)
 
     def value_changed(self, new_val):


### PR DESCRIPTION
There is an issue in recent versions of PyDM where if you use a `PyDMDatetimeWidget` with `timeBase` set to `Seconds`, connecting to a integer PV (e.g. `longout` record), the values set are incorrect and seemingly random.

I wrote a test case to validate this that simply puts a value and tries to get it again, which had the following failures before my fix:

```
==================================================================== short test summary info ====================================================================
FAILED pydm/tests/widgets/test_datetime_edit.py::test_value_round_trip[0-1] - assert 396362160 == 0
FAILED pydm/tests/widgets/test_datetime_edit.py::test_value_round_trip[1000-1] - assert 397209712 == 1000
FAILED pydm/tests/widgets/test_datetime_edit.py::test_value_round_trip[60000-1] - assert 396369808 == 60000
FAILED pydm/tests/widgets/test_datetime_edit.py::test_value_round_trip[3600000-1] - assert 396370224 == 3600000
FAILED pydm/tests/widgets/test_datetime_edit.py::test_value_round_trip[18000000-1] - assert 397213264 == 18000000
============================================================ 5 failed, 10 passed, 1 warning in 1.31s ==========================================================
```

And the test passes after my fix.

The fix is simple: cast the value back to an integer (in this case, whatever the `channeltype` is) before passing the value to Qt.

The problem was:

- Converting the ms value to seconds via division changes the value to a float
- Putting a float into an int signal causes Qt to cast the underlying data at the pointer location to integer (at least, this is what I assume: I didn't check the byte representations)

The result was some seemingly chaotic behavior where setting a value would give a random output.

I think this snuck in during #1230, where the signal was made to emit with a specific type for PySide6 compatibility. It's at least somewhat notable that this widget didn't have any test cases for the setpoint behavior, which made it easy for this to slip through. I suspect most users are using milliseconds/relative time, and I'm the only one using seconds/absolute time.

The rest are some incidental test formatting cleanup, like making the early exit case an xfail instead of a pass. Please let me know if you want me to undo this or clean it up even more.