### PR TITLE
ENH: Add title property and fix paint crash in PyDMAnalogIndicator

### DIFF
--- a/pydm/tests/widgets/test_analog_indicator.py
+++ b/pydm/tests/widgets/test_analog_indicator.py
@@ -37,3 +37,62 @@ def test_construct(qtbot, init_channel):
     # ("Internal C++ object (PyDMDateTimeLabel) already deleted")
     parent.deleteLater()
     pydm_analog_indicator.deleteLater()
+
+
+def test_title_default(qtbot):
+    parent = QWidget()
+    qtbot.addWidget(parent)
+    indicator = PyDMAnalogIndicator(parent=parent)
+    qtbot.addWidget(indicator)
+
+    assert indicator.title == ""
+    assert indicator.title_label.isHidden()
+
+    parent.deleteLater()
+    indicator.deleteLater()
+
+
+def test_title_set_and_get(qtbot):
+    parent = QWidget()
+    qtbot.addWidget(parent)
+    indicator = PyDMAnalogIndicator(parent=parent)
+    qtbot.addWidget(indicator)
+
+    indicator.title = "Test Title"
+    assert indicator.title == "Test Title"
+    assert indicator.title_label.text() == "Test Title"
+    assert not indicator.title_label.isHidden()
+
+    parent.deleteLater()
+    indicator.deleteLater()
+
+
+def test_title_clear_hides_label(qtbot):
+    parent = QWidget()
+    qtbot.addWidget(parent)
+    indicator = PyDMAnalogIndicator(parent=parent)
+    qtbot.addWidget(indicator)
+
+    indicator.title = "Visible"
+    assert not indicator.title_label.isHidden()
+
+    indicator.title = ""
+    assert indicator.title_label.isHidden()
+
+    parent.deleteLater()
+    indicator.deleteLater()
+
+
+def test_title_reset(qtbot):
+    parent = QWidget()
+    qtbot.addWidget(parent)
+    indicator = PyDMAnalogIndicator(parent=parent)
+    qtbot.addWidget(indicator)
+
+    indicator.title = "Something"
+    indicator.resetTitle()
+    assert indicator.title == ""
+    assert indicator.title_label.isHidden()
+
+    parent.deleteLater()
+    indicator.deleteLater()

--- a/pydm/widgets/analog_indicator.py
+++ b/pydm/widgets/analog_indicator.py
@@ -261,6 +261,8 @@ class QScaleAlarmed(QScale):
         ----------
         event : QPaintEvent
         """
+        if self.width() <= 0 or self.height() <= 0:
+            return
         self.adjust_transformation()
         self._painter.begin(self)
         self._painter.translate(0, self._painter_translation_y)  # Draw vertically if needed

--- a/pydm/widgets/analog_indicator.py
+++ b/pydm/widgets/analog_indicator.py
@@ -1,6 +1,6 @@
 from .base import PyDMWidget
 from qtpy.QtGui import QColor, QPolygon, QPainter, QFontMetrics
-from qtpy.QtWidgets import QFrame, QSizePolicy
+from qtpy.QtWidgets import QFrame, QLabel, QSizePolicy
 from qtpy.QtCore import Qt, QPoint, QSize
 from .scale import QScale, PyDMScaleIndicator
 from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
@@ -419,6 +419,10 @@ class PyDMAnalogIndicator(PyDMScaleIndicator):
         self._show_limits = False
         self.scale_indicator = QScaleAlarmed()
 
+        self.title_label = QLabel()
+        self.title_label.setAlignment(Qt.AlignCenter)
+        self.title_label.hide()
+
         self._value_position = Qt.RightEdge
         self._minor_alarm_from_channel = True
         self._major_alarm_from_channel = True
@@ -437,6 +441,31 @@ class PyDMAnalogIndicator(PyDMScaleIndicator):
         makes default size nice when dragging into designer nice
         """
         return QSize(250, 70)
+
+    def _grid_row_offset(self):
+        return 1 if hasattr(self, "title_label") else 0
+
+    def setup_widgets_for_orientation(self, new_orientation, flipped, inverted, value_position):
+        super().setup_widgets_for_orientation(new_orientation, flipped, inverted, value_position)
+        if hasattr(self, "title_label"):
+            num_cols = self.widget_layout.columnCount()
+            self.widget_layout.addWidget(self.title_label, 0, 0, 1, num_cols)
+
+    def readTitle(self) -> str:
+        return self.title_label.text()
+
+    def setTitle(self, title: str) -> None:
+        title = str(title)
+        self.title_label.setText(title)
+        if title:
+            self.title_label.show()
+        else:
+            self.title_label.hide()
+
+    def resetTitle(self) -> None:
+        self.setTitle("")
+
+    title = Property(str, readTitle, setTitle, resetTitle)
 
     def lower_warning_limit_changed(self, new_minor_alarm):
         """

--- a/pydm/widgets/scale.py
+++ b/pydm/widgets/scale.py
@@ -491,6 +491,7 @@ class PyDMScaleIndicator(QFrame, TextFormatter, PyDMWidget):
         """
         self.limits_layout = None
         self.widget_layout = None
+        r = self._grid_row_offset()
         if new_orientation == Qt.Horizontal or new_orientation == 1:
             self.limits_layout = QHBoxLayout()
             if not inverted:
@@ -503,21 +504,21 @@ class PyDMScaleIndicator(QFrame, TextFormatter, PyDMWidget):
             self.widget_layout = QGridLayout()
             if not flipped:
                 if value_position == Qt.LeftEdge:
-                    self.widget_layout.addWidget(self.value_label, 0, 0)
-                    self.widget_layout.addWidget(self.scale_indicator, 0, 1)
-                    self.widget_layout.addItem(self.limits_layout, 1, 1)
+                    self.widget_layout.addWidget(self.value_label, r, 0)
+                    self.widget_layout.addWidget(self.scale_indicator, r, 1)
+                    self.widget_layout.addItem(self.limits_layout, r + 1, 1)
                 elif value_position == Qt.RightEdge:
-                    self.widget_layout.addWidget(self.value_label, 0, 1)
-                    self.widget_layout.addWidget(self.scale_indicator, 0, 0)
-                    self.widget_layout.addItem(self.limits_layout, 1, 0)
+                    self.widget_layout.addWidget(self.value_label, r, 1)
+                    self.widget_layout.addWidget(self.scale_indicator, r, 0)
+                    self.widget_layout.addItem(self.limits_layout, r + 1, 0)
                 elif value_position == Qt.TopEdge:
-                    self.widget_layout.addWidget(self.value_label, 0, 0)
-                    self.widget_layout.addWidget(self.scale_indicator, 1, 0)
-                    self.widget_layout.addItem(self.limits_layout, 2, 0)
+                    self.widget_layout.addWidget(self.value_label, r, 0)
+                    self.widget_layout.addWidget(self.scale_indicator, r + 1, 0)
+                    self.widget_layout.addItem(self.limits_layout, r + 2, 0)
                 elif value_position == Qt.BottomEdge:
-                    self.widget_layout.addWidget(self.scale_indicator, 0, 0)
-                    self.widget_layout.addItem(self.limits_layout, 1, 0)
-                    self.widget_layout.addWidget(self.value_label, 2, 0)
+                    self.widget_layout.addWidget(self.scale_indicator, r, 0)
+                    self.widget_layout.addItem(self.limits_layout, r + 1, 0)
+                    self.widget_layout.addWidget(self.value_label, r + 2, 0)
 
                 if not inverted:
                     self.lower_label.setAlignment(Qt.AlignTop | Qt.AlignLeft)
@@ -527,21 +528,21 @@ class PyDMScaleIndicator(QFrame, TextFormatter, PyDMWidget):
                     self.upper_label.setAlignment(Qt.AlignTop | Qt.AlignLeft)
             else:
                 if value_position == Qt.LeftEdge:
-                    self.widget_layout.addItem(self.limits_layout, 0, 1)
-                    self.widget_layout.addWidget(self.scale_indicator, 1, 1)
-                    self.widget_layout.addWidget(self.value_label, 1, 0)
+                    self.widget_layout.addItem(self.limits_layout, r, 1)
+                    self.widget_layout.addWidget(self.scale_indicator, r + 1, 1)
+                    self.widget_layout.addWidget(self.value_label, r + 1, 0)
                 elif value_position == Qt.RightEdge:
-                    self.widget_layout.addItem(self.limits_layout, 0, 0)
-                    self.widget_layout.addWidget(self.scale_indicator, 1, 0)
-                    self.widget_layout.addWidget(self.value_label, 1, 1)
+                    self.widget_layout.addItem(self.limits_layout, r, 0)
+                    self.widget_layout.addWidget(self.scale_indicator, r + 1, 0)
+                    self.widget_layout.addWidget(self.value_label, r + 1, 1)
                 elif value_position == Qt.TopEdge:
-                    self.widget_layout.addWidget(self.value_label, 0, 0)
-                    self.widget_layout.addItem(self.limits_layout, 1, 0)
-                    self.widget_layout.addWidget(self.scale_indicator, 2, 0)
+                    self.widget_layout.addWidget(self.value_label, r, 0)
+                    self.widget_layout.addItem(self.limits_layout, r + 1, 0)
+                    self.widget_layout.addWidget(self.scale_indicator, r + 2, 0)
                 elif value_position == Qt.BottomEdge:
-                    self.widget_layout.addItem(self.limits_layout, 0, 0)
-                    self.widget_layout.addWidget(self.scale_indicator, 1, 0)
-                    self.widget_layout.addWidget(self.value_label, 2, 0)
+                    self.widget_layout.addItem(self.limits_layout, r, 0)
+                    self.widget_layout.addWidget(self.scale_indicator, r + 1, 0)
+                    self.widget_layout.addWidget(self.value_label, r + 2, 0)
 
                 if not inverted:
                     self.lower_label.setAlignment(Qt.AlignBottom | Qt.AlignLeft)
@@ -574,20 +575,20 @@ class PyDMScaleIndicator(QFrame, TextFormatter, PyDMWidget):
             self.widget_layout = QGridLayout()
             if not flipped:
                 if value_position == Qt.LeftEdge:
-                    self.widget_layout.addWidget(self.value_label, 0, 0)
-                    self.widget_layout.addWidget(self.scale_indicator, 0, 1)
-                    self.widget_layout.addItem(self.limits_layout, 0, 2)
+                    self.widget_layout.addWidget(self.value_label, r, 0)
+                    self.widget_layout.addWidget(self.scale_indicator, r, 1)
+                    self.widget_layout.addItem(self.limits_layout, r, 2)
                 elif value_position == Qt.RightEdge:
-                    self.widget_layout.addWidget(self.scale_indicator, 0, 0)
-                    self.widget_layout.addItem(self.limits_layout, 0, 1)
+                    self.widget_layout.addWidget(self.scale_indicator, r, 0)
+                    self.widget_layout.addItem(self.limits_layout, r, 1)
                 elif value_position == Qt.TopEdge:
-                    self.widget_layout.addWidget(self.value_label, 0, 0, 1, 2)
-                    self.widget_layout.addWidget(self.scale_indicator, 1, 0)
-                    self.widget_layout.addItem(self.limits_layout, 1, 1)
+                    self.widget_layout.addWidget(self.value_label, r, 0, 1, 2)
+                    self.widget_layout.addWidget(self.scale_indicator, r + 1, 0)
+                    self.widget_layout.addItem(self.limits_layout, r + 1, 1)
                 elif value_position == Qt.BottomEdge:
-                    self.widget_layout.addWidget(self.scale_indicator, 0, 0)
-                    self.widget_layout.addItem(self.limits_layout, 0, 1)
-                    self.widget_layout.addWidget(self.value_label, 1, 0, 1, 2)
+                    self.widget_layout.addWidget(self.scale_indicator, r, 0)
+                    self.widget_layout.addItem(self.limits_layout, r, 1)
+                    self.widget_layout.addWidget(self.value_label, r + 1, 0, 1, 2)
 
                 if not inverted:
                     self.lower_label.setAlignment(Qt.AlignLeft | Qt.AlignBottom)
@@ -597,20 +598,20 @@ class PyDMScaleIndicator(QFrame, TextFormatter, PyDMWidget):
                     self.upper_label.setAlignment(Qt.AlignLeft | Qt.AlignBottom)
             else:
                 if value_position == Qt.LeftEdge:
-                    self.widget_layout.addItem(self.limits_layout, 0, 1)
-                    self.widget_layout.addWidget(self.scale_indicator, 0, 2)
+                    self.widget_layout.addItem(self.limits_layout, r, 1)
+                    self.widget_layout.addWidget(self.scale_indicator, r, 2)
                 elif value_position == Qt.RightEdge:
-                    self.widget_layout.addItem(self.limits_layout, 0, 0)
-                    self.widget_layout.addWidget(self.scale_indicator, 0, 1)
-                    self.widget_layout.addWidget(self.value_label, 0, 2)
+                    self.widget_layout.addItem(self.limits_layout, r, 0)
+                    self.widget_layout.addWidget(self.scale_indicator, r, 1)
+                    self.widget_layout.addWidget(self.value_label, r, 2)
                 elif value_position == Qt.TopEdge:
-                    self.widget_layout.addWidget(self.value_label, 0, 0, 1, 2)
-                    self.widget_layout.addItem(self.limits_layout, 1, 0)
-                    self.widget_layout.addWidget(self.scale_indicator, 1, 1)
+                    self.widget_layout.addWidget(self.value_label, r, 0, 1, 2)
+                    self.widget_layout.addItem(self.limits_layout, r + 1, 0)
+                    self.widget_layout.addWidget(self.scale_indicator, r + 1, 1)
                 elif value_position == Qt.BottomEdge:
-                    self.widget_layout.addItem(self.limits_layout, 0, 0)
-                    self.widget_layout.addWidget(self.scale_indicator, 0, 1)
-                    self.widget_layout.addWidget(self.value_label, 1, 0, 1, 2)
+                    self.widget_layout.addItem(self.limits_layout, r, 0)
+                    self.widget_layout.addWidget(self.scale_indicator, r, 1)
+                    self.widget_layout.addWidget(self.value_label, r + 1, 0, 1, 2)
 
                 if not inverted:
                     self.lower_label.setAlignment(Qt.AlignRight | Qt.AlignBottom)
@@ -626,6 +627,9 @@ class PyDMScaleIndicator(QFrame, TextFormatter, PyDMWidget):
             QWidget().setLayout(self.layout())
         self.widget_layout.setContentsMargins(1, 1, 1, 1)
         self.setLayout(self.widget_layout)
+
+    def _grid_row_offset(self) -> int:
+        return 0
 
     def readShowValue(self) -> bool:
         """


### PR DESCRIPTION
- Add a configurable title property to PyDMAnalogIndicator, displayed as a label above the scale that can be set in Qt Designer or programmatically
- Fix a crash where paintEvent ran on a zero-sized widget, causing "QPainter not active" and "Paint device returned engine == 0" errors