### PR TITLE
BUG: fix IndexError in local plugin precision_for_value

### DIFF
--- a/pydm/data_plugins/local_plugin.py
+++ b/pydm/data_plugins/local_plugin.py
@@ -383,9 +383,15 @@ class Connection(PyDMConnection):
 
     @staticmethod
     def precision_for_value(value, max_precision=8):
-        dec = decimal.Decimal(str(value))
-        solution = min((len(str(dec).split(".")[1]), max_precision))
-        return solution
+        exponent = decimal.Decimal(str(value)).as_tuple().exponent
+        # The exponent is a string ("n", "N", "F") for NaN and Infinity, and is
+        # zero or positive for values with no fractional digits. Decimal renders
+        # both of those without a ".", so reading str(dec).split(".")[1] used to
+        # raise IndexError, which also caught floats in exponential form such as
+        # 1e-9 and 1e20.
+        if not isinstance(exponent, int) or exponent >= 0:
+            return 0
+        return min(-exponent, max_precision)
 
 
 class LocalPlugin(PyDMPlugin):

--- a/pydm/tests/data_plugins/test_local_plugin.py
+++ b/pydm/tests/data_plugins/test_local_plugin.py
@@ -1,0 +1,29 @@
+import pytest
+
+from pydm.data_plugins.local_plugin import Connection
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        # Values Decimal renders with a decimal point, unchanged behavior.
+        (3.14159, 5),
+        (0.0001, 4),
+        (12345.6, 1),
+        (5.0, 1),
+        (0.123456789, 8),
+        # Values Decimal renders without one, which used to raise IndexError.
+        (1e-9, 8),
+        (1e-12, 8),
+        (1e20, 0),
+        (float("nan"), 0),
+        (float("inf"), 0),
+        (5, 0),
+    ],
+)
+def test_precision_for_value(value, expected):
+    assert Connection.precision_for_value(value) == expected
+
+
+def test_precision_for_value_honors_max_precision():
+    assert Connection.precision_for_value(1e-9, max_precision=3) == 3


### PR DESCRIPTION
`Connection.precision_for_value` in `pydm/data_plugins/local_plugin.py` works out the number of decimal places by splitting the rendered `Decimal` on a period:

```python
dec = decimal.Decimal(str(value))
solution = min((len(str(dec).split(".")[1]), max_precision))
```

`Decimal` does not always render one. `str(Decimal(str(1e-9)))` is `"1E-9"` and `str(Decimal(str(1e20)))` is `"1E+20"`, and NaN, Infinity and whole numbers have no period either, so `[1]` raises `IndexError: list index out of range`.

That is reachable from normal use. A local float channel with no explicit precision, say `loc://charge?type=float&init=1e-9`, goes through `add_listener` to `send_precision` and lands here during connection setup, and writing such a value from a widget gets there through `put_value`. Magnitudes like nA and pC readings, or anything past 1e16, are routine for the sort of data a `loc://` channel carries.

Switched to `Decimal(str(value)).as_tuple().exponent`, which is the count of fractional digits directly, and return 0 when there are none. I checked the values that already worked come back identical: 3.14159 gives 5, 0.0001 gives 4, 12345.6 and 5.0 and 1e15 give 1, 0.123456789 gives 8. The previously crashing ones now give 8 for 1e-9 and 0 for 1e20, NaN and Infinity.

Added `pydm/tests/data_plugins/test_local_plugin.py` covering both groups plus the `max_precision` cap. Seven of the twelve cases fail on master with the IndexError; all pass with the change. `ruff` and `ruff-format` at the line length in the pre-commit config are clean.