### PR TITLE
ENH: Support for custom enums in PySide6-installed Designer

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -12,7 +12,15 @@ with pip.
 Please note, this guide is written with Unix in mind, so there are probably some differences when installing on Windows.
 
 Installing PyDM and Prerequisites with Conda (PyQt6)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. note::
+  These PyQt6 instructions currently work on Linux and Windows only.  Due to packaging
+  issues in the conda-forge PyQt6 packages for MacOS, Qt Designer cannot load Python
+  plugins there so the PyDM widgets will not show up.  On MacOS, follow the PySide6
+  instructions in the next section instead. This section will be updated once those
+  issues are resolved.
+
 After installing Miniforge (see https://conda-forge.org/download/), create a new
 environment for PyDM::
 
@@ -22,11 +30,34 @@ environment for PyDM::
 
 Once you've installed and activated the environment, you should be able to run 'pydm' to launch PyDM, or run 'designer6' to launch Qt Designer.  If you are on Windows, run these commands from the Anaconda Prompt.
 
+Installing PyDM and Prerequisites with Conda (PySide6)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-MacOS instructions in progress...
+After installing Miniforge (see https://conda-forge.org/download/), create and activate the environment::
+
+  $ conda create -n pydm-environment python=3.12 pyside6 pip numpy six psutil pyqtgraph pydm -c conda-forge
+  $ conda activate pydm-environment
+  $ export QT_API=pyside6
+
+Once the environment is activated, you should be able to run 'pydm' to launch PyDM.
+
+If using linux, Qt Designer needs libpython preloaded before the PyDM widgets will load.
+With the environment activated, run (replace 3.12 if you chose a different Python version)::
+
+  $ export LD_PRELOAD=$CONDA_PREFIX/lib/libpython3.12.so
+  $ designer6  # or pyside-designer6 if on a pip install
+
+Likewise on MacOS, Qt Designer also takes an extra step to get custom widgets to load.
+With the environment activated, run (replace 3.12 if you chose a different Python version)::
+
+  $ export DYLD_INSERT_LIBRARIES=$CONDA_PREFIX/lib/libpython3.12.dylib
+  $ Designer6
+
+When everything is working, the terminal will print "Loading PyDM Widgets" while
+Designer starts, and the PyDM widgets will appear in Designer's widget box.
 
 Installing PyDM and Prerequisites with Conda (PyQt5)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. warning::
     There is currently no PyQt 5.15+ build available on conda or PyPI that has
@@ -63,7 +94,7 @@ Now, you can use 'open' to open Designer.app::
     $ export QT_MAC_WANTS_LAYER=1
 
 Installing Manually, Without Anaconda (PyQt5)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 This alternate installation method is only recommended for large 'site' installations that want to avoid using Anaconda.
 
 Qt 5
@@ -93,7 +124,7 @@ build and install it.  Note that you may need to manually set the '--qmake' opti
 qmake binary you created when you built Qt5.
 
 Installing Manually, Without Anaconda (PySide6)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Instructions coming soon...
 
 Installing PyDM with PIP
@@ -121,6 +152,7 @@ If you want to use Designer to build displays with PyDM widgets, you'll need to
 add the PyDM install location to the PYQTDESIGNERPATH environment variable.  This
 directory might be buried pretty deep, depending on how Python is installed on your
 system.  For example, mine lives at '/usr/local/lib/python2.7/site-packages/pydm/'.
+If you are using PySide6, the equivalent environment variable is PYSIDE_DESIGNER_PLUGINS.
 
 Default Data Source
 ###################
@@ -143,4 +175,3 @@ installed.  This is usually done as part of the PyQt install process, but some
 package managers (like homebrew on OSX) don't install the plugin when PyQt is
 installed.  In that case, you'll probably need to install PyQt from source.
 Follow the directions from the PyQt documentation: http://pyqt.sourceforge.net/Docs/PyQt5/installation.html#building-and-installing-from-source
-

--- a/examples/tutorial/inline_motor.ui
+++ b/examples/tutorial/inline_motor.ui
@@ -517,7 +517,7 @@
         <bool>true</bool>
        </property>
        <property name="labelPosition" stdset="0">
-        <enum>QTabWidget::East</enum>
+        <enum>PyDMByteIndicator::East</enum>
        </property>
        <property name="labels" stdset="0">
         <stringlist>

--- a/pydm/tests/widgets/test_slider.py
+++ b/pydm/tests/widgets/test_slider.py
@@ -425,7 +425,7 @@ def test_properties_and_setters(qtbot, show_labels, orientation, tick_position):
     pydm_slider.orientation = orientation
 
     pydm_slider.tickPosition = tick_position
-    assert pydm_slider.tickPosition == tick_position
+    assert int(pydm_slider.tickPosition) == int(getattr(tick_position, "value", tick_position))
     pydm_slider.num_steps = 5
     assert pydm_slider.num_steps == 5
 

--- a/pydm/tests/widgets/test_slider.py
+++ b/pydm/tests/widgets/test_slider.py
@@ -425,7 +425,11 @@ def test_properties_and_setters(qtbot, show_labels, orientation, tick_position):
     pydm_slider.orientation = orientation
 
     pydm_slider.tickPosition = tick_position
-    assert int(pydm_slider.tickPosition) == int(getattr(tick_position, "value", tick_position))
+    expected_tick_position = int(getattr(tick_position, "value", tick_position))
+    assert int(pydm_slider.tickPosition) == expected_tick_position
+    # The value must also read back intact through the meta-object system (Designer's path).
+    stored = pydm_slider.property("tickPosition")
+    assert int(getattr(stored, "value", stored)) == expected_tick_position
     pydm_slider.num_steps = 5
     assert pydm_slider.num_steps == 5
 

--- a/pydm/utilities/__init__.py
+++ b/pydm/utilities/__init__.py
@@ -74,6 +74,24 @@ if ACTIVE_QT_WRAPPER == QtWrapperTypes.UNSUPPORTED:
     raise RuntimeError(error_message)
 
 
+# Cross-wrapper custom-enum Designer registration
+# ------------------------------------------------
+# For a custom "enum" widget property to render as a NAMED DROPDOWN in Qt Designer (rather than a
+# bare integer spin-box) the enum has to be registered with the meta-object system, and each Qt
+# wrapper does it differently:
+#   * PyQt5   -- ``Q_ENUM(TheEnum)`` in the widget class body.
+#   * PyQt6   -- ``pyqt6_designer_enum("PyDMWidget", TheEnum)`` (a per-widget ``pyqtEnum`` copy).
+#   * PySide6 -- ``@QEnum`` on a QObject-derived *carrier base class* whose NAME EQUALS the widget
+#                class, so the enum's meta-type scope becomes ``PyDMWidget::TheEnum`` and a value
+#                saved in a ``.ui`` round-trips across wrappers.  The real widget then subclasses the
+#                carrier (``class PyDMWidget(*_PyDMWidgetBases)``).  A shared enum needs one carrier
+#                per widget; a single carrier may host several enums.
+# The canonical enum is a real ``IntEnum`` on the Qt6 bindings (:func:`int_enum_from`).  Two rules
+# every such property must follow, or Designer/attribute-assignment break: initialise the backing
+# attribute from the registered enum (``self._x = self.TheEnum.Member`` -- a module-global member has
+# no C++ meta-type and Designer's property editor can't convert it), and funnel every incoming value
+# through :func:`coerce_enum_value` in the setter (a bare int assigned via ``setattr`` is not
+# auto-coerced on the Qt6 bindings and would otherwise read back wrong).
 def int_enum_from(name, source):
     """Build an IntEnum mirroring the input source value.
 
@@ -119,6 +137,37 @@ def pyqt6_designer_enum(owner, source):
     registered = int_enum_from(source.__name__, source)
     registered.__qualname__ = f"{owner}.{source.__name__}"
     return pyqtEnum(registered)
+
+
+def coerce_enum_value(value, enum_type):
+    """Coerce a bare ``int`` to a member of ``enum_type`` on the Qt6 bindings.
+
+    PyQt6 and PySide6 corrupt an enum-typed ``Property`` when a bare ``int`` is stored in
+    its backing attribute (it reads back wrong through the meta-object).  Assigning e.g.
+    ``widget.displayFormat = 2`` -- as the rules engine does (``setattr`` in
+    ``pydm.widgets.base``), as user code may, or as a widget constructor may -- must be
+    normalised to ``enum_type(2)`` first.  ``setProperty`` / ``.ui`` loading already
+    auto-coerce, but attribute assignment does not, so every custom-enum setter runs its
+    incoming value through this before storing it.
+
+    Idempotent for values that are already members; a no-op on PyQt5 (whose ``Q_ENUM``
+    properties accept plain ints); and a pass-through when ``value`` is not a valid member
+    (e.g. a custom ``logging`` level that is not in ``LogLevels``), so callers that accept
+    out-of-enum ints keep working.
+
+    Parameters
+    ----------
+    value : Any
+        The incoming value -- typically an ``int`` or an existing member of ``enum_type``.
+    enum_type : type
+        The per-wrapper registered enum (``self.<Enum>``) the property is typed as.
+    """
+    if ACTIVE_QT_WRAPPER in (QtWrapperTypes.PYQT6, QtWrapperTypes.PYSIDE6) and isinstance(value, int):
+        try:
+            return enum_type(value)
+        except ValueError:
+            return value
+    return value
 
 
 def is_ssh_session():

--- a/pydm/utilities/__init__.py
+++ b/pydm/utilities/__init__.py
@@ -76,22 +76,19 @@ if ACTIVE_QT_WRAPPER == QtWrapperTypes.UNSUPPORTED:
 
 # Cross-wrapper custom-enum Designer registration
 # ------------------------------------------------
-# For a custom "enum" widget property to render as a NAMED DROPDOWN in Qt Designer (rather than a
+# For a custom enum property to render as a named dropdown in Qt Designer (rather than a
 # bare integer spin-box) the enum has to be registered with the meta-object system, and each Qt
 # wrapper does it differently:
-#   * PyQt5   -- ``Q_ENUM(TheEnum)`` in the widget class body.
-#   * PyQt6   -- ``pyqt6_designer_enum("PyDMWidget", TheEnum)`` (a per-widget ``pyqtEnum`` copy).
-#   * PySide6 -- ``@QEnum`` on a QObject-derived *carrier base class* whose NAME EQUALS the widget
-#                class, so the enum's meta-type scope becomes ``PyDMWidget::TheEnum`` and a value
-#                saved in a ``.ui`` round-trips across wrappers.  The real widget then subclasses the
-#                carrier (``class PyDMWidget(*_PyDMWidgetBases)``).  A shared enum needs one carrier
-#                per widget; a single carrier may host several enums.
-# The canonical enum is a real ``IntEnum`` on the Qt6 bindings (:func:`int_enum_from`).  Two rules
-# every such property must follow, or Designer/attribute-assignment break: initialise the backing
-# attribute from the registered enum (``self._x = self.TheEnum.Member`` -- a module-global member has
-# no C++ meta-type and Designer's property editor can't convert it), and funnel every incoming value
-# through :func:`coerce_enum_value` in the setter (a bare int assigned via ``setattr`` is not
-# auto-coerced on the Qt6 bindings and would otherwise read back wrong).
+#   * PyQt5   -- Q_ENUM(TheEnum) in the widget class body.
+#   * PyQt6   -- pyqt6_designer_enum("PyDMWidget", TheEnum) (a per-widget pyqtEnum copy).
+#   * PySide6 -- @QEnum on a QObject-derived carrier base class whose name equals the widget
+#                class, so the enum's meta-type scope becomes PyDMWidget::TheEnum and a value
+#                saved in a .ui file works across wrappers.  The real widget then subclasses the
+#                carrier class.  A shared enum needs one carrier per widget, and a single
+#                carrier may host several enums.
+# Every wrapper must also leave TheEnum bound as a class attribute. PyQt6/PySide6 bind it by assignment, while
+# PyQt5 follows Q_ENUM (which registers the enum but binds nothing) with TheEnum = TheEnum to publish
+# the module-level enum on the class.
 def int_enum_from(name, source):
     """Build an IntEnum mirroring the input source value.
 
@@ -140,25 +137,22 @@ def pyqt6_designer_enum(owner, source):
 
 
 def coerce_enum_value(value, enum_type):
-    """Coerce a bare ``int`` to a member of ``enum_type`` on the Qt6 bindings.
+    """Coerce an int to a member of enum_type on the Qt6 bindings.
 
-    PyQt6 and PySide6 corrupt an enum-typed ``Property`` when a bare ``int`` is stored in
-    its backing attribute (it reads back wrong through the meta-object).  Assigning e.g.
-    ``widget.displayFormat = 2`` -- as the rules engine does (``setattr`` in
-    ``pydm.widgets.base``), as user code may, or as a widget constructor may -- must be
-    normalised to ``enum_type(2)`` first.  ``setProperty`` / ``.ui`` loading already
+    PyQt6 and PySide6 corrupt an enum-typed Property when an int is stored in
+    its backing attribute (it reads back wrong through the meta-object).  Assigning something like
+    widget.displayFormat = 2 must be normalised to enum_type(2) first.  Loading .ui files will already
     auto-coerce, but attribute assignment does not, so every custom-enum setter runs its
     incoming value through this before storing it.
 
-    Idempotent for values that are already members; a no-op on PyQt5 (whose ``Q_ENUM``
-    properties accept plain ints); and a pass-through when ``value`` is not a valid member
-    (e.g. a custom ``logging`` level that is not in ``LogLevels``), so callers that accept
-    out-of-enum ints keep working.
+    Idempotent for values that are already members and a no-op on PyQt5.
+
+    A pass-through when value is not a valid member so callers that accept out-of-enum ints keep working.
 
     Parameters
     ----------
     value : Any
-        The incoming value -- typically an ``int`` or an existing member of ``enum_type``.
+        The incoming value -- typically an int or an existing member of enum_type.
     enum_type : type
         The per-wrapper registered enum (``self.<Enum>``) the property is typed as.
     """

--- a/pydm/widgets/byte.py
+++ b/pydm/widgets/byte.py
@@ -123,14 +123,13 @@ class PyDMByteIndicator(*_PyDMByteIndicatorBases):
         from PyQt5.QtCore import Q_ENUM
 
         Q_ENUM(LabelPosition)
+        LabelPosition = LabelPosition
     elif ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT6:
         from pydm.utilities import pyqt6_designer_enum
 
         LabelPosition = pyqt6_designer_enum("PyDMByteIndicator", LabelPosition)
-    else:  # PySide6: adopt this widget's carrier-registered enum
+    elif ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
         LabelPosition = _PyDMByteIndicatorBases[0].LabelPosition
-
-    LabelPosition = LabelPosition  # PyQt5 Q_ENUM binds no class attr; keep this publish
 
     # Make enum definitions known to this class
     North = LabelPosition.North
@@ -694,7 +693,7 @@ class PyDMByteIndicator(*_PyDMByteIndicatorBases):
         ----------
         new_pos : LabelPosition, int
         """
-        new_pos = coerce_enum_value(new_pos, self.LabelPosition)
+        new_pos = coerce_enum_value(int(getattr(new_pos, "value", new_pos)), self.LabelPosition)
         self._label_position = new_pos
         self.rebuild_layout()
 

--- a/pydm/widgets/byte.py
+++ b/pydm/widgets/byte.py
@@ -1,9 +1,9 @@
-from qtpy.QtWidgets import QWidget, QTabWidget, QGridLayout, QLabel, QStyle, QStyleOption
+from qtpy.QtWidgets import QWidget, QGridLayout, QLabel, QStyle, QStyleOption
 from qtpy.QtGui import QColor, QPen, QFontMetrics, QPainter, QPaintEvent, QBrush
 from qtpy.QtCore import Qt, QSize, QPoint, QTimer
 from typing import List, Optional
 from .base import PyDMWidget, PostParentClassInitSetup
-from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
+from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes, coerce_enum_value
 
 if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
     from PySide6.QtCore import Property
@@ -72,7 +72,41 @@ class PyDMBitIndicator(QWidget):
         return QSize(fm.height(), fm.height())
 
 
-class PyDMByteIndicator(QWidget, PyDMWidget):
+# LabelPosition is scoped to PyDMByteIndicator so it renders as a Designer dropdown on
+# every qt wrapper. PySide6's Designer won't work with a built-in QTabWidget::TabPosition
+# enum used as a custom-widget property.
+class LabelPosition(object):
+    North = 0
+    South = 1
+    West = 2
+    East = 3
+
+
+if ACTIVE_QT_WRAPPER in (QtWrapperTypes.PYQT6, QtWrapperTypes.PYSIDE6):
+    from pydm.utilities import int_enum_from
+
+    LabelPosition = int_enum_from("LabelPosition", LabelPosition)
+
+
+# PySide6 Designer-dropdown carrier for this widget's enum. See the cross-wrapper enum note in pydm.utilities.
+if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
+    from PySide6.QtCore import QEnum
+    from enum import IntEnum
+
+    class PyDMByteIndicator(QWidget, PyDMWidget):
+        @QEnum
+        class LabelPosition(IntEnum):
+            North = 0
+            South = 1
+            West = 2
+            East = 3
+
+    _PyDMByteIndicatorBases = (PyDMByteIndicator,)
+else:
+    _PyDMByteIndicatorBases = (QWidget, PyDMWidget)
+
+
+class PyDMByteIndicator(*_PyDMByteIndicatorBases):
     """
     Widget for graphical representation of bits from an integer number
     with support for Channels and more from PyDM, including blinking functionality.
@@ -84,6 +118,25 @@ class PyDMByteIndicator(QWidget, PyDMWidget):
     init_channel : str, optional
         The channel to be used by the widget.
     """
+
+    if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT5:
+        from PyQt5.QtCore import Q_ENUM
+
+        Q_ENUM(LabelPosition)
+    elif ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT6:
+        from pydm.utilities import pyqt6_designer_enum
+
+        LabelPosition = pyqt6_designer_enum("PyDMByteIndicator", LabelPosition)
+    else:  # PySide6: adopt this widget's carrier-registered enum
+        LabelPosition = _PyDMByteIndicatorBases[0].LabelPosition
+
+    LabelPosition = LabelPosition  # PyQt5 Q_ENUM binds no class attr; keep this publish
+
+    # Make enum definitions known to this class
+    North = LabelPosition.North
+    South = LabelPosition.South
+    West = LabelPosition.West
+    East = LabelPosition.East
 
     def __init__(self, parent: Optional[QWidget] = None, init_channel=None):
         QWidget.__init__(self, parent)
@@ -108,11 +161,9 @@ class PyDMByteIndicator(QWidget, PyDMWidget):
 
         self._orientation = Qt.Vertical
 
-        # This is kind of ridiculous, importing QTabWidget just to get a 4-item enum that's usable in Designer.
-        # PyQt5 lets you define custom enums that you can use in designer with QtCore.Q_ENUMS(), doesn't exist in PyQt4.
         self._labels = []
         self._show_labels = True
-        self._label_position = QTabWidget.East
+        self._label_position = self.LabelPosition.East
 
         self._num_bits = 1
 
@@ -213,11 +264,11 @@ class PyDMByteIndicator(QWidget, PyDMWidget):
         orient = self.orientation
         if orient == Qt.Vertical or orient == 2:
             for i, (label, indicator) in enumerate(pairs):
-                if self.labelPosition == QTabWidget.East:
+                if self.labelPosition == self.LabelPosition.East:
                     self.layout().addWidget(indicator, i, 0)
                     self.layout().addWidget(label, i, 1, 1, 1, Qt.AlignVCenter)
                     label.setVisible(self._show_labels)
-                elif self.labelPosition == QTabWidget.West:
+                elif self.labelPosition == self.LabelPosition.West:
                     self.layout().addWidget(label, i, 0, 1, 1, Qt.AlignVCenter)
                     self.layout().addWidget(indicator, i, 1)
                     label.setVisible(self._show_labels)
@@ -227,11 +278,11 @@ class PyDMByteIndicator(QWidget, PyDMWidget):
                     # so we don't reset label visibility here.
         elif orient == Qt.Horizontal or orient == 1:
             for i, (label, indicator) in enumerate(pairs):
-                if self.labelPosition == QTabWidget.North:
+                if self.labelPosition == self.LabelPosition.North:
                     self.layout().addWidget(label, 0, i, 1, 1, Qt.AlignHCenter)
                     self.layout().addWidget(indicator, 1, i)
                     label.setVisible(self._show_labels)
-                elif self.labelPosition == QTabWidget.South:
+                elif self.labelPosition == self.LabelPosition.South:
                     self.layout().addWidget(indicator, 0, i)
                     self.layout().addWidget(label, 1, i, 1, 1, Qt.AlignHCenter)
                     label.setVisible(self._show_labels)
@@ -625,7 +676,7 @@ class PyDMByteIndicator(QWidget, PyDMWidget):
 
     circles = Property(bool, readCircles, setCircles)
 
-    def readLabelPosition(self) -> QTabWidget.TabPosition:
+    def readLabelPosition(self) -> LabelPosition:
         """
         The side of the widget to display labels on.
 
@@ -635,18 +686,19 @@ class PyDMByteIndicator(QWidget, PyDMWidget):
         """
         return self._label_position
 
-    def setLabelPosition(self, new_pos: QTabWidget.TabPosition) -> None:
+    def setLabelPosition(self, new_pos) -> None:
         """
         The side of the widget to display labels on.
 
         Parameters
         ----------
-        new_pos : QTabWidget.TabPosition, int
+        new_pos : LabelPosition, int
         """
+        new_pos = coerce_enum_value(new_pos, self.LabelPosition)
         self._label_position = new_pos
         self.rebuild_layout()
 
-    labelPosition = Property(QTabWidget.TabPosition, readLabelPosition, setLabelPosition)
+    labelPosition = Property(LabelPosition, readLabelPosition, setLabelPosition)
 
     def readNumBits(self) -> int:
         """

--- a/pydm/widgets/colormaps.py
+++ b/pydm/widgets/colormaps.py
@@ -1080,26 +1080,14 @@ class PyDMColorMap(object):
     Hot = 6
 
 
-if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT6:
+# Under the Qt6 bindings (PyQt6 + PySide6) PyDMColorMap must be a real IntEnum so the per-widget
+# carrier in image.py can register it as a Qt Designer dropdown.  The cmaps/cmap_names dicts and
+# module-level colour arrays below are then keyed by IntEnum members (compared by value).
+# PyQt5 keeps the plain int-attribute class defined above.
+if ACTIVE_QT_WRAPPER in (QtWrapperTypes.PYQT6, QtWrapperTypes.PYSIDE6):
     from pydm.utilities import int_enum_from
 
     PyDMColorMap = int_enum_from("PyDMColorMap", PyDMColorMap)
-
-
-if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
-    from PySide6.QtCore import QEnum
-    from enum import Enum
-
-    @QEnum
-    # overrides prev enum def
-    class PyDMColorMap(Enum):  # noqa F811
-        Magma = 0
-        Inferno = 1
-        Plasma = 2
-        Viridis = 3
-        Jet = 4
-        Monochrome = 5
-        Hot = 6
 
 
 for name, data in (

--- a/pydm/widgets/datetime.py
+++ b/pydm/widgets/datetime.py
@@ -2,7 +2,7 @@ import logging
 from qtpy import QtWidgets, QtCore
 
 from .base import PyDMWritableWidget, PyDMWidget, PostParentClassInitSetup
-from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
+from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes, coerce_enum_value
 
 if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
     from PySide6.QtCore import Property
@@ -12,29 +12,46 @@ else:
 logger = logging.getLogger(__name__)
 
 
+# Canonical TimeBase: a plain int-attr class for PyQt5; a real IntEnum for the Qt6 bindings
+# (PyQt6 + PySide6).  TimeBase (PascalCase) is intentionally distinct from the ``timeBase``
+# property name -- a same-name collision silently breaks uic runtime loading.
 class TimeBase(object):
     Milliseconds = 0
     Seconds = 1
 
 
-if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT6:
+if ACTIVE_QT_WRAPPER in (QtWrapperTypes.PYQT6, QtWrapperTypes.PYSIDE6):
     from pydm.utilities import int_enum_from
 
     TimeBase = int_enum_from("TimeBase", TimeBase)
 
 
+# PySide6 Designer-dropdown carrier(s) for this widget's enum(s) -- see the cross-wrapper enum note in pydm.utilities.
+# TimeBase is shared by two widgets, so each gets its OWN carrier base (named like that widget).
 if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
     from PySide6.QtCore import QEnum
-    from enum import Enum
+    from enum import IntEnum
 
-    @QEnum
-    # overrides prev enum def
-    class TimeBase(Enum):  # noqa F811
-        Milliseconds = 0
-        Seconds = 1
+    class PyDMDateTimeEdit(QtWidgets.QDateTimeEdit, PyDMWritableWidget):
+        @QEnum
+        class TimeBase(IntEnum):
+            Milliseconds = 0
+            Seconds = 1
+
+    class PyDMDateTimeLabel(QtWidgets.QLabel, PyDMWidget):
+        @QEnum
+        class TimeBase(IntEnum):
+            Milliseconds = 0
+            Seconds = 1
+
+    _PyDMDateTimeEditBases = (PyDMDateTimeEdit,)
+    _PyDMDateTimeLabelBases = (PyDMDateTimeLabel,)
+else:
+    _PyDMDateTimeEditBases = (QtWidgets.QDateTimeEdit, PyDMWritableWidget)
+    _PyDMDateTimeLabelBases = (QtWidgets.QLabel, PyDMWidget)
 
 
-class PyDMDateTimeEdit(QtWidgets.QDateTimeEdit, PyDMWritableWidget):
+class PyDMDateTimeEdit(*_PyDMDateTimeEditBases):
     """
     A QDateTimeEdit with support for setting the text via a PyDM Channel, or
     through the PyDM Rules system.
@@ -55,8 +72,13 @@ class PyDMDateTimeEdit(QtWidgets.QDateTimeEdit, PyDMWritableWidget):
         from pydm.utilities import pyqt6_designer_enum
 
         TimeBase = pyqt6_designer_enum("PyDMDateTimeEdit", TimeBase)
+    else:  # PySide6: adopt this widget's carrier-registered enum
+        TimeBase = _PyDMDateTimeEditBases[0].TimeBase
 
-    # Make enum definitions known to this class
+    # Publish the registered enum as a class attribute on every wrapper (PyQt5's Q_ENUM
+    # registers it in the metaobject but does not assign it here), so both ``self.TimeBase``
+    # and uic's ``PyDMDateTimeEdit.TimeBase.<key>`` resolve.
+    TimeBase = TimeBase
     Milliseconds = TimeBase.Milliseconds
     Seconds = TimeBase.Seconds
 
@@ -65,7 +87,7 @@ class PyDMDateTimeEdit(QtWidgets.QDateTimeEdit, PyDMWritableWidget):
     def __init__(self, parent=None, init_channel=None):
         self._block_past_date = True
         self._relative = True
-        self._time_base = TimeBase.Milliseconds
+        self._time_base = self.TimeBase.Milliseconds
 
         QtWidgets.QDateTimeEdit.__init__(self, parent)
         PyDMWritableWidget.__init__(self, init_channel=init_channel)
@@ -88,6 +110,7 @@ class PyDMDateTimeEdit(QtWidgets.QDateTimeEdit, PyDMWritableWidget):
         return self._time_base
 
     def setTimeBase(self, base) -> None:
+        base = coerce_enum_value(base, self.TimeBase)
         if self._time_base != base:
             self._time_base = base
 
@@ -134,7 +157,7 @@ class PyDMDateTimeEdit(QtWidgets.QDateTimeEdit, PyDMWritableWidget):
         else:
             new_value = val.toMSecsSinceEpoch()
 
-        if self.timeBase == TimeBase.Seconds:
+        if self.timeBase == self.TimeBase.Seconds:
             new_value /= 1000.0
 
         # Force to the same base type as the data source, else qt can cast the pointer wrong
@@ -145,7 +168,7 @@ class PyDMDateTimeEdit(QtWidgets.QDateTimeEdit, PyDMWritableWidget):
         super().value_changed(new_val)
         new_val = int(new_val)
 
-        if self.timeBase == TimeBase.Seconds:
+        if self.timeBase == self.TimeBase.Seconds:
             new_val *= 1000
 
         val = QtCore.QDateTime.currentDateTime()
@@ -156,7 +179,7 @@ class PyDMDateTimeEdit(QtWidgets.QDateTimeEdit, PyDMWritableWidget):
         self.setDateTime(val)
 
 
-class PyDMDateTimeLabel(QtWidgets.QLabel, PyDMWidget):
+class PyDMDateTimeLabel(*_PyDMDateTimeLabelBases):
     """
     A QLabel with support for setting the text via a PyDM Channel, or
     through the PyDM Rules system.
@@ -177,8 +200,13 @@ class PyDMDateTimeLabel(QtWidgets.QLabel, PyDMWidget):
         from pydm.utilities import pyqt6_designer_enum
 
         TimeBase = pyqt6_designer_enum("PyDMDateTimeLabel", TimeBase)
+    else:  # PySide6: adopt this widget's carrier-registered enum
+        TimeBase = _PyDMDateTimeLabelBases[0].TimeBase
 
-    # Make enum definitions known to this class
+    # Publish the registered enum as a class attribute on every wrapper (PyQt5's Q_ENUM
+    # registers it in the metaobject but does not assign it here), so both ``self.TimeBase``
+    # and uic's ``PyDMDateTimeLabel.TimeBase.<key>`` resolve.
+    TimeBase = TimeBase
     Milliseconds = TimeBase.Milliseconds
     Seconds = TimeBase.Seconds
 
@@ -188,7 +216,7 @@ class PyDMDateTimeLabel(QtWidgets.QLabel, PyDMWidget):
 
         self._block_past_date = True
         self._relative = True
-        self._time_base = TimeBase.Milliseconds
+        self._time_base = self.TimeBase.Milliseconds
         self._text_format = "yyyy/MM/dd hh:mm:ss.zzz"
         self.setText("")
 
@@ -219,6 +247,7 @@ class PyDMDateTimeLabel(QtWidgets.QLabel, PyDMWidget):
         return self._time_base
 
     def setTimeBase(self, base) -> None:
+        base = coerce_enum_value(base, self.TimeBase)
         if self._time_base != base:
             self._time_base = base
 
@@ -241,7 +270,7 @@ class PyDMDateTimeLabel(QtWidgets.QLabel, PyDMWidget):
         super().value_changed(new_val)
         new_val = int(new_val)
 
-        if self.timeBase == TimeBase.Seconds:
+        if self.timeBase == self.TimeBase.Seconds:
             new_val *= 1000
 
         val = QtCore.QDateTime.currentDateTime()

--- a/pydm/widgets/datetime.py
+++ b/pydm/widgets/datetime.py
@@ -12,9 +12,6 @@ else:
 logger = logging.getLogger(__name__)
 
 
-# Canonical TimeBase: a plain int-attr class for PyQt5; a real IntEnum for the Qt6 bindings
-# (PyQt6 + PySide6).  TimeBase (PascalCase) is intentionally distinct from the ``timeBase``
-# property name -- a same-name collision silently breaks uic runtime loading.
 class TimeBase(object):
     Milliseconds = 0
     Seconds = 1
@@ -27,7 +24,7 @@ if ACTIVE_QT_WRAPPER in (QtWrapperTypes.PYQT6, QtWrapperTypes.PYSIDE6):
 
 
 # PySide6 Designer-dropdown carrier(s) for this widget's enum(s) -- see the cross-wrapper enum note in pydm.utilities.
-# TimeBase is shared by two widgets, so each gets its OWN carrier base (named like that widget).
+# TimeBase is shared by two widgets, so each gets its own carrier base named like that widget.
 if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
     from PySide6.QtCore import QEnum
     from enum import IntEnum
@@ -68,17 +65,14 @@ class PyDMDateTimeEdit(*_PyDMDateTimeEditBases):
         from PyQt5.QtCore import Q_ENUM
 
         Q_ENUM(TimeBase)
+        TimeBase = TimeBase
     elif ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT6:
         from pydm.utilities import pyqt6_designer_enum
 
         TimeBase = pyqt6_designer_enum("PyDMDateTimeEdit", TimeBase)
-    else:  # PySide6: adopt this widget's carrier-registered enum
+    elif ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
         TimeBase = _PyDMDateTimeEditBases[0].TimeBase
 
-    # Publish the registered enum as a class attribute on every wrapper (PyQt5's Q_ENUM
-    # registers it in the metaobject but does not assign it here), so both ``self.TimeBase``
-    # and uic's ``PyDMDateTimeEdit.TimeBase.<key>`` resolve.
-    TimeBase = TimeBase
     Milliseconds = TimeBase.Milliseconds
     Seconds = TimeBase.Seconds
 
@@ -196,17 +190,14 @@ class PyDMDateTimeLabel(*_PyDMDateTimeLabelBases):
         from PyQt5.QtCore import Q_ENUM
 
         Q_ENUM(TimeBase)
+        TimeBase = TimeBase
     elif ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT6:
         from pydm.utilities import pyqt6_designer_enum
 
         TimeBase = pyqt6_designer_enum("PyDMDateTimeLabel", TimeBase)
-    else:  # PySide6: adopt this widget's carrier-registered enum
+    elif ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
         TimeBase = _PyDMDateTimeLabelBases[0].TimeBase
 
-    # Publish the registered enum as a class attribute on every wrapper (PyQt5's Q_ENUM
-    # registers it in the metaobject but does not assign it here), so both ``self.TimeBase``
-    # and uic's ``PyDMDateTimeLabel.TimeBase.<key>`` resolve.
-    TimeBase = TimeBase
     Milliseconds = TimeBase.Milliseconds
     Seconds = TimeBase.Seconds
 

--- a/pydm/widgets/display_format.py
+++ b/pydm/widgets/display_format.py
@@ -26,25 +26,13 @@ class DisplayFormat(object):
     Binary = 5
 
 
-if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT6:
+# Under the Qt6 bindings (PyQt6 + PySide6) DisplayFormat must be a real IntEnum so the
+# per-widget carriers (in label.py / line_edit.py) can register it as a Qt Designer dropdown.
+# PyQt5 keeps the plain int-attribute class defined above.
+if ACTIVE_QT_WRAPPER in (QtWrapperTypes.PYQT6, QtWrapperTypes.PYSIDE6):
     from pydm.utilities import int_enum_from
 
     DisplayFormat = int_enum_from("DisplayFormat", DisplayFormat)
-
-
-if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
-    from PySide6.QtCore import QEnum
-    from enum import Enum
-
-    @QEnum
-    # overrides prev enum def
-    class DisplayFormat(Enum):  # noqa F811
-        Default = 0
-        String = 1
-        Decimal = 2
-        Exponential = 3
-        Hex = 4
-        Binary = 5
 
 
 def parse_value_for_display(

--- a/pydm/widgets/enum_button.py
+++ b/pydm/widgets/enum_button.py
@@ -80,13 +80,13 @@ class PyDMEnumButton(*_PyDMEnumButtonBases):
         from PyQt5.QtCore import Q_ENUM
 
         Q_ENUM(WidgetType)
+        WidgetType = WidgetType
     elif ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT6:
         from pydm.utilities import pyqt6_designer_enum
 
         WidgetType = pyqt6_designer_enum("PyDMEnumButton", WidgetType)
-    else:  # PySide6: adopt this widget's carrier-registered enum
+    elif ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
         WidgetType = _PyDMEnumButtonBases[0].WidgetType
-    WidgetType = WidgetType
 
     # Make enum definitions known to this class
     PushButton = WidgetType.PushButton

--- a/pydm/widgets/enum_button.py
+++ b/pydm/widgets/enum_button.py
@@ -16,7 +16,7 @@ from qtpy.QtWidgets import (
 
 from .base import PyDMWritableWidget, PostParentClassInitSetup
 from pydm import data_plugins
-from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
+from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes, coerce_enum_value
 
 if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
     from PySide6.QtCore import Property
@@ -29,21 +29,26 @@ class WidgetType(object):
     RadioButton = 1
 
 
-if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT6:
+if ACTIVE_QT_WRAPPER in (QtWrapperTypes.PYQT6, QtWrapperTypes.PYSIDE6):
     from pydm.utilities import int_enum_from
 
     WidgetType = int_enum_from("WidgetType", WidgetType)
 
 
+# PySide6 Designer-dropdown carrier(s) for this widget's enum(s) -- see the cross-wrapper enum note in pydm.utilities.
 if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
     from PySide6.QtCore import QEnum
-    from enum import Enum
+    from enum import IntEnum
 
-    @QEnum
-    # overrides prev enum def
-    class WidgetType(Enum):  # noqa: F811
-        PushButton = 0
-        RadioButton = 1
+    class PyDMEnumButton(QWidget, PyDMWritableWidget):
+        @QEnum
+        class WidgetType(IntEnum):
+            PushButton = 0
+            RadioButton = 1
+
+    _PyDMEnumButtonBases = (PyDMEnumButton,)
+else:
+    _PyDMEnumButtonBases = (QWidget, PyDMWritableWidget)
 
 
 class_for_type = {WidgetType.PushButton: QPushButton, WidgetType.RadioButton: QRadioButton}
@@ -51,7 +56,7 @@ class_for_type = {WidgetType.PushButton: QPushButton, WidgetType.RadioButton: QR
 logger = logging.getLogger(__name__)
 
 
-class PyDMEnumButton(QWidget, PyDMWritableWidget):
+class PyDMEnumButton(*_PyDMEnumButtonBases):
     """
     A QWidget that renders buttons for every option of Enum Items.
     For now, two types of buttons can be rendered:
@@ -79,6 +84,8 @@ class PyDMEnumButton(QWidget, PyDMWritableWidget):
         from pydm.utilities import pyqt6_designer_enum
 
         WidgetType = pyqt6_designer_enum("PyDMEnumButton", WidgetType)
+    else:  # PySide6: adopt this widget's carrier-registered enum
+        WidgetType = _PyDMEnumButtonBases[0].WidgetType
     WidgetType = WidgetType
 
     # Make enum definitions known to this class
@@ -100,7 +107,7 @@ class PyDMEnumButton(QWidget, PyDMWritableWidget):
         self._btn_group = QButtonGroup()
         self._btn_group.setExclusive(True)
         self._btn_group.buttonClicked.connect(self.handle_button_clicked)
-        self._widget_type = WidgetType.PushButton
+        self._widget_type = self.WidgetType.PushButton
         self._orientation = Qt.Vertical
         self._widgets = []
         self.rebuild_widgets()
@@ -219,6 +226,7 @@ class PyDMEnumButton(QWidget, PyDMWritableWidget):
         ----------
         new_type : WidgetType
         """
+        new_type = coerce_enum_value(new_type, self.WidgetType)
         if new_type != self._widget_type:
             self._widget_type = new_type
             self.rebuild_widgets()

--- a/pydm/widgets/image.py
+++ b/pydm/widgets/image.py
@@ -179,23 +179,19 @@ class PyDMImageView(*_PyDMImageViewBases):
         Q_ENUM(ReadingOrder)
         Q_ENUM(DimensionOrder)
         Q_ENUM(PyDMColorMap)
+        ReadingOrder = ReadingOrder
+        DimensionOrder = DimensionOrder
+        PyDMColorMap = PyDMColorMap
     elif ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT6:
         from pydm.utilities import pyqt6_designer_enum
 
         ReadingOrder = pyqt6_designer_enum("PyDMImageView", ReadingOrder)
         DimensionOrder = pyqt6_designer_enum("PyDMImageView", DimensionOrder)
         PyDMColorMap = pyqt6_designer_enum("PyDMImageView", PyDMColorMap)
-    else:  # PySide6: adopt this widget's carrier-registered enums
+    elif ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
         ReadingOrder = _PyDMImageViewBases[0].ReadingOrder
         DimensionOrder = _PyDMImageViewBases[0].DimensionOrder
         PyDMColorMap = _PyDMImageViewBases[0].PyDMColorMap
-
-    # Publish the registered enums as class attributes on every wrapper (PyQt5's Q_ENUM
-    # registers them in the metaobject but does not assign here) so self.<Enum> and uic's
-    # PyDMImageView.<Enum>.<Key> resolve.
-    ReadingOrder = ReadingOrder
-    DimensionOrder = DimensionOrder
-    PyDMColorMap = PyDMColorMap
 
     # Make enum definitions known to this class
     Fortranlike = ReadingOrder.Fortranlike

--- a/pydm/widgets/image.py
+++ b/pydm/widgets/image.py
@@ -254,11 +254,11 @@ class PyDMImageView(*_PyDMImageViewBases):
 
         # Make a right-click menu for changing the color map.
         self.cm_group = QActionGroup(self)
-        self.cmap_for_action = {}
+        self.cmap_for_name = {}
         for cm in self.color_maps:
             action = self.cm_group.addAction(cmap_names[cm])
             action.setCheckable(True)
-            self.cmap_for_action[action] = cm
+            self.cmap_for_name[cmap_names[cm]] = cm
 
         self.colorMap = self._colormap
 
@@ -308,7 +308,7 @@ class PyDMImageView(*_PyDMImageViewBases):
         """
         self.menu = ViewBoxMenu(self.getView().getViewBox())
         cm_menu = self.menu.addMenu("Color Map")
-        for act in self.cmap_for_action.keys():
+        for act in self.cm_group.actions():
             cm_menu.addAction(act)
         cm_menu.triggered.connect(self._changeColorMap)
         return self.menu
@@ -323,7 +323,7 @@ class PyDMImageView(*_PyDMImageViewBases):
         ----------
         action : QAction
         """
-        self.colorMap = self.cmap_for_action[action]
+        self.colorMap = self.cmap_for_name[action.text()]
 
     def readColorMapMin(self) -> float:
         """
@@ -415,11 +415,12 @@ class PyDMImageView(*_PyDMImageViewBases):
         self._colormap = new_cmap
         self._cm_colors = self.color_maps[new_cmap]
         self.setColorMap()
+        # Sync the right-click menu's check marks.  The QActions created in __init__
+        # can be invalidated when the widget is loaded from a .ui (Qt reparents or
+        # recreates them), so use the live group actions, matched by their stable text.
+        current_name = cmap_names.get(self._colormap)
         for action in self.cm_group.actions():
-            if self.cmap_for_action[action] == self._colormap:
-                action.setChecked(True)
-            else:
-                action.setChecked(False)
+            action.setChecked(action.text() == current_name)
 
     colorMap = Property(PyDMColorMap, readColorMap, _setColorMap)
 

--- a/pydm/widgets/image.py
+++ b/pydm/widgets/image.py
@@ -8,7 +8,7 @@ import logging
 from .channel import PyDMChannel
 from .colormaps import cmaps, cmap_names, PyDMColorMap
 from .base import PyDMWidget, PostParentClassInitSetup
-from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
+from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes, coerce_enum_value
 
 if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
     from PySide6.QtCore import Property
@@ -25,21 +25,10 @@ class ReadingOrder(object):
     Clike = 1
 
 
-if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT6:
+if ACTIVE_QT_WRAPPER in (QtWrapperTypes.PYQT6, QtWrapperTypes.PYSIDE6):
     from pydm.utilities import int_enum_from
 
     ReadingOrder = int_enum_from("ReadingOrder", ReadingOrder)
-
-
-if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
-    from PySide6.QtCore import QEnum
-    from enum import Enum
-
-    @QEnum
-    # overrides prev enum def
-    class ReadingOrder(Enum):  # noqa F811
-        Fortranlike = 0
-        Clike = 1
 
 
 class DimensionOrder(object):
@@ -64,21 +53,10 @@ class DimensionOrder(object):
     WidthFirst = 1
 
 
-if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT6:
+if ACTIVE_QT_WRAPPER in (QtWrapperTypes.PYQT6, QtWrapperTypes.PYSIDE6):
     from pydm.utilities import int_enum_from
 
     DimensionOrder = int_enum_from("DimensionOrder", DimensionOrder)
-
-
-if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
-    from PySide6.QtCore import QEnum
-    from enum import Enum
-
-    @QEnum
-    # overrides prev enum def
-    class DimensionOrder(Enum):  # noqa F811
-        HeightFirst = 0
-        WidthFirst = 1
 
 
 class ImageUpdateThread(QThread):
@@ -139,7 +117,38 @@ class ImageUpdateThread(QThread):
         self.image_view.needs_redraw = False
 
 
-class PyDMImageView(ImageView, PyDMWidget):
+# PySide6 Designer-dropdown carrier(s) for this widget's enum(s) -- see the cross-wrapper enum note in pydm.utilities.
+if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
+    from PySide6.QtCore import QEnum
+    from enum import IntEnum
+
+    class PyDMImageView(ImageView, PyDMWidget):
+        @QEnum
+        class ReadingOrder(IntEnum):
+            Fortranlike = 0
+            Clike = 1
+
+        @QEnum
+        class DimensionOrder(IntEnum):
+            HeightFirst = 0
+            WidthFirst = 1
+
+        @QEnum
+        class PyDMColorMap(IntEnum):
+            Magma = 0
+            Inferno = 1
+            Plasma = 2
+            Viridis = 3
+            Jet = 4
+            Monochrome = 5
+            Hot = 6
+
+    _PyDMImageViewBases = (PyDMImageView,)
+else:
+    _PyDMImageViewBases = (ImageView, PyDMWidget)
+
+
+class PyDMImageView(*_PyDMImageViewBases):
     """
     A PyQtGraph ImageView with support for Channels and more from PyDM.
 
@@ -164,9 +173,6 @@ class PyDMImageView(ImageView, PyDMWidget):
         information
     """
 
-    ReadingOrder = ReadingOrder
-    DimensionOrder = DimensionOrder
-
     if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT5:
         from PyQt5.QtCore import Q_ENUM
 
@@ -179,6 +185,17 @@ class PyDMImageView(ImageView, PyDMWidget):
         ReadingOrder = pyqt6_designer_enum("PyDMImageView", ReadingOrder)
         DimensionOrder = pyqt6_designer_enum("PyDMImageView", DimensionOrder)
         PyDMColorMap = pyqt6_designer_enum("PyDMImageView", PyDMColorMap)
+    else:  # PySide6: adopt this widget's carrier-registered enums
+        ReadingOrder = _PyDMImageViewBases[0].ReadingOrder
+        DimensionOrder = _PyDMImageViewBases[0].DimensionOrder
+        PyDMColorMap = _PyDMImageViewBases[0].PyDMColorMap
+
+    # Publish the registered enums as class attributes on every wrapper (PyQt5's Q_ENUM
+    # registers them in the metaobject but does not assign here) so self.<Enum> and uic's
+    # PyDMImageView.<Enum>.<Key> resolve.
+    ReadingOrder = ReadingOrder
+    DimensionOrder = DimensionOrder
+    PyDMColorMap = PyDMColorMap
 
     # Make enum definitions known to this class
     Fortranlike = ReadingOrder.Fortranlike
@@ -200,7 +217,7 @@ class PyDMImageView(ImageView, PyDMWidget):
     def __init__(self, parent=None, image_channel=None, width_channel=None):
         """Initialize widget."""
         # Set the default colormap.
-        self._colormap = PyDMColorMap.Inferno
+        self._colormap = self.PyDMColorMap.Inferno
         self._cm_colors = None
         self._imagechannel = None
         self._widthchannel = None
@@ -211,8 +228,8 @@ class PyDMImageView(ImageView, PyDMWidget):
         self._show_axes = False
 
         # Set default reading order of numpy array data to Fortranlike.
-        self._reading_order = ReadingOrder.Fortranlike
-        self._dimension_order = DimensionOrder.HeightFirst
+        self._reading_order = self.ReadingOrder.Fortranlike
+        self._dimension_order = self.DimensionOrder.HeightFirst
 
         self._redraw_rate = 30
 
@@ -394,6 +411,7 @@ class PyDMImageView(ImageView, PyDMWidget):
         -------
         new_cmap : PyDMColorMap
         """
+        new_cmap = coerce_enum_value(new_cmap, self.PyDMColorMap)
         self._colormap = new_cmap
         self._cm_colors = self.color_maps[new_cmap]
         self.setColorMap()
@@ -622,6 +640,7 @@ class PyDMImageView(ImageView, PyDMWidget):
         ----------
         new_order: ReadingOrder
         """
+        new_order = coerce_enum_value(new_order, self.ReadingOrder)
         if self._reading_order != new_order:
             self._reading_order = new_order
 
@@ -646,6 +665,7 @@ class PyDMImageView(ImageView, PyDMWidget):
         ----------
         new_order: DimensionOrder
         """
+        new_order = coerce_enum_value(new_order, self.DimensionOrder)
         if self._dimension_order != new_order:
             self._dimension_order = new_order
 

--- a/pydm/widgets/label.py
+++ b/pydm/widgets/label.py
@@ -2,7 +2,7 @@ from .base import PyDMWidget, TextFormatter, str_types, PostParentClassInitSetup
 from qtpy.QtWidgets import QLabel, QApplication
 from qtpy.QtCore import Qt
 from .display_format import DisplayFormat, parse_value_for_display
-from pydm.utilities import is_pydm_app, is_qt_designer, ACTIVE_QT_WRAPPER, QtWrapperTypes
+from pydm.utilities import is_pydm_app, is_qt_designer, ACTIVE_QT_WRAPPER, QtWrapperTypes, coerce_enum_value
 from pydm import config
 from pydm.widgets.base import only_if_channel_set
 from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
@@ -15,7 +15,27 @@ else:
 _labelRuleProperties = {"Text": ["value_changed", str]}
 
 
-class PyDMLabel(QLabel, TextFormatter, PyDMWidget):
+# PySide6 Designer-dropdown carrier(s) for this widget's enum(s) -- see the cross-wrapper enum note in pydm.utilities.
+if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
+    from PySide6.QtCore import QEnum
+    from enum import IntEnum
+
+    class PyDMLabel(QLabel, TextFormatter, PyDMWidget):
+        @QEnum
+        class DisplayFormat(IntEnum):
+            Default = 0
+            String = 1
+            Decimal = 2
+            Exponential = 3
+            Hex = 4
+            Binary = 5
+
+    _PyDMLabelBases = (PyDMLabel,)
+else:
+    _PyDMLabelBases = (QLabel, TextFormatter, PyDMWidget)
+
+
+class PyDMLabel(*_PyDMLabelBases):
     """
     A QLabel with support for setting the text via a PyDM Channel, or
     through the PyDM Rules system.
@@ -43,6 +63,8 @@ class PyDMLabel(QLabel, TextFormatter, PyDMWidget):
         from pydm.utilities import pyqt6_designer_enum
 
         DisplayFormat = pyqt6_designer_enum("PyDMLabel", DisplayFormat)
+    else:  # PySide6: adopt this widget's carrier-registered enum
+        DisplayFormat = _PyDMLabelBases[0].DisplayFormat
 
     DisplayFormat = DisplayFormat
 
@@ -126,6 +148,7 @@ class PyDMLabel(QLabel, TextFormatter, PyDMWidget):
         return self._display_format_type
 
     def setDisplayFormat(self, new_type):
+        new_type = coerce_enum_value(new_type, self.DisplayFormat)
         if self._display_format_type == new_type:
             return
         self._display_format_type = new_type

--- a/pydm/widgets/label.py
+++ b/pydm/widgets/label.py
@@ -58,14 +58,13 @@ class PyDMLabel(*_PyDMLabelBases):
         from PyQt5.QtCore import Q_ENUM
 
         Q_ENUM(DisplayFormat)
+        DisplayFormat = DisplayFormat
     elif ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT6:
         from pydm.utilities import pyqt6_designer_enum
 
         DisplayFormat = pyqt6_designer_enum("PyDMLabel", DisplayFormat)
-    else:  # PySide6: adopt this widget's carrier-registered enum
+    elif ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
         DisplayFormat = _PyDMLabelBases[0].DisplayFormat
-
-    DisplayFormat = DisplayFormat
 
     # Make enum definitions known to this class
     Default = DisplayFormat.Default

--- a/pydm/widgets/label.py
+++ b/pydm/widgets/label.py
@@ -5,7 +5,6 @@ from .display_format import DisplayFormat, parse_value_for_display
 from pydm.utilities import is_pydm_app, is_qt_designer, ACTIVE_QT_WRAPPER, QtWrapperTypes, coerce_enum_value
 from pydm import config
 from pydm.widgets.base import only_if_channel_set
-from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
 
 if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
     from PySide6.QtCore import Property

--- a/pydm/widgets/line_edit.py
+++ b/pydm/widgets/line_edit.py
@@ -10,7 +10,7 @@ from qtpy.QtGui import QFocusEvent
 from .base import PyDMWritableWidget, TextFormatter, str_types, PostParentClassInitSetup
 from pydm import utilities
 from .display_format import DisplayFormat, parse_value_for_display
-from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
+from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes, coerce_enum_value
 
 if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
     from PySide6.QtCore import Property
@@ -20,7 +20,27 @@ else:
 logger = logging.getLogger(__name__)
 
 
-class PyDMLineEdit(QLineEdit, TextFormatter, PyDMWritableWidget):
+# PySide6 Designer-dropdown carrier(s) for this widget's enum(s) -- see the cross-wrapper enum note in pydm.utilities.
+if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
+    from PySide6.QtCore import QEnum
+    from enum import IntEnum
+
+    class PyDMLineEdit(QLineEdit, TextFormatter, PyDMWritableWidget):
+        @QEnum
+        class DisplayFormat(IntEnum):
+            Default = 0
+            String = 1
+            Decimal = 2
+            Exponential = 3
+            Hex = 4
+            Binary = 5
+
+    _PyDMLineEditBases = (PyDMLineEdit,)
+else:
+    _PyDMLineEditBases = (QLineEdit, TextFormatter, PyDMWritableWidget)
+
+
+class PyDMLineEdit(*_PyDMLineEditBases):
     """
     A QLineEdit (writable text field) with support for Channels and more
     from PyDM.
@@ -43,6 +63,8 @@ class PyDMLineEdit(QLineEdit, TextFormatter, PyDMWritableWidget):
         from pydm.utilities import pyqt6_designer_enum
 
         DisplayFormat = pyqt6_designer_enum("PyDMLineEdit", DisplayFormat)
+    else:  # PySide6: adopt this widget's carrier-registered enum
+        DisplayFormat = _PyDMLineEditBases[0].DisplayFormat
     DisplayFormat = DisplayFormat
 
     # Make enum definitions known to this class
@@ -82,6 +104,7 @@ class PyDMLineEdit(QLineEdit, TextFormatter, PyDMWritableWidget):
         return self._display_format_type
 
     def setDisplayFormat(self, new_type) -> None:
+        new_type = coerce_enum_value(new_type, self.DisplayFormat)
         if self._display_format_type != new_type:
             self._display_format_type = new_type
             # Trigger the update of display format

--- a/pydm/widgets/line_edit.py
+++ b/pydm/widgets/line_edit.py
@@ -59,13 +59,13 @@ class PyDMLineEdit(*_PyDMLineEditBases):
         from PyQt5.QtCore import Q_ENUM
 
         Q_ENUM(DisplayFormat)
+        DisplayFormat = DisplayFormat
     elif ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT6:
         from pydm.utilities import pyqt6_designer_enum
 
         DisplayFormat = pyqt6_designer_enum("PyDMLineEdit", DisplayFormat)
-    else:  # PySide6: adopt this widget's carrier-registered enum
+    elif ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
         DisplayFormat = _PyDMLineEditBases[0].DisplayFormat
-    DisplayFormat = DisplayFormat
 
     # Make enum definitions known to this class
     Default = DisplayFormat.Default

--- a/pydm/widgets/logdisplay.py
+++ b/pydm/widgets/logdisplay.py
@@ -176,13 +176,13 @@ class PyDMLogDisplay(*_PyDMLogDisplayBases):
         from PyQt5.QtCore import Q_ENUM
 
         Q_ENUM(LogLevels)
+        LogLevels = LogLevels
     elif ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT6:
         from pydm.utilities import pyqt6_designer_enum
 
         LogLevels = pyqt6_designer_enum("PyDMLogDisplay", LogLevels)
-    else:  # PySide6: adopt this widget's carrier-registered enum
+    elif ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
         LogLevels = _PyDMLogDisplayBases[0].LogLevels
-    LogLevels = LogLevels
 
     # Make enum definitions known to this class
     NOTSET = LogLevels.NOTSET

--- a/pydm/widgets/logdisplay.py
+++ b/pydm/widgets/logdisplay.py
@@ -16,7 +16,7 @@ from qtpy.QtWidgets import (
     QStyle,
 )
 from qtpy.QtGui import QPainter
-from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
+from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes, coerce_enum_value
 
 if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
     from PySide6.QtCore import Property
@@ -111,7 +111,10 @@ class LogLevels(object):
         return OrderedDict(sorted(entries, key=lambda x: x[1], reverse=False))
 
 
-if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT6:
+# Under the Qt6 bindings (PyQt6 + PySide6) LogLevels must be a real IntEnum (preserving the
+# Python logging-level values) so it can be registered as a Qt Designer dropdown.  PyQt5 keeps
+# the plain int-attribute class above.
+if ACTIVE_QT_WRAPPER in (QtWrapperTypes.PYQT6, QtWrapperTypes.PYSIDE6):
     from enum import IntEnum
 
     class LogLevels(IntEnum):  # noqa F811
@@ -128,33 +131,27 @@ if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT6:
             return OrderedDict(sorted(entries, key=lambda item: item[1]))
 
 
+# PySide6 Designer-dropdown carrier for LogLevels (see the cross-wrapper enum note in pydm.utilities); the
+# module-global LogLevels above keeps as_dict() for the combo box.
 if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
     from PySide6.QtCore import QEnum
-    from enum import Enum
 
-    @QEnum
-    class LogLevels(Enum):  # noqa F811
-        NOTSET = 0
-        DEBUG = 10
-        INFO = 20
-        WARNING = 30
-        ERROR = 40
-        CRITICAL = 50
+    class PyDMLogDisplay(QWidget):
+        @QEnum
+        class LogLevels(IntEnum):
+            NOTSET = 0
+            DEBUG = 10
+            INFO = 20
+            WARNING = 30
+            ERROR = 40
+            CRITICAL = 50
 
-        @staticmethod
-        def as_dict():
-            """
-            Returns an ordered dict of LogLevels ordered by value.
-            Returns
-            -------
-            OrderedDict
-            """
-            # First let's remove the internals
-            entries = [(k, v.value) for k, v in LogLevels.__members__.items()]
-            return OrderedDict(sorted(entries, key=lambda x: x[1], reverse=False))
+    _PyDMLogDisplayBases = (PyDMLogDisplay,)
+else:
+    _PyDMLogDisplayBases = (QWidget,)
 
 
-class PyDMLogDisplay(QWidget):
+class PyDMLogDisplay(*_PyDMLogDisplayBases):
     """
     Standard display for Log Output
 
@@ -183,6 +180,8 @@ class PyDMLogDisplay(QWidget):
         from pydm.utilities import pyqt6_designer_enum
 
         LogLevels = pyqt6_designer_enum("PyDMLogDisplay", LogLevels)
+    else:  # PySide6: adopt this widget's carrier-registered enum
+        LogLevels = _PyDMLogDisplayBases[0].LogLevels
     LogLevels = LogLevels
 
     # Make enum definitions known to this class
@@ -228,13 +227,7 @@ class PyDMLogDisplay(QWidget):
         self.log = None
         self.level = None
         self.logName = logname or ""
-        if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT6:
-            # PyQt6 enum properties won't accept a bare int; coerce the logging
-            # level into a LogLevels member (leave custom levels untouched).
-            try:
-                level = LogLevels(level)
-            except ValueError:
-                pass
+        # setLogLevel coerces a bare int (e.g. logging.NOTSET) into a LogLevels member.
         self.logLevel = level
         self.destroyed.connect(functools.partial(logger_destroyed, self.log))
 
@@ -245,6 +238,7 @@ class PyDMLogDisplay(QWidget):
         return self.level
 
     def setLogLevel(self, level) -> None:
+        level = coerce_enum_value(level, self.LogLevels)
         if level != self.level:
             self.level = level
             # Search by the int value (getattr handles both an enum member and an int across all three Qt wrappers).

--- a/pydm/widgets/qtplugin_base.py
+++ b/pydm/widgets/qtplugin_base.py
@@ -41,6 +41,10 @@ if ACTIVE_QT_WRAPPER in (QtWrapperTypes.PYQT5, QtWrapperTypes.PYQT6):
 elif ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
     BASE_PLUGIN_CLASS = QtDesigner.QDesignerCustomWidgetInterface
 
+#: Top-level module names of the Qt bindings PyDM supports.  Used to find a
+#: widget's nearest genuine Qt base class for the Designer "<extends>" field.
+_QT_BINDING_MODULES = ("PyQt5", "PyQt6", "PySide6")
+
 
 class WidgetCategory(str, enum.Enum):
     """Categories for PyDM Widgets in the Qt Designer."""
@@ -224,17 +228,55 @@ class PyDMDesignerPlugin(BASE_PLUGIN_CLASS):
         """
         return QtGui.QIcon(self._icon.pixmap(QtCore.QSize(32, 32)))
 
+    def designer_base_class(self):
+        """
+        Return the name of this widget's nearest genuine Qt base class.
+
+        Qt Designer records a custom widget's base class -- its ``<extends>``
+        -- so that a saved ``.ui`` file stays loadable in an environment that
+        uses a different Qt wrapper.  By default Designer infers this from the
+        widget's immediate metaobject superclass, but some PyDM widgets
+        interpose a pure-Python base class (for example a per-widget carrier
+        class used to scope a custom enum so it appears as a Designer
+        dropdown).  Such a base is not a real Qt type and is not portable
+        across wrappers, so instead we walk the MRO and report the first
+        genuine Qt class (``QGraphicsView``, ``QLabel``, ...).  For widgets
+        that subclass a Qt type directly this is exactly what Designer would
+        have inferred on its own.
+        """
+        for klass in self.cls.__mro__:
+            module = (getattr(klass, "__module__", "") or "").split(".")[0]
+            if module in _QT_BINDING_MODULES:
+                return klass.__name__
+        return "QWidget"
+
     def domXml(self):
         """
-        XML Description of the widget's properties.
+        XML description of the widget's default property values.
+
+        The ``<widget>`` element supplies the values Designer uses when the
+        widget is first dropped onto a form.  The accompanying
+        ``<customwidgets>`` element declares the widget's Qt base class
+        explicitly via ``<extends>``; pinning this to a real Qt type (rather
+        than relying on Designer's metaobject inference) keeps saved ``.ui``
+        files portable across Qt wrappers.
         """
         return (
-            '<widget class="{0}" name="{0}">\n'
-            ' <property name="toolTip" >\n'
-            "  <string>{1}</string>\n"
-            " </property>\n"
-            "</widget>\n"
-        ).format(self.name(), self.toolTip())
+            '<ui language="c++">\n'
+            ' <widget class="{0}" name="{0}">\n'
+            '  <property name="toolTip">\n'
+            "   <string>{1}</string>\n"
+            "  </property>\n"
+            " </widget>\n"
+            " <customwidgets>\n"
+            "  <customwidget>\n"
+            "   <class>{0}</class>\n"
+            "   <extends>{2}</extends>\n"
+            "   <header>{3}</header>\n"
+            "  </customwidget>\n"
+            " </customwidgets>\n"
+            "</ui>\n"
+        ).format(self.name(), self.toolTip(), self.designer_base_class(), self.includeFile())
 
     def includeFile(self):
         """

--- a/pydm/widgets/qtplugin_base.py
+++ b/pydm/widgets/qtplugin_base.py
@@ -23,6 +23,7 @@ import enum
 import inspect
 import logging
 from typing import Dict, List, Optional, Type
+from xml.sax.saxutils import escape
 
 import entrypoints
 from qtpy import QtCore, QtDesigner, QtGui, QtWidgets
@@ -230,23 +231,39 @@ class PyDMDesignerPlugin(BASE_PLUGIN_CLASS):
 
     def designer_base_class(self):
         """
-        Return the name of this widget's nearest genuine Qt base class.
+        Return the base class Designer should record as this widget's ``<extends>``.
 
         Qt Designer records a custom widget's base class -- its ``<extends>``
         -- so that a saved ``.ui`` file stays loadable in an environment that
-        uses a different Qt wrapper.  By default Designer infers this from the
-        widget's immediate metaobject superclass, but some PyDM widgets
-        interpose a pure-Python base class (for example a per-widget carrier
-        class used to scope a custom enum so it appears as a Designer
-        dropdown).  Such a base is not a real Qt type and is not portable
-        across wrappers, so instead we walk the MRO and report the first
-        genuine Qt class (``QGraphicsView``, ``QLabel``, ...).  For widgets
-        that subclass a Qt type directly this is exactly what Designer would
-        have inferred on its own.
+        uses a different Qt wrapper.  Designer normally infers this from the
+        widget's metaobject superclass; two PyDM specifics need correcting:
+
+        * A per-widget PySide6 *carrier* base (used to scope a custom enum so
+          it renders as a Designer dropdown) is a pure-Python class named
+          identically to the widget.  Left alone, Designer would emit a
+          self-referential ``<extends>`` that no other wrapper can resolve.
+        * PyDM's abstract intermediate bases (``PyDMDrawing``, ``BasePlot``,
+          ...) are not registered widgets, so they are not resolvable as an
+          ``<extends>`` either.
+
+        So we walk the MRO, skip the same-named carrier, and report the first
+        base that is a genuine Qt class *or* another registered PyDM widget --
+        exactly what Designer infers for a directly-subclassed widget
+        (``PyDMDrawingPie`` -> ``PyDMDrawingArc``, ``PyDMLabel`` -> ``QLabel``).
         """
-        for klass in self.cls.__mro__:
+        try:
+            from pydm.widgets.qtplugins import get_pydm_custom_widgets
+
+            registered = {plugin.plugin_name for plugin in get_pydm_custom_widgets().values()}
+        except Exception:
+            # If the registry can't be read, fall back to the nearest genuine Qt
+            # base -- always resolvable, just less specific than the true parent.
+            registered = set()
+        for klass in self.cls.__mro__[1:]:
+            if klass.__name__ == self.cls.__name__:
+                continue  # a PySide6 enum carrier, named like the widget itself
             module = (getattr(klass, "__module__", "") or "").split(".")[0]
-            if module in _QT_BINDING_MODULES:
+            if module in _QT_BINDING_MODULES or klass.__name__ in registered:
                 return klass.__name__
         return "QWidget"
 
@@ -276,7 +293,7 @@ class PyDMDesignerPlugin(BASE_PLUGIN_CLASS):
             "  </customwidget>\n"
             " </customwidgets>\n"
             "</ui>\n"
-        ).format(self.name(), self.toolTip(), self.designer_base_class(), self.includeFile())
+        ).format(self.name(), escape(self.toolTip()), self.designer_base_class(), self.includeFile())
 
     def includeFile(self):
         """

--- a/pydm/widgets/qtplugin_base.py
+++ b/pydm/widgets/qtplugin_base.py
@@ -42,8 +42,6 @@ if ACTIVE_QT_WRAPPER in (QtWrapperTypes.PYQT5, QtWrapperTypes.PYQT6):
 elif ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
     BASE_PLUGIN_CLASS = QtDesigner.QDesignerCustomWidgetInterface
 
-#: Top-level module names of the Qt bindings PyDM supports.  Used to find a
-#: widget's nearest genuine Qt base class for the Designer "<extends>" field.
 _QT_BINDING_MODULES = ("PyQt5", "PyQt6", "PySide6")
 
 
@@ -231,33 +229,30 @@ class PyDMDesignerPlugin(BASE_PLUGIN_CLASS):
 
     def designer_base_class(self):
         """
-        Return the base class Designer should record as this widget's ``<extends>``.
+        Return the base class Designer should record as this widget's <extends>.
 
-        Qt Designer records a custom widget's base class -- its ``<extends>``
-        -- so that a saved ``.ui`` file stays loadable in an environment that
-        uses a different Qt wrapper.  Designer normally infers this from the
-        widget's metaobject superclass; two PyDM specifics need correcting:
+        Qt Designer records a custom widget's base class -- its <extends>
+        -- so that a saved .ui file stays loadable in an environment that
+        uses a different Qt wrapper.  Designer infers this from the
+        widget's metaobject superclass, but two PyDM specifics need correcting:
 
-        * A per-widget PySide6 *carrier* base (used to scope a custom enum so
+        * A per-widget PySide6 carrier base (used to scope a custom enum so
           it renders as a Designer dropdown) is a pure-Python class named
           identically to the widget.  Left alone, Designer would emit a
-          self-referential ``<extends>`` that no other wrapper can resolve.
-        * PyDM's abstract intermediate bases (``PyDMDrawing``, ``BasePlot``,
+          self-referential <extends> that no other wrapper can resolve.
+        * PyDM's abstract intermediate bases (PyDMDrawing, BasePlot,
           ...) are not registered widgets, so they are not resolvable as an
-          ``<extends>`` either.
+          <extends> either.
 
         So we walk the MRO, skip the same-named carrier, and report the first
-        base that is a genuine Qt class *or* another registered PyDM widget --
-        exactly what Designer infers for a directly-subclassed widget
-        (``PyDMDrawingPie`` -> ``PyDMDrawingArc``, ``PyDMLabel`` -> ``QLabel``).
+        base that is a genuine Qt class or another registered PyDM widget.
         """
         try:
             from pydm.widgets.qtplugins import get_pydm_custom_widgets
 
             registered = {plugin.plugin_name for plugin in get_pydm_custom_widgets().values()}
         except Exception:
-            # If the registry can't be read, fall back to the nearest genuine Qt
-            # base -- always resolvable, just less specific than the true parent.
+            # If the registry can't be read, fall back to the nearest genuine Qt base.
             registered = set()
         for klass in self.cls.__mro__[1:]:
             if klass.__name__ == self.cls.__name__:
@@ -271,11 +266,11 @@ class PyDMDesignerPlugin(BASE_PLUGIN_CLASS):
         """
         XML description of the widget's default property values.
 
-        The ``<widget>`` element supplies the values Designer uses when the
+        The <widget> element supplies the values Designer uses when the
         widget is first dropped onto a form.  The accompanying
-        ``<customwidgets>`` element declares the widget's Qt base class
-        explicitly via ``<extends>``; pinning this to a real Qt type (rather
-        than relying on Designer's metaobject inference) keeps saved ``.ui``
+        <customwidgets> element declares the widget's Qt base class
+        explicitly via <extends>. Pinning this to a real Qt type (rather
+        than relying on Designer's metaobject inference) keeps saved .ui
         files portable across Qt wrappers.
         """
         return (

--- a/pydm/widgets/qtplugins.py
+++ b/pydm/widgets/qtplugins.py
@@ -346,3 +346,11 @@ def get_all_custom_widgets_in_order() -> list[type[PyDMDesignerPlugin]]:
     for category in sorted(entrypoint_widgets_by_group):
         all_custom_widgets.extend(sorted(entrypoint_widgets_by_group[category], key=lambda pl: pl.plugin_name))
     return all_custom_widgets
+
+
+# Restrict `from pydm.widgets.qtplugins import *` to the generated Designer plugin classes only.
+# A stale copy of register_pydm_designer_plugin.py (older PyDM installs used that wildcard import)
+# would otherwise also pull in the PyDMDesignerPlugin base; the Qt Designer bridge then tries to
+# instantiate it with no args and raises
+# "PyDMDesignerPlugin.__init__() missing 1 required positional argument: 'cls'".
+__all__ = [_name for _name, _obj in list(globals().items()) if is_designer_widget(_obj)]

--- a/pydm/widgets/qtplugins.py
+++ b/pydm/widgets/qtplugins.py
@@ -346,11 +346,3 @@ def get_all_custom_widgets_in_order() -> list[type[PyDMDesignerPlugin]]:
     for category in sorted(entrypoint_widgets_by_group):
         all_custom_widgets.extend(sorted(entrypoint_widgets_by_group[category], key=lambda pl: pl.plugin_name))
     return all_custom_widgets
-
-
-# Restrict `from pydm.widgets.qtplugins import *` to the generated Designer plugin classes only.
-# A stale copy of register_pydm_designer_plugin.py (older PyDM installs used that wildcard import)
-# would otherwise also pull in the PyDMDesignerPlugin base; the Qt Designer bridge then tries to
-# instantiate it with no args and raises
-# "PyDMDesignerPlugin.__init__() missing 1 required positional argument: 'cls'".
-__all__ = [_name for _name, _obj in list(globals().items()) if is_designer_widget(_obj)]

--- a/pydm/widgets/shell_command.py
+++ b/pydm/widgets/shell_command.py
@@ -12,7 +12,7 @@ from qtpy.QtGui import QCursor, QIcon, QMouseEvent, QColor
 from qtpy.QtCore import QSize, Qt, QTimer, Signal
 from qtpy import QtDesigner
 from .base import PyDMWidget, only_if_channel_set, PostParentClassInitSetup
-from pydm.utilities import IconFont, ACTIVE_QT_WRAPPER, QtWrapperTypes
+from pydm.utilities import IconFont, ACTIVE_QT_WRAPPER, QtWrapperTypes, coerce_enum_value
 from typing import Optional, Union, List
 from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
 
@@ -34,25 +34,30 @@ class TermOutputMode:
     STORE = 2
 
 
-if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT6:
+if ACTIVE_QT_WRAPPER in (QtWrapperTypes.PYQT6, QtWrapperTypes.PYSIDE6):
     from pydm.utilities import int_enum_from
 
     TermOutputMode = int_enum_from("TermOutputMode", TermOutputMode)
 
 
+# PySide6 Designer-dropdown carrier(s) for this widget's enum(s) -- see the cross-wrapper enum note in pydm.utilities.
 if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
     from PySide6.QtCore import QEnum
-    from enum import Enum
+    from enum import IntEnum
 
-    @QEnum
-    # overrides prev enum def
-    class TermOutputMode(Enum):  # noqa: F811
-        HIDE = 0
-        SHOW = 1
-        STORE = 2
+    class PyDMShellCommand(QPushButton, PyDMWidget):
+        @QEnum
+        class TermOutputMode(IntEnum):
+            HIDE = 0
+            SHOW = 1
+            STORE = 2
+
+    _PyDMShellCommandBases = (PyDMShellCommand,)
+else:
+    _PyDMShellCommandBases = (QPushButton, PyDMWidget)
 
 
-class PyDMShellCommand(QPushButton, PyDMWidget):
+class PyDMShellCommand(*_PyDMShellCommandBases):
     """
     A QPushButton capable of executing shell commands.
 
@@ -76,6 +81,8 @@ class PyDMShellCommand(QPushButton, PyDMWidget):
         from pydm.utilities import pyqt6_designer_enum
 
         TermOutputMode = pyqt6_designer_enum("PyDMShellCommand", TermOutputMode)
+    else:  # PySide6: adopt this widget's carrier-registered enum
+        TermOutputMode = _PyDMShellCommandBases[0].TermOutputMode
     TermOutputMode = TermOutputMode
 
     # Make enum definitions known to this class
@@ -116,8 +123,8 @@ class PyDMShellCommand(QPushButton, PyDMWidget):
         self._allow_multiple = False
         self.process = None
         self._show_icon = True
-        self._stdout = TermOutputMode.HIDE
-        self._stderr = TermOutputMode.HIDE
+        self._stdout = self.TermOutputMode.HIDE
+        self._stderr = self.TermOutputMode.HIDE
         self._uses_stdout_intf = False
         # shell allows for more options such as command chaining ("cmd1;cmd2", "cmd1 && cmd2", etc ...),
         # use of environment variables, glob expansion ('ls *.txt'), etc...
@@ -406,9 +413,9 @@ class PyDMShellCommand(QPushButton, PyDMWidget):
             )
             return
         if value:
-            self._stdout = TermOutputMode.SHOW
+            self._stdout = self.TermOutputMode.SHOW
         else:
-            self._stdout = TermOutputMode.HIDE
+            self._stdout = self.TermOutputMode.HIDE
 
     redirectCommandOutput = Property(bool, readRedirectCommandOutput, setRedirectCommandOutput, designable=False)
 
@@ -431,6 +438,7 @@ class PyDMShellCommand(QPushButton, PyDMWidget):
         return self._stdout
 
     def setStdout(self, value: TermOutputMode) -> None:
+        value = coerce_enum_value(value, self.TermOutputMode)
         self._uses_stdout_intf = True
         self._stdout = value
 
@@ -449,6 +457,7 @@ class PyDMShellCommand(QPushButton, PyDMWidget):
         return self._stderr
 
     def setStderr(self, value: TermOutputMode) -> None:
+        value = coerce_enum_value(value, self.TermOutputMode)
         self._stderr = value
 
     stderr = Property(TermOutputMode, readStderr, setStderr)

--- a/pydm/widgets/shell_command.py
+++ b/pydm/widgets/shell_command.py
@@ -76,13 +76,13 @@ class PyDMShellCommand(*_PyDMShellCommandBases):
         from PyQt5.QtCore import Q_ENUM
 
         Q_ENUM(TermOutputMode)
+        TermOutputMode = TermOutputMode
     elif ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT6:
         from pydm.utilities import pyqt6_designer_enum
 
         TermOutputMode = pyqt6_designer_enum("PyDMShellCommand", TermOutputMode)
-    else:  # PySide6: adopt this widget's carrier-registered enum
+    elif ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
         TermOutputMode = _PyDMShellCommandBases[0].TermOutputMode
-    TermOutputMode = TermOutputMode
 
     # Make enum definitions known to this class
     HIDE = TermOutputMode.HIDE

--- a/pydm/widgets/shell_command.py
+++ b/pydm/widgets/shell_command.py
@@ -14,7 +14,6 @@ from qtpy import QtDesigner
 from .base import PyDMWidget, only_if_channel_set, PostParentClassInitSetup
 from pydm.utilities import IconFont, ACTIVE_QT_WRAPPER, QtWrapperTypes, coerce_enum_value
 from typing import Optional, Union, List
-from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
 
 if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
     from PySide6.QtCore import Property

--- a/pydm/widgets/slider.py
+++ b/pydm/widgets/slider.py
@@ -18,7 +18,7 @@ from qtpy.QtWidgets import (
 from pydm.widgets import PyDMLabel
 from .base import PyDMWritableWidget, TextFormatter, is_channel_valid
 from .channel import PyDMChannel
-from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
+from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes, coerce_enum_value
 
 if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
     from PySide6.QtCore import Property
@@ -236,7 +236,41 @@ class PyDMPrimitiveSlider(QSlider):
             return (1 - proportion) * slider_length + self.getHandleSize().height() / 2
 
 
-class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget):
+# TickPosition mirrors QSlider.TickPosition's values but is scoped to PyDMSlider so it renders as
+# a Designer dropdown on every wrapper -- PySide6's Designer can't handle a built-in
+# QSlider::TickPosition enum reused as a custom-widget property.
+class TickPosition(object):
+    NoTicks = 0
+    TicksAbove = 1
+    TicksBelow = 2
+    TicksBothSides = 3
+
+
+if ACTIVE_QT_WRAPPER in (QtWrapperTypes.PYQT6, QtWrapperTypes.PYSIDE6):
+    from pydm.utilities import int_enum_from
+
+    TickPosition = int_enum_from("TickPosition", TickPosition)
+
+
+# PySide6 Designer-dropdown carrier for this widget's enum -- see the cross-wrapper enum note in pydm.utilities.
+if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
+    from PySide6.QtCore import QEnum
+    from enum import IntEnum
+
+    class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget):
+        @QEnum
+        class TickPosition(IntEnum):
+            NoTicks = 0
+            TicksAbove = 1
+            TicksBelow = 2
+            TicksBothSides = 3
+
+    _PyDMSliderBases = (PyDMSlider,)
+else:
+    _PyDMSliderBases = (QFrame, TextFormatter, PyDMWritableWidget)
+
+
+class PyDMSlider(*_PyDMSliderBases):
     """
     A QSlider with support for Channels and more from PyDM.
 
@@ -247,6 +281,25 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget):
     init_channel : str, optional
         The channel to be used by the widget.
     """
+
+    if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT5:
+        from PyQt5.QtCore import Q_ENUM
+
+        Q_ENUM(TickPosition)
+    elif ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT6:
+        from pydm.utilities import pyqt6_designer_enum
+
+        TickPosition = pyqt6_designer_enum("PyDMSlider", TickPosition)
+    else:  # PySide6: adopt this widget's carrier-registered enum
+        TickPosition = _PyDMSliderBases[0].TickPosition
+
+    TickPosition = TickPosition  # PyQt5 Q_ENUM binds no class attr; keep this publish
+
+    # Make enum definitions known to this class
+    NoTicks = TickPosition.NoTicks
+    TicksAbove = TickPosition.TicksAbove
+    TicksBelow = TickPosition.TicksBelow
+    TicksBothSides = TickPosition.TicksBothSides
 
     new_properties = _step_size_properties
 
@@ -1033,15 +1086,16 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget):
 
     showValueLabel = Property(bool, readShowValueLabel, setShowValueLabel)
 
-    def readTickPosition(self) -> QSlider.TickPosition:
+    def readTickPosition(self) -> TickPosition:
         """
         Where to draw tick marks for the slider.
 
         Returns
         -------
-        QSlider.TickPosition
+        TickPosition
         """
-        return self._slider.tickPosition()
+        pos = self._slider.tickPosition()
+        return coerce_enum_value(int(getattr(pos, "value", pos)), self.TickPosition)
 
     def setTickPosition(self, position) -> None:
         """
@@ -1049,11 +1103,15 @@ class PyDMSlider(QFrame, TextFormatter, PyDMWritableWidget):
 
         Parameter
         ---------
-        position : QSlider.TickPosition
+        position : TickPosition, int
         """
-        self._slider.setTickPosition(position)
+        # tickPosition drives the internal QSlider, which needs a real QSlider.TickPosition (the
+        # Qt6 bindings reject a bare int).  The incoming value may be a bare int (rules engine),
+        # this widget's TickPosition, or a legacy QSlider.TickPosition -- normalise via its int.
+        value = int(getattr(position, "value", position))
+        self._slider.setTickPosition(QSlider.TickPosition(value))
 
-    tickPosition = Property(QSlider.TickPosition, readTickPosition, setTickPosition)
+    tickPosition = Property(TickPosition, readTickPosition, setTickPosition)
 
     def readUserDefinedLimits(self) -> bool:
         """

--- a/pydm/widgets/slider.py
+++ b/pydm/widgets/slider.py
@@ -286,14 +286,13 @@ class PyDMSlider(*_PyDMSliderBases):
         from PyQt5.QtCore import Q_ENUM
 
         Q_ENUM(TickPosition)
+        TickPosition = TickPosition
     elif ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT6:
         from pydm.utilities import pyqt6_designer_enum
 
         TickPosition = pyqt6_designer_enum("PyDMSlider", TickPosition)
-    else:  # PySide6: adopt this widget's carrier-registered enum
+    elif ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
         TickPosition = _PyDMSliderBases[0].TickPosition
-
-    TickPosition = TickPosition  # PyQt5 Q_ENUM binds no class attr; keep this publish
 
     # Make enum definitions known to this class
     NoTicks = TickPosition.NoTicks

--- a/pydm/widgets/template_repeater.py
+++ b/pydm/widgets/template_repeater.py
@@ -9,8 +9,7 @@ from pydm.utilities import is_qt_designer
 import pydm.data_plugins
 from pydm.utilities import find_file
 from pydm.display import load_file
-from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
-from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes
+from pydm.utilities import ACTIVE_QT_WRAPPER, QtWrapperTypes, coerce_enum_value
 
 if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
     from PySide6.QtCore import Property
@@ -124,22 +123,27 @@ class LayoutType(object):
     Flow = 2
 
 
-if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT6:
+if ACTIVE_QT_WRAPPER in (QtWrapperTypes.PYQT6, QtWrapperTypes.PYSIDE6):
     from pydm.utilities import int_enum_from
 
     LayoutType = int_enum_from("LayoutType", LayoutType)
 
 
+# PySide6 Designer-dropdown carrier(s) for this widget's enum(s) -- see the cross-wrapper enum note in pydm.utilities.
 if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
     from PySide6.QtCore import QEnum
-    from enum import Enum
+    from enum import IntEnum
 
-    @QEnum
-    # overrides prev enum def
-    class LayoutType(Enum):  # noqa F811
-        Vertical = 0
-        Horizontal = 1
-        Flow = 2
+    class PyDMTemplateRepeater(QFrame, PyDMPrimitiveWidget):
+        @QEnum
+        class LayoutType(IntEnum):
+            Vertical = 0
+            Horizontal = 1
+            Flow = 2
+
+    _PyDMTemplateRepeaterBases = (PyDMTemplateRepeater,)
+else:
+    _PyDMTemplateRepeaterBases = (QFrame, PyDMPrimitiveWidget)
 
 
 layout_class_for_type = {
@@ -149,7 +153,7 @@ layout_class_for_type = {
 }
 
 
-class PyDMTemplateRepeater(QFrame, PyDMPrimitiveWidget):
+class PyDMTemplateRepeater(*_PyDMTemplateRepeaterBases):
     """
     PyDMTemplateRepeater takes a .ui file with macro variables as a template, and a JSON
     file (or a list of dictionaries) with a list of values to use to fill in
@@ -177,6 +181,8 @@ class PyDMTemplateRepeater(QFrame, PyDMPrimitiveWidget):
         from pydm.utilities import pyqt6_designer_enum
 
         LayoutType = pyqt6_designer_enum("PyDMTemplateRepeater", LayoutType)
+    else:  # PySide6: adopt this widget's carrier-registered enum
+        LayoutType = _PyDMTemplateRepeaterBases[0].LayoutType
     LayoutType = LayoutType
 
     # Make enum definitions known to this class
@@ -196,7 +202,7 @@ class PyDMTemplateRepeater(QFrame, PyDMPrimitiveWidget):
         self._recursive_data_search = False
         self._cached_template = None
         self._parent_macros = None
-        self._layout_type = LayoutType.Vertical
+        self._layout_type = self.LayoutType.Vertical
         self._temp_layout_spacing = 4
         self.app = QApplication.instance()
         self.rebuild()
@@ -224,6 +230,7 @@ class PyDMTemplateRepeater(QFrame, PyDMPrimitiveWidget):
         ----------
         new_type : LayoutType
         """
+        new_type = coerce_enum_value(new_type, self.LayoutType)
         if new_type != self._layout_type:
             self._layout_type = new_type
             self.rebuild()

--- a/pydm/widgets/template_repeater.py
+++ b/pydm/widgets/template_repeater.py
@@ -177,13 +177,13 @@ class PyDMTemplateRepeater(*_PyDMTemplateRepeaterBases):
         from PyQt5.QtCore import Q_ENUM
 
         Q_ENUM(LayoutType)
+        LayoutType = LayoutType
     elif ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT6:
         from pydm.utilities import pyqt6_designer_enum
 
         LayoutType = pyqt6_designer_enum("PyDMTemplateRepeater", LayoutType)
-    else:  # PySide6: adopt this widget's carrier-registered enum
+    elif ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
         LayoutType = _PyDMTemplateRepeaterBases[0].LayoutType
-    LayoutType = LayoutType
 
     # Make enum definitions known to this class
     Vertical = LayoutType.Vertical

--- a/pydm/widgets/timeplot.py
+++ b/pydm/widgets/timeplot.py
@@ -474,35 +474,23 @@ class TimePlotCurveItem(BasePlotCurveItem):
         return [self.channel]
 
 
+# PySide6 Designer-dropdown carrier for this widget's enum. See the cross-wrapper enum note in pydm.utilities.
 if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
     from enum import IntEnum
     from PySide6.QtCore import QEnum
 
-    # PySide6 shows a custom enum as a Designer dropdown only when it is registered with a
-    # meta-type via @QEnum, and that requires the enum to live on a QObject-derived *base*
-    # class -- declaring the enum and a Property of that type in the same class body raises
-    # "Invalid property type" (the meta-type isn't registered until the class is finalized).
-    # This carrier base is named PyDMTimePlot (not a private name) on purpose: the registered
-    # enum's meta-type then becomes "PyDMTimePlot::UpdateMode", matching the widget class, so a
-    # value saved in a .ui ("PyDMTimePlot::UpdateMode::AtFixedRate") round-trips through both
-    # pyside6-designer and pyside6-uic. The real widget below redefines PyDMTimePlot as its
-    # subclass; the enum is already registered by the time its updateMode Property is built.
     class PyDMTimePlot(BasePlot):
         @QEnum
         class UpdateMode(IntEnum):
             OnValueChange = 1
             AtFixedRate = 2
 
-    _PyDMTimePlotBase = PyDMTimePlot
-    # Read/stored values must be members of this exact registered enum for the Property to
-    # round-trip, so adopt it as the canonical UpdateMode under PySide6.
-    UpdateMode = PyDMTimePlot.UpdateMode
-    updateMode = UpdateMode  # keep the back-compat alias pointing at the registered enum
+    _PyDMTimePlotBases = (PyDMTimePlot,)
 else:
-    _PyDMTimePlotBase = BasePlot
+    _PyDMTimePlotBases = (BasePlot,)
 
 
-class PyDMTimePlot(_PyDMTimePlotBase):
+class PyDMTimePlot(*_PyDMTimePlotBases):
     """
     PyDMTimePlot is a widget to plot one or more channels vs. time.
 
@@ -531,14 +519,13 @@ class PyDMTimePlot(_PyDMTimePlotBase):
         from PyQt5.QtCore import Q_ENUM
 
         Q_ENUM(UpdateMode)
+        UpdateMode = UpdateMode
     elif ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT6:
         from pydm.utilities import pyqt6_designer_enum
 
         UpdateMode = pyqt6_designer_enum("PyDMTimePlot", UpdateMode)
-    # Publish the registered enum on the class as ``UpdateMode``.  The Property below is named
-    # ``updateMode`` (camelCase) -- a deliberately different name, so it no longer shadows the
-    # enum and ``PyDMTimePlot.UpdateMode.AtFixedRate`` stays reachable for uic-generated code.
-    UpdateMode = UpdateMode
+    elif ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
+        UpdateMode = _PyDMTimePlotBases[0].UpdateMode
 
     # Make enum definitions known to this class
     OnValueChange = UpdateMode.OnValueChange
@@ -1085,15 +1072,8 @@ class PyDMTimePlot(_PyDMTimePlotBase):
             self.setUpdatesAsynchronously(self._updateMode)
 
     # UpdateMode is the per-wrapper registered enum (see the enum setup in the class body and,
-    # for PySide6, _PyDMTimePlotBase above): PyQt5 Q_ENUM, PyQt6 pyqt6_designer_enum, PySide6
-    # @QEnum on the base. Typing the Property as it makes Designer render a named dropdown of
-    # the members on all three wrappers. The property is intentionally named differently from
+    # for PySide6, the carrier in _PyDMTimePlotBases above). The property is intentionally named differently from
     # the enum (updateMode vs UpdateMode) so uic-generated code can still reach enum members.
-    # setUpdateMode runs its incoming value through pydm.utilities.coerce_enum_value so a bare int
-    # (from the rules engine's setattr, user code, or a constructor) is normalised to an UpdateMode
-    # member -- the Qt6 bindings corrupt an enum-typed property when a bare int is stored via
-    # attribute assignment. (.ui loading is unaffected either way: uic emits
-    # ``setProperty("updateMode", PyDMTimePlot.AtFixedRate)``, routed through the Qt metaobject.)
     updateMode = Property(UpdateMode, readUpdateMode, setUpdateMode)
 
     def getTimeSpan(self):

--- a/pydm/widgets/timeplot.py
+++ b/pydm/widgets/timeplot.py
@@ -8,7 +8,7 @@ from qtpy.QtGui import QColor, QCursor
 from qtpy.QtCore import Signal, Slot, QTimer
 from .baseplot import BasePlot, BasePlotCurveItem
 from .channel import PyDMChannel
-from pydm.utilities import remove_protocol, ACTIVE_QT_WRAPPER, QtWrapperTypes
+from pydm.utilities import remove_protocol, ACTIVE_QT_WRAPPER, QtWrapperTypes, coerce_enum_value
 from datetime import datetime
 
 if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
@@ -33,8 +33,8 @@ DEFAULT_SEVERITY_RAW = -1
 DEFAULT_SEVERITY_STRING = "N/A"
 
 
-class updateMode(object):
-    """updateMode as new type for plot update"""
+class UpdateMode(object):
+    """UpdateMode as new type for plot update"""
 
     OnValueChange = 1
     AtFixedRate = 2
@@ -45,8 +45,17 @@ if ACTIVE_QT_WRAPPER in (QtWrapperTypes.PYQT6, QtWrapperTypes.PYSIDE6):
 
     # Both Qt6 bindings need a real enum here (PyQt5 keeps the plain int-attribute class
     # above). int_enum_from returns an IntEnum, so members stay equal to their int value,
-    # which the `value == updateMode.AtFixedRate` checks elsewhere in this module rely on.
-    updateMode = int_enum_from("updateMode", updateMode)
+    # which the `value == UpdateMode.AtFixedRate` checks elsewhere in this module rely on.
+    UpdateMode = int_enum_from("UpdateMode", UpdateMode)
+
+# Back-compat alias.  This enum was historically named ``updateMode`` -- the same name as the
+# Qt property below.  That collision is invisible to Designer (it resolves enums through the
+# C++ metaobject) but breaks ``uic``-generated code, which reaches an enum member by attribute
+# access: ``PyDMTimePlot.updateMode.AtFixedRate`` lands on the *property*, not the enum, so any
+# ``.ui`` with updateMode set fails to load on every wrapper.  The canonical name is now the
+# PascalCase ``UpdateMode`` (matching ``TimeBase``, ``ReadingOrder``, ... on the other widgets);
+# keep the old name importable for existing code.
+updateMode = UpdateMode
 
 
 class TimePlotCurveItem(BasePlotCurveItem):
@@ -428,7 +437,7 @@ class TimePlotCurveItem(BasePlotCurveItem):
         """
         Check if value is from updatesAsynchronously(bool) or updateMode(int)
         """
-        if isinstance(value, int) and value == updateMode.AtFixedRate or isinstance(value, bool) and value is True:
+        if isinstance(value, int) and value == UpdateMode.AtFixedRate or isinstance(value, bool) and value is True:
             self._update_mode = PyDMTimePlot.AtFixedRate
         else:
             self._update_mode = PyDMTimePlot.OnValueChange
@@ -465,7 +474,35 @@ class TimePlotCurveItem(BasePlotCurveItem):
         return [self.channel]
 
 
-class PyDMTimePlot(BasePlot):
+if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6:
+    from enum import IntEnum
+    from PySide6.QtCore import QEnum
+
+    # PySide6 shows a custom enum as a Designer dropdown only when it is registered with a
+    # meta-type via @QEnum, and that requires the enum to live on a QObject-derived *base*
+    # class -- declaring the enum and a Property of that type in the same class body raises
+    # "Invalid property type" (the meta-type isn't registered until the class is finalized).
+    # This carrier base is named PyDMTimePlot (not a private name) on purpose: the registered
+    # enum's meta-type then becomes "PyDMTimePlot::UpdateMode", matching the widget class, so a
+    # value saved in a .ui ("PyDMTimePlot::UpdateMode::AtFixedRate") round-trips through both
+    # pyside6-designer and pyside6-uic. The real widget below redefines PyDMTimePlot as its
+    # subclass; the enum is already registered by the time its updateMode Property is built.
+    class PyDMTimePlot(BasePlot):
+        @QEnum
+        class UpdateMode(IntEnum):
+            OnValueChange = 1
+            AtFixedRate = 2
+
+    _PyDMTimePlotBase = PyDMTimePlot
+    # Read/stored values must be members of this exact registered enum for the Property to
+    # round-trip, so adopt it as the canonical UpdateMode under PySide6.
+    UpdateMode = PyDMTimePlot.UpdateMode
+    updateMode = UpdateMode  # keep the back-compat alias pointing at the registered enum
+else:
+    _PyDMTimePlotBase = BasePlot
+
+
+class PyDMTimePlot(_PyDMTimePlotBase):
     """
     PyDMTimePlot is a widget to plot one or more channels vs. time.
 
@@ -493,20 +530,19 @@ class PyDMTimePlot(BasePlot):
     if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT5:
         from PyQt5.QtCore import Q_ENUM
 
-        Q_ENUM(updateMode)
+        Q_ENUM(UpdateMode)
     elif ACTIVE_QT_WRAPPER == QtWrapperTypes.PYQT6:
         from pydm.utilities import pyqt6_designer_enum
 
-        updateMode = pyqt6_designer_enum("PyDMTimePlot", updateMode)
-        # The Property defined below is also named "updateMode" and would replace
-        # this enum in the class namespace before PyQt6 registers it. Keep a
-        # reference under another name so it is still published as an enum type.
-        _updateMode_enum = updateMode
-    updateMode = updateMode
+        UpdateMode = pyqt6_designer_enum("PyDMTimePlot", UpdateMode)
+    # Publish the registered enum on the class as ``UpdateMode``.  The Property below is named
+    # ``updateMode`` (camelCase) -- a deliberately different name, so it no longer shadows the
+    # enum and ``PyDMTimePlot.UpdateMode.AtFixedRate`` stays reachable for uic-generated code.
+    UpdateMode = UpdateMode
 
     # Make enum definitions known to this class
-    OnValueChange = updateMode.OnValueChange
-    AtFixedRate = updateMode.AtFixedRate
+    OnValueChange = UpdateMode.OnValueChange
+    AtFixedRate = UpdateMode.AtFixedRate
 
     plot_redrawn_signal = Signal(TimePlotCurveItem)
 
@@ -529,7 +565,7 @@ class PyDMTimePlot(BasePlot):
             The background color for the plot.  Accepts any arguments that
             pyqtgraph.mkColor will accept.
         """
-        self._updateMode = updateMode.OnValueChange
+        self._updateMode = UpdateMode.OnValueChange
         self._plot_by_timestamps = plot_by_timestamps
 
         if bottom_axis is not None:
@@ -1008,7 +1044,7 @@ class PyDMTimePlot(BasePlot):
         """
         Check if value is from updatesAsynchronously(bool) or updateMode(int)
         """
-        if isinstance(value, int) and value == updateMode.AtFixedRate or isinstance(value, bool) and value is True:
+        if isinstance(value, int) and value == UpdateMode.AtFixedRate or isinstance(value, bool) and value is True:
             self._update_mode = PyDMTimePlot.AtFixedRate
             self.update_timer.start()
         else:
@@ -1025,16 +1061,15 @@ class PyDMTimePlot(BasePlot):
         "bool", getUpdatesAsynchronously, setUpdatesAsynchronously, resetUpdatesAsynchronously, designable=False
     )
 
-    def readUpdateMode(self) -> updateMode:
+    def readUpdateMode(self) -> UpdateMode:
         """
         The updateMode to be used as property to set plot update mode.
 
         Returns
         -------
-        updateMode
+        UpdateMode
         """
-        # Property is int-typed under PySide6 (see prop_type below); return int there.
-        return int(self._updateMode) if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6 else self._updateMode
+        return self._updateMode
 
     def setUpdateMode(self, new_type) -> None:
         """
@@ -1042,17 +1077,24 @@ class PyDMTimePlot(BasePlot):
 
         Parameters
         ----------
-        new_type : updateMode
+        new_type : UpdateMode
         """
+        new_type = coerce_enum_value(new_type, self.UpdateMode)
         if new_type != self._updateMode:
             self._updateMode = new_type
             self.setUpdatesAsynchronously(self._updateMode)
 
-    # PySide6 exposes this as a plain int field: its module-level QEnum never registered on
-    # the class, so Designer reported the property as an unsupported PyObjectWrapper. int keeps
-    # it editable/saveable (no dropdown, consistent with the other enum props under PySide6).
-    prop_type = int if ACTIVE_QT_WRAPPER == QtWrapperTypes.PYSIDE6 else updateMode
-    updateMode = Property(prop_type, readUpdateMode, setUpdateMode)
+    # UpdateMode is the per-wrapper registered enum (see the enum setup in the class body and,
+    # for PySide6, _PyDMTimePlotBase above): PyQt5 Q_ENUM, PyQt6 pyqt6_designer_enum, PySide6
+    # @QEnum on the base. Typing the Property as it makes Designer render a named dropdown of
+    # the members on all three wrappers. The property is intentionally named differently from
+    # the enum (updateMode vs UpdateMode) so uic-generated code can still reach enum members.
+    # setUpdateMode runs its incoming value through pydm.utilities.coerce_enum_value so a bare int
+    # (from the rules engine's setattr, user code, or a constructor) is normalised to an UpdateMode
+    # member -- the Qt6 bindings corrupt an enum-typed property when a bare int is stored via
+    # attribute assignment. (.ui loading is unaffected either way: uic emits
+    # ``setProperty("updateMode", PyDMTimePlot.AtFixedRate)``, routed through the Qt metaobject.)
+    updateMode = Property(UpdateMode, readUpdateMode, setUpdateMode)
 
     def getTimeSpan(self):
         """

--- a/pydm/widgets/timeplot.py
+++ b/pydm/widgets/timeplot.py
@@ -48,13 +48,12 @@ if ACTIVE_QT_WRAPPER in (QtWrapperTypes.PYQT6, QtWrapperTypes.PYSIDE6):
     # which the `value == UpdateMode.AtFixedRate` checks elsewhere in this module rely on.
     UpdateMode = int_enum_from("UpdateMode", UpdateMode)
 
-# Back-compat alias.  This enum was historically named ``updateMode`` -- the same name as the
-# Qt property below.  That collision is invisible to Designer (it resolves enums through the
-# C++ metaobject) but breaks ``uic``-generated code, which reaches an enum member by attribute
-# access: ``PyDMTimePlot.updateMode.AtFixedRate`` lands on the *property*, not the enum, so any
-# ``.ui`` with updateMode set fails to load on every wrapper.  The canonical name is now the
-# PascalCase ``UpdateMode`` (matching ``TimeBase``, ``ReadingOrder``, ... on the other widgets);
-# keep the old name importable for existing code.
+# Backwards-compatibility alias.  This enum was historically named updateMode which is the same name as the
+# Qt property below.  That collision breaks uic-generated code, which reaches an enum member by attribute
+# access: PyDMTimePlot.updateMode.AtFixedRate lands on the property, not the enum, so any
+# .ui with updateMode set fails to load on every wrapper.  The canonical name is now UpdateMode
+# (matching TimeBase, ReadingOrder, etc.,  on the other widgets)
+# Keep the old name importable for existing code.
 updateMode = UpdateMode
 
 

--- a/pydm/widgets/timeplot.py
+++ b/pydm/widgets/timeplot.py
@@ -565,7 +565,7 @@ class PyDMTimePlot(_PyDMTimePlotBase):
             The background color for the plot.  Accepts any arguments that
             pyqtgraph.mkColor will accept.
         """
-        self._updateMode = UpdateMode.OnValueChange
+        self._updateMode = self.UpdateMode.OnValueChange
         self._plot_by_timestamps = plot_by_timestamps
 
         if bottom_axis is not None:


### PR DESCRIPTION
### Context

As mentioned in this comment: https://github.com/slaclab/pydm/pull/1335#issuecomment-4774539450, getting custom enums to work properly with Designer in PySide6 was the last issue I knew of for getting full PySide6 support working. Pointing claude at the PySide6 source code followed by PyDM's source turned up a potential solution, which I've refined a bit and seems to be working well.

### Description

To get custom enums to show up correctly with PySide6, they need to be registered via `@QEnum` on a QObject-derived base class whose meta-type scope matches the widget class. So for PySide6 we define a small carrier base class named like the widget that declares the enum, and the real widget subclasses it. PyQt5 uses `Q_ENUM,` PyQt6 uses `pyqtEnum`.

The code for handling enums has been moved into `utilities` where possible, the boilerplate for setting up the `@QEnum` has been added to each class that needs it.

The `domXml` method has also been updated to ensure that a `.ui` file saved using a PySide6 Designer can be read and modified in a PyQt6 Designer as well as the other way around.

The one Designer path that will not work anymore is a file saved using either version of Qt6 Designer will not be able to be read by a Qt5 Designer if enums are present in the saved `.ui` file.

### Documentation

Added installation instructions for PySide6, including MacOS. Added docstrings explaining the need for the extra class definitions, and the helper methods for dealing with enums.

### Testing

Created a display with every PyDM widget using both PySide6 and PyQt6. Saved the resulting files, opened successfully in the other version of Designer for both.

Verified that modified `.ui` files look as expected.

Verified that all existing `.ui` files under examples still load properly in all 3 wrappers.

After this, I think we should have full Qt6 support. Testing on this did turn up issues with the PyQt6 conda-forge install for MacOS, but those need to be fixed on the feedstock side, nothing we can do here. (I will follow up with that separately).
