### PR TITLE
MNT: Fix remaining non-ignored tests in PySide6

### DIFF
--- a/.github/workflows/run-tests-pyside6.yml
+++ b/.github/workflows/run-tests-pyside6.yml
@@ -75,10 +75,9 @@ jobs:
     - name: Test with pytest
       shell: bash -el {0}
       timeout-minutes: 30
-      continue-on-error: true # remove this once all pyside6 tests pass!
       run: |
         if [ "$RUNNER_OS" == "macOS" ]; then
           python run_tests.py --ignore=pydm/tests/data_plugins/test_p4p_plugin_component.py --ignore=pydm/tests/widgets/test_slider.py  # disable just for now, until fix intermittent issue
-        else 
+        else
           python run_tests.py
         fi

--- a/pydm/data_plugins/calc_plugin.py
+++ b/pydm/data_plugins/calc_plugin.py
@@ -57,7 +57,7 @@ class CalcThread(QThread):
     def __init__(self, config, *args, **kwargs):
         QThread.__init__(self, *args, **kwargs)
         self.app = QApplication.instance()
-        self.app.aboutToQuit.connect(self.requestInterruption)
+        self.app.aboutToQuit.connect(self.close)
 
         self.config = config
         self.listen_for_update = None
@@ -113,6 +113,10 @@ class CalcThread(QThread):
                 break
             self.calculate_expression()
         self._disconnect()
+
+    def close(self):
+        self.requestInterruption()
+        self._calculate.set()
 
     def callback_value(self, name, value):
         """
@@ -238,7 +242,8 @@ class Connection(PyDMConnection):
             logger.debug("Value was not available yet for calc.")
 
     def close(self):
-        self._calc_thread.requestInterruption()
+        self._calc_thread.close()
+        self._calc_thread.wait()
 
 
 class CalculationPlugin(PyDMPlugin):

--- a/pydm/tests/conftest.py
+++ b/pydm/tests/conftest.py
@@ -130,7 +130,9 @@ def qapp(qapp_args):
     if "pytest-qt-qapp" == qapp_args[0]:
         qapp_args.remove("pytest-qt-qapp")
 
-    yield PyDMApplication(use_main_window=False, *qapp_args)
+    app = PyDMApplication(use_main_window=False, *qapp_args)
+    yield app
+    app.aboutToQuit.emit()  # Force signal emission on pytest environment
 
 
 @pytest.fixture(scope="session")

--- a/pydm/tests/data_plugins/test_plugin.py
+++ b/pydm/tests/data_plugins/test_plugin.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock
 
 from pydm.data_plugins import PyDMPlugin
+from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
 from pydm.widgets.channel import PyDMChannel
 
 
@@ -86,7 +87,13 @@ def assert_all_signal_receivers(connection, expected_receivers):
 
     for signal_name in signals:
         signal = getattr(connection, signal_name)
-        assert connection.receivers(signal) == expected_receivers
+        if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
+            from qtpy.QtCore import QMetaMethod, SIGNAL
+
+            signal_name = bytes(QMetaMethod.fromSignal(signal).methodSignature().data()).decode()
+            assert connection.receivers(SIGNAL(signal_name)) == expected_receivers
+        else:
+            assert connection.receivers(signal) == expected_receivers
 
 
 def create_channel(address, value_signal):

--- a/pydm/tests/widgets/test_baseplot.py
+++ b/pydm/tests/widgets/test_baseplot.py
@@ -70,7 +70,7 @@ def test_baseplotcurveitem_to_dict(qtbot):
     assert isinstance(dictionary, OrderedDict)
     assert dictionary["name"] == base_plotcurve_item.name()
     assert dictionary["color"] == base_plotcurve_item.color_string
-    assert dictionary["lineStyle"] == base_plotcurve_item.lineStyle
+    assert dictionary["lineStyle"] == base_plotcurve_item.lineStyle.value
     assert dictionary["lineWidth"] == base_plotcurve_item.lineWidth
     assert dictionary["symbol"] == base_plotcurve_item.symbol
     assert dictionary["symbolSize"] == base_plotcurve_item.symbolSize

--- a/pydm/tests/widgets/test_baseplot.py
+++ b/pydm/tests/widgets/test_baseplot.py
@@ -10,7 +10,7 @@ from qtpy.QtCore import QTimer, Qt, QPointF
 from qtpy.QtWidgets import QWidget
 
 from collections import OrderedDict
-from pydm.widgets.baseplot import BasePlotCurveItem, BasePlot
+from pydm.widgets.baseplot import BasePlotCurveItem, BasePlot, pen_style_to_int
 
 
 logger = logging.getLogger(__name__)
@@ -70,7 +70,7 @@ def test_baseplotcurveitem_to_dict(qtbot):
     assert isinstance(dictionary, OrderedDict)
     assert dictionary["name"] == base_plotcurve_item.name()
     assert dictionary["color"] == base_plotcurve_item.color_string
-    assert dictionary["lineStyle"] == base_plotcurve_item.lineStyle.value
+    assert dictionary["lineStyle"] == pen_style_to_int(base_plotcurve_item.lineStyle)
     assert dictionary["lineWidth"] == base_plotcurve_item.lineWidth
     assert dictionary["symbol"] == base_plotcurve_item.symbol
     assert dictionary["symbolSize"] == base_plotcurve_item.symbolSize

--- a/pydm/tests/widgets/test_waveform_plot.py
+++ b/pydm/tests/widgets/test_waveform_plot.py
@@ -2,6 +2,7 @@ import numpy as np
 from pyqtgraph import BarGraphItem
 from unittest import mock
 from unittest.mock import MagicMock, patch
+from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
 from pydm.widgets.waveformplot import PyDMWaveformPlot, WaveformCurveItem
 
 
@@ -180,8 +181,13 @@ def test_redrawPlot_with_crosshair():
     widget.mapFromGlobal = MagicMock(return_value=dummy_local_pos)
     widget.mapToScene = MagicMock(return_value=dummy_scene_pos)
 
+    if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
+        patch_path = "PySide6.QtGui.QCursor.pos"
+    else:
+        patch_path = "PyQt5.QtGui.QCursor.pos"
+
     # Patch QCursor.pos to return dummy_global_pos.
-    with patch("PyQt5.QtGui.QCursor.pos", return_value=dummy_global_pos):
+    with patch(patch_path, return_value=dummy_global_pos):
         # Set up a dummy plotItem with sceneBoundingRect() and vb.mapSceneToView().
         dummy_rect = MagicMock()
         dummy_rect.contains.return_value = True  # Indicate scene_pos is within bounds

--- a/pydm/widgets/baseplot.py
+++ b/pydm/widgets/baseplot.py
@@ -431,7 +431,7 @@ class BasePlotCurveItem(PlotDataItem):
             [
                 ("name", self.name()),
                 ("color", self.color_string),
-                ("lineStyle", self.lineStyle),
+                ("lineStyle", self.lineStyle.value),
                 ("lineWidth", self.lineWidth),
                 ("symbol", self.symbol),
                 ("symbolSize", self.symbolSize),

--- a/pydm/widgets/baseplot.py
+++ b/pydm/widgets/baseplot.py
@@ -31,6 +31,10 @@ else:
     from PyQt5.QtCore import pyqtProperty as Property
 
 
+def pen_style_to_int(pen_style) -> int:
+    return pen_style if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT5 else pen_style.value
+
+
 class NoDataError(Exception):
     """NoDataError is raised when a curve tries to perform an operation,
     but does not yet have any data."""
@@ -431,7 +435,7 @@ class BasePlotCurveItem(PlotDataItem):
             [
                 ("name", self.name()),
                 ("color", self.color_string),
-                ("lineStyle", self.lineStyle.value),
+                ("lineStyle", pen_style_to_int(self.lineStyle)),
                 ("lineWidth", self.lineWidth),
                 ("symbol", self.symbol),
                 ("symbolSize", self.symbolSize),

--- a/pydm/widgets/shell_command.py
+++ b/pydm/widgets/shell_command.py
@@ -846,6 +846,7 @@ class PyDMShellCommand(QPushButton, PyDMWidget):
                     self.timer.timeout.connect(
                         lambda: self._check_process_done(action, original_button_text, original_action_text)
                     )
+                    self.destroyed.connect(self.timer.stop)
                     self.timer.start()
 
             except Exception as exc:


### PR DESCRIPTION
This tackles a couple broken tests on PySide6, along with their fixes. With that, I've also enabled the CI pipeline to fail when any of these tests fail, so we can better keep track of their state.