### PR TITLE
ENH: Add property for setting text to display if the channel a PyDMLabel is connected to disconnects

### DIFF
--- a/pydm/tests/widgets/test_label.py
+++ b/pydm/tests/widgets/test_label.py
@@ -494,6 +494,32 @@ def test_display_label_text_unchecked_uses_channel_value_and_address(qtbot, sign
     assert pydm_label.text() == "CA://MTEST"
 
 
+def test_disconnected_text_replaces_channel_address(qtbot, signals):
+    """Verify the label's text changes correctly based on text the user specified."""
+    pydm_label = PyDMLabel()
+    pydm_label.disconnectedText = "------"
+    pydm_label.channel = "CA://MTEST"
+    qtbot.addWidget(pydm_label)
+
+    signals.connection_state_signal.connect(pydm_label.connectionStateChanged)
+    signals.new_value_signal[str].connect(pydm_label.channelValueChanged)
+
+    # Displays the expected value when the channel is connected
+    signals.connection_state_signal.emit(True)
+    signals.new_value_signal[str].emit("Channel Value")
+    assert pydm_label.text() == "Channel Value"
+
+    # Changes to the disconnected text if the channel disconnects
+    signals.connection_state_signal.emit(False)
+    assert pydm_label._connected is False
+    assert pydm_label.text() == "------"
+
+    # Back to the actual value when the connection is restored
+    signals.connection_state_signal.emit(True)
+    signals.new_value_signal[str].emit("Channel Value")
+    assert pydm_label.text() == "Channel Value"
+
+
 @pytest.mark.parametrize(
     "alarm_sensitive_content, alarm_sensitive_border, tooltip",
     [

--- a/pydm/widgets/label.py
+++ b/pydm/widgets/label.py
@@ -65,6 +65,7 @@ class PyDMLabel(QLabel, TextFormatter, PyDMWidget):
         self._string_encoding = "utf_8"
         self._enable_rich_text = False
         self._display_label_text = False
+        self._disconnected_text = ""
 
         if is_pydm_app():
             self._string_encoding = self.app.get_string_encoding()
@@ -114,6 +115,24 @@ class PyDMLabel(QLabel, TextFormatter, PyDMWidget):
         self._display_label_text = new_value
 
     displayLabelText = Property(bool, readDisplayLabelText, setDisplayLabelText)
+
+    def readDisconnectedText(self):
+        """
+        disconnectedText property.
+
+        The text to display when the label's channel is disconnected. When
+        left empty, the channel address is displayed instead.
+
+        :getter: Returns the text shown while the channel is disconnected.
+        :setter: Sets the text shown while the channel is disconnected.
+        :type: str
+        """
+        return self._disconnected_text
+
+    def setDisconnectedText(self, new_text):
+        self._disconnected_text = new_text
+
+    disconnectedText = Property(str, readDisconnectedText, setDisconnectedText)
 
     def readDisplayFormat(self):
         """
@@ -182,7 +201,8 @@ class PyDMLabel(QLabel, TextFormatter, PyDMWidget):
 
     @only_if_channel_set
     def check_enable_state(self):
-        """If the channel this label is connected to becomes disconnected, display only the name of the channel."""
+        """If the channel this label is connected to becomes disconnected, display the disconnectedText
+        if set, otherwise the name of the channel."""
         if not self._connected and not self._display_label_text:
-            self.setText(self.channel)
+            self.setText(self._disconnected_text or self.channel)
         super().check_enable_state()


### PR DESCRIPTION
### Description

Implementation of #1338.

Adds a new designable property for PyDMLabel called `disconnectedText`.

If a user sets this property, then when a channel the label is connected to disconnects, it will show that text. If the property is not set, then it defaults to the current behavior of showing the channel name, so existing displays will be unaffected.

### Testing

Verified the new property works manually. Added a test case for it.

### Screenshots

<img width="753" height="372" alt="Screenshot From 2026-07-17 10-10-12" src="https://github.com/user-attachments/assets/6b52dfef-37a9-4370-b8d9-cb55e559372d" />
