### PR TITLE
ENH: Add PyQt6 support to PyDM

### DIFF
--- a/.github/workflows/run-tests-pyqt6.yml
+++ b/.github/workflows/run-tests-pyqt6.yml
@@ -1,0 +1,83 @@
+# This workflow will install pydm dependencies and run the test suite using PyQt6 for all combinations
+# of operating systems and version numbers specified in the matrix
+
+name: PyQt6 Testing
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+permissions:
+  contents: read
+
+jobs:
+  test-pyqt6:
+    if: ${{ github.repository == 'slaclab/pydm' }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        python-version: ["3.12"]
+
+    env:
+      DISPLAY: ':99.0'
+      QT_MAC_WANTS_LAYER: 1
+      QT_API: pyqt6
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Setup conda
+      uses: conda-incubator/setup-miniconda@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+        miniforge-variant: Miniforge3
+        miniforge-version: latest
+        activate-environment: pydm-env
+        conda-remove-defaults: true
+        architecture: x64
+
+    - name: Install PyDM with PyQt6
+      shell: bash -el {0}
+      run: |
+        if [ "$RUNNER_OS" == "Windows" ]; then
+          conda install -c conda-forge pydm pyqt6
+        elif [ "$RUNNER_OS" == "macOS" ]; then
+          mamba install -c conda-forge pydm pyqt6 git pyca
+        else
+          mamba install -c conda-forge pydm pyqt6
+        fi
+
+    - name: Install additional Python dependencies with pip
+      shell: bash -el {0}
+      run: |
+        if [ "$RUNNER_OS" == "Linux" ]; then
+          pip install .[test]
+        else
+          pip install .[test-no-optional]
+        fi
+
+    - name: Install packages for testing a PyQt/PySide app on Linux
+      shell: bash -el {0}
+      run: |
+        if [ "$RUNNER_OS" == "Linux" ]; then
+          sudo apt update
+          sudo apt install -y xvfb herbstluftwm libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 x11-utils
+          sudo /sbin/start-stop-daemon --start --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1024x768x24 -ac +extension GLX +render -noreset
+          sleep 3
+          sudo /sbin/start-stop-daemon --start --pidfile /tmp/custom_herbstluftwm_99.pid --make-pidfile --background --exec /usr/bin/herbstluftwm
+          sleep 1
+        fi
+
+    - name: Test with pytest
+      shell: bash -el {0}
+      timeout-minutes: 30
+      run: |
+        if [ "$RUNNER_OS" == "macOS" ]; then
+          python run_tests.py --ignore=pydm/tests/data_plugins/test_p4p_plugin_component.py --ignore=pydm/tests/widgets/test_slider.py  # disable just for now, until fix intermittent issue
+        else
+          python run_tests.py
+        fi

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-[![Build Status: PySide6](https://github.com/slaclab/pydm/actions/workflows/run-tests-pyqt5.yml/badge.svg?branch=master)](https://github.com/slaclab/pydm/actions/workflows/run-tests-pyqt5.yml)
-[![Build Status: PyQt5](https://github.com/slaclab/pydm/actions/workflows/run-tests-pyside6.yml/badge.svg?branch=master)](https://github.com/slaclab/pydm/actions/workflows/run-tests-pyside6.yml)
+[![Build Status: PyQt5](https://github.com/slaclab/pydm/actions/workflows/run-tests-pyqt5.yml/badge.svg?branch=master)](https://github.com/slaclab/pydm/actions/workflows/run-tests-pyqt5.yml)
+[![Build Status: PyQt6](https://github.com/slaclab/pydm/actions/workflows/run-tests-pyqt6.yml/badge.svg?branch=master)](https://github.com/slaclab/pydm/actions/workflows/run-tests-pyqt6.yml)
+[![Build Status: PySide6](https://github.com/slaclab/pydm/actions/workflows/run-tests-pyside6.yml/badge.svg?branch=master)](https://github.com/slaclab/pydm/actions/workflows/run-tests-pyside6.yml)
 
 ![PyDM: Python Display Manager](pydm_banner_full.png)
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -11,7 +11,21 @@ with pip.
 
 Please note, this guide is written with Unix in mind, so there are probably some differences when installing on Windows.
 
-Installing PyDM and Prerequisites with Conda
+Installing PyDM and Prerequisites with Conda (PyQt6)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+After installing Miniforge (see https://conda-forge.org/download/), create a new
+environment for PyDM::
+
+  $ conda create -n pydm-environment python=3.12 pyqt6 pip numpy six psutil pyqtgraph pydm -c conda-forge
+  $ conda activate pydm-environment
+  $ export QT_API=pyqt6
+
+Once you've installed and activated the environment, you should be able to run 'pydm' to launch PyDM, or run 'designer6' to launch Qt Designer.  If you are on Windows, run these commands from the Anaconda Prompt.
+
+
+MacOS instructions in progress...
+
+Installing PyDM and Prerequisites with Conda (PyQt5)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. warning::

--- a/pydm/about_pydm/about.py
+++ b/pydm/about_pydm/about.py
@@ -27,7 +27,7 @@ class AboutWindow(QWidget):
         self.ui.setupUi(self)
         self.ui.pydmVersionLabel.setText(str(self.ui.pydmVersionLabel.text()).format(version=pydm.__version__))
         pyver = ".".join([str(v) for v in sys.version_info[0:3]])
-        python_binding_name = "PyQt" if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT5 else "PySide"
+        python_binding_name = "PyQt" if ACTIVE_QT_WRAPPER in (QtWrapperTypes.PYQT5, QtWrapperTypes.PYQT6) else "PySide"
         self.ui.modulesVersionLabel.setText(
             str(self.ui.modulesVersionLabel.text()).format(
                 pyver=pyver,

--- a/pydm/data_plugins/archiver_plugin.py
+++ b/pydm/data_plugins/archiver_plugin.py
@@ -114,8 +114,8 @@ class Connection(PyDMConnection):
         reply: The response from the archiver appliance
         """
         success = (
-            reply.error() == QNetworkReply.NoError
-            and reply.header(QNetworkRequest.ContentTypeHeader) == "application/json"
+            reply.error() == QNetworkReply.NetworkError.NoError
+            and reply.header(QNetworkRequest.KnownHeaders.ContentTypeHeader) == "application/json"
         )
         self.connection_state_signal.emit(success)
         if success:
@@ -129,7 +129,7 @@ class Connection(PyDMConnection):
         else:
             logger.debug(
                 f"Request for data from archiver failed, request url: {reply.url()} retrieved header: "
-                f"{reply.header(QNetworkRequest.ContentTypeHeader)} error: {reply.error()}"
+                f"{reply.header(QNetworkRequest.KnownHeaders.ContentTypeHeader)} error: {reply.error()}"
             )
         reply.deleteLater()
 

--- a/pydm/display.py
+++ b/pydm/display.py
@@ -20,7 +20,7 @@ from .help_files import HelpWindow
 from .utilities import import_module_by_filename, is_pydm_app, macro, ACTIVE_QT_WRAPPER, QtWrapperTypes
 
 
-if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT5:
+if ACTIVE_QT_WRAPPER in (QtWrapperTypes.PYQT5, QtWrapperTypes.PYQT6):
     from qtpy import uic
 
 
@@ -98,7 +98,7 @@ def _compile_ui_file(uifile: str) -> Tuple[str, str]:
     -------
     Tuple[str, str] - The first element is the compiled ui file, the second is the name of the class (e.g. Ui_Form)
     """
-    if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT5:
+    if ACTIVE_QT_WRAPPER in (QtWrapperTypes.PYQT5, QtWrapperTypes.PYQT6):
         code_string = StringIO()
         uic.compileUi(uifile, code_string)
         code_string = code_string.getvalue()
@@ -126,7 +126,7 @@ def _compile_ui_file(uifile: str) -> Tuple[str, str]:
 
 
 def _load_ui_into_display(uifile, display):
-    if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT5:
+    if ACTIVE_QT_WRAPPER in (QtWrapperTypes.PYQT5, QtWrapperTypes.PYQT6):
         klass, _ = uic.loadUiType(uifile)
     else:  # pyside6
         from PySide6.QtUiTools import loadUiType

--- a/pydm/register_pydm_designer_plugin.py
+++ b/pydm/register_pydm_designer_plugin.py
@@ -4,7 +4,7 @@ from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
 from pydm.widgets.qtplugins import get_all_custom_widgets_in_order
 
 
-if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT5:
+if ACTIVE_QT_WRAPPER in (QtWrapperTypes.PYQT5, QtWrapperTypes.PYQT6):
     globals().update({pl.plugin_name: pl for pl in get_all_custom_widgets_in_order()})
 
 elif ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:

--- a/pydm/tests/data_plugins/test_archiver_plugin.py
+++ b/pydm/tests/data_plugins/test_archiver_plugin.py
@@ -56,7 +56,7 @@ class MockNetworkReply:
         return self.url_obj
 
     def error(self):
-        return QNetworkReply.NoError
+        return QNetworkReply.NetworkError.NoError
 
     def header(self, content_type):
         return "application/json"

--- a/pydm/tests/data_plugins/test_pyepics_plugin_component.py
+++ b/pydm/tests/data_plugins/test_pyepics_plugin_component.py
@@ -11,8 +11,17 @@ def ensure_thread_pool():
     # Connection.__init__ submits work to the class-level PyEPICSPlugin.thread_pool, which is
     # normally created when the plugin itself is instantiated. These tests build a Connection
     # directly, so initialize the pool here to keep them independent of test ordering.
-    if PyEPICSPlugin.thread_pool is None:
+    created_here = PyEPICSPlugin.thread_pool is None
+    if created_here:
         PyEPICSPlugin.thread_pool = ThreadPoolExecutor()
+    try:
+        yield
+    finally:
+        # Only tear down a pool this fixture created, so we don't leak worker threads or
+        # class-level state into other tests.
+        if created_here:
+            PyEPICSPlugin.thread_pool.shutdown(wait=False, cancel_futures=True)
+            PyEPICSPlugin.thread_pool = None
 
 
 def test_update_ctrl_vars(signals: ConnectionSignals):

--- a/pydm/tests/data_plugins/test_pyepics_plugin_component.py
+++ b/pydm/tests/data_plugins/test_pyepics_plugin_component.py
@@ -1,6 +1,18 @@
-from pydm.data_plugins.epics_plugins.pyepics_plugin_component import Connection
+import pytest
+from concurrent.futures import ThreadPoolExecutor
+
+from pydm.data_plugins.epics_plugins.pyepics_plugin_component import Connection, PyEPICSPlugin
 from pydm.tests.conftest import ConnectionSignals
 from pydm.widgets.channel import PyDMChannel
+
+
+@pytest.fixture(autouse=True)
+def ensure_thread_pool():
+    # Connection.__init__ submits work to the class-level PyEPICSPlugin.thread_pool, which is
+    # normally created when the plugin itself is instantiated. These tests build a Connection
+    # directly, so initialize the pool here to keep them independent of test ordering.
+    if PyEPICSPlugin.thread_pool is None:
+        PyEPICSPlugin.thread_pool = ThreadPoolExecutor()
 
 
 def test_update_ctrl_vars(signals: ConnectionSignals):

--- a/pydm/tests/test_display.py
+++ b/pydm/tests/test_display.py
@@ -48,17 +48,26 @@ def test_reimplemented_ui_filename(qtbot):
     qtbot.addWidget(my_display)
 
 
-if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT5:
+if ACTIVE_QT_WRAPPER in (QtWrapperTypes.PYQT5, QtWrapperTypes.PYQT6):
+    # Both PyQt wrappers compile .ui in-process via uic.compileUi and raise on a missing
+    # file, but the exception type differs: PyQt5 raises IOError, while PyQt6's uic wraps
+    # it in its own UIFileException.
+    if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT6:
+        from PyQt6.uic.exceptions import UIFileException
 
-    def test_nonexistent_ui_file_raises_pyqt5(qtbot):
-        with pytest.raises(IOError):
+        _expected_ui_error = UIFileException
+    else:
+        _expected_ui_error = IOError
+
+    def test_nonexistent_ui_file_raises_pyqt(qtbot):
+        with pytest.raises(_expected_ui_error):
             Display(parent=None, ui_filename="this_doesnt_exist.ui")
 
         class TestDisplay(Display):
             def ui_filename(self):
                 return "this_doesnt_exist.ui"
 
-        with pytest.raises(IOError):
+        with pytest.raises(_expected_ui_error):
             TestDisplay(parent=None)
 
 else:  # pyside6

--- a/pydm/tests/widgets/test_base.py
+++ b/pydm/tests/widgets/test_base.py
@@ -3,7 +3,7 @@ import pytest
 import json
 import logging
 
-from qtpy.QtCore import Qt
+from qtpy.QtCore import Qt, QPointF
 from qtpy.QtWidgets import QMenu
 from qtpy.QtGui import QClipboard, QColor, QMouseEvent
 from pydm.tests.conftest import ConnectionSignals
@@ -219,8 +219,8 @@ def test_open_context_menu(qtbot, monkeypatch, caplog):
 
     mouse_event = QMouseEvent(
         QMouseEvent.MouseButtonRelease,
-        pydm_label.rect().center(),  # localPos
-        pydm_label.rect().center(),  # globalPos
+        QPointF(pydm_label.rect().center()),  # localPos
+        QPointF(pydm_label.rect().center()),  # globalPos
         Qt.RightButton,  # button
         Qt.RightButton,  # buttons
         Qt.ShiftModifier,  # modifiers

--- a/pydm/tests/widgets/test_slider.py
+++ b/pydm/tests/widgets/test_slider.py
@@ -3,7 +3,7 @@ from logging import ERROR
 import numpy as np
 
 from qtpy.QtWidgets import QLabel, QVBoxLayout, QHBoxLayout, QSizePolicy, QApplication, QSlider, QWidget
-from qtpy.QtCore import Qt, QMargins, QPoint, QEvent, QRect, QSize
+from qtpy.QtCore import Qt, QMargins, QPoint, QPointF, QEvent, QRect, QSize
 from qtpy.QtGui import QMouseEvent
 from pydm.widgets.slider import PyDMSlider, PyDMPrimitiveSlider
 from pydm.widgets.base import PyDMWidget
@@ -87,8 +87,8 @@ def test_mouseMoveEvent(slider_fixture, qtbot, request):
 
     press_event = QMouseEvent(
         QEvent.MouseButtonPress,
-        start_pos,  # localPos
-        start_pos,  # globalPos
+        QPointF(start_pos),  # localPos
+        QPointF(start_pos),  # globalPos
         Qt.LeftButton,  # button
         Qt.LeftButton,  # buttons
         Qt.NoModifier,
@@ -98,8 +98,8 @@ def test_mouseMoveEvent(slider_fixture, qtbot, request):
 
     move_event = QMouseEvent(
         QEvent.MouseMove,
-        end_pos,  # localPos
-        end_pos,  # globalPos
+        QPointF(end_pos),  # localPos
+        QPointF(end_pos),  # globalPos
         Qt.LeftButton,  # button
         Qt.LeftButton,  # buttons
         Qt.NoModifier,
@@ -109,8 +109,8 @@ def test_mouseMoveEvent(slider_fixture, qtbot, request):
 
     release_event = QMouseEvent(
         QEvent.MouseButtonRelease,
-        end_pos,  # localPos
-        end_pos,  # globalPos
+        QPointF(end_pos),  # localPos
+        QPointF(end_pos),  # globalPos
         Qt.LeftButton,  # button
         Qt.LeftButton,  # buttons
         Qt.NoModifier,
@@ -152,7 +152,7 @@ def test_getHandleRect(slider_fixture, request):
 def test_getPositions(slider_fixture, request):
     """Test getPositions method."""
     test_slider = request.getfixturevalue(slider_fixture)
-    event = QMouseEvent(QEvent.MouseButtonPress, QPoint(50, 10), Qt.LeftButton, Qt.LeftButton, Qt.NoModifier)
+    event = QMouseEvent(QEvent.MouseButtonPress, QPointF(50, 10), Qt.LeftButton, Qt.LeftButton, Qt.NoModifier)
     handle_pos, click_pos = test_slider.getPositions(event)
     assert isinstance(handle_pos, float)
     assert isinstance(click_pos, int)
@@ -260,13 +260,11 @@ def test_construct(qtbot):
 
     assert type(pydm_slider.low_lim_label) == QLabel
     assert pydm_slider.low_lim_label.sizePolicy() == QSizePolicy(QSizePolicy.Maximum, QSizePolicy.Fixed)
-    assert pydm_slider.low_lim_label.alignment() == Qt.Alignment(int(Qt.AlignLeft | Qt.AlignTrailing | Qt.AlignVCenter))
+    assert pydm_slider.low_lim_label.alignment() == (Qt.AlignLeft | Qt.AlignTrailing | Qt.AlignVCenter)
 
     assert type(pydm_slider.high_lim_label) == QLabel
     assert pydm_slider.high_lim_label.sizePolicy() == QSizePolicy(QSizePolicy.Maximum, QSizePolicy.Fixed)
-    assert pydm_slider.high_lim_label.alignment() == Qt.Alignment(
-        int(Qt.AlignRight | Qt.AlignTrailing | Qt.AlignVCenter)
-    )
+    assert pydm_slider.high_lim_label.alignment() == (Qt.AlignRight | Qt.AlignTrailing | Qt.AlignVCenter)
 
     assert type(pydm_slider._slider) == PyDMPrimitiveSlider
     assert pydm_slider._slider.orientation() == Qt.Orientation(Qt.Horizontal)

--- a/pydm/tests/widgets/test_timeplot.py
+++ b/pydm/tests/widgets/test_timeplot.py
@@ -50,7 +50,7 @@ def test_timeplotcurveitem_severityChanged_updates_attributes_and_emits(timeplot
     assert timeplotcurveitem_widget.severity_raw == 2
     assert timeplotcurveitem_widget.severity == "MAJOR"
 
-    if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT5:
+    if ACTIVE_QT_WRAPPER in (QtWrapperTypes.PYQT5, QtWrapperTypes.PYQT6):
         assert len(severity_spy) == 1
         assert severity_spy[0] == [2]
     else:

--- a/pydm/tests/widgets/test_waveform_plot.py
+++ b/pydm/tests/widgets/test_waveform_plot.py
@@ -2,7 +2,7 @@ import numpy as np
 from pyqtgraph import BarGraphItem
 from unittest import mock
 from unittest.mock import MagicMock, patch
-from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
+import qtpy
 from pydm.widgets.waveformplot import PyDMWaveformPlot, WaveformCurveItem
 
 
@@ -181,10 +181,9 @@ def test_redrawPlot_with_crosshair():
     widget.mapFromGlobal = MagicMock(return_value=dummy_local_pos)
     widget.mapToScene = MagicMock(return_value=dummy_scene_pos)
 
-    if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
-        patch_path = "PySide6.QtGui.QCursor.pos"
-    else:
-        patch_path = "PyQt5.QtGui.QCursor.pos"
+    # Patch QCursor.pos on whichever binding is active. Avoids hardcoding a wrapper that
+    # may not be installed (e.g. PyQt5 under a PyQt6 environment). API_NAME is the module name.
+    patch_path = f"{qtpy.API_NAME}.QtGui.QCursor.pos"
 
     # Patch QCursor.pos to return dummy_global_pos.
     with patch(patch_path, return_value=dummy_global_pos):

--- a/pydm/utilities/__init__.py
+++ b/pydm/utilities/__init__.py
@@ -51,6 +51,7 @@ class QtWrapperTypes(IntEnum):
     UNSUPPORTED = 0
     PYSIDE6 = 1
     PYQT5 = 2
+    PYQT6 = 3
 
 
 ACTIVE_QT_WRAPPER = QtWrapperTypes.UNSUPPORTED
@@ -61,14 +62,63 @@ if qt_api == "pyside6":
     ACTIVE_QT_WRAPPER = QtWrapperTypes.PYSIDE6
 elif qt_api == "pyqt5":
     ACTIVE_QT_WRAPPER = QtWrapperTypes.PYQT5
+elif qt_api == "pyqt6":
+    ACTIVE_QT_WRAPPER = QtWrapperTypes.PYQT6
 
 if ACTIVE_QT_WRAPPER == QtWrapperTypes.UNSUPPORTED:
     error_message = (
         "The QT_API variable is not set to a supported Qt Python wrapper "
-        "(PySide6 or PyQt5). Please set QT_API to 'pyside6' or 'pyqt5'."
+        "(PySide6, PyQt5, or PyQt6). Please set QT_API to 'pyside6', 'pyqt5', or 'pyqt6'."
     )
     logger.error(error_message)
     raise RuntimeError(error_message)
+
+
+def int_enum_from(name, source):
+    """Build an IntEnum mirroring the input source value.
+
+    source may be an enum.Enum or a legacy class whose integer
+    attributes define the members.  Used to give PyQt6 a real enum where the
+    other Qt wrappers historically used a plain int-attribute class (PyQt5) or
+    a QEnum-decorated enum (PySide6).
+    """
+    import enum
+
+    if isinstance(source, type) and issubclass(source, enum.Enum):
+        members = [(member.name, member.value) for member in source]
+    else:
+        members = [
+            (key, value) for key, value in vars(source).items() if isinstance(value, int) and not key.startswith("_")
+        ]
+    return enum.IntEnum(name, members)
+
+
+def pyqt6_designer_enum(owner, source):
+    """Register an enum as a PyQt6 Qt Designer property type.
+
+    PyQt6 removed Q_ENUM, its replacement requires an enum.Enum
+    whose __qualname__ matches the owning widget class, and
+    each owner needs its own object. Build a per-owner copy of source and
+    register it so the property appears as a proper enum (dropdown) in Designer.
+
+    Parameters
+    ----------
+    owner : str
+        Name of the owning widget class, used for the registered enum's
+        ``__qualname__`` so each widget gets a distinct meta-type.
+    source : type
+        The enum, or legacy class of integer attributes, to mirror.
+
+    Returns
+    -------
+    enum.IntEnum
+        A registered copy suitable as a ``Property`` type under PyQt6.
+    """
+    from PyQt6.QtCore import pyqtEnum
+
+    registered = int_enum_from(source.__name__, source)
+    registered.__qualname__ = f"{owner}.{source.__name__}"
+    return pyqtEnum(registered)
 
 
 def is_ssh_session():

--- a/pydm/widgets/analog_indicator.py
+++ b/pydm/widgets/analog_indicator.py
@@ -8,7 +8,7 @@ from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
 if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
     from PySide6.QtCore import Property
 else:
-    from PyQt5.QtCore import pyqtProperty as Property
+    from qtpy.QtCore import Property
 
 
 class QScaleAlarmed(QScale):

--- a/pydm/widgets/archiver_time_plot.py
+++ b/pydm/widgets/archiver_time_plot.py
@@ -1496,8 +1496,13 @@ class PyDMArchiverTimePlot(PyDMTimePlot):
                 liveData=d.get("liveData"),
             )
 
-    # Set to True under PyQt6 only since setting to False leads to an error on saving
-    curves = Property("QStringList", getCurves, setCurves, designable=ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT6)
+    # Set to True on Qt6. With designable=False the curve editor fails to save in Designer ("Unable to set property")
+    curves = Property(
+        "QStringList",
+        getCurves,
+        setCurves,
+        designable=ACTIVE_QT_WRAPPER in (QtWrapperTypes.PYQT6, QtWrapperTypes.PYSIDE6),
+    )
 
     def addYChannel(
         self,

--- a/pydm/widgets/archiver_time_plot.py
+++ b/pydm/widgets/archiver_time_plot.py
@@ -6,7 +6,7 @@ import warnings
 from collections import OrderedDict
 from typing import List, Optional, Union
 from pyqtgraph import DateAxisItem, ErrorBarItem, PlotCurveItem
-from pydm.utilities import remove_protocol, is_qt_designer
+from pydm.utilities import remove_protocol, is_qt_designer, ACTIVE_QT_WRAPPER, QtWrapperTypes
 from pydm.widgets.channel import PyDMChannel
 from pydm.widgets.timeplot import TimePlotCurveItem
 from pydm.widgets import PyDMTimePlot
@@ -1496,7 +1496,8 @@ class PyDMArchiverTimePlot(PyDMTimePlot):
                 liveData=d.get("liveData"),
             )
 
-    curves = Property("QStringList", getCurves, setCurves, designable=False)
+    # Set to True under PyQt6 only since setting to False leads to an error on saving
+    curves = Property("QStringList", getCurves, setCurves, designable=ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT6)
 
     def addYChannel(
         self,

--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -20,7 +20,7 @@ from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
 if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
     from PySide6.QtCore import Property
 else:
-    from PyQt5.QtCore import pyqtProperty as Property
+    from qtpy.QtCore import Property
 from .rules import RulesDispatcher
 from datetime import datetime
 from typing import Optional

--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -363,7 +363,7 @@ class PyDMPrimitiveWidget(object):
             except JSONDecodeError:
                 logger.exception("Invalid format for Rules")
 
-    # Set to True on Qt6. With designable=False the curve editor fails to save in Designer ("Unable to set property")
+    # Set to True on Qt6. With designable=False this fails to save in Designer ("Unable to set property")
     rules = Property(
         str, readRules, setRules, designable=ACTIVE_QT_WRAPPER in (QtWrapperTypes.PYQT6, QtWrapperTypes.PYSIDE6)
     )

--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -363,8 +363,10 @@ class PyDMPrimitiveWidget(object):
             except JSONDecodeError:
                 logger.exception("Invalid format for Rules")
 
-    # Set to True under PyQt6 only since setting to False leads to an error on saving
-    rules = Property(str, readRules, setRules, designable=ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT6)
+    # Set to True on Qt6. With designable=False the curve editor fails to save in Designer ("Unable to set property")
+    rules = Property(
+        str, readRules, setRules, designable=ACTIVE_QT_WRAPPER in (QtWrapperTypes.PYQT6, QtWrapperTypes.PYSIDE6)
+    )
 
     def find_parent_display(self):
         widget = self.parent()

--- a/pydm/widgets/base.py
+++ b/pydm/widgets/base.py
@@ -363,7 +363,8 @@ class PyDMPrimitiveWidget(object):
             except JSONDecodeError:
                 logger.exception("Invalid format for Rules")
 
-    rules = Property(str, readRules, setRules, designable=False)
+    # Set to True under PyQt6 only since setting to False leads to an error on saving
+    rules = Property(str, readRules, setRules, designable=ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT6)
 
     def find_parent_display(self):
         widget = self.parent()

--- a/pydm/widgets/baseplot.py
+++ b/pydm/widgets/baseplot.py
@@ -315,7 +315,9 @@ class BasePlotCurveItem(PlotDataItem):
         new_style: Qt.PenStyle
         """
         valid_styles = set(self.lines.values())
-        if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6 and isinstance(new_style, int):
+        # Qt6 enums (both PySide6 and PyQt6) are strict: a bare int neither equals nor is in
+        # the set of Qt.PenStyle members, so it must be converted first.
+        if isinstance(new_style, int):
             new_style = Qt.PenStyle(new_style)
         if new_style in valid_styles:
             self._pen.setStyle(new_style)
@@ -1140,7 +1142,10 @@ class BasePlot(PlotWidget, PyDMPrimitiveWidget):
         if self.getShowYGrid() or self.getShowXGrid():
             self.plotItem.updateGrid()
 
-    yAxes = Property("QStringList", getYAxes, setYAxes, designable=False)
+    # designable=False keeps the raw JSON out of the Designer property grid, but the PyQt6
+    # designer bridge then refuses to commit it via the curve editor's cursor().setProperty();
+    # expose it under PyQt6 so edits save (stays hidden under PyQt5/PySide6).
+    yAxes = Property("QStringList", getYAxes, setYAxes, designable=ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT6)
 
     def getBottomAxisLabel(self) -> str:
         return self.getAxis("bottom").labelText

--- a/pydm/widgets/baseplot.py
+++ b/pydm/widgets/baseplot.py
@@ -28,7 +28,7 @@ from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
 if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
     from PySide6.QtCore import Property
 else:
-    from PyQt5.QtCore import pyqtProperty as Property
+    from qtpy.QtCore import Property
 
 
 def pen_style_to_int(pen_style) -> int:

--- a/pydm/widgets/baseplot.py
+++ b/pydm/widgets/baseplot.py
@@ -1142,10 +1142,13 @@ class BasePlot(PlotWidget, PyDMPrimitiveWidget):
         if self.getShowYGrid() or self.getShowXGrid():
             self.plotItem.updateGrid()
 
-    # designable=False keeps the raw JSON out of the Designer property grid, but the PyQt6
-    # designer bridge then refuses to commit it via the curve editor's cursor().setProperty();
-    # expose it under PyQt6 so edits save (stays hidden under PyQt5/PySide6).
-    yAxes = Property("QStringList", getYAxes, setYAxes, designable=ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT6)
+    # Set to True on Qt6. With designable=False the curve editor fails to save in Designer ("Unable to set property")
+    yAxes = Property(
+        "QStringList",
+        getYAxes,
+        setYAxes,
+        designable=ACTIVE_QT_WRAPPER in (QtWrapperTypes.PYQT6, QtWrapperTypes.PYSIDE6),
+    )
 
     def getBottomAxisLabel(self) -> str:
         return self.getAxis("bottom").labelText

--- a/pydm/widgets/baseplot_table_model.py
+++ b/pydm/widgets/baseplot_table_model.py
@@ -128,7 +128,7 @@ class BasePlotCurvesModel(QAbstractTableModel):
         elif column_name == "Y-Axis Name":
             curve.y_axis_name = str(value)
         elif column_name == "Line Style":
-            curve.lineStyle = int(value)
+            curve.lineStyle = value
         elif column_name == "Line Width":
             curve.lineWidth = int(value)
         elif column_name == "Symbol":

--- a/pydm/widgets/byte.py
+++ b/pydm/widgets/byte.py
@@ -515,12 +515,13 @@ class PyDMByteIndicator(QWidget, PyDMWidget):
         -------
         new_orientation : Qt.Orientation, int
         """
+        if isinstance(new_orientation, int):
+            new_orientation = Qt.Orientation(new_orientation)
         self._orientation = new_orientation
         self.set_spacing()
         self.rebuild_layout()
 
-    prop_type = int if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6 else Qt.Orientation
-    orientation = Property(prop_type, readOrientation, setOrientation)
+    orientation = Property(Qt.Orientation, readOrientation, setOrientation)
 
     def set_spacing(self) -> None:
         """

--- a/pydm/widgets/byte.py
+++ b/pydm/widgets/byte.py
@@ -8,7 +8,7 @@ from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
 if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
     from PySide6.QtCore import Property
 else:
-    from PyQt5.QtCore import pyqtProperty as Property
+    from qtpy.QtCore import Property
 
 
 class PyDMBitIndicator(QWidget):

--- a/pydm/widgets/colormaps.py
+++ b/pydm/widgets/colormaps.py
@@ -1080,6 +1080,12 @@ class PyDMColorMap(object):
     Hot = 6
 
 
+if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT6:
+    from pydm.utilities import int_enum_from
+
+    PyDMColorMap = int_enum_from("PyDMColorMap", PyDMColorMap)
+
+
 if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
     from PySide6.QtCore import QEnum
     from enum import Enum

--- a/pydm/widgets/datetime.py
+++ b/pydm/widgets/datetime.py
@@ -7,7 +7,7 @@ from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
 if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
     from PySide6.QtCore import Property
 else:
-    from PyQt5.QtCore import pyqtProperty as Property
+    from qtpy.QtCore import Property
 
 logger = logging.getLogger(__name__)
 
@@ -15,6 +15,12 @@ logger = logging.getLogger(__name__)
 class TimeBase(object):
     Milliseconds = 0
     Seconds = 1
+
+
+if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT6:
+    from pydm.utilities import int_enum_from
+
+    TimeBase = int_enum_from("TimeBase", TimeBase)
 
 
 if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
@@ -45,6 +51,10 @@ class PyDMDateTimeEdit(QtWidgets.QDateTimeEdit, PyDMWritableWidget):
         from PyQt5.QtCore import Q_ENUM
 
         Q_ENUM(TimeBase)
+    elif ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT6:
+        from pydm.utilities import pyqt6_designer_enum
+
+        TimeBase = pyqt6_designer_enum("PyDMDateTimeEdit", TimeBase)
 
     # Make enum definitions known to this class
     Milliseconds = TimeBase.Milliseconds
@@ -163,6 +173,10 @@ class PyDMDateTimeLabel(QtWidgets.QLabel, PyDMWidget):
         from PyQt5.QtCore import Q_ENUM
 
         Q_ENUM(TimeBase)
+    elif ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT6:
+        from pydm.utilities import pyqt6_designer_enum
+
+        TimeBase = pyqt6_designer_enum("PyDMDateTimeLabel", TimeBase)
 
     # Make enum definitions known to this class
     Milliseconds = TimeBase.Milliseconds

--- a/pydm/widgets/display_format.py
+++ b/pydm/widgets/display_format.py
@@ -26,6 +26,12 @@ class DisplayFormat(object):
     Binary = 5
 
 
+if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT6:
+    from pydm.utilities import int_enum_from
+
+    DisplayFormat = int_enum_from("DisplayFormat", DisplayFormat)
+
+
 if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
     from PySide6.QtCore import QEnum
     from enum import Enum

--- a/pydm/widgets/drawing.py
+++ b/pydm/widgets/drawing.py
@@ -14,7 +14,7 @@ from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
 if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
     from PySide6.QtCore import Property
 else:
-    from PyQt5.QtCore import pyqtProperty as Property
+    from qtpy.QtCore import Property
 from typing import List, Optional
 
 logger = logging.getLogger(__name__)

--- a/pydm/widgets/drawing.py
+++ b/pydm/widgets/drawing.py
@@ -350,8 +350,8 @@ class PyDMDrawing(QWidget, PyDMWidget):
         new_style : int
             Index at Qt.PenStyle enum or int
         """
-        # pyside6 enums are more strict and will error if passed int
-        if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6 and isinstance(new_style, int):
+        # Qt6 enums (both PySide6 and PyQt6) are strict and will error if passed an int
+        if isinstance(new_style, int):
             new_style = Qt.PenCapStyle(new_style)
         if new_style != self._pen_cap_style:
             self._pen_cap_style = new_style
@@ -381,8 +381,8 @@ class PyDMDrawing(QWidget, PyDMWidget):
         new_style : int
             Index at Qt.PenStyle enum or int
         """
-        # pyside6 enums are more strict and will error if passed int
-        if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6 and isinstance(new_style, int):
+        # Qt6 enums (both PySide6 and PyQt6) are strict and will error if passed an int
+        if isinstance(new_style, int):
             new_style = Qt.PenJoinStyle(new_style)
         if new_style != self._pen_join_style:
             self._pen_join_style = new_style
@@ -1072,6 +1072,9 @@ class PyDMDrawingImage(PyDMDrawing):
         new_mode : int
             Index at Qt.AspectRatioMode enum
         """
+        # Qt6 rejects an int, so normalize here before storing it.
+        if isinstance(new_mode, int):
+            new_mode = Qt.AspectRatioMode(new_mode)
         if new_mode != self._aspect_ratio_mode:
             self._aspect_ratio_mode = new_mode
             self.update()

--- a/pydm/widgets/drawing.py
+++ b/pydm/widgets/drawing.py
@@ -5,7 +5,7 @@ import logging
 
 from qtpy.QtWidgets import QWidget, QStyle, QStyleOption
 from qtpy.QtGui import QColor, QPainter, QBrush, QPen, QPolygonF, QPixmap, QMovie
-from qtpy.QtCore import Qt, QPoint, QPointF, QSize, Slot, QTimer, QRectF
+from qtpy.QtCore import Qt, QPointF, QSize, Slot, QTimer, QRectF
 from qtpy.QtDesigner import QDesignerFormWindowInterface
 from .base import PyDMWidget, PostParentClassInitSetup
 from pydm.utilities import is_qt_designer, find_file
@@ -327,8 +327,7 @@ class PyDMDrawing(QWidget, PyDMWidget):
             self._pen.setStyle(new_style)
             self.update()
 
-    prop_type = int if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6 else Qt.PenStyle
-    penStyle = Property(prop_type, readPenStyle, setPenStyle)
+    penStyle = Property(Qt.PenStyle, readPenStyle, setPenStyle)
 
     def readPenCapStyle(self) -> int | Qt.PenCapStyle:
         """
@@ -358,8 +357,7 @@ class PyDMDrawing(QWidget, PyDMWidget):
             self._pen.setCapStyle(new_style)
             self.update()
 
-    prop_type = int if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6 else Qt.PenCapStyle
-    penCapStyle = Property(prop_type, readPenCapStyle, setPenCapStyle)
+    penCapStyle = Property(Qt.PenCapStyle, readPenCapStyle, setPenCapStyle)
 
     def readPenJoinStyle(self) -> int | Qt.PenJoinStyle:
         """
@@ -389,8 +387,7 @@ class PyDMDrawing(QWidget, PyDMWidget):
             self._pen.setJoinStyle(new_style)
             self.update()
 
-    prop_type = int if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6 else Qt.PenJoinStyle
-    penJoinStyle = Property(prop_type, readPenJoinStyle, setPenJoinStyle)
+    penJoinStyle = Property(Qt.PenJoinStyle, readPenJoinStyle, setPenJoinStyle)
 
     def readPenColor(self) -> QColor:
         """
@@ -1079,8 +1076,7 @@ class PyDMDrawingImage(PyDMDrawing):
             self._aspect_ratio_mode = new_mode
             self.update()
 
-    prop_type = int if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6 else Qt.AspectRatioMode
-    aspectRatioMode = Property(prop_type, readAspectRatioMode, setAspectRatioMode)
+    aspectRatioMode = Property(Qt.AspectRatioMode, readAspectRatioMode, setAspectRatioMode)
 
     def draw_item(self, painter):
         """
@@ -1215,7 +1211,9 @@ class PyDMDrawingEllipse(PyDMDrawing):
         super().draw_item(painter)
         maxsize = not self.is_square()
         _, _, w, h = self.get_bounds(maxsize=maxsize)
-        painter.drawEllipse(QPoint(0, 0), w / 2.0, h / 2.0)
+        # QPointF (not QPoint) so the float-radii drawEllipse overload matches under
+        # PyQt6's strict overload resolution (PyQt5/PySide6 coerce, PyQt6 does not).
+        painter.drawEllipse(QPointF(0, 0), w / 2.0, h / 2.0)
 
 
 class PyDMDrawingCircle(PyDMDrawing):
@@ -1245,7 +1243,9 @@ class PyDMDrawingCircle(PyDMDrawing):
         super().draw_item(painter)
         _, _, w, h = self.get_bounds()
         r = self._calculate_radius(w, h)
-        painter.drawEllipse(QPoint(0, 0), r, r)
+        # QPointF (not QPoint) so the float-radii drawEllipse overload matches under
+        # PyQt6's strict overload resolution (PyQt5/PySide6 coerce, PyQt6 does not).
+        painter.drawEllipse(QPointF(0, 0), r, r)
 
 
 class PyDMDrawingArc(PyDMDrawing):

--- a/pydm/widgets/embedded_display.py
+++ b/pydm/widgets/embedded_display.py
@@ -21,7 +21,7 @@ from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
 if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
     from PySide6.QtCore import Property
 else:
-    from PyQt5.QtCore import pyqtProperty as Property
+    from qtpy.QtCore import Property
 
 logger = logging.getLogger(__name__)
 

--- a/pydm/widgets/enum_button.py
+++ b/pydm/widgets/enum_button.py
@@ -243,12 +243,13 @@ class PyDMEnumButton(QWidget, PyDMWritableWidget):
         -------
         new_orientation : Qt.Orientation, int
         """
+        if isinstance(new_orientation, int):
+            new_orientation = Qt.Orientation(new_orientation)
         if new_orientation != self._orientation:
             self._orientation = new_orientation
             self.rebuild_layout()
 
-    prop_type = int if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6 else Qt.Orientation
-    orientation = Property(prop_type, readOrientation, setOrientation)
+    orientation = Property(Qt.Orientation, readOrientation, setOrientation)
 
     def readMarginTop(self) -> int:
         """

--- a/pydm/widgets/enum_button.py
+++ b/pydm/widgets/enum_button.py
@@ -21,12 +21,18 @@ from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
 if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
     from PySide6.QtCore import Property
 else:
-    from PyQt5.QtCore import pyqtProperty as Property
+    from qtpy.QtCore import Property
 
 
 class WidgetType(object):
     PushButton = 0
     RadioButton = 1
+
+
+if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT6:
+    from pydm.utilities import int_enum_from
+
+    WidgetType = int_enum_from("WidgetType", WidgetType)
 
 
 if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
@@ -69,6 +75,10 @@ class PyDMEnumButton(QWidget, PyDMWritableWidget):
         from PyQt5.QtCore import Q_ENUM
 
         Q_ENUM(WidgetType)
+    elif ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT6:
+        from pydm.utilities import pyqt6_designer_enum
+
+        WidgetType = pyqt6_designer_enum("PyDMEnumButton", WidgetType)
     WidgetType = WidgetType
 
     # Make enum definitions known to this class

--- a/pydm/widgets/eventplot.py
+++ b/pydm/widgets/eventplot.py
@@ -456,8 +456,13 @@ class PyDMEventPlot(BasePlot):
                 yAxisName=d.get("yAxisName"),
             )
 
-    # Set to True under PyQt6 only since setting to False leads to an error on saving
-    curves = Property("QStringList", getCurves, setCurves, designable=ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT6)
+    # Set to True on Qt6. With designable=False the curve editor fails to save in Designer ("Unable to set property")
+    curves = Property(
+        "QStringList",
+        getCurves,
+        setCurves,
+        designable=ACTIVE_QT_WRAPPER in (QtWrapperTypes.PYQT6, QtWrapperTypes.PYSIDE6),
+    )
 
     def channels(self):
         """

--- a/pydm/widgets/eventplot.py
+++ b/pydm/widgets/eventplot.py
@@ -6,6 +6,7 @@ from qtpy.QtGui import QColor
 from qtpy.QtCore import Slot, Property, Qt
 from .baseplot import BasePlot, NoDataError, BasePlotCurveItem
 from .channel import PyDMChannel
+from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
 
 
 DEFAULT_BUFFER_SIZE = 1200
@@ -455,7 +456,8 @@ class PyDMEventPlot(BasePlot):
                 yAxisName=d.get("yAxisName"),
             )
 
-    curves = Property("QStringList", getCurves, setCurves, designable=False)
+    # Set to True under PyQt6 only since setting to False leads to an error on saving
+    curves = Property("QStringList", getCurves, setCurves, designable=ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT6)
 
     def channels(self):
         """

--- a/pydm/widgets/frame.py
+++ b/pydm/widgets/frame.py
@@ -5,7 +5,7 @@ from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
 if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
     from PySide6.QtCore import Property
 else:
-    from PyQt5.QtCore import pyqtProperty as Property
+    from qtpy.QtCore import Property
 
 
 class PyDMFrame(QFrame, PyDMWidget):

--- a/pydm/widgets/image.py
+++ b/pydm/widgets/image.py
@@ -13,7 +13,7 @@ from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
 if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
     from PySide6.QtCore import Property
 else:
-    from PyQt5.QtCore import pyqtProperty as Property
+    from qtpy.QtCore import Property
 
 logger = logging.getLogger(__name__)
 
@@ -23,6 +23,12 @@ class ReadingOrder(object):
 
     Fortranlike = 0
     Clike = 1
+
+
+if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT6:
+    from pydm.utilities import int_enum_from
+
+    ReadingOrder = int_enum_from("ReadingOrder", ReadingOrder)
 
 
 if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
@@ -56,6 +62,12 @@ class DimensionOrder(object):
 
     HeightFirst = 0
     WidthFirst = 1
+
+
+if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT6:
+    from pydm.utilities import int_enum_from
+
+    DimensionOrder = int_enum_from("DimensionOrder", DimensionOrder)
 
 
 if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
@@ -161,6 +173,12 @@ class PyDMImageView(ImageView, PyDMWidget):
         Q_ENUM(ReadingOrder)
         Q_ENUM(DimensionOrder)
         Q_ENUM(PyDMColorMap)
+    elif ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT6:
+        from pydm.utilities import pyqt6_designer_enum
+
+        ReadingOrder = pyqt6_designer_enum("PyDMImageView", ReadingOrder)
+        DimensionOrder = pyqt6_designer_enum("PyDMImageView", DimensionOrder)
+        PyDMColorMap = pyqt6_designer_enum("PyDMImageView", PyDMColorMap)
 
     # Make enum definitions known to this class
     Fortranlike = ReadingOrder.Fortranlike

--- a/pydm/widgets/label.py
+++ b/pydm/widgets/label.py
@@ -10,7 +10,7 @@ from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
 if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
     from PySide6.QtCore import Property
 else:
-    from PyQt5.QtCore import pyqtProperty as Property
+    from qtpy.QtCore import Property
 
 _labelRuleProperties = {"Text": ["value_changed", str]}
 
@@ -39,6 +39,10 @@ class PyDMLabel(QLabel, TextFormatter, PyDMWidget):
         from PyQt5.QtCore import Q_ENUM
 
         Q_ENUM(DisplayFormat)
+    elif ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT6:
+        from pydm.utilities import pyqt6_designer_enum
+
+        DisplayFormat = pyqt6_designer_enum("PyDMLabel", DisplayFormat)
 
     DisplayFormat = DisplayFormat
 

--- a/pydm/widgets/line_edit.py
+++ b/pydm/widgets/line_edit.py
@@ -15,7 +15,7 @@ from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
 if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
     from PySide6.QtCore import Property
 else:
-    from PyQt5.QtCore import pyqtProperty as Property
+    from qtpy.QtCore import Property
 
 logger = logging.getLogger(__name__)
 
@@ -39,6 +39,10 @@ class PyDMLineEdit(QLineEdit, TextFormatter, PyDMWritableWidget):
         from PyQt5.QtCore import Q_ENUM
 
         Q_ENUM(DisplayFormat)
+    elif ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT6:
+        from pydm.utilities import pyqt6_designer_enum
+
+        DisplayFormat = pyqt6_designer_enum("PyDMLineEdit", DisplayFormat)
     DisplayFormat = DisplayFormat
 
     # Make enum definitions known to this class

--- a/pydm/widgets/logdisplay.py
+++ b/pydm/widgets/logdisplay.py
@@ -247,7 +247,8 @@ class PyDMLogDisplay(QWidget):
     def setLogLevel(self, level) -> None:
         if level != self.level:
             self.level = level
-            idx = self.combo.findData(level)
+            # Search by the int value (getattr handles both an enum member and an int across all three Qt wrappers).
+            idx = self.combo.findData(getattr(level, "value", level))
             self.combo.setCurrentIndex(idx)
 
     logLevel = Property(LogLevels, readLogLevel, setLogLevel)

--- a/pydm/widgets/logdisplay.py
+++ b/pydm/widgets/logdisplay.py
@@ -21,7 +21,7 @@ from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
 if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
     from PySide6.QtCore import Property
 else:
-    from PyQt5.QtCore import pyqtProperty as Property
+    from qtpy.QtCore import Property
 
 logger = logging.getLogger(__name__)
 
@@ -111,6 +111,23 @@ class LogLevels(object):
         return OrderedDict(sorted(entries, key=lambda x: x[1], reverse=False))
 
 
+if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT6:
+    from enum import IntEnum
+
+    class LogLevels(IntEnum):  # noqa F811
+        NOTSET = 0
+        DEBUG = 10
+        INFO = 20
+        WARNING = 30
+        ERROR = 40
+        CRITICAL = 50
+
+        @staticmethod
+        def as_dict():
+            entries = [(name, member.value) for name, member in LogLevels.__members__.items()]
+            return OrderedDict(sorted(entries, key=lambda item: item[1]))
+
+
 if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
     from PySide6.QtCore import QEnum
     from enum import Enum
@@ -162,6 +179,10 @@ class PyDMLogDisplay(QWidget):
         from PyQt5.QtCore import Q_ENUM
 
         Q_ENUM(LogLevels)
+    elif ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT6:
+        from pydm.utilities import pyqt6_designer_enum
+
+        LogLevels = pyqt6_designer_enum("PyDMLogDisplay", LogLevels)
     LogLevels = LogLevels
 
     # Make enum definitions known to this class
@@ -207,6 +228,13 @@ class PyDMLogDisplay(QWidget):
         self.log = None
         self.level = None
         self.logName = logname or ""
+        if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT6:
+            # PyQt6 enum properties won't accept a bare int; coerce the logging
+            # level into a LogLevels member (leave custom levels untouched).
+            try:
+                level = LogLevels(level)
+            except ValueError:
+                pass
         self.logLevel = level
         self.destroyed.connect(functools.partial(logger_destroyed, self.log))
 

--- a/pydm/widgets/nt_table.py
+++ b/pydm/widgets/nt_table.py
@@ -8,7 +8,7 @@ from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
 if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
     from PySide6.QtCore import Property
 else:
-    from PyQt5.QtCore import pyqtProperty as Property
+    from qtpy.QtCore import Property
 
 logger = logging.getLogger(__name__)
 

--- a/pydm/widgets/pushbutton.py
+++ b/pydm/widgets/pushbutton.py
@@ -12,7 +12,7 @@ from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
 if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
     from PySide6.QtCore import Property
 else:
-    from PyQt5.QtCore import pyqtProperty as Property
+    from qtpy.QtCore import Property
 
 
 logger = logging.getLogger(__name__)

--- a/pydm/widgets/qtplugin_base.py
+++ b/pydm/widgets/qtplugin_base.py
@@ -36,7 +36,7 @@ logger = logging.getLogger(__name__)
 
 
 BASE_PLUGIN_CLASS = type
-if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT5:
+if ACTIVE_QT_WRAPPER in (QtWrapperTypes.PYQT5, QtWrapperTypes.PYQT6):
     BASE_PLUGIN_CLASS = QtDesigner.QPyDesignerCustomWidgetPlugin
 elif ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
     BASE_PLUGIN_CLASS = QtDesigner.QDesignerCustomWidgetInterface

--- a/pydm/widgets/related_display_button.py
+++ b/pydm/widgets/related_display_button.py
@@ -19,7 +19,7 @@ from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
 if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
     from PySide6.QtCore import Property
 else:
-    from PyQt5.QtCore import pyqtProperty as Property
+    from qtpy.QtCore import Property
 
 logger = logging.getLogger(__name__)
 

--- a/pydm/widgets/scale.py
+++ b/pydm/widgets/scale.py
@@ -8,7 +8,7 @@ from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
 if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
     from PySide6.QtCore import Property
 else:
-    from PyQt5.QtCore import pyqtProperty as Property
+    from qtpy.QtCore import Property
 
 
 class QScale(QFrame):

--- a/pydm/widgets/scale.py
+++ b/pydm/widgets/scale.py
@@ -489,6 +489,9 @@ class PyDMScaleIndicator(QFrame, TextFormatter, PyDMWidget):
         inverted : bool
             Indicates if scale appearance is inverted
         """
+        # Under strict Qt6 enums an int value_position would match none of them, so normalize to the enum first.
+        if isinstance(value_position, int):
+            value_position = Qt.Edge(value_position)
         self.limits_layout = None
         self.widget_layout = None
         r = self._grid_row_offset()

--- a/pydm/widgets/scale.py
+++ b/pydm/widgets/scale.py
@@ -732,11 +732,12 @@ class PyDMScaleIndicator(QFrame, TextFormatter, PyDMWidget):
         new_orientation : int
             Qt.Horizontal or Qt.Vertical
         """
+        if isinstance(orientation, int):
+            orientation = Qt.Orientation(orientation)
         self.scale_indicator.set_orientation(orientation)
         self.setup_widgets_for_orientation(orientation, self.flipScale, self.invertedAppearance, self._value_position)
 
-    prop_type = int if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6 else Qt.Orientation
-    orientation = Property(prop_type, readOrientation, setOrientation)
+    orientation = Property(Qt.Orientation, readOrientation, setOrientation)
 
     def readFlipScale(self) -> bool:
         """
@@ -984,11 +985,12 @@ class PyDMScaleIndicator(QFrame, TextFormatter, PyDMWidget):
          position : int
              Qt.TopEdge, Qt.BottomEdge, Qt.LeftEdge or Qt.RightEdge
         """
+        if isinstance(position, int):
+            position = Qt.Edge(position)
         self._value_position = position
         self.setup_widgets_for_orientation(self.orientation, self.flipScale, self.invertedAppearance, position)
 
-    prop_type = int if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6 else Qt.Edge
-    valuePosition = Property(prop_type, readValuePosition, setValuePosition)
+    valuePosition = Property(Qt.Edge, readValuePosition, setValuePosition)
 
     def readOriginAtZero(self) -> bool:
         """

--- a/pydm/widgets/scatterplot.py
+++ b/pydm/widgets/scatterplot.py
@@ -6,7 +6,7 @@ from qtpy.QtGui import QColor
 from qtpy.QtCore import Slot, Property, Qt
 from .baseplot import BasePlot, NoDataError, BasePlotCurveItem
 from .channel import PyDMChannel
-from pydm.utilities import remove_protocol
+from pydm.utilities import remove_protocol, ACTIVE_QT_WRAPPER, QtWrapperTypes
 
 
 DEFAULT_BUFFER_SIZE = 1200
@@ -544,7 +544,8 @@ class PyDMScatterPlot(BasePlot):
                 yAxisName=d.get("yAxisName"),
             )
 
-    curves = Property("QStringList", getCurves, setCurves, designable=False)
+    # Set to True under PyQt6 only since setting to False leads to an error on saving
+    curves = Property("QStringList", getCurves, setCurves, designable=ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT6)
 
     def channels(self):
         """

--- a/pydm/widgets/scatterplot.py
+++ b/pydm/widgets/scatterplot.py
@@ -544,8 +544,13 @@ class PyDMScatterPlot(BasePlot):
                 yAxisName=d.get("yAxisName"),
             )
 
-    # Set to True under PyQt6 only since setting to False leads to an error on saving
-    curves = Property("QStringList", getCurves, setCurves, designable=ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT6)
+    # Set to True on Qt6. With designable=False the curve editor fails to save in Designer ("Unable to set property")
+    curves = Property(
+        "QStringList",
+        getCurves,
+        setCurves,
+        designable=ACTIVE_QT_WRAPPER in (QtWrapperTypes.PYQT6, QtWrapperTypes.PYSIDE6),
+    )
 
     def channels(self):
         """

--- a/pydm/widgets/shell_command.py
+++ b/pydm/widgets/shell_command.py
@@ -19,7 +19,7 @@ from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
 if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
     from PySide6.QtCore import Property
 else:
-    from PyQt5.QtCore import pyqtProperty as Property
+    from qtpy.QtCore import Property
 
 logger = logging.getLogger(__name__)
 
@@ -32,6 +32,12 @@ class TermOutputMode:
     HIDE = 0
     SHOW = 1
     STORE = 2
+
+
+if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT6:
+    from pydm.utilities import int_enum_from
+
+    TermOutputMode = int_enum_from("TermOutputMode", TermOutputMode)
 
 
 if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
@@ -66,6 +72,10 @@ class PyDMShellCommand(QPushButton, PyDMWidget):
         from PyQt5.QtCore import Q_ENUM
 
         Q_ENUM(TermOutputMode)
+    elif ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT6:
+        from pydm.utilities import pyqt6_designer_enum
+
+        TermOutputMode = pyqt6_designer_enum("PyDMShellCommand", TermOutputMode)
     TermOutputMode = TermOutputMode
 
     # Make enum definitions known to this class

--- a/pydm/widgets/slider.py
+++ b/pydm/widgets/slider.py
@@ -23,7 +23,7 @@ from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
 if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
     from PySide6.QtCore import Property
 else:
-    from PyQt5.QtCore import pyqtProperty as Property
+    from qtpy.QtCore import Property
 
 logger = logging.getLogger(__name__)
 _step_size_properties = {

--- a/pydm/widgets/slider.py
+++ b/pydm/widgets/slider.py
@@ -527,11 +527,12 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget):
         new_orientation : Qt.Orientation
             Qt.Horizontal or Qt.Vertical
         """
+        if isinstance(new_orientation, int):
+            new_orientation = Qt.Orientation(new_orientation)
         self._orientation = new_orientation
         self.setup_widgets_for_orientation(new_orientation)
 
-    prop_type = int if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6 else Qt.Orientation
-    orientation = Property(prop_type, readOrientation, setOrientation)
+    orientation = Property(Qt.Orientation, readOrientation, setOrientation)
 
     def setup_widgets_for_orientation(self, new_orientation):
         """

--- a/pydm/widgets/slider.py
+++ b/pydm/widgets/slider.py
@@ -546,6 +546,7 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget):
             logger.error("Invalid orientation '{0}'. The existing layout will not change.".format(new_orientation))
             return
 
+        new_orientation = Qt.Orientation(new_orientation)
         layout = None
         if new_orientation == Qt.Horizontal or new_orientation == 1:
             layout = QVBoxLayout()

--- a/pydm/widgets/spinbox.py
+++ b/pydm/widgets/spinbox.py
@@ -6,7 +6,7 @@ from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
 if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
     from PySide6.QtCore import Property
 else:
-    from PyQt5.QtCore import pyqtProperty as Property
+    from qtpy.QtCore import Property
 
 
 class PyDMSpinbox(QDoubleSpinBox, TextFormatter, PyDMWritableWidget):

--- a/pydm/widgets/symbol.py
+++ b/pydm/widgets/symbol.py
@@ -157,6 +157,8 @@ class PyDMSymbol(QWidget, PyDMWidget):
         -----------
         new_mode : Qt.AspectRatioMode
         """
+        if isinstance(new_mode, int):
+            new_mode = Qt.AspectRatioMode(new_mode)
         if new_mode != self._aspect_ratio_mode:
             self._aspect_ratio_mode = new_mode
             self.update()

--- a/pydm/widgets/symbol.py
+++ b/pydm/widgets/symbol.py
@@ -12,7 +12,7 @@ from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
 if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
     from PySide6.QtCore import Property
 else:
-    from PyQt5.QtCore import pyqtProperty as Property
+    from qtpy.QtCore import Property
 
 
 logger = logging.getLogger(__name__)

--- a/pydm/widgets/symbol.py
+++ b/pydm/widgets/symbol.py
@@ -163,8 +163,7 @@ class PyDMSymbol(QWidget, PyDMWidget):
             self._aspect_ratio_mode = new_mode
             self.update()
 
-    prop_type = int if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6 else Qt.AspectRatioMode
-    aspectRatioMode = Property(prop_type, readAspectRatioMode, setAspectRatioMode)
+    aspectRatioMode = Property(Qt.AspectRatioMode, readAspectRatioMode, setAspectRatioMode)
 
     def connection_changed(self, connected):
         """

--- a/pydm/widgets/tab_bar.py
+++ b/pydm/widgets/tab_bar.py
@@ -10,7 +10,7 @@ from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
 if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
     from PySide6.QtCore import Property
 else:
-    from PyQt5.QtCore import pyqtProperty as Property
+    from qtpy.QtCore import Property
 
 
 class PyDMTabBar(QTabBar, PyDMWidget):

--- a/pydm/widgets/template_repeater.py
+++ b/pydm/widgets/template_repeater.py
@@ -15,7 +15,7 @@ from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
 if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
     from PySide6.QtCore import Property
 else:
-    from PyQt5.QtCore import pyqtProperty as Property
+    from qtpy.QtCore import Property
 
 logger = logging.getLogger(__name__)
 
@@ -124,6 +124,12 @@ class LayoutType(object):
     Flow = 2
 
 
+if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT6:
+    from pydm.utilities import int_enum_from
+
+    LayoutType = int_enum_from("LayoutType", LayoutType)
+
+
 if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
     from PySide6.QtCore import QEnum
     from enum import Enum
@@ -167,6 +173,10 @@ class PyDMTemplateRepeater(QFrame, PyDMPrimitiveWidget):
         from PyQt5.QtCore import Q_ENUM
 
         Q_ENUM(LayoutType)
+    elif ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT6:
+        from pydm.utilities import pyqt6_designer_enum
+
+        LayoutType = pyqt6_designer_enum("PyDMTemplateRepeater", LayoutType)
     LayoutType = LayoutType
 
     # Make enum definitions known to this class

--- a/pydm/widgets/terminator.py
+++ b/pydm/widgets/terminator.py
@@ -11,7 +11,7 @@ from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
 if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
     from PySide6.QtCore import Property
 else:
-    from PyQt5.QtCore import pyqtProperty as Property
+    from qtpy.QtCore import Property
 
 
 logger = logging.getLogger(__name__)

--- a/pydm/widgets/timeplot.py
+++ b/pydm/widgets/timeplot.py
@@ -10,7 +10,6 @@ from .baseplot import BasePlot, BasePlotCurveItem
 from .channel import PyDMChannel
 from pydm.utilities import remove_protocol, ACTIVE_QT_WRAPPER, QtWrapperTypes
 from datetime import datetime
-from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
 
 if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
     from PySide6.QtCore import Property
@@ -41,21 +40,13 @@ class updateMode(object):
     AtFixedRate = 2
 
 
-if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT6:
+if ACTIVE_QT_WRAPPER in (QtWrapperTypes.PYQT6, QtWrapperTypes.PYSIDE6):
     from pydm.utilities import int_enum_from
 
+    # Both Qt6 bindings need a real enum here (PyQt5 keeps the plain int-attribute class
+    # above). int_enum_from returns an IntEnum, so members stay equal to their int value,
+    # which the `value == updateMode.AtFixedRate` checks elsewhere in this module rely on.
     updateMode = int_enum_from("updateMode", updateMode)
-
-
-if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
-    from PySide6.QtCore import QEnum
-    from enum import Enum
-
-    @QEnum
-    # overrides prev enum def
-    class updateMode(Enum):  # noqa F811
-        OnValueChange = 1
-        AtFixedRate = 2
 
 
 class TimePlotCurveItem(BasePlotCurveItem):
@@ -846,8 +837,13 @@ class PyDMTimePlot(BasePlot):
                 yAxisName=d.get("yAxisName"),
             )
 
-    # Set to True under PyQt6 only since setting to False leads to an error on saving
-    curves = Property("QStringList", getCurves, setCurves, designable=ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT6)
+    # Set to True on Qt6. With designable=False the curve editor fails to save in Designer ("Unable to set property")
+    curves = Property(
+        "QStringList",
+        getCurves,
+        setCurves,
+        designable=ACTIVE_QT_WRAPPER in (QtWrapperTypes.PYQT6, QtWrapperTypes.PYSIDE6),
+    )
 
     def findCurve(self, pv_name):
         """
@@ -1037,7 +1033,8 @@ class PyDMTimePlot(BasePlot):
         -------
         updateMode
         """
-        return self._updateMode
+        # Property is int-typed under PySide6 (see prop_type below); return int there.
+        return int(self._updateMode) if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6 else self._updateMode
 
     def setUpdateMode(self, new_type) -> None:
         """
@@ -1051,7 +1048,11 @@ class PyDMTimePlot(BasePlot):
             self._updateMode = new_type
             self.setUpdatesAsynchronously(self._updateMode)
 
-    updateMode = Property(updateMode, readUpdateMode, setUpdateMode)
+    # PySide6 exposes this as a plain int field: its module-level QEnum never registered on
+    # the class, so Designer reported the property as an unsupported PyObjectWrapper. int keeps
+    # it editable/saveable (no dropdown, consistent with the other enum props under PySide6).
+    prop_type = int if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6 else updateMode
+    updateMode = Property(prop_type, readUpdateMode, setUpdateMode)
 
     def getTimeSpan(self):
         """

--- a/pydm/widgets/timeplot.py
+++ b/pydm/widgets/timeplot.py
@@ -15,7 +15,7 @@ from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
 if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
     from PySide6.QtCore import Property
 else:
-    from PyQt5.QtCore import pyqtProperty as Property
+    from qtpy.QtCore import Property
 
 import logging
 
@@ -39,6 +39,12 @@ class updateMode(object):
 
     OnValueChange = 1
     AtFixedRate = 2
+
+
+if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT6:
+    from pydm.utilities import int_enum_from
+
+    updateMode = int_enum_from("updateMode", updateMode)
 
 
 if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
@@ -497,6 +503,14 @@ class PyDMTimePlot(BasePlot):
         from PyQt5.QtCore import Q_ENUM
 
         Q_ENUM(updateMode)
+    elif ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT6:
+        from pydm.utilities import pyqt6_designer_enum
+
+        updateMode = pyqt6_designer_enum("PyDMTimePlot", updateMode)
+        # The Property defined below is also named "updateMode" and would replace
+        # this enum in the class namespace before PyQt6 registers it. Keep a
+        # reference under another name so it is still published as an enum type.
+        _updateMode_enum = updateMode
     updateMode = updateMode
 
     # Make enum definitions known to this class

--- a/pydm/widgets/timeplot.py
+++ b/pydm/widgets/timeplot.py
@@ -846,7 +846,8 @@ class PyDMTimePlot(BasePlot):
                 yAxisName=d.get("yAxisName"),
             )
 
-    curves = Property("QStringList", getCurves, setCurves, designable=False)
+    # Set to True under PyQt6 only since setting to False leads to an error on saving
+    curves = Property("QStringList", getCurves, setCurves, designable=ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT6)
 
     def findCurve(self, pv_name):
         """

--- a/pydm/widgets/waveformplot.py
+++ b/pydm/widgets/waveformplot.py
@@ -7,7 +7,7 @@ from .channel import PyDMChannel
 import itertools
 import json
 from collections import OrderedDict
-from pydm.utilities import remove_protocol
+from pydm.utilities import remove_protocol, ACTIVE_QT_WRAPPER, QtWrapperTypes
 
 
 class WaveformCurveItem(BasePlotCurveItem):
@@ -582,7 +582,8 @@ class PyDMWaveformPlot(BasePlot):
                 yAxisName=d.get("yAxisName"),
             )
 
-    curves = Property("QStringList", getCurves, setCurves, designable=False)
+    # Set to True under PyQt6 only since setting to False leads to an error on saving
+    curves = Property("QStringList", getCurves, setCurves, designable=ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT6)
 
     def channels(self):
         """

--- a/pydm/widgets/waveformplot.py
+++ b/pydm/widgets/waveformplot.py
@@ -582,8 +582,13 @@ class PyDMWaveformPlot(BasePlot):
                 yAxisName=d.get("yAxisName"),
             )
 
-    # Set to True under PyQt6 only since setting to False leads to an error on saving
-    curves = Property("QStringList", getCurves, setCurves, designable=ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT6)
+    # Set to True on Qt6. With designable=False the curve editor fails to save in Designer ("Unable to set property")
+    curves = Property(
+        "QStringList",
+        getCurves,
+        setCurves,
+        designable=ACTIVE_QT_WRAPPER in (QtWrapperTypes.PYQT6, QtWrapperTypes.PYSIDE6),
+    )
 
     def channels(self):
         """

--- a/pydm/widgets/waveformtable.py
+++ b/pydm/widgets/waveformtable.py
@@ -8,7 +8,7 @@ from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
 if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
     from PySide6.QtCore import Property
 else:
-    from PyQt5.QtCore import pyqtProperty as Property
+    from qtpy.QtCore import Property
 
 
 class PyDMWaveformTable(QTableWidget, PyDMWritableWidget):


### PR DESCRIPTION
### Context

Adds support for PyQt6 to PyDM.

Thanks to https://github.com/conda-forge/pyqt-feedstock/pull/182 this installation will now just work with designer using the conda-forge build without needing any workarounds or hacks on our side.

Like the PySide6 changes, the majority of the changes here are around getting enums to work both as designable properties and at runtime.

Existing and new displays were tested and working on both PyQt5 and 6. Added PyQt6 to our automated test run. Updated the installation instructions with a section on PyQt6. Put it at the top since it doesn't need the workaround of PyQt5.

One note is we need to unpin the version of PyQt in our conda-forge feedstock so it doesn't always install PyQt 5 when doing a conda/mamba installation. Can work around it while testing this by setting `export QT_API=pyqt6` or leaving PyDM off of the initial conda install command, but will make the update to the feedstock as well.

I also need to find a newer mac to test on to see what the Designer instructions for it should be.

### Testing

Tested displays interactively. Checked that all widgets seem ok both at runtime and while interacting with them in designer. Ran test suite for all 3 wrappers.
