### PR TITLE
MNT: Fix github pages workflow

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -6,6 +6,10 @@ on:
   push:
     branches: [ "master" ]
 
+# Required to push the built docs to the gh-pages branch
+permissions:
+  contents: write
+
 jobs:
   deploy:
     if: ${{ github.repository == 'slaclab/pydm' }}


### PR DESCRIPTION
Adds write permissions so that the workflow for updating documentation can push to the gh-pages branch.

Attempt to fix the error here: https://github.com/slaclab/pydm/actions/runs/29535732833/job/87746483449 after changes to default permissions to the slaclab org.