### PR TITLE
MNT: establish a deterministic designer widget order

### DIFF
--- a/pydm/register_pydm_designer_plugin.py
+++ b/pydm/register_pydm_designer_plugin.py
@@ -1,16 +1,17 @@
 print("Loading PyDM Widgets")
 
 from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
+from pydm.widgets.qtplugins import get_all_custom_widgets_in_order
+
 
 if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT5:
-    from pydm.widgets.qtplugins import *  # noqa: E402, F403
-elif ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
-    from pydm.widgets import qtplugins
+    globals().update({pl.plugin_name: pl for pl in get_all_custom_widgets_in_order()})
 
+elif ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
     from PySide6.QtDesigner import QDesignerCustomWidgetInterface, QPyDesignerCustomWidgetCollection
 
     import inspect
 
-    for _, value in inspect.getmembers(qtplugins):
+    for value in get_all_custom_widgets_in_order():
         if inspect.isclass(value) and issubclass(value, QDesignerCustomWidgetInterface):
             QPyDesignerCustomWidgetCollection.addCustomWidget(value())

--- a/pydm/widgets/qtplugin_base.py
+++ b/pydm/widgets/qtplugin_base.py
@@ -90,6 +90,9 @@ def qtplugin_factory(
     class Plugin(PyDMDesignerPlugin):
         __doc__ = "PyDMDesigner Plugin for {}".format(cls.__name__)
 
+        plugin_name = cls.__name__
+        plugin_group = group
+
         def __init__(self):
             super().__init__(cls, is_container, group, extensions, icon)
 
@@ -101,6 +104,9 @@ class PyDMDesignerPlugin(BASE_PLUGIN_CLASS):
     Parent class to standardize how pydm plugins are accessed in qt designer.
     All functions have default returns that can be overridden as necessary.
     """
+
+    plugin_name: str
+    plugin_group: str
 
     def __init__(
         self,

--- a/pydm/widgets/qtplugins.py
+++ b/pydm/widgets/qtplugins.py
@@ -281,6 +281,7 @@ PyDMTemplateRepeaterPlugin = qtplugin_factory(
 # Terminator Widget plugin
 PyDMTerminatorPlugin = qtplugin_factory(PyDMTerminator, group=WidgetCategory.MISC, extensions=BASE_EXTENSIONS)
 
+
 # **********************************************
 # NOTE: Add in new PyDM widgets above this line.
 # **********************************************
@@ -288,7 +289,9 @@ def is_designer_widget(WidgetCls: type) -> bool:
     """
     Returns True if the object is a designer plugin class that is usable in designer.
     """
-    return inspect.isclass(WidgetCls) and issubclass(WidgetCls, PyDMDesignerPlugin) and WidgetCls is not PyDMDesignerPlugin
+    return (
+        inspect.isclass(WidgetCls) and issubclass(WidgetCls, PyDMDesignerPlugin) and WidgetCls is not PyDMDesignerPlugin
+    )
 
 
 def get_pydm_custom_widgets() -> dict[str, type[PyDMDesignerPlugin]]:

--- a/pydm/widgets/qtplugins.py
+++ b/pydm/widgets/qtplugins.py
@@ -1,5 +1,7 @@
+import inspect
 import logging
 import os
+from collections import defaultdict
 
 from pydm.utilities.iconfont import IconFont
 from .archiver_time_plot import PyDMArchiverTimePlot
@@ -30,7 +32,7 @@ from .label import PyDMLabel
 from .line_edit import PyDMLineEdit
 from .logdisplay import PyDMLogDisplay
 from .pushbutton import PyDMPushButton
-from .qtplugin_base import WidgetCategory, get_widgets_from_entrypoints, qtplugin_factory
+from .qtplugin_base import PyDMDesignerPlugin, WidgetCategory, get_widgets_from_entrypoints, qtplugin_factory
 from .qtplugin_extensions import (
     ArchiveTimeCurveEditorExtension,
     BasicSettingsExtension,
@@ -282,6 +284,62 @@ PyDMTerminatorPlugin = qtplugin_factory(PyDMTerminator, group=WidgetCategory.MIS
 # **********************************************
 # NOTE: Add in new PyDM widgets above this line.
 # **********************************************
+def is_designer_widget(WidgetCls: type) -> bool:
+    """
+    Returns True if the object is a designer plugin class that is usable in designer.
+    """
+    return inspect.isclass(WidgetCls) and issubclass(WidgetCls, PyDMDesignerPlugin) and WidgetCls is not PyDMDesignerPlugin
 
-# Add in designer widget plugins from other classes via entrypoints:
-globals().update(**get_widgets_from_entrypoints())
+
+def get_pydm_custom_widgets() -> dict[str, type[PyDMDesignerPlugin]]:
+    """
+    Returns a dictionary of all the widgets defined by PyDM itself.
+    """
+    return {key: value for key, value in globals().items() if is_designer_widget(value)}
+
+
+def get_all_custom_widgets_in_order() -> list[type[PyDMDesignerPlugin]]:
+    """
+    Yields all custom widgets in the order they should be presented to designer.
+
+    The order matters and determines how the groups are ordered and how
+    widgets within each group are order.
+
+    Widgets are added in the order they are encountered, creating new groups as necessary.
+    There is no sorting done. This is especially unfortunate for entrypoint widgets,
+    which always load alphabetically by widget name in per-library chunks, leading to a
+    chaotic group ordering by default.
+
+    Here we will sort in the following way:
+    1. PyDM widget groups in the same order as their corresponding built-in groups
+    2. PyDM widget groups with no corresponding built-in groups in alphabetical order
+    3. Entrypoint widgets groups in alphabetical order
+
+    Within each group, we will sort widget names alphabetically,
+    because doing this manually or randomly lead to extra work or confusing results.
+    """
+    pydm_widgets_by_group: dict[str, list[type[PyDMDesignerPlugin]]] = defaultdict(list)
+    for plugin in get_pydm_custom_widgets().values():
+        pydm_widgets_by_group[plugin.plugin_group].append(plugin)
+
+    entrypoint_widgets_by_group: dict[str, list[type[PyDMDesignerPlugin]]] = defaultdict(list)
+    for plugin in get_widgets_from_entrypoints().values():
+        entrypoint_widgets_by_group[plugin.plugin_group].append(plugin)
+
+    all_custom_widgets = []
+    standard_category_order = (
+        WidgetCategory.CONTAINER,
+        WidgetCategory.INPUT,
+        WidgetCategory.DISPLAY,
+        WidgetCategory.PLOT,
+        WidgetCategory.DRAWING,
+        WidgetCategory.MISC,
+    )
+    for category in standard_category_order:
+        all_custom_widgets.extend(sorted(pydm_widgets_by_group[category], key=lambda pl: pl.plugin_name))
+    for category in pydm_widgets_by_group:
+        if category not in standard_category_order:
+            all_custom_widgets.extend(sorted(pydm_widgets_by_group[category], key=lambda pl: pl.plugin_name))
+    for category in sorted(entrypoint_widgets_by_group):
+        all_custom_widgets.extend(sorted(entrypoint_widgets_by_group[category], key=lambda pl: pl.plugin_name))
+    return all_custom_widgets

--- a/pydm/widgets/tab_bar_qtplugin.py
+++ b/pydm/widgets/tab_bar_qtplugin.py
@@ -8,6 +8,9 @@ class TabWidgetPlugin(PyDMDesignerPlugin):
 
     TabClass = PyDMTabWidget
 
+    plugin_name = "TabWidgetPlugin"
+    plugin_group = WidgetCategory.CONTAINER
+
     def __init__(self, extensions=None):
         super().__init__(self.TabClass, group=WidgetCategory.CONTAINER, extensions=extensions)
 


### PR DESCRIPTION
In this PR, I'm looking for:
- Is this a good idea?
- Is this the correct order?
- Is the implementation OK?

### Problem Statement

The PyDM widget order in designer is currently chaotic. I didn't notice this until I started adding some custom widget categories and got very confused about the ordering, then investigated how the ordering is established, and then finally decided that the only way to handle it was to either patch PyDM or make my own designer plugin loader. If others think this is useful I'd prefer to do it in PyDM itself.

### Background

Here's a quick primer about how the ordering of the widgets is determined:
- Select widgets one by one in order, different by qt wrapper:
  - in pyqt5: by the order in globals(), which is the order in which each widget's attr name in the module is first introduced, via import or otherwise
  - in pyside6: presumably, by the order we pass the widgets to `addCustomWidget` (I haven't tested pyside6). Note that currently in pydm this also ends up being essentially the import/plugin creation order.
- Add this widget to the bottom of an existing group, or start a new group if needed
- Do no sorting at all

So this leads to funny things like `PyDMNTTable` being the first input widget and `PyDMTabWidget` being the first container widget, simply because their names are early in `globals()` due to the imports and attribute name re-use, while other widgets are ordered somewhat deliberately. Small permutations to the ordering in these files can chaotically interfere with the overall designer ordering.

<img width="381" height="342" alt="image" src="https://github.com/user-attachments/assets/deed36b3-7578-4d4c-b149-8cfb40352b5f" />


It also leads to nonsense ordering for entrypoint widget groups:

<img width="386" height="210" alt="image" src="https://github.com/user-attachments/assets/fc6b7fe2-d1a6-46d3-bd1b-be274eac490f" />

This ends up depending on the order in which the widgets are loaded from the entrypoint, which to my eye seems to always be sorted by widget name. So the first group is the group associated with a widget that starts with A, and so-on.

### This PR

This PR simply creates an opinionated ordering of the designer widgets:

1. All the pydm widgets, in the current category orders that people are used to, which roughly tracks how the built-in widgets are sorted.
2. Pydm widgets sorted by name within each category
3. Entrypoint widgets sorted by group name, then by name

The details can be changed as much as we like.

I tried to change as little as possible unrelated to this PR- if you'd like me to change more, let me know.

### Notes about conda

The conda-forge build uses the internal widgets submodule to set up the designer plugins and would need to be changed to use the proper top-level file.

https://github.com/conda-forge/pydm-feedstock/blob/main/recipe/build.sh#L15